### PR TITLE
Update duckduckgo.po ja_JP translation

### DIFF
--- a/locales/ja_JP/LC_MESSAGES/duckduckgo.po
+++ b/locales/ja_JP/LC_MESSAGES/duckduckgo.po
@@ -1040,7 +1040,7 @@ msgstr "著作権侵害"
 
 msgctxt "SERP footer content"
 msgid "Coronavirus Info & Tips"
-msgstr "新型コロナウイルスの情報と対策"
+msgstr "新型コロナウイルスの情報"
 
 #. Instant Answer Tab Name
 msgid "Coupons"
@@ -1567,7 +1567,7 @@ msgstr "Webのリンクを追加する"
 
 msgctxt "SERP footer content"
 msgid "Get official COVID-19 info and tips to help stop the spread."
-msgstr "新型コロナウイルス(COVID-19)に関する公式の情報と、予防策を知る。"
+msgstr "新型コロナウイルス(COVID-19)に関する公式の情報と予防策を知る。"
 
 msgctxt "Homepage alert button "
 msgid "Get official COVID-19 info and tips."
@@ -2365,7 +2365,7 @@ msgid "More from"
 msgstr "もっと"
 
 msgid "More on %s "
-msgstr ""
+msgstr "%s で更に見る"
 
 #. A link to get more results from a particular domain.
 msgid "More results"
@@ -2377,7 +2377,7 @@ msgstr "結果をさらに表示"
 
 msgctxt "more_reviews_on_external_website"
 msgid "More reviews on %s "
-msgstr ""
+msgstr "%s でレビューを更に見る"
 
 msgctxt "video-duration"
 msgid "More than 20 minutes"
@@ -2780,7 +2780,7 @@ msgstr "100億件を越える匿名での検索がありました。"
 
 msgctxt "maps_places"
 msgid "Overview"
-msgstr ""
+msgstr "概要"
 
 #. Instant Answer Tab Name
 msgid "Packages"


### PR DESCRIPTION
EN:
I made it short because some strings were protruding from the box.
And, add some translations.

JA:
一部の文字列(COVID-19関連)がボックスからはみ出していたため、翻訳を短くしました。
その他、いくつかの翻訳を追加しました。