### PR TITLE
Cleaning up bad msgmerge fuzzy match

### DIFF
--- a/locales/af_ZA/LC_MESSAGES/duckduckgo.po
+++ b/locales/af_ZA/LC_MESSAGES/duckduckgo.po
@@ -3215,7 +3215,7 @@ msgstr "Kies %sVoorkeure%s."
 #, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Kies %s%s%s, dan %sSoekenjin%s"
+msgstr "Kies %sSoekenjin%s"
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/ar_DZ/LC_MESSAGES/duckduckgo.po
+++ b/locales/ar_DZ/LC_MESSAGES/duckduckgo.po
@@ -3157,10 +3157,9 @@ msgstr ""
 msgid "Select %sPreferences%s."
 msgstr ""
 
-#, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "اضبط كمحرك بحث إفتراضي"
+msgstr ""
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/ar_EG/LC_MESSAGES/duckduckgo.po
+++ b/locales/ar_EG/LC_MESSAGES/duckduckgo.po
@@ -3172,10 +3172,9 @@ msgstr ""
 msgid "Select %sPreferences%s."
 msgstr ""
 
-#, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "اذهب إلى محرك البحث"
+msgstr ""
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/ar_SA/LC_MESSAGES/duckduckgo.po
+++ b/locales/ar_SA/LC_MESSAGES/duckduckgo.po
@@ -3187,10 +3187,9 @@ msgstr ""
 msgid "Select %sPreferences%s."
 msgstr "اختر %s تفصيلات %s."
 
-#, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "إختار %sإعدادات%s"
+msgstr ""
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/ast_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/ast_ES/LC_MESSAGES/duckduckgo.po
@@ -3181,10 +3181,9 @@ msgstr ""
 msgid "Select %sPreferences%s."
 msgstr "Seleicionar %sPreferencies%s."
 
-#, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Dir al motor de gueta"
+msgstr ""
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/az_AZ/LC_MESSAGES/duckduckgo.po
+++ b/locales/az_AZ/LC_MESSAGES/duckduckgo.po
@@ -3189,10 +3189,9 @@ msgstr ""
 msgid "Select %sPreferences%s."
 msgstr "Seç %sÜstünlüklər%s."
 
-#, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Standart Axtarış Motoru kimi qurun"
+msgstr ""
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/be_BY/LC_MESSAGES/duckduckgo.po
+++ b/locales/be_BY/LC_MESSAGES/duckduckgo.po
@@ -3218,7 +3218,7 @@ msgstr "Выберыце %sНалады%s."
 #, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Выберыце %s%s%s, потым %sПашукавая сістэма%s "
+msgstr "Выберыце %sПашукавая сістэма%s"
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/bg_BG/LC_MESSAGES/duckduckgo.po
+++ b/locales/bg_BG/LC_MESSAGES/duckduckgo.po
@@ -3211,10 +3211,9 @@ msgstr ""
 msgid "Select %sPreferences%s."
 msgstr "Изберете %sПредпочитания%s."
 
-#, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Изберете %sНастройки%s"
+msgstr ""
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/bn_BD/LC_MESSAGES/duckduckgo.po
+++ b/locales/bn_BD/LC_MESSAGES/duckduckgo.po
@@ -3182,10 +3182,9 @@ msgstr ""
 msgid "Select %sPreferences%s."
 msgstr "%sPreferences%s সিলেক্ট করুন।"
 
-#, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "%sSettings%s সিলেক্ট করুন"
+msgstr ""
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/br_FR/LC_MESSAGES/duckduckgo.po
+++ b/locales/br_FR/LC_MESSAGES/duckduckgo.po
@@ -3205,10 +3205,9 @@ msgstr ""
 msgid "Select %sPreferences%s."
 msgstr "Diuzit %sGwellvezioù%s."
 
-#, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Diuzit %sArventennoù%s"
+msgstr ""
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/bs_BA/LC_MESSAGES/duckduckgo.po
+++ b/locales/bs_BA/LC_MESSAGES/duckduckgo.po
@@ -3181,10 +3181,9 @@ msgstr ""
 msgid "Select %sPreferences%s."
 msgstr ""
 
