### PR TITLE
Add missing question mark

### DIFF
--- a/locales/en_CA/LC_MESSAGES/duckduckgo.po
+++ b/locales/en_CA/LC_MESSAGES/duckduckgo.po
@@ -706,7 +706,7 @@ msgid "Clear Region"
 msgstr "Clear Region"
 
 msgid "Clear your cookies often?"
-msgstr "Clear your cookies often"
+msgstr "Clear your cookies often?"
 
 msgid "Click %s+%s!"
 msgstr "Click %s+%s!"


### PR DESCRIPTION
@jbarrett should we just not have a `msgstr` for all strings that don't actually need to be "translated"?

i.e. only translate the strings the contain words which are different from en_US