### PR TITLE
Start translating weather tokens

### DIFF
--- a/locales/de_DE/LC_MESSAGES/duckduckgo.po
+++ b/locales/de_DE/LC_MESSAGES/duckduckgo.po
@@ -1208,7 +1208,7 @@ msgstr "DuckDuckGo-Einstellungen"
 
 msgctxt "forecast"
 msgid "E"
-msgstr ""
+msgstr "O"
 
 #. Stuff explaining <em>how does passphrase generation work</em>.
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>. 
@@ -1635,7 +1635,7 @@ msgstr "Wieso ist es anonym?"
 
 msgctxt "forecast"
 msgid "Humidity"
-msgstr ""
+msgstr "Luftfeuchtigkeit"
 
 msgid "Hungary"
 msgstr "Ungarn"
@@ -2251,11 +2251,11 @@ msgstr "Gedecktes Rot"
 #, fuzzy
 msgctxt "forecast"
 msgid "N"
-msgstr "Nein"
+msgstr "N"
 
 msgctxt "forecast"
 msgid "NE"
-msgstr ""
+msgstr "NO"
 
 #. NPM = node.js package manager.
 #. e.g. https://duckduckgo.com/?q=npm+packages
@@ -2264,7 +2264,7 @@ msgstr ""
 
 msgctxt "forecast"
 msgid "NW"
-msgstr ""
+msgstr "NW"
 
 #. Used in 0-click box for local results, e.g. <a href="http://duckduckgo.com/?q=black+lab+bistro">http://duckduckgo.com/?q=black+lab+bistro</a>
 msgid "Nearby"
@@ -3039,15 +3039,15 @@ msgstr "Russland"
 
 msgctxt "forecast"
 msgid "S"
-msgstr ""
+msgstr "S"
 
 msgctxt "forecast"
 msgid "SE"
-msgstr ""
+msgstr "SO"
 
 msgctxt "forecast"
 msgid "SW"
-msgstr ""
+msgstr "SW"
 
 msgid "Safe Search"
 msgstr "Sichere Suche"
@@ -4069,7 +4069,7 @@ msgstr "Besuchte Verweise:"
 
 msgctxt "forecast"
 msgid "W"
-msgstr ""
+msgstr "W"
 
 #. in https://duckduckgo.com/feedback under "DuckDuckHack" header
 msgid "Want to develop an instant answer?"
@@ -4328,7 +4328,7 @@ msgstr "Wikipedia-Info"
 
 msgctxt "forecast"
 msgid "Wind"
-msgstr ""
+msgstr "Wind"
 
 #. https://duckduckgo.com/feedback under "Community Platform" header
 msgid "Would you like to help develop the platform?"

--- a/locales/es_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_ES/LC_MESSAGES/duckduckgo.po
@@ -4304,7 +4304,7 @@ msgstr "Información Wikipedia"
 
 msgctxt "forecast"
 msgid "Wind"
-msgstr "Eólico"
+msgstr "Viento"
 
 #. https://duckduckgo.com/feedback under "Community Platform" header
 msgid "Would you like to help develop the platform?"

--- a/locales/es_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_ES/LC_MESSAGES/duckduckgo.po
@@ -1207,7 +1207,7 @@ msgstr "Ajustes de DuckDuckGo"
 
 msgctxt "forecast"
 msgid "E"
-msgstr ""
+msgstr "E"
 
 #. Stuff explaining <em>how does passphrase generation work</em>.
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>. 
@@ -1627,7 +1627,7 @@ msgstr "¿Cómo se mantiene anónimo?"
 
 msgctxt "forecast"
 msgid "Humidity"
-msgstr ""
+msgstr "Humedad"
 
 msgid "Hungary"
 msgstr "Hungría"
@@ -2239,11 +2239,11 @@ msgstr "Granate"
 
 msgctxt "forecast"
 msgid "N"
-msgstr ""
+msgstr "N"
 
 msgctxt "forecast"
 msgid "NE"
-msgstr ""
+msgstr "NE"
 
 #. NPM = node.js package manager.
 #. e.g. https://duckduckgo.com/?q=npm+packages
@@ -2252,7 +2252,7 @@ msgstr ""
 
 msgctxt "forecast"
 msgid "NW"
-msgstr ""
+msgstr "NO"
 
 #. Used in 0-click box for local results, e.g. <a href="http://duckduckgo.com/?q=black+lab+bistro">http://duckduckgo.com/?q=black+lab+bistro</a>
 msgid "Nearby"
@@ -3023,15 +3023,15 @@ msgstr "Rusia"
 
 msgctxt "forecast"
 msgid "S"
