### PR TITLE
Update duckduckgo.po ja_JP

### DIFF
--- a/locales/ja_JP/LC_MESSAGES/duckduckgo.po
+++ b/locales/ja_JP/LC_MESSAGES/duckduckgo.po
@@ -1287,7 +1287,7 @@ msgstr "エンターテイメント"
 
 msgctxt "SERP footer content"
 msgid "Escape The Filter Bubble"
-msgstr "フィルターバブルを抜け出す"
+msgstr "フィルターバブルから脱出"
 
 msgid "Estonia"
 msgstr "エストニア"
@@ -1442,7 +1442,7 @@ msgstr "新しいテーマを入手する"
 
 msgctxt "showcase_app"
 msgid "Get Our App & Extension"
-msgstr "DuckDuckGoのアプリと拡張機能を手に入れる"
+msgstr "アプリと拡張機能を入手"
 
 msgctxt "showcase_privacy"
 msgid "Get Privacy Tips"
@@ -2806,7 +2806,7 @@ msgstr "エッセンシャル"
 
 msgctxt "SERP footer content"
 msgid "Privacy Newsletter"
-msgstr "プライバシーニュースレター"
+msgstr "ニュースレター"
 
 msgctxt "settings"
 msgid "Privacy Newsletter"
@@ -2859,7 +2859,7 @@ msgid "Protect Your Devices"
 msgstr "あなたのデバイスを守る"
 
 msgid "Protect Your Privacy!"
-msgstr "あなたのプライバシーを守る！"
+msgstr "プライバシーを守る！"
 
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
@@ -2899,8 +2899,7 @@ msgstr "さらに詳しく"
 
 msgctxt "SERP footer content"
 msgid "Read about how Google influences what people click."
-msgstr ""
-"Google がユーザーのクリックにどのように影響を及ぼすかについてお読みください。"
+msgstr "Googleが人々に及ぼす影響についてお読みください。"
 
 msgid "Recent News"
 msgstr "最新ニュース"
@@ -3122,7 +3121,7 @@ msgstr "設定内容を匿名でクラウドに保存します"
 
 msgctxt "SERP footer content"
 msgid "Say Goodbye To Google"
-msgstr "Googleにさよならを言おう"
+msgstr "Googleにさよならを言う"
 
 #. Needs Context
 msgid "Score"
@@ -3797,9 +3796,7 @@ msgstr "あなたを追跡しない検索エンジン。%sさらに詳しく%s"
 
 msgctxt "SERP footer content"
 msgid "The world needs an alternative to the collect-it-all business model."
-msgstr ""
-"世界は、ありとあらゆる情報を収集する(Collect It All)ビジネスモデルに代わるも"
-"のを必要としています。"
+msgstr "世界は、全情報を収集するビジネスモデルに代わるものを必要としています。"
 
 #. Title for the theme menu:
 #. https://duck.co/media/files/theme.png


### PR DESCRIPTION
The text was shortened because it was out of view.
(ja)文章が長すぎて表示がはみ出していたため文章を短くしました。