### PR TITLE
Adding empty translations, fixing a few

### DIFF
--- a/locales/es_CO/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_CO/LC_MESSAGES/duckduckgo.po
@@ -23,11 +23,11 @@ msgstr ""
 
 msgctxt "showcase_donations"
 msgid "$800,000 in privacy donations!"
-msgstr ""
+msgstr "¡$800,000 en donaciones privadas!"
 
 msgctxt "SERP footer content"
 msgid "%s Billion Searches"
-msgstr ""
+msgstr "%s millardos de búsquedas"
 
 msgid "%s blocked by safe search."
 msgstr "%s bloqueado por la búsqueda segura"
@@ -38,7 +38,7 @@ msgstr "%s para %s"
 
 msgctxt "showcase_donations"
 msgid "%s in privacy donations!"
-msgstr ""
+msgstr "¡%s en donaciones privadas!"
 
 msgid "%s km"
 msgstr ""
@@ -71,15 +71,15 @@ msgstr ""
 
 msgctxt "noresults"
 msgid "%sClick here%s to try again, if you think there should be results for this search."
-msgstr ""
+msgstr "%sHaz clic aquí%s para intentar nuevamente, si crees que debería haber resultados para esta búsqueda."
 
 msgctxt "frontpage"
 msgid "%sHelp Spread DuckDuckGo!%s"
-msgstr ""
+msgstr "%s¡Ayuda a difundir DuckDuckGo!%s"
 
 msgctxt "frontpage"
 msgid "%sHelp Spread DuckDuckGo%s."
-msgstr ""
+msgstr "%sAyuda a difundir DuckDuckGo%s."
 
 msgctxt "frontpage"
 msgid "%sLearn More%s."
@@ -103,10 +103,10 @@ msgstr "Una cadena para identificar la fuente"
 #. at least in:
 #. * https://duckduckgo.com/about. Appears in the window title when you open the link
 msgid "About DuckDuckGo"
-msgstr "Acerca de DuckDuck Go"
+msgstr "Acerca de DuckDuckGo"
 
 msgid "About Us"
-msgstr ""
+msgstr "Sobre nosotros"
 
 #. In the new DDG website, this token appears as the Tab name for Instant Answers that give general information about a subject. eg. https://duckduckgo.com/?q=Sony
 #. It is not "About DuckDuckGo".
@@ -120,23 +120,23 @@ msgstr "Acerca de"
 
 msgctxt "feedback form"
 msgid "Ad is annoying"
-msgstr ""
+msgstr "El anuncio es molesto"
 
 msgctxt "feedback form"
 msgid "Ad is inappropriate"
-msgstr ""
+msgstr "El anuncio es inapropiado"
 
 msgctxt "feedback form"
 msgid "Ad is irrelevant"
-msgstr ""
+msgstr "El anuncio es irrelevante"
 
 msgctxt "feedback form"
 msgid "Ad is malware"
-msgstr ""
+msgstr "El anuncio es malware"
 
 msgctxt "feedback form"
 msgid "Ad is suspicious"
-msgstr ""
+msgstr "El anuncio es sospechoso"
 
 #. Ad like 'advertisement'
 msgid "Ad"
@@ -145,7 +145,7 @@ msgstr "Anuncio"
 #. https://duckduckgo.com/search_box near the top
 #. e.g.: Add a DuckDuckGo search box to your site! 
 msgid "Add a %s search box to your site!"
-msgstr "Agregue un cajón de búsqueda %s a su sitio!"
+msgstr "¡Agregue un cajón de búsqueda %s a su sitio!"
 
 msgid "Add DuckDuckGo as a search engine"
 msgstr "Agregue DuckDuckGo como un motor de búsqueda"
@@ -174,7 +174,7 @@ msgstr "Barra de direcciones:"
 
 msgctxt "maps_places"
 msgid "Address"
-msgstr ""
+msgstr "Dirección"
 
 #. http://i.imgur.com/ZG0Mz3R.png
 msgctxt "settings"
@@ -239,15 +239,15 @@ msgstr "¡Ya casi!"
 #. "Help Spread DuckDuckGo!" links to /spread page
 msgctxt "frontpage"
 msgid "Already a fan? %sHelp Spread DuckDuckGo!%s"
