### PR TITLE
Incorrect spanish translation

### DIFF
--- a/locales/es_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_ES/LC_MESSAGES/duckduckgo.po
@@ -148,7 +148,7 @@ msgstr "Anuncio irrelevante"
 
 msgctxt "feedback form"
 msgid "Ad is malware"
-msgstr "Los anuncios son malware"
+msgstr "El anuncio es malware"
 
 msgctxt "feedback form"
 msgid "Ad is suspicious"


### PR DESCRIPTION
Ad is malware = El anuncio es malware
(Not = los anuncios son malware)