### PR TITLE
Update zh_CN translation

### DIFF
--- a/locales/zh_CN/LC_MESSAGES/duckduckgo.po
+++ b/locales/zh_CN/LC_MESSAGES/duckduckgo.po
@@ -297,7 +297,7 @@ msgid "Anywhere"
 msgstr "随地"
 
 msgid "App"
-msgstr ""
+msgstr "App"
 
 msgid "App and Extension"
 msgstr "应用与扩展"
@@ -711,7 +711,7 @@ msgid "Click %sAdd or change home page...%s"
 msgstr "点击%s添加或改变主页…%s"
 
 msgid "Click %sAdd%s"
-msgstr ""
+msgstr "点击%s添加%s"
 
 msgctxt "install-duckduckgo"
 msgid "Click %sAllow%s, then %sAdd%s."
@@ -745,7 +745,7 @@ msgstr "点击%s开启%s下载及打开DuckDuckGo的Safari扩张"
 msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
-msgstr ""
+msgstr "在菜单中点击 %sSafari%s（Windows 下点击右上角的%s齿轮图标%s）"
 
 msgid "Click %sSettings%s"
 msgstr "点击 %s设置%s"
@@ -806,10 +806,10 @@ msgid "Click the Duck icon at the top of your browser to search!"
 msgstr "点击顶部的小鸭子图标返回搜索页！"
 
 msgid "Click the Expand Icon."
-msgstr ""
+msgstr "点击展开图标。"
 
 msgid "Click the Search Engine Icon in the Address Bar."
-msgstr ""
+msgstr "点击地址栏中的搜索引擎图标。"
 
 msgid "Click the arrow to the right of the %shome icon%s"
 msgstr "点击在%s主页图标%s右边的箭头"
@@ -1186,7 +1186,7 @@ msgstr "DuckDuckGo 设置"
 
 msgctxt "forecast"
 msgid "E"
-msgstr ""
+msgstr "东风"
 
 #. Stuff explaining <em>how does passphrase generation work</em>.
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>. 
@@ -1474,11 +1474,11 @@ msgstr "此答案无法使用栅格模式"
 #. http://i.imgur.com/LHG4IZQ.png
 msgctxt "settings"
 msgid "HTTPS"
-msgstr ""
+msgstr "HTTPS"
 
 #. <em>kh</em>'s label for one of the privacy settings query parameters into <a href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "HTTPS:"
-msgstr "安全链接："
+msgstr "HTTPS："
 
 msgctxt "settings"
 msgid "Header Appearance"
@@ -1562,7 +1562,7 @@ msgstr "营业时间"
 
 msgctxt "SERP footer content"
 msgid "How We Are Profitable"
-msgstr ""
+msgstr "我们如何盈利"
 
 #. Title for the stuffs explaining <em>how to change your passphrase</em>.
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>. 
@@ -1595,7 +1595,7 @@ msgstr "这是匿名的吗？"
 
 msgctxt "forecast"
 msgid "Humidity"
-msgstr ""
+msgstr "湿度"
 
 msgid "Hungary"
 msgstr "匈牙利"
@@ -2190,20 +2190,20 @@ msgstr "暗红色"
 
 msgctxt "forecast"
 msgid "N"
-msgstr ""
+msgstr "北风"
 
 msgctxt "forecast"
 msgid "NE"
-msgstr ""
+msgstr "东北风"
 
 #. NPM = node.js package manager.
 #. e.g. https://duckduckgo.com/?q=npm+packages
 msgid "NPM"
-msgstr ""
+msgstr "NPM"
 
 msgctxt "forecast"
 msgid "NW"
-msgstr ""
+msgstr "西北风"
 
 #. Used in 0-click box for local results, e.g. <a href="http://duckduckgo.com/?q=black+lab+bistro">http://duckduckgo.com/?q=black+lab+bistro</a>
 msgid "Nearby"
@@ -2342,7 +2342,7 @@ msgstr "挪威"
 
 msgctxt "settingsvalue"
 msgid "Not Set"
-msgstr "未设置"
+msgstr "默认"
 
 msgid "Not many results contain %s."
 msgstr "%s 的搜索结果较少。"
@@ -2477,7 +2477,7 @@ msgstr "在新窗口/标签中打开结果"
 
 msgctxt "feedback form"
 msgid "Optional"
-msgstr ""
+msgstr "非必填"
 
 msgctxt "maps_maps_module"
 msgid "Or did you mean:"
@@ -2726,7 +2726,7 @@ msgid "Privacy Newsletter"
 msgstr "隐私简报"
 
 msgid "Privacy Policy"