-msgstr ""
+msgstr "S"
 
 msgctxt "forecast"
 msgid "SE"
-msgstr ""
+msgstr "SE"
 
 msgctxt "forecast"
 msgid "SW"
-msgstr ""
+msgstr "SO"
 
 msgid "Safe Search"
 msgstr "Búsqueda segura"
@@ -4046,7 +4046,7 @@ msgstr "Enlaces visitados:"
 
 msgctxt "forecast"
 msgid "W"
-msgstr ""
+msgstr "O"
 
 #. in https://duckduckgo.com/feedback under "DuckDuckHack" header
 msgid "Want to develop an instant answer?"
@@ -4304,7 +4304,7 @@ msgstr "Información Wikipedia"
 
 msgctxt "forecast"
 msgid "Wind"
-msgstr ""
+msgstr "Eólico"
 
 #. https://duckduckgo.com/feedback under "Community Platform" header
 msgid "Would you like to help develop the platform?"

--- a/locales/fr_FR/LC_MESSAGES/duckduckgo.po
+++ b/locales/fr_FR/LC_MESSAGES/duckduckgo.po
@@ -1216,7 +1216,7 @@ msgstr "Paramètres de DuckDuckGo"
 
 msgctxt "forecast"
 msgid "E"
-msgstr ""
+msgstr "E"
 
 #. Stuff explaining <em>how does passphrase generation work</em>.
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>. 
@@ -1637,7 +1637,7 @@ msgstr "Anonyme, c'est-à-dire ?"
 
 msgctxt "forecast"
 msgid "Humidity"
-msgstr ""
+msgstr "Humidité"
 
 msgid "Hungary"
 msgstr "Hongrie"
@@ -2256,11 +2256,11 @@ msgstr "Rouge Doux"
 #, fuzzy
 msgctxt "forecast"
 msgid "N"
-msgstr "Non"
+msgstr "N"
 
 msgctxt "forecast"
 msgid "NE"
-msgstr ""
+msgstr "NE"
 
 #. NPM = node.js package manager.
 #. e.g. https://duckduckgo.com/?q=npm+packages
@@ -2269,7 +2269,7 @@ msgstr ""
 
 msgctxt "forecast"
 msgid "NW"
-msgstr ""
+msgstr "NO"
 
 #. Used in 0-click box for local results, e.g. <a href="http://duckduckgo.com/?q=black+lab+bistro">http://duckduckgo.com/?q=black+lab+bistro</a>
 msgid "Nearby"
@@ -3047,15 +3047,15 @@ msgstr "Russie"
 
 msgctxt "forecast"
 msgid "S"
-msgstr ""
+msgstr "S"
 
 msgctxt "forecast"
 msgid "SE"
-msgstr ""
+msgstr "SE"
 
 msgctxt "forecast"
 msgid "SW"
-msgstr ""
+msgstr "SO"
 
 msgid "Safe Search"
 msgstr "Recherche sécurisée"
@@ -4084,7 +4084,7 @@ msgstr "Liens visités :"
 
 msgctxt "forecast"
 msgid "W"
-msgstr ""
+msgstr "O"
 
 #. in https://duckduckgo.com/feedback under "DuckDuckHack" header
 msgid "Want to develop an instant answer?"
@@ -4344,7 +4344,7 @@ msgstr "information wikipédia"
 
 msgctxt "forecast"
 msgid "Wind"
-msgstr ""
+msgstr "Vent"
 
 #. https://duckduckgo.com/feedback under "Community Platform" header
 msgid "Would you like to help develop the platform?"

--- a/locales/it_IT/LC_MESSAGES/duckduckgo.po
+++ b/locales/it_IT/LC_MESSAGES/duckduckgo.po
@@ -1204,7 +1204,7 @@ msgstr "Impostazioni DuckDuckGo"
 
 msgctxt "forecast"
 msgid "E"
-msgstr ""
+msgstr "E"
 
 #. Stuff explaining <em>how does passphrase generation work</em>.
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>. 
@@ -1622,7 +1622,7 @@ msgstr "Come può essere anonimo?"
 
 msgctxt "forecast"
 msgid "Humidity"
-msgstr ""
+msgstr "Umidità"
 
 msgid "Hungary"
 msgstr "Ungheria"
@@ -2230,11 +2230,11 @@ msgstr "Rosso tenue"
 
 msgctxt "forecast"
 msgid "N"
-msgstr ""
+msgstr "N"
 
 msgctxt "forecast"
 msgid "NE"
-msgstr ""
+msgstr "NE"
 
 #. NPM = node.js package manager.
 #. e.g. https://duckduckgo.com/?q=npm+packages