-#, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Idite u Tražilicu"
+msgstr ""
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/ca_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/ca_ES/LC_MESSAGES/duckduckgo.po
@@ -3246,7 +3246,7 @@ msgstr "Seleccioneu %sPreferències%s."
 #, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Seleccioneu %s%s%s, a continuació %sMotor de cerca%s"
+msgstr "Seleccioneu %sMotor de cerca%s"
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/cs_CZ/LC_MESSAGES/duckduckgo.po
+++ b/locales/cs_CZ/LC_MESSAGES/duckduckgo.po
@@ -3214,7 +3214,7 @@ msgstr "Vyberte %sNastavení%s."
 #, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Zvolte %s%s%s, pak %sVyhledávač%s"
+msgstr "Zvolte %sVyhledávač%s"
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/cy_GB/LC_MESSAGES/duckduckgo.po
+++ b/locales/cy_GB/LC_MESSAGES/duckduckgo.po
@@ -3182,10 +3182,9 @@ msgstr ""
 msgid "Select %sPreferences%s."
 msgstr "Dewiswch %sDewisiadau%s"
 
-#, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Ewch i'r Peiriant Chwilio"
+msgstr ""
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/da_DK/LC_MESSAGES/duckduckgo.po
+++ b/locales/da_DK/LC_MESSAGES/duckduckgo.po
@@ -3215,7 +3215,7 @@ msgstr "Vælg %sForetrukne%s"
 #, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr " Vælg %s%s%s og derefter %sSøgemaskine%s "
+msgstr "Vælg %sSøgemaskine%s"
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/de_CH/LC_MESSAGES/duckduckgo.po
+++ b/locales/de_CH/LC_MESSAGES/duckduckgo.po
@@ -3239,7 +3239,7 @@ msgstr "Wähle %sEinstellungen%s."
 #, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Wähle %s%s%s, dann %sSuchmaschine%s"
+msgstr "Wähle %sSuchmaschine%s"
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/de_DE/LC_MESSAGES/duckduckgo.po
+++ b/locales/de_DE/LC_MESSAGES/duckduckgo.po
@@ -3259,7 +3259,7 @@ msgstr "%sEinstellungen%s auswählen."
 #, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "%s%s%s auswählen, dann %sSuchmaschine%s"
+msgstr "%sSuchmaschine%s auswählen"
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/el_GR/LC_MESSAGES/duckduckgo.po
+++ b/locales/el_GR/LC_MESSAGES/duckduckgo.po
@@ -3264,7 +3264,7 @@ msgstr "Επιλέξτε %sΠροτιμήσεις%s."
 #, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Επιλέξτε %s%s%s, μετά %sΜηχανή Αναζήτησης%s"
+msgstr "Επιλέξτε %sΜηχανή Αναζήτησης%s"
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/en_AU/LC_MESSAGES/duckduckgo.po
+++ b/locales/en_AU/LC_MESSAGES/duckduckgo.po
@@ -3206,10 +3206,9 @@ msgstr ""
 msgid "Select %sPreferences%s."
 msgstr "Select %sPreferences%s."
 
-#, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Select %s%s%s, then %sSearch Engine%s"
+msgstr "Select %sSearch Engine%s"
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/en_CA/LC_MESSAGES/duckduckgo.po
+++ b/locales/en_CA/LC_MESSAGES/duckduckgo.po
@@ -3206,10 +3206,9 @@ msgstr ""
 msgid "Select %sPreferences%s."
 msgstr "Select %sPreferences%s."
 
-#, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Select %s%s%s, then %sSearch Engine%s"
+msgstr "Select %sSearch Engine%s"
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/en_GB/LC_MESSAGES/duckduckgo.po
+++ b/locales/en_GB/LC_MESSAGES/duckduckgo.po
@@ -3209,10 +3209,9 @@ msgstr ""
 msgid "Select %sPreferences%s."
 msgstr "Select %sPreferences%s"
 
-#, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Select %s%s%s, then %sSearch Engine%s"
+msgstr "Select %sSearch Engine%s"
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/eo_XX/LC_MESSAGES/duckduckgo.po
+++ b/locales/eo_XX/LC_MESSAGES/duckduckgo.po
@@ -3214,7 +3214,7 @@ msgstr "Elektu %sPreferoj%s."
 #, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr " Elektu %s%s%s, kaj poste %sSerĉilo%s"
