### PR TITLE
clic over click for es_AR.

### DIFF
--- a/locales/es_AR/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_AR/LC_MESSAGES/duckduckgo.po
@@ -98,7 +98,7 @@ msgstr "1. Abrí %sDescargas%s"
 
 msgctxt "install-extension"
 msgid "2. Double-click %sduckduckgo.safariextz%s"
-msgstr "2. Haz doble click sobre %sduckduckgo.safariextz%s"
+msgstr "2. Haz doble clic sobre %sduckduckgo.safariextz%s"
 
 #. https://duckduckgo.com/params in the end under " Source:"
 msgid "A string to identify the source."
@@ -1136,7 +1136,7 @@ msgstr "¿No ves a DuckDuckGo en la lista?"
 
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr "¿No lo ves? %s%s%sHacé click acá para descargarlo nuevamente%s"
+msgstr "¿No lo ves? %s%s%sHacé clic acá para descargarlo nuevamente%s"
 
 msgid "Don't see the checkbox? %sFollow these steps%s."
 msgstr "¿No ves la casilla de confirmación? %sSeguí estos pasos%s."
@@ -1367,7 +1367,7 @@ msgid "Final"
 msgstr ""
 
 msgid "Finally, click %sAdd%s"
-msgstr "Por último, haga click en %sañadir%s"
+msgstr "Por último, haga clic en %sañadir%s"
 
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
 msgstr "Encontrá %sDuckDuckGo%s y hacé clic en %sHacer predeterminado%s"


### PR DESCRIPTION
For the sake of uniformity, `clic` is preferred over `click` for this locale.