@@ -2243,7 +2243,7 @@ msgstr ""
 
 msgctxt "forecast"
 msgid "NW"
-msgstr ""
+msgstr "NO"
 
 #. Used in 0-click box for local results, e.g. <a href="http://duckduckgo.com/?q=black+lab+bistro">http://duckduckgo.com/?q=black+lab+bistro</a>
 msgid "Nearby"
@@ -3016,15 +3016,15 @@ msgstr ""
 
 msgctxt "forecast"
 msgid "S"
-msgstr ""
+msgstr "S"
 
 msgctxt "forecast"
 msgid "SE"
-msgstr ""
+msgstr "SE"
 
 msgctxt "forecast"
 msgid "SW"
-msgstr ""
+msgstr "SO"
 
 msgid "Safe Search"
 msgstr "Ricerca sicura"
@@ -4044,7 +4044,7 @@ msgstr "Link visitati:"
 
 msgctxt "forecast"
 msgid "W"
-msgstr ""
+msgstr "O"
 
 #. in https://duckduckgo.com/feedback under "DuckDuckHack" header
 msgid "Want to develop an instant answer?"
@@ -4304,7 +4304,7 @@ msgstr "Informazioni di Wikipedia"
 
 msgctxt "forecast"
 msgid "Wind"
-msgstr ""
+msgstr "Vento"
 
 #. https://duckduckgo.com/feedback under "Community Platform" header
 msgid "Would you like to help develop the platform?"

--- a/locales/nl_NL/LC_MESSAGES/duckduckgo.po
+++ b/locales/nl_NL/LC_MESSAGES/duckduckgo.po
@@ -1615,7 +1615,7 @@ msgstr "Hoe is het anoniem?"
 
 msgctxt "forecast"
 msgid "Humidity"
-msgstr "Vochtigheid"
+msgstr "Luchtvochtigheid"
 
 msgid "Hungary"
 msgstr "Hongarije"

--- a/locales/nl_NL/LC_MESSAGES/duckduckgo.po
+++ b/locales/nl_NL/LC_MESSAGES/duckduckgo.po
@@ -1198,7 +1198,7 @@ msgstr "DuckDuckGo instellingen"
 
 msgctxt "forecast"
 msgid "E"
-msgstr ""
+msgstr "O"
 
 #. Stuff explaining <em>how does passphrase generation work</em>.
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>. 
@@ -1615,7 +1615,7 @@ msgstr "Hoe is het anoniem?"
 
 msgctxt "forecast"
 msgid "Humidity"
-msgstr ""
+msgstr "Vochtigheid"
 
 msgid "Hungary"
 msgstr "Hongarije"
@@ -2226,11 +2226,11 @@ msgstr "aangepast rood"
 #, fuzzy
 msgctxt "forecast"
 msgid "N"
-msgstr "Nee"
+msgstr "N"
 
 msgctxt "forecast"
 msgid "NE"
-msgstr ""
+msgstr "NO"
 
 #. NPM = node.js package manager.
 #. e.g. https://duckduckgo.com/?q=npm+packages
@@ -2239,7 +2239,7 @@ msgstr ""
 
 msgctxt "forecast"
 msgid "NW"
-msgstr ""
+msgstr "NW"
 
 #. Used in 0-click box for local results, e.g. <a href="http://duckduckgo.com/?q=black+lab+bistro">http://duckduckgo.com/?q=black+lab+bistro</a>
 msgid "Nearby"
@@ -3007,15 +3007,15 @@ msgstr "Rusland"
 
 msgctxt "forecast"
 msgid "S"
-msgstr ""
+msgstr "Z"
 
 msgctxt "forecast"
 msgid "SE"
-msgstr ""
+msgstr "ZO"
 
 msgctxt "forecast"
 msgid "SW"
-msgstr ""
+msgstr "ZW"
 
 msgid "Safe Search"
 msgstr "Veilig Zoeken"
@@ -4025,7 +4025,7 @@ msgstr "Bezochte links:"
 
 msgctxt "forecast"
 msgid "W"
-msgstr ""
+msgstr "W"
 
 #. in https://duckduckgo.com/feedback under "DuckDuckHack" header
 msgid "Want to develop an instant answer?"
@@ -4281,7 +4281,7 @@ msgstr ""
 
 msgctxt "forecast"
 msgid "Wind"
-msgstr ""
+msgstr "Wind"
 
 #. https://duckduckgo.com/feedback under "Community Platform" header
 msgid "Would you like to help develop the platform?"


### PR DESCRIPTION
Translations included for:
- Italian
- French
- Dutch
- German
- Spanish

Translated tokens are:
- "Humidity"
- "Wind"
- wind directions ("N", "S", "E", "W", etc)