+msgstr "Elektu %sSerĉilo%s"
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/es_AR/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_AR/LC_MESSAGES/duckduckgo.po
@@ -3259,7 +3259,7 @@ msgstr "Seleccione %sPreferencias%s."
 #, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Seleccioná %s%s%s, luego %sMotor de búsqueda%s"
+msgstr "Seleccioná %sMotor de búsqueda%s"
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/es_CL/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_CL/LC_MESSAGES/duckduckgo.po
@@ -3226,10 +3226,9 @@ msgstr ""
 msgid "Select %sPreferences%s."
 msgstr "Seleccione %sPreferencias%s."
 
-#, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Seleccione %sOpciones%s"
+msgstr ""
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/es_CO/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_CO/LC_MESSAGES/duckduckgo.po
@@ -3244,7 +3244,7 @@ msgstr "Selecciona %sPreferencias%s"
 #, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Select %s%s%s, then %sMotor de búsqueda%s"
+msgstr "Select %sMotor de búsqueda%s"
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/es_CR/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_CR/LC_MESSAGES/duckduckgo.po
@@ -3183,10 +3183,9 @@ msgstr ""
 msgid "Select %sPreferences%s."
 msgstr ""
 
-#, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Ir al Motor de Búsqueda."
+msgstr ""
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/es_EC/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_EC/LC_MESSAGES/duckduckgo.po
@@ -3191,10 +3191,9 @@ msgstr ""
 msgid "Select %sPreferences%s."
 msgstr "Seleccione %sPreferencias%s."
 
-#, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Seleccionar %sConfiguraciones%s"
+msgstr ""
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/es_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_ES/LC_MESSAGES/duckduckgo.po
@@ -3246,7 +3246,7 @@ msgstr "Selecciona %sConfiguración%s. "
 #, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Selecciona %s%s%s, después %sMotor de Búsqueda%s"
+msgstr "Selecciona %sMotor de Búsqueda%s"
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/es_MX/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_MX/LC_MESSAGES/duckduckgo.po
@@ -3235,7 +3235,7 @@ msgstr "Selecciona %sPreferencias%s."
 #, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Selecciona %s%s%s, después %sMotor de búsqueda%s"
+msgstr "Selecciona %sMotor de búsqueda%s"
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/es_PE/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_PE/LC_MESSAGES/duckduckgo.po
@@ -3203,10 +3203,9 @@ msgstr ""
 msgid "Select %sPreferences%s."
 msgstr "Selecciona %sPreferencias%s."
 
-#, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Seleccionar %sAjustes%s"
+msgstr ""
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/es_VE/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_VE/LC_MESSAGES/duckduckgo.po
@@ -3193,10 +3193,9 @@ msgstr ""
 msgid "Select %sPreferences%s."
 msgstr "Selecciona %sPreferencias%s."
 
-#, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Seleccionar %sAjustes%s"
+msgstr ""
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/et_EE/LC_MESSAGES/duckduckgo.po
+++ b/locales/et_EE/LC_MESSAGES/duckduckgo.po
@@ -3178,10 +3178,9 @@ msgstr ""
 msgid "Select %sPreferences%s."
 msgstr "Valige %sEelistused%s."
 
-#, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Valige %sSeaded%s"
+msgstr ""
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/fa_IR/LC_MESSAGES/duckduckgo.po
+++ b/locales/fa_IR/LC_MESSAGES/duckduckgo.po
@@ -3232,7 +3232,7 @@ msgstr "%sPreferences%s را انتخاب کنید."
 #, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "‫%s%s%s را انتخاب کنید، سپس %sSearch Engine%s‬"
+msgstr "%sSearch Engine%s ﺭﺍ ﺎﻨﺘﺧﺎﺑ کﻥیﺩ"
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/fi_FI/LC_MESSAGES/duckduckgo.po
+++ b/locales/fi_FI/LC_MESSAGES/duckduckgo.po
@@ -3210,7 +3210,7 @@ msgstr "Valitse %sAsetukset%s"
 #, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Valitse %s%s%s, sitten %sHakukone%s"
+msgstr "Valitse %sHakukone%s"
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/fr_BE/LC_MESSAGES/duckduckgo.po
+++ b/locales/fr_BE/LC_MESSAGES/duckduckgo.po
@@ -3249,7 +3249,7 @@ msgstr "Sélctionnez %sPréférences%s."
 #, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Sélectionnez %s%s%s puis %sMoteur de recherche%s"