-msgstr "¿Ya eres un fan? %sAyuda a difundir DuckDuckGo%s"
+msgstr "¿Ya eres un admirador? %sAyuda a difundir DuckDuckGo%s"
 
 msgctxt "homepage onboarding"
 msgid "Already a fan?"
-msgstr "¿Ya es un admirador?"
+msgstr "¿Ya eres un admirador?"
 
 msgctxt "mobile promotion on desktop"
 msgid "Also search privately on your iPad, iPhone, or Android!"
-msgstr ""
+msgstr "¡Busca también de forma privada en tu iPad, iPhone o Android!"
 
 #. Instant Answer Tab Name
 msgid "Alternatives"
@@ -290,7 +290,7 @@ msgid "Anywhere"
 msgstr "En todas partes"
 
 msgid "App and Extension"
-msgstr ""
+msgstr "Aplicación y Extensión"
 
 msgid "App"
 msgstr "Aplicación"
@@ -311,11 +311,11 @@ msgid "Argentina"
 msgstr ""
 
 msgid "As per our privacy policy, we do not collect or share any personal information ourselves. All of this privacy protection happens on your device."
-msgstr ""
+msgstr "Por nuestra política de privacidad, no recolectamos ninguna información personal. Toda esta protección de la privacidad se da en su dispositivo."
 
 msgctxt "homepage ATB modal"
 msgid "At DuckDuckGo, we agree."
-msgstr ""
+msgstr "En DuckDuckGo, estamos de acuerdo"
 
 msgctxt "settings"
 msgid "ATB Dismiss"
@@ -332,7 +332,7 @@ msgstr ""
 
 msgctxt "settings"
 msgid "Auto-Load Images"
-msgstr ""
+msgstr "Carga automática de Imágenes"
 
 #. http://i.imgur.com/7VuBXGO.png
 msgctxt "settings"
@@ -354,7 +354,7 @@ msgid "Automatically open relevant Instant Answers"
 msgstr "Abrir automáticamente respuestas instantáneas pertinentes"
 
 msgid "Avoid eavesdropping and enhance wi-fi security."
-msgstr "Evite el espinonaje ilegal y mejore la seguridad de wi-fi."
+msgstr "Evite el espinonaje ilegal y mejore la seguridad del wi-fi."
 
 msgctxt "homepage onboarding"
 msgid "Back to search"
@@ -381,12 +381,12 @@ msgstr "Categoría Bang"
 #. Subcategory
 msgctxt "newbang"
 msgid "Bang command"
-msgstr "Comando bang"
+msgstr "Comando Bang (atajo)"
 
 #. https://duckduckgo.com/newbang
 #. e.g.: Bang command, e.g. duckduckgo (usually is domain name, e.g. nytimes) 
 msgid "Bang command, e.g. %s (usually is domain name, e.g. %s)"
-msgstr "Atajo, p. ej. %s (por lo general es un nombre de dominio, p. ej. %s)"
+msgstr "Comando Bang, p. ej. %s (por lo general es un nombre de dominio, p. ej. %s)"
 
 #. In <a href="https://duckduckgo.com/newbang">duckduckgo.com/newbang</a> in the error message <br/>
 #. <br/>
@@ -399,7 +399,7 @@ msgstr "Atajo, p. ej. %s (por lo general es un nombre de dominio, p. ej. %s)"
 #. Subcategory
 msgctxt "Newbang"
 msgid "Bang url"
-msgstr "Url de bang"
+msgstr "Url del Bang"
 
 #. https://duckduckgo.com/newbang
 #. The following required fields were not filled:
@@ -415,7 +415,7 @@ msgstr "Direccion url del nuevo Bang"
 #. https://duckduckgo.com/newbang
 #. e.g.: Bang url, e.g. http://duckduckgo.com/?q={{{s}}} 
 msgid "Bang url, e.g. %s"
-msgstr "Url de bang, ej: %s"
+msgstr "Url del Bang, ej: %s"
 
 #. This text always refers to the DuckDuckGo bangs function: https://duckduckgo.com/bang 
 msgid "Bangs"
@@ -441,7 +441,7 @@ msgstr "Bélgica (nl)"
 
 msgctxt "settingsvalue"
 msgid "Best Available"
-msgstr ""
+msgstr "El mejor disponible"
 
 #. In the right menu panel of the homepage.
 msgid "Beta"
