### PR TITLE
fix Greek word for Shopping

### DIFF
--- a/locales/el_GR/LC_MESSAGES/duckduckgo.po
+++ b/locales/el_GR/LC_MESSAGES/duckduckgo.po
@@ -3470,7 +3470,7 @@ msgstr ""
 
 #. in https://duckduckgo.com/newbang under "Bang category " inside the drop-menu
 msgid "Shopping"
-msgstr "Ψώνισμα"
+msgstr "Ψώνια"
 
 msgctxt "video-duration"
 msgid "Short"


### PR DESCRIPTION
The commonly used word for *Shopping*, is *Ψώνια*. The currently used translation is almost always mean something completely different in Greek.