+msgstr "Sélectionnez %sMoteur de recherche%s"
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/fr_CA/LC_MESSAGES/duckduckgo.po
+++ b/locales/fr_CA/LC_MESSAGES/duckduckgo.po
@@ -3245,7 +3245,7 @@ msgstr "Choisi %sPreferences%s"
 #, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Sélectionnez %s%s%s, puis %sMoteur de recherche%s"
+msgstr "Sélectionnez %sMoteur de recherche%s"
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/fr_CH/LC_MESSAGES/duckduckgo.po
+++ b/locales/fr_CH/LC_MESSAGES/duckduckgo.po
@@ -3238,10 +3238,9 @@ msgstr ""
 msgid "Select %sPreferences%s."
 msgstr "Sélecter %sPréférences%s"
 
-#, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Séléctionnez %sParamètres%s"
+msgstr ""
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/fr_FR/LC_MESSAGES/duckduckgo.po
+++ b/locales/fr_FR/LC_MESSAGES/duckduckgo.po
@@ -3273,7 +3273,7 @@ msgstr "Sélectionner %sPréférences%s."
 #, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Sélectionner %s%s%s, puis %sMoteur de recherche%s"
+msgstr "Sélectionner %sMoteur de recherche%s"
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/ga_IE/LC_MESSAGES/duckduckgo.po
+++ b/locales/ga_IE/LC_MESSAGES/duckduckgo.po
@@ -3227,10 +3227,9 @@ msgstr ""
 msgid "Select %sPreferences%s."
 msgstr "Roghnaigh %sSainroghanna%s."
 
-#, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Roghnaigh %sSocruithe%s"
+msgstr ""
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/gd_GB/LC_MESSAGES/duckduckgo.po
+++ b/locales/gd_GB/LC_MESSAGES/duckduckgo.po
@@ -3249,7 +3249,7 @@ msgstr "Tagh %sRoghainnean%s."
 #, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Tagh %s%s%s is %sEinnsean-luirg%s an uairsin"
+msgstr "Tagh %sEinnsean-luirg%s"
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/gl_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/gl_ES/LC_MESSAGES/duckduckgo.po
@@ -3222,7 +3222,7 @@ msgstr "Escolla %sPreferencias%s."
 #, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Escolle %s%s%s, despois %sMotor de busca%s"
+msgstr "Escolle %sMotor de busca%s"
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/he_IL/LC_MESSAGES/duckduckgo.po
+++ b/locales/he_IL/LC_MESSAGES/duckduckgo.po
@@ -3180,10 +3180,9 @@ msgstr "בחרו %sOpera > העדפות%s (ב-Mac) או %sOpera > אפשרויו
 msgid "Select %sPreferences%s."
 msgstr "בחר ב%sהעדפות%s."
 
-#, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "בחר %sהגדרות%s"
+msgstr ""
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/hi_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/hi_IN/LC_MESSAGES/duckduckgo.po
@@ -3174,10 +3174,9 @@ msgstr ""
 msgid "Select %sPreferences%s."
 msgstr "चुनिए  %sप्रिफरेंस %s "
 
-#, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "%s सेटिंग्स %s चुनिये"
+msgstr ""
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/hr_HR/LC_MESSAGES/duckduckgo.po
+++ b/locales/hr_HR/LC_MESSAGES/duckduckgo.po
@@ -3221,7 +3221,7 @@ msgstr "Klikni %sPostavke%s."
 #, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Odaberite %s%s%s, a zatim %sTražilica%s"
+msgstr "Odaberite %sTražilica%s"
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/hu_HU/LC_MESSAGES/duckduckgo.po
+++ b/locales/hu_HU/LC_MESSAGES/duckduckgo.po
@@ -3245,7 +3245,7 @@ msgstr "%sBeállítások%s"
 #, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Válaszd %s%s%s, aztán a %sKeresőszolgáltatás%s-t"
+msgstr "Válaszd %sKeresőszolgáltatás%s"
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/hy_AM/LC_MESSAGES/duckduckgo.po
+++ b/locales/hy_AM/LC_MESSAGES/duckduckgo.po
@@ -3174,10 +3174,9 @@ msgstr ""
 msgid "Select %sPreferences%s."
 msgstr "Սեղմիր %sՆախընտրություններ%s"
 