@@ -465,7 +465,7 @@ msgstr "Negro"
 
 msgctxt "reasons-to-use-duckduckgo"
 msgid "Block advertising trackers."
-msgstr ""
+msgstr "Bloquear rastreadores de publicidad"
 
 msgid "Block Trackers"
 msgstr "Bloquear rastreadores"
@@ -488,11 +488,11 @@ msgid "Bookmarklet URL:"
 msgstr "Agregue el URL a sus marcadores"
 
 msgid "Brazil"
-msgstr ""
+msgstr "Brasil"
 
 msgctxt "color"
 msgid "Brown"
-msgstr "Cafe"
+msgstr "Café"
 
 msgctxt "settingsvalue"
 msgid "Browser Preferred Language"
@@ -528,10 +528,10 @@ msgid "Call"
 msgstr "Llamar"
 
 msgid "Canada (fr)"
-msgstr ""
+msgstr "Canadá (fr)"
 
 msgid "Canada"
-msgstr ""
+msgstr "Canadá"
 
 msgid "Cancel"
 msgstr "Cancelar"
@@ -577,7 +577,7 @@ msgstr "Cambios cuando espacio ocupa la cabecera y lo que le sucede cuando se de
 #. http://i.imgur.com/mcZdcaF.png
 msgctxt "settings"
 msgid "Changes results to be region specific"
-msgstr "Cambiar los resultados de region especifica"
+msgstr "Cambiar resultados a los de una region especifica"
 
 #. http://i.imgur.com/NdpkbY0.png
 msgctxt "settings"
@@ -639,7 +639,7 @@ msgid "Chat"
 msgstr "chat"
 
 msgid "Check %sMake this the current search engine%s"
-msgstr "Comprueba %sHas este el motor de búsqueda actual%s"
+msgstr "Comprueba %sHaz este el motor de búsqueda actual%s"
 
 msgctxt "showcase_privacy"
 msgid "Check out our privacy device guides."
@@ -651,11 +651,11 @@ msgstr ""
 
 msgctxt "showcase_aria_label"
 msgid "Check out the list of things that we've also made."
-msgstr ""
+msgstr "Revisa la lista de cosas que hemos hecho."
 
 msgctxt "Report image modal"
 msgid "Child sexual abuse"
-msgstr ""
+msgstr "Abuso sexual infantil"
 
 msgid "Chile"
 msgstr ""
@@ -666,7 +666,7 @@ msgstr ""
 #. http://i.imgur.com/f8Ae6jo.png
 msgctxt "cloudsave"
 msgid "Choose a unique pass phrase for your settings:"
-msgstr "Elige una única frase secreta para tus ajustes"
+msgstr "Elige una frase secreta única para tus ajustes:"
 
 #. https://duckduckgo.com/newbang in a list
 msgid "Choose category"
@@ -701,10 +701,10 @@ msgstr "Haz clic en %s+%s!"
 
 msgctxt "install-duckduckgo"
 msgid "Click %sAdd Extension%s."
-msgstr ""
+msgstr "Haga clic en %sAgregar Extension%s."
 
 msgid "Click %sAdd or change home page...%s"
-msgstr " Haga clic en %sAgregar o cambiar la página de inicio...%s"
+msgstr "Haga clic en %sAgregar o cambiar la página de inicio...%s"
 
 msgid "Click %sAdd%s"
 msgstr "Clic %sAgregar%s"
@@ -920,7 +920,7 @@ msgstr "Conversión"
 #. http://i.imgur.com/fd7EjAN.png
 msgctxt "settings"
 msgid "Cookie Data:"
-msgstr "Informacion de la Cookie"
+msgstr "Informacion de la Cookie:"
 
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
 msgstr ""
@@ -1096,14 +1096,14 @@ msgstr ""
 
 msgctxt "showcase_donate"
 msgid "Donate and support online privacy."
-msgstr ""
+msgstr "Dona y apoya la privacidad en línea"
 
 msgid "Donating for Privacy"
-msgstr ""
+msgstr "Donar por la Privacidad"
 
 msgctxt "SERP footer content"
 msgid "Donating for Privacy"
-msgstr ""
+msgstr "Donar por la Privacidad"
 
 msgid "Download file"
 msgstr "Descargar archivo"
@@ -1236,7 +1236,7 @@ msgstr "Entretenimiento"
 
 msgctxt "SERP footer content"
 msgid "Escape The Filter Bubble"
