### PR TITLE
Update Japanese translation

### DIFF
--- a/locales/ja_JP/LC_MESSAGES/duckduckgo.po
+++ b/locales/ja_JP/LC_MESSAGES/duckduckgo.po
@@ -253,7 +253,7 @@ msgstr ""
 "ください"
 
 msgid "All"
-msgstr "全ての"
+msgstr "全て"
 
 msgctxt "image-color"
 msgid "All Colors"


### PR DESCRIPTION
update "全ての" → "全て"
(画像や動画等の検索形式の一つとして現在、"全ての"と表示されていますが、これは日本語的に不自然な表現です。"全て"に修正するべきです。)