-#, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Նշել որպես Հիմնական Որոնիչ"
+msgstr ""
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/id_ID/LC_MESSAGES/duckduckgo.po
+++ b/locales/id_ID/LC_MESSAGES/duckduckgo.po
@@ -3222,7 +3222,7 @@ msgstr "Pilih %sPreferensi%s."
 #, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Pilih %s%s%s, lalu %sMesin Pencari%s"
+msgstr "Pilih %sMesin Pencari%s"
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/it_IT/LC_MESSAGES/duckduckgo.po
+++ b/locales/it_IT/LC_MESSAGES/duckduckgo.po
@@ -3235,7 +3235,7 @@ msgstr "Seleziona %sPreferenze%s."
 #, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Seleziona %s%s%s, poi %sMotore di ricerca%s"
+msgstr "Seleziona %sMotore di ricerca%s"
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/ja_JP/LC_MESSAGES/duckduckgo.po
+++ b/locales/ja_JP/LC_MESSAGES/duckduckgo.po
@@ -3225,7 +3225,7 @@ msgstr " 「%s設定%s」を選択 "
 #, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "%s%s%sを選択し%s検索エンジン%sを選択"
+msgstr "%s検索エンジン%sを選択"
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/ko_KR/LC_MESSAGES/duckduckgo.po
+++ b/locales/ko_KR/LC_MESSAGES/duckduckgo.po
@@ -3203,7 +3203,7 @@ msgstr "설정을 %s선택%s."
 #, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "%s%s%s를 선택하고, %s검색 엔진%s을 선택하세요"
+msgstr "%s검색 엔진%s를 선택하고"
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/lt_LT/LC_MESSAGES/duckduckgo.po
+++ b/locales/lt_LT/LC_MESSAGES/duckduckgo.po
@@ -3180,10 +3180,9 @@ msgstr ""
 msgid "Select %sPreferences%s."
 msgstr "Pasirinkite %sNustatymai%s."
 
-#, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Pasirinkite %sNustatymai%s"
+msgstr ""
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/lv_LV/LC_MESSAGES/duckduckgo.po
+++ b/locales/lv_LV/LC_MESSAGES/duckduckgo.po
@@ -3189,7 +3189,7 @@ msgstr "Izvēlies %sPrefences%s."
 #, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Izvēlies %s%s%s, tad %sMeklētājprogramma%s"
+msgstr "Izvēlies %sMeklētājprogramma%s"
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/ml_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/ml_IN/LC_MESSAGES/duckduckgo.po
@@ -3177,10 +3177,9 @@ msgstr ""
 msgid "Select %sPreferences%s."
 msgstr ""
 
-#, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "സ്ഥിരസ്ഥിതി തിരയൽ എഞ്ചിൻ ആയി സജ്ജമാക്കുക"
+msgstr ""
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/mr_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/mr_IN/LC_MESSAGES/duckduckgo.po
@@ -3151,10 +3151,9 @@ msgstr ""
 msgid "Select %sPreferences%s."
 msgstr ""
 
-#, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "%sसेटिंग्ज निवडा%s"
+msgstr ""
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/ms_MY/LC_MESSAGES/duckduckgo.po
+++ b/locales/ms_MY/LC_MESSAGES/duckduckgo.po
@@ -3199,10 +3199,9 @@ msgstr ""
 msgid "Select %sPreferences%s."
 msgstr "Pilih %sPreferences%s."
 
-#, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Pilih %sTetapan%s"
+msgstr ""
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/nb_NO/LC_MESSAGES/duckduckgo.po
+++ b/locales/nb_NO/LC_MESSAGES/duckduckgo.po
@@ -3215,7 +3215,7 @@ msgstr "Velg %sPreferanser%s."
 #, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Velg %s%s%s og så %sSøkemotor%s"
+msgstr "Velg %sSøkemotor%s"
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/nl_BE/LC_MESSAGES/duckduckgo.po
+++ b/locales/nl_BE/LC_MESSAGES/duckduckgo.po
@@ -3208,7 +3208,7 @@ msgstr "Selecteer %sVoorkeuren%s."
 #, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Selecteer %s%s%s, en vervolgens %sZoekmachine%s"