-msgstr ""
+msgstr "隐私协议"
 
 #. https://duckduckgo.com/params. it is a bold header
 msgid "Privacy Settings"
@@ -2826,7 +2826,7 @@ msgid "Red"
 msgstr "红色"
 
 msgid "Reddit"
-msgstr ""
+msgstr "Reddit"
 
 msgctxt "settings"
 msgid "Redirect (when necessary)"
@@ -2961,15 +2961,15 @@ msgstr "俄罗斯"
 
 msgctxt "forecast"
 msgid "S"
-msgstr ""
+msgstr "南风"
 
 msgctxt "forecast"
 msgid "SE"
-msgstr ""
+msgstr "东南风"
 
 msgctxt "forecast"
 msgid "SW"
-msgstr ""
+msgstr "西南风"
 
 msgid "Safe Search"
 msgstr "安全搜索"
@@ -3171,7 +3171,7 @@ msgstr "选择%s外观%s"
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch Engine%s"
-msgstr ""
+msgstr "点击%s搜索引擎%s"
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"
@@ -3182,7 +3182,7 @@ msgstr "选择 %s设置%s"
 
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s"
-msgstr ""
+msgstr "点击%s设置%s"
 
 msgid "Select %sSettings%s from the drop-down menu."
 msgstr "在下拉菜单中选择%s设置%s。"
@@ -3625,7 +3625,8 @@ msgid ""
 "That means information sent between your device and the webpage behind this "
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
-msgstr ""
+msgstr "这意味着你与网站之间传输的信息更有可能被第三方截获，其中甚至包括你的"
+"密码和银行账号。"
 
 #. Click "What is this?" - http://i.imgur.com/KhmRHth.png
 #. Then in the cloud save box - http://i.imgur.com/elru00b.png
@@ -3670,7 +3671,7 @@ msgstr "一个不会跟踪你隐私的搜索引擎。%s了解详情%s"
 
 msgctxt "SERP footer content"
 msgid "The world needs an alternative to the collect-it-all business model."
-msgstr ""
+msgstr "这个世界需要一种不践踏用户隐私的商业模式。"
 
 #. Title for the theme menu:
 #. https://duck.co/media/files/theme.png
@@ -3721,7 +3722,7 @@ msgstr "这个页面需要JavaScript。"
 
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
+msgstr "此网页没有使用安全的加密连接（HTTPS）。"
 
 #. In spanish: Esto borrará todos los ajustes. ¿Desea continuar?
 msgctxt "settings"
@@ -3796,7 +3797,7 @@ msgid "Turn off:"
 msgstr "关闭："
 
 msgid "Twitter"
-msgstr ""
+msgstr "Twitter"
 
 msgid "Type %sDuckDuckGo%s in the first %sform field"
 msgstr "在第一个文本框中输入 %sDuckDuckGo%s%s"
@@ -3865,7 +3866,7 @@ msgstr "下划线"
 
 #. Instant Answer tab name
 msgid "Unicode"
-msgstr ""
+msgstr "Unicode"
 
 msgid "United Kingdom"
 msgstr "英国"
@@ -3948,7 +3949,7 @@ msgstr "已访问的链接："
 
 msgctxt "forecast"
 msgid "W"
-msgstr ""
+msgstr "西风"
 
 #. in https://duckduckgo.com/feedback under "DuckDuckHack" header
 msgid "Want to develop an instant answer?"
@@ -3963,7 +3964,7 @@ msgstr "在YouTube观看"
 
 msgctxt "SERP footer content"
 msgid "We Protect Your Privacy"
-msgstr ""
+msgstr "我们重视你的隐私"
 
 #. Click "What is this?" - http://i.imgur.com/KhmRHth.png
 #. Then in the cloud save box - http://i.imgur.com/vBsbibl.png
@@ -4014,7 +4015,7 @@ msgstr "我们不会存储您的私人信息。"
 
 msgctxt "SERP footer content"
 msgid "We don't store your search history or follow you around the web."
-msgstr ""
+msgstr "我们不记录你的搜索内容，也不跟踪你的行为轨迹。"
 
 msgctxt "SERP footer content"
 msgid "We don't track you, but others do."
@@ -4187,7 +4188,7 @@ msgstr "维基百科的信息"
 
 msgctxt "forecast"
 msgid "Wind"
-msgstr ""
+msgstr "风速"
 
 #. https://duckduckgo.com/feedback under "Community Platform" header
 msgid "Would you like to help develop the platform?"


### PR DESCRIPTION
```PO
msgid "ATB related (not displayed on settings page)"
msgid "Mobile Instructions (not displayed on settings page)"
```
The above strings are left untranslated. They should be ignored, shouldn’t they?