### PR TITLE
translate hours ago

### DIFF
--- a/locales/de_DE/LC_MESSAGES/duckduckgo.po
+++ b/locales/de_DE/LC_MESSAGES/duckduckgo.po
@@ -44,7 +44,7 @@ msgstr "%s für %s"
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "%s hours ago"
-msgstr ""
+msgstr "vor %s Stunden"
 
 msgctxt "showcase_donations"
 msgid "%s in privacy donations!"
@@ -120,7 +120,7 @@ msgstr "vor 1 Tag"
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 hour ago"
-msgstr ""
+msgstr "vor 1 Stunde"
 
 msgctxt "install-extension"
 msgid "1. Open %sDownloads%s"

--- a/locales/es_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_ES/LC_MESSAGES/duckduckgo.po
@@ -44,7 +44,7 @@ msgstr "%s para %s"
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "%s hours ago"
-msgstr ""
+msgstr "hace %s horas"
 
 msgctxt "showcase_donations"
 msgid "%s in privacy donations!"
@@ -124,7 +124,7 @@ msgstr "hace 1 día"
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 hour ago"
-msgstr ""
+msgstr "1 hora antes"
 
 msgctxt "install-extension"
 msgid "1. Open %sDownloads%s"

--- a/locales/fr_FR/LC_MESSAGES/duckduckgo.po
+++ b/locales/fr_FR/LC_MESSAGES/duckduckgo.po
@@ -44,7 +44,7 @@ msgstr "%s pour %s"
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "%s hours ago"
-msgstr ""
+msgstr "Il y a %s heures"
 
 msgctxt "showcase_donations"
 msgid "%s in privacy donations!"
@@ -124,7 +124,7 @@ msgstr "Il y a 1 jour"
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 hour ago"
-msgstr ""
+msgstr "Il ya 1 heure"
 
 msgctxt "install-extension"
 msgid "1. Open %sDownloads%s"

--- a/locales/nl_NL/LC_MESSAGES/duckduckgo.po
+++ b/locales/nl_NL/LC_MESSAGES/duckduckgo.po
@@ -45,7 +45,7 @@ msgstr "%s voor %s"
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "%s hours ago"
-msgstr ""
+msgstr "%s uur geleden"
 
 msgctxt "showcase_donations"
 msgid "%s in privacy donations!"
@@ -121,7 +121,7 @@ msgstr "1 dag geleden"
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 hour ago"
-msgstr ""
+msgstr "1 uur geleden"
 
 msgctxt "install-extension"
 msgid "1. Open %sDownloads%s"

--- a/locales/th_TH/LC_MESSAGES/duckduckgo.po
+++ b/locales/th_TH/LC_MESSAGES/duckduckgo.po
@@ -2294,7 +2294,7 @@ msgstr "เบราเซอร์หรือคอมพิวเตอร์
 
 msgctxt "new user poll"
 msgid "New to DuckDuckGo?"
-msgstr "เพิ่งใช้ DuckDUckGo หรือเปล่า"
+msgstr "เพิ่งใช้ DuckDuckGo หรือเปล่า"
 
 #. For rotating carousel on the home page.
 #. "Take a Tour" will link to /tour page


### PR DESCRIPTION
Translates "1 hour ago", "3 hours ago" for:

* Dutch
* French
* German
* Spanish