+msgstr "Selecteer %sZoekmachine%s"
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/nl_NL/LC_MESSAGES/duckduckgo.po
+++ b/locales/nl_NL/LC_MESSAGES/duckduckgo.po
@@ -3224,7 +3224,7 @@ msgstr "Selecteer %sVoorkeuren%s."
 #, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Selecteer %s%s%s, en dan %sZoekmachine%s"
+msgstr "Selecteer %sZoekmachine%s"
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/nn_NO/LC_MESSAGES/duckduckgo.po
+++ b/locales/nn_NO/LC_MESSAGES/duckduckgo.po
@@ -3203,7 +3203,7 @@ msgstr "Vel %sInnstillingar%s."
 #, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Vel %s%s%s, så %sSøkjemotor%s"
+msgstr "Vel %sSøkjemotor%s"
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/pl_PL/LC_MESSAGES/duckduckgo.po
+++ b/locales/pl_PL/LC_MESSAGES/duckduckgo.po
@@ -3228,7 +3228,7 @@ msgstr "Wybierz %sUstawienia%s."
 #, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Wybierz %s%s%s, a następnie %sWyszukiwarki%s"
+msgstr "Wybierz %sWyszukiwarki%s"
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/pt_BR/LC_MESSAGES/duckduckgo.po
+++ b/locales/pt_BR/LC_MESSAGES/duckduckgo.po
@@ -3233,7 +3233,7 @@ msgstr "Selecione %sConfigurações%s."
 #, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Selecione %s%s%s, e posteriormente %sBuscador%s"
+msgstr "Selecione %sBuscador%s"
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/pt_PT/LC_MESSAGES/duckduckgo.po
+++ b/locales/pt_PT/LC_MESSAGES/duckduckgo.po
@@ -3231,7 +3231,7 @@ msgstr "Selecione %sPreferências%s"
 #, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Selecione %s%s%s, e depois %sMotor de busca%s"
+msgstr "Selecione %sMotor de busca%s"
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/ro_RO/LC_MESSAGES/duckduckgo.po
+++ b/locales/ro_RO/LC_MESSAGES/duckduckgo.po
@@ -3250,7 +3250,7 @@ msgstr "Selectati %sPreferinte%s"
 #, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Selectează %s%s%s, apoi %sMotor de căutare%s"
+msgstr "Selectează %sMotor de căutare%s"
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/ru_RU/LC_MESSAGES/duckduckgo.po
+++ b/locales/ru_RU/LC_MESSAGES/duckduckgo.po
@@ -3238,7 +3238,7 @@ msgstr "Выберите %sНастройки%s."
 #, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Выберите %s%s%s, затем %sПоисковые системы%s"
+msgstr "Выберите %sПоисковые системы%s"
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/sk_SK/LC_MESSAGES/duckduckgo.po
+++ b/locales/sk_SK/LC_MESSAGES/duckduckgo.po
@@ -3185,10 +3185,9 @@ msgstr ""
 msgid "Select %sPreferences%s."
 msgstr "Vyberte %sReferencie%s"
 
-#, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "vyberte %snastavenia%s"
+msgstr ""
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/sl_SI/LC_MESSAGES/duckduckgo.po
+++ b/locales/sl_SI/LC_MESSAGES/duckduckgo.po
@@ -3188,10 +3188,9 @@ msgstr "Izberi %sOpera > Možnosti%s (Mac) ali %sOpera > Nastavitve%s (Windows)"
 msgid "Select %sPreferences%s."
 msgstr "Izberi %sMožnosti%s."
 
-#, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Izberi %sNastavitve%s"
+msgstr ""
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/sq_AL/LC_MESSAGES/duckduckgo.po
+++ b/locales/sq_AL/LC_MESSAGES/duckduckgo.po
@@ -3203,7 +3203,7 @@ msgstr "Kliko %sPreferenca%s"
 #, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Zgjidh %sKonfigurimin%s"
+msgstr ""
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/sr_RS/LC_MESSAGES/duckduckgo.po
+++ b/locales/sr_RS/LC_MESSAGES/duckduckgo.po
@@ -3236,7 +3236,7 @@ msgstr "Изабери %sПодешавања%s"
 #, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Одаберите %s%s%s, затим %sПретражи %s "
