### PR TITLE
Update duckduckgo.po ja_JP Translation

### DIFF
--- a/locales/ja_JP/LC_MESSAGES/duckduckgo.po
+++ b/locales/ja_JP/LC_MESSAGES/duckduckgo.po
@@ -2772,7 +2772,7 @@ msgstr "プライバシーニュースレター"
 
 #, fuzzy
 msgid "Privacy Policy"
-msgstr "ブログ"
+msgstr "プライバシーポリシー"
 
 #. https://duckduckgo.com/params. it is a bold header
 msgid "Privacy Settings"


### PR DESCRIPTION
The Japanese translation of the current "Privacy Policy" is incorrect.