-msgstr ""
+msgstr "Escapa a la Burbuja que Filtra"
 
 msgid "Estonia"
 msgstr ""
@@ -1250,7 +1250,7 @@ msgstr "Incluso si pudiera hacer eso, no tiene sentido ya que toda la informaci�
 
 msgctxt "Report image modal"
 msgid "Explicit content"
-msgstr ""
+msgstr "Contenido explícito"
 
 msgid "Extensions & More"
 msgstr "Extensiones & Mas"
@@ -1305,7 +1305,7 @@ msgstr ""
 
 msgctxt "SERP footer content"
 msgid "Fine-tune Your Search"
-msgstr ""
+msgstr "Afina tu búsqueda"
 
 msgid "Finland"
 msgstr "Finlandia"
@@ -1381,12 +1381,12 @@ msgstr ""
 
 msgctxt "showcase_privacy"
 msgid "Get Privacy Tips"
-msgstr ""
+msgstr "Obten consejos sobre privacidad"
 
 #. http://i.imgur.com/tGau0Vx.png
 msgctxt "settings"
 msgid "GET requests"
-msgstr "Solicitudes tipo GET"
+msgstr "Peticiones tipo GET"
 
 msgctxt "SERP footer content"
 msgid "Get Started at Duck.com"
@@ -1397,7 +1397,7 @@ msgstr "Vaya a la versión no-JS de %s"
 
 msgctxt "access_song"
 msgid "Get this song on:"
-msgstr "Obtén esta canción"
+msgstr "Obtén esta canción en:"
 
 msgctxt "SERP footer content"
 msgid "Get to DuckDuckGo faster. Share duck.com with your friends."
@@ -4127,10 +4127,10 @@ msgid "You're in control. Customize the look-and-feel of DuckDuckGo."
 msgstr ""
 
 msgid "You're now searching with privacy!"
-msgstr "¡Ahora está buscando con privacidad!"
+msgstr "¡Ahora estás buscando con privacidad!"
 
 msgid "You're now searching with privacy. %sGet tips to reduce your footprint even more."
-msgstr "Estás buscando ahora con privacidad. %sConsigue consejos para reduir tu huella aún más."
+msgstr "Estás buscando ahora con privacidad. %sObtén consejos para reducir tu huella aún más."
 
 #. Floating text over a tick next to search results which indicates if a link has been visited.
 msgid "Your browser indicates if you've visited this link"
@@ -4152,7 +4152,7 @@ msgstr "Tus comentarios ayudan realmente. Por favor, usa este campo cuando quier
 #. Text describing how passphrases are encrypted
 msgctxt "cloudsave"
 msgid "Your passphrase is used to generate a key using the Secure Hash Algorithm known as %sSHA-2%s, using a 512 bit key."
-msgstr "Su contrasena es usada para generar una llave usando el seguro algoritmo hash conocido como %sSHA-2%s, con una llave de 512 bit."
+msgstr "Su contraseña es usada para generar una llave usando el seguro algoritmo hash conocido como %sSHA-2%s, con una llave de 512 bit."
 
 #. Click "What is this?" - http://i.imgur.com/KhmRHth.png
 #. In the cloud save box - http://i.imgur.com/xwcnjZL.png
@@ -4162,15 +4162,15 @@ msgstr "Tu contraseña nunca sale del navegador, sólo la llave y el archivo de 
 
 msgctxt "new user poll"
 msgid "Your response is 100% anonymous."
-msgstr "Su respuesta es 100% anónima"
+msgstr "Su respuesta es 100% anónima."
 
 msgid "YouTube (owned by Google) does not let you watch videos anonymously. As such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr "Youtube (propiedad de Google) no te deja ver vídeos anonimamente. Como tal, ver vídeos de Youtube aquí sera rastreado por Youtube/Google"
 
 msgid "YouTube Privacy Warning"
-msgstr "Alerta de privacidad de youtube"
+msgstr "Alerta de privacidad de YouTube"
 
 msgctxt "video-license"
 msgid "YouTube Standard"
-msgstr "Standard YouTube "
+msgstr "Estándar de YouTube "
 


### PR DESCRIPTION
There were several empty translations at the beginning of the file. Also, there were some incomplete or wrong.
It is not clear whether the messages are intended to address the user in a formal or informal way (similar to the difference between you and thou). This could be included in the README for clarity.