### PR TITLE
Change "i fjol" in Swedish translation

### DIFF
--- a/locales/sv_SE/LC_MESSAGES/duckduckgo.po
+++ b/locales/sv_SE/LC_MESSAGES/duckduckgo.po
@@ -2683,7 +2683,7 @@ msgstr "Senaste veckan"
 
 #. Option for the filter-by-date search.
 msgid "Past Year"
-msgstr "I fjol"
+msgstr "Senaste året"
 
 msgctxt "settings"
 msgid "Personalize DuckDuckGo"


### PR DESCRIPTION
"I fjol" translates to "last year", rather than "past year". That is, it would mean all of 2018 rather than October 2018 - today.

"Senaste året" fits better, and is consistent with the other values.

Reference:
https://en.wiktionary.org/wiki/i_fjol