### PR TITLE
Update duckduckgo.po ja_JP Translation

### DIFF
--- a/locales/ja_JP/LC_MESSAGES/duckduckgo.po
+++ b/locales/ja_JP/LC_MESSAGES/duckduckgo.po
@@ -2562,7 +2562,7 @@ msgstr "%s0億件を越える匿名での検索がありました。 "
 
 msgctxt "SERP footer content"
 msgid "Over %s in DuckDuckGo privacy donations."
-msgstr "DuckDuckGoに%sの匿名の寄付がありました。"
+msgstr "DuckDuckGoは%s以上の寄付を行いました。"
 
 msgctxt "showcase_traffic"
 msgid "Over 15 Billion anonymous searches."

--- a/locales/ja_JP/LC_MESSAGES/duckduckgo.po
+++ b/locales/ja_JP/LC_MESSAGES/duckduckgo.po
@@ -38,7 +38,7 @@ msgstr "%sは%sのため"
 
 msgctxt "showcase_donations"
 msgid "%s in privacy donations!"
-msgstr "%sドルのプライバシーへの寄付がありました！"
+msgstr "プライバシー関連の組織へ%sドルを寄付しました！"
 
 msgid "%s km"
 msgstr ""

--- a/locales/ja_JP/LC_MESSAGES/duckduckgo.po
+++ b/locales/ja_JP/LC_MESSAGES/duckduckgo.po
@@ -38,7 +38,7 @@ msgstr "%sは%sのため"
 
 msgctxt "showcase_donations"
 msgid "%s in privacy donations!"
-msgstr "%s万ドルの匿名の寄付がありました！"
+msgstr "%sドルのプライバシーへの寄付がありました！"
 
 msgid "%s km"
 msgstr ""
@@ -1967,7 +1967,7 @@ msgid "Left"
 msgstr "左"
 
 msgid "Legal"
-msgstr ""
+msgstr "リーガル"
 
 msgctxt "video-duration"
 msgid "Less than 4 minutes"
@@ -2558,7 +2558,7 @@ msgstr ""
 
 msgctxt "showcase_traffic"
 msgid "Over %s Billion anonymous searches."
-msgstr "%s 億件を越える匿名での検索がありました。 "
+msgstr "%s0億件を越える匿名での検索がありました。 "
 
 msgctxt "SERP footer content"
 msgid "Over %s in DuckDuckGo privacy donations."

--- a/locales/ja_JP/LC_MESSAGES/duckduckgo.po
+++ b/locales/ja_JP/LC_MESSAGES/duckduckgo.po
@@ -27,7 +27,7 @@ msgstr "80万ドルの匿名の寄付がありました！"
 
 msgctxt "SERP footer content"
 msgid "%s Billion Searches"
-msgstr "%s億件の検索"
+msgstr "%s0億件の検索"
 
 msgid "%s blocked by safe search."
 msgstr "セーフサーチにより、%sはブロックされました。"


### PR DESCRIPTION
Fixed a different digit expression in Japanese and English.
Fixed a "Donations to privacy (related organizations)" rather than "anonymous donations".

1 Billionは10億であるため匿名での検索が一桁間違っている点を修正。
寄付額に万がついている点を修正。
「匿名の寄付」ではなく「プライバシー(関連の団体)への寄付」である点を修正。