+msgstr "Одаберите %sПретражи %s"
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/sv_SE/LC_MESSAGES/duckduckgo.po
+++ b/locales/sv_SE/LC_MESSAGES/duckduckgo.po
@@ -3219,7 +3219,7 @@ msgstr "Välj %sInställningar%s."
 #, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Välj %s%s%s, sedan %sSökmotor%s"
+msgstr "Välj %sSökmotor%s"
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/ta_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/ta_IN/LC_MESSAGES/duckduckgo.po
@@ -3183,10 +3183,9 @@ msgstr ""
 msgid "Select %sPreferences%s."
 msgstr "விருப்பங்களை %sதேர்ந்தெடுக்கவும்%s"
 
-#, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "தேர்வு %sஅமைப்புக்கள்%s   "
+msgstr ""
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/th_TH/LC_MESSAGES/duckduckgo.po
+++ b/locales/th_TH/LC_MESSAGES/duckduckgo.po
@@ -3149,10 +3149,9 @@ msgstr ""
 msgid "Select %sPreferences%s."
 msgstr ""
 
-#, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "เลือก %sตั้งค่า%s, จากนั้น %sSearch Engine%s"
+msgstr ""
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/tokipona_XX/LC_MESSAGES/duckduckgo.po
+++ b/locales/tokipona_XX/LC_MESSAGES/duckduckgo.po
@@ -3231,7 +3231,7 @@ msgstr "pale e %snimi tawa kama%s."
 #, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "pali %s%s%s, en pali %s”ilo tawa lukin”%s"
+msgstr "pali %s”ilo tawa lukin”%s"
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/tr_TR/LC_MESSAGES/duckduckgo.po
+++ b/locales/tr_TR/LC_MESSAGES/duckduckgo.po
@@ -3217,7 +3217,7 @@ msgstr "%sTercihler%s'i seç."
 #, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "%s%s%s, sonra %sArama Motoru%snu seçin."
+msgstr "%sArama Motoru%s nu seçin."
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/uk_UA/LC_MESSAGES/duckduckgo.po
+++ b/locales/uk_UA/LC_MESSAGES/duckduckgo.po
@@ -3221,7 +3221,7 @@ msgstr "Натисніть %sНалаштування%s"
 #, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Оберіть %sНалаштування%s, потім %sПошук%s"
+msgstr ""
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/ur_PK/LC_MESSAGES/duckduckgo.po
+++ b/locales/ur_PK/LC_MESSAGES/duckduckgo.po
@@ -3171,7 +3171,7 @@ msgstr ""
 #, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "پہلے سے طے شدہ تلاش انجن کے طور پر مقرر"
+msgstr ""
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/vi_VN/LC_MESSAGES/duckduckgo.po
+++ b/locales/vi_VN/LC_MESSAGES/duckduckgo.po
@@ -3206,7 +3206,7 @@ msgstr "Chọn %sƯu tiên%s."
 #, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "Lựa chọn %s%s%s, sau đó %sCông cụ tìm kiếm%s"
+msgstr "Lựa chọn %sCông cụ tìm kiếm%s"
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/zh_CN/LC_MESSAGES/duckduckgo.po
+++ b/locales/zh_CN/LC_MESSAGES/duckduckgo.po
@@ -3169,7 +3169,7 @@ msgstr "选择%s外观%s"
 #, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "选择%s%s%s，并且%s搜索引擎%s"
+msgstr "选择%s搜索引擎%s"
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"

--- a/locales/zh_TW/LC_MESSAGES/duckduckgo.po
+++ b/locales/zh_TW/LC_MESSAGES/duckduckgo.po
@@ -3161,10 +3161,9 @@ msgstr "選擇 %sOpera > 偏好設定%s (Mac)或 %sOpera > 選項%s (Windows)"
 msgid "Select %sPreferences%s."
 msgstr "選擇 %s偏好設定%s"
 
-#, fuzzy
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr "選擇 %s%s%s，然後 %s搜尋引擎%s"
+msgstr ""
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"


### PR DESCRIPTION
I missed this on review - the mismatched format specifiers in the fuzzy-matched string are causing trouble. This change:

- Reformats the fuzzy string where possible
- Removes the translation / fuzzy flag where not