### PR TITLE
Update ja_JP duckduckgo.po

### DIFF
--- a/locales/ja_JP/LC_MESSAGES/duckduckgo.po
+++ b/locales/ja_JP/LC_MESSAGES/duckduckgo.po
@@ -294,7 +294,7 @@ msgstr "すべての解像度"
 
 #. Option for the filter-by-date search.
 msgid "Any Time"
-msgstr "いつでも"
+msgstr "全期間"
 
 msgid "Anywhere"
 msgstr "どこでも"
@@ -2336,7 +2336,7 @@ msgstr "追跡しません。どんなときでも。"
 
 msgctxt "safe search"
 msgid "No adult content"
-msgstr "アダルトコンテンツを除く"
+msgstr "アダルトコンテンツを排除する"
 
 msgctxt "safe search"
 msgid "No explicit images or videos"
@@ -4070,7 +4070,7 @@ msgstr "西"
 
 msgctxt "size"
 msgid "Wallpaper"
-msgstr ""
+msgstr "壁紙"
 
 #. in https://duckduckgo.com/feedback under "DuckDuckHack" header
 msgid "Want to develop an instant answer?"


### PR DESCRIPTION
セーフサーチ関係の表現を"排除"に統一。
期間であるため"Any Time"の翻訳を"いつでも"から"全期間"に修正。
"Wallpaper"の翻訳追加。

The expression of safe search relationship is unified to  "eliminated ".
Fixed the  "Any Time" translation from  "Anytime " to  "whole period " because it is a period. Added translation of  "Wallpaper".