### PR TITLE
Import new ad badge tooltip tokens (2020-03-30-2133)

### DIFF
--- a/duckduckgo.pot
+++ b/duckduckgo.pot
@@ -2249,6 +2249,10 @@ msgstr ""
 msgid "More Info"
 msgstr ""
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr ""
 
@@ -4224,6 +4228,12 @@ msgstr ""
 
 msgctxt "maps_maps_module"
 msgid "View on Map"
+msgstr ""
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
 msgstr ""
 
 msgctxt "mobile promotion on desktop"

--- a/locales/af_ZA/LC_MESSAGES/duckduckgo.po
+++ b/locales/af_ZA/LC_MESSAGES/duckduckgo.po
@@ -2314,6 +2314,10 @@ msgstr "Nog Beelde"
 msgid "More Info"
 msgstr "Nog Inligting"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Meer Skakels"
 
@@ -4328,6 +4332,12 @@ msgstr "Bekyk op %s"
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "Bekyk op Kaart"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/ar_DZ/LC_MESSAGES/duckduckgo.po
+++ b/locales/ar_DZ/LC_MESSAGES/duckduckgo.po
@@ -2279,6 +2279,10 @@ msgstr ""
 msgid "More Info"
 msgstr ""
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "المزيد من الروابط"
 
@@ -4267,6 +4271,12 @@ msgstr ""
 
 msgctxt "maps_maps_module"
 msgid "View on Map"
+msgstr ""
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
 msgstr ""
 
 msgctxt "mobile promotion on desktop"

--- a/locales/ar_EG/LC_MESSAGES/duckduckgo.po
+++ b/locales/ar_EG/LC_MESSAGES/duckduckgo.po
@@ -2317,6 +2317,10 @@ msgstr ""
 msgid "More Info"
 msgstr ""
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "المزيد من الروابط"
 
@@ -4308,6 +4312,12 @@ msgstr ""
 
 msgctxt "maps_maps_module"
 msgid "View on Map"
+msgstr ""
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
 msgstr ""
 
 msgctxt "mobile promotion on desktop"

--- a/locales/ar_JO/LC_MESSAGES/duckduckgo.po
+++ b/locales/ar_JO/LC_MESSAGES/duckduckgo.po
@@ -2301,6 +2301,10 @@ msgstr ""
 msgid "More Info"
 msgstr ""
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "روابط أخرى"
 
@@ -4285,6 +4289,12 @@ msgstr ""
 
 msgctxt "maps_maps_module"
 msgid "View on Map"
+msgstr ""
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
 msgstr ""
 
 msgctxt "mobile promotion on desktop"

--- a/locales/ar_SA/LC_MESSAGES/duckduckgo.po
+++ b/locales/ar_SA/LC_MESSAGES/duckduckgo.po
@@ -2305,6 +2305,10 @@ msgstr "المزيد من الصور"
 msgid "More Info"
 msgstr "معلومات أكثر "
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "المزيد من الروابط"
 
@@ -4314,6 +4318,12 @@ msgstr ""
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "اظهار على الخريطة"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/ast_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/ast_ES/LC_MESSAGES/duckduckgo.po
@@ -2261,6 +2261,10 @@ msgstr "Más imáxenes"
 msgid "More Info"
 msgstr "Más información"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Más enllaces"
 
@@ -4246,6 +4250,12 @@ msgstr ""
 
 msgctxt "maps_maps_module"
 msgid "View on Map"
+msgstr ""
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
 msgstr ""
 
 msgctxt "mobile promotion on desktop"

--- a/locales/az_AZ/LC_MESSAGES/duckduckgo.po
+++ b/locales/az_AZ/LC_MESSAGES/duckduckgo.po
@@ -2291,6 +2291,10 @@ msgstr "Daha çox şəkillər"
 msgid "More Info"
 msgstr "Daha çox informasiya"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Əlavə keçidlər"
 
@@ -4286,6 +4290,12 @@ msgstr ""
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "Xəritədə Bax"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/be_BY/LC_MESSAGES/duckduckgo.po
+++ b/locales/be_BY/LC_MESSAGES/duckduckgo.po
@@ -2327,6 +2327,10 @@ msgstr "Дадатковыя выявы"
 msgid "More Info"
 msgstr "Больш звестак"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Больш спасылак"
 
@@ -4351,6 +4355,12 @@ msgstr "Прагляд у %s"
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "Паглядзець на мапе"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/bg_BG/LC_MESSAGES/duckduckgo.po
+++ b/locales/bg_BG/LC_MESSAGES/duckduckgo.po
@@ -2306,6 +2306,10 @@ msgstr "Още Изображения"
 msgid "More Info"
 msgstr "Повече информация"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Повече Линкове"
 
@@ -4322,6 +4326,12 @@ msgstr ""
 
 msgctxt "maps_maps_module"
 msgid "View on Map"
+msgstr ""
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
 msgstr ""
 
 msgctxt "mobile promotion on desktop"

--- a/locales/bn_BD/LC_MESSAGES/duckduckgo.po
+++ b/locales/bn_BD/LC_MESSAGES/duckduckgo.po
@@ -2302,6 +2302,10 @@ msgstr ""
 msgid "More Info"
 msgstr "আরো তথ্য"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "আরো লিংক দেখুন"
 
@@ -4299,6 +4303,12 @@ msgstr ""
 
 msgctxt "maps_maps_module"
 msgid "View on Map"
+msgstr ""
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
 msgstr ""
 
 msgctxt "mobile promotion on desktop"

--- a/locales/bn_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/bn_IN/LC_MESSAGES/duckduckgo.po
@@ -2292,6 +2292,10 @@ msgstr ""
 msgid "More Info"
 msgstr ""
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "আরও কিছু লিঙ্কস"
 
@@ -4269,6 +4273,12 @@ msgstr ""
 
 msgctxt "maps_maps_module"
 msgid "View on Map"
+msgstr ""
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
 msgstr ""
 
 msgctxt "mobile promotion on desktop"

--- a/locales/bo_CN/LC_MESSAGES/duckduckgo.po
+++ b/locales/bo_CN/LC_MESSAGES/duckduckgo.po
@@ -2256,6 +2256,10 @@ msgstr ""
 msgid "More Info"
 msgstr ""
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr ""
 
@@ -4231,6 +4235,12 @@ msgstr ""
 
 msgctxt "maps_maps_module"
 msgid "View on Map"
+msgstr ""
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
 msgstr ""
 
 msgctxt "mobile promotion on desktop"

--- a/locales/br_FR/LC_MESSAGES/duckduckgo.po
+++ b/locales/br_FR/LC_MESSAGES/duckduckgo.po
@@ -2304,6 +2304,10 @@ msgstr ""
 msgid "More Info"
 msgstr "Muioc'h a ditouroù"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Muioc'h a ereoù"
 
@@ -4313,6 +4317,12 @@ msgstr ""
 
 msgctxt "maps_maps_module"
 msgid "View on Map"
+msgstr ""
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
 msgstr ""
 
 msgctxt "mobile promotion on desktop"

--- a/locales/bs_BA/LC_MESSAGES/duckduckgo.po
+++ b/locales/bs_BA/LC_MESSAGES/duckduckgo.po
@@ -2287,6 +2287,10 @@ msgstr ""
 msgid "More Info"
 msgstr ""
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Više linkova"
 
@@ -4273,6 +4277,12 @@ msgstr ""
 
 msgctxt "maps_maps_module"
 msgid "View on Map"
+msgstr ""
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
 msgstr ""
 
 msgctxt "mobile promotion on desktop"

--- a/locales/ca_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/ca_ES/LC_MESSAGES/duckduckgo.po
@@ -2339,6 +2339,10 @@ msgstr "Més imatges"
 msgid "More Info"
 msgstr "Més informació"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Més enllaços"
 
@@ -4393,6 +4397,12 @@ msgstr "Mostra-ho a %s"
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "Mostra-ho al mapa"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/cs_CZ/LC_MESSAGES/duckduckgo.po
+++ b/locales/cs_CZ/LC_MESSAGES/duckduckgo.po
@@ -2309,6 +2309,10 @@ msgstr "Více obrázků"
 msgid "More Info"
 msgstr "Více informací"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Další odkazy"
 
@@ -4322,6 +4326,12 @@ msgstr "Zobraziv v %s"
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "Zobrazit na mapě"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/cy_GB/LC_MESSAGES/duckduckgo.po
+++ b/locales/cy_GB/LC_MESSAGES/duckduckgo.po
@@ -2287,6 +2287,10 @@ msgstr ""
 msgid "More Info"
 msgstr ""
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Mwy o ddolenni"
 
@@ -4277,6 +4281,12 @@ msgstr ""
 
 msgctxt "maps_maps_module"
 msgid "View on Map"
+msgstr ""
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
 msgstr ""
 
 msgctxt "mobile promotion on desktop"

--- a/locales/da_DK/LC_MESSAGES/duckduckgo.po
+++ b/locales/da_DK/LC_MESSAGES/duckduckgo.po
@@ -2319,6 +2319,10 @@ msgstr "Flere billeder"
 msgid "More Info"
 msgstr "Mere Info"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Flere Links"
 
@@ -4342,6 +4346,12 @@ msgstr "Se på %s"
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "Vis på kort"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/de_CH/LC_MESSAGES/duckduckgo.po
+++ b/locales/de_CH/LC_MESSAGES/duckduckgo.po
@@ -2326,6 +2326,10 @@ msgstr "Mehr Bilder"
 msgid "More Info"
 msgstr "Mehr Info"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Weitere Links"
 
@@ -4374,6 +4378,12 @@ msgstr "Auf %s anschauen"
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "Auf der Karte zeigen"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/de_DE/LC_MESSAGES/duckduckgo.po
+++ b/locales/de_DE/LC_MESSAGES/duckduckgo.po
@@ -2341,6 +2341,10 @@ msgstr "Mehr Bilder"
 msgid "More Info"
 msgstr "Weitere Informationen"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Weitere Verweise"
 
@@ -4398,6 +4402,12 @@ msgstr "Sehe auf %s"
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "Auf Karte anzeigen"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/el_GR/LC_MESSAGES/duckduckgo.po
+++ b/locales/el_GR/LC_MESSAGES/duckduckgo.po
@@ -2351,6 +2351,10 @@ msgstr "Περισσότερες Εικόνες"
 msgid "More Info"
 msgstr "Περισσότερες πληροφορίες"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Περισσοτεροι σύνδεσμοι"
 
@@ -4403,6 +4407,12 @@ msgstr "Προβολή στο %s"
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "Προβολή σε Χάρτη"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/en_AU/LC_MESSAGES/duckduckgo.po
+++ b/locales/en_AU/LC_MESSAGES/duckduckgo.po
@@ -2302,6 +2302,10 @@ msgstr "More Images"
 msgid "More Info"
 msgstr "More Info"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "More Links"
 
@@ -4309,6 +4313,12 @@ msgstr "View on %s"
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "View on Map"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/en_CA/LC_MESSAGES/duckduckgo.po
+++ b/locales/en_CA/LC_MESSAGES/duckduckgo.po
@@ -2302,6 +2302,10 @@ msgstr "More Images"
 msgid "More Info"
 msgstr "More Info"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "More Links"
 
@@ -4309,6 +4313,12 @@ msgstr "View on %s"
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "View on Map"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/en_GB/LC_MESSAGES/duckduckgo.po
+++ b/locales/en_GB/LC_MESSAGES/duckduckgo.po
@@ -2302,6 +2302,10 @@ msgstr "More Images"
 msgid "More Info"
 msgstr "More Info"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "More Links"
 
@@ -4309,6 +4313,12 @@ msgstr "View on %s"
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "View on Map"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/en_US/LC_MESSAGES/duckduckgo.po
+++ b/locales/en_US/LC_MESSAGES/duckduckgo.po
@@ -2256,6 +2256,10 @@ msgstr ""
 msgid "More Info"
 msgstr ""
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr ""
 
@@ -4231,6 +4235,12 @@ msgstr ""
 
 msgctxt "maps_maps_module"
 msgid "View on Map"
+msgstr ""
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
 msgstr ""
 
 msgctxt "mobile promotion on desktop"

--- a/locales/eo_XX/LC_MESSAGES/duckduckgo.po
+++ b/locales/eo_XX/LC_MESSAGES/duckduckgo.po
@@ -2309,6 +2309,10 @@ msgstr "Pliaj bildoj"
 msgid "More Info"
 msgstr "Pliaj informoj"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Pliaj ligiloj"
 
@@ -4320,6 +4324,12 @@ msgstr "Vidi sur %s"
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "Vidi sur mapo"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/es_AR/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_AR/LC_MESSAGES/duckduckgo.po
@@ -2339,6 +2339,10 @@ msgstr "Más Imágenes"
 msgid "More Info"
 msgstr "Más información"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Más Links"
 
@@ -4380,6 +4384,12 @@ msgstr "Ver en %s"
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "Ver en el mapa"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/es_CL/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_CL/LC_MESSAGES/duckduckgo.po
@@ -2311,6 +2311,10 @@ msgstr "Más Imagenes"
 msgid "More Info"
 msgstr "Más información"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Más enlaces"
 
@@ -4336,6 +4340,12 @@ msgstr ""
 
 msgctxt "maps_maps_module"
 msgid "View on Map"
+msgstr ""
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
 msgstr ""
 
 msgctxt "mobile promotion on desktop"

--- a/locales/es_CO/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_CO/LC_MESSAGES/duckduckgo.po
@@ -2324,6 +2324,10 @@ msgstr "Más Imágenes"
 msgid "More Info"
 msgstr "Más información"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Mas enlaces "
 
@@ -4353,6 +4357,12 @@ msgstr ""
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "Ver en el Mapa"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/es_CR/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_CR/LC_MESSAGES/duckduckgo.po
@@ -2289,6 +2289,10 @@ msgstr ""
 msgid "More Info"
 msgstr ""
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Más Enlaces"
 
@@ -4278,6 +4282,12 @@ msgstr ""
 
 msgctxt "maps_maps_module"
 msgid "View on Map"
+msgstr ""
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
 msgstr ""
 
 msgctxt "mobile promotion on desktop"

--- a/locales/es_EC/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_EC/LC_MESSAGES/duckduckgo.po
@@ -2293,6 +2293,10 @@ msgstr ""
 msgid "More Info"
 msgstr "Más Información"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Más enlaces"
 
@@ -4297,6 +4301,12 @@ msgstr "Ver en %s"
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "Ver en el Mapa"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/es_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_ES/LC_MESSAGES/duckduckgo.po
@@ -1578,7 +1578,9 @@ msgstr "Obtener enlaces web"
 
 msgctxt "SERP footer content"
 msgid "Get official COVID-19 info and tips to help stop the spread."
-msgstr "Obtenga información oficial y consejos sobre el COVID-19 para ayudar a detener el avance"
+msgstr ""
+"Obtenga información oficial y consejos sobre el COVID-19 para ayudar a "
+"detener el avance"
 
 msgctxt "Homepage alert button "
 msgid "Get official COVID-19 info and tips."
@@ -2338,6 +2340,10 @@ msgstr "Más Imágenes"
 
 msgid "More Info"
 msgstr "Más Información"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
 
 msgid "More Links"
 msgstr "Más Enlaces"
@@ -4376,6 +4382,12 @@ msgstr "Ver en %s"
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "Ver en el mapa"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/es_MX/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_MX/LC_MESSAGES/duckduckgo.po
@@ -2319,6 +2319,10 @@ msgstr "Más Imágenes"
 msgid "More Info"
 msgstr "Más información"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Más enlaces"
 
@@ -4352,6 +4356,12 @@ msgstr "Ver en %s"
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "Ver en el mapa"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/es_PE/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_PE/LC_MESSAGES/duckduckgo.po
@@ -2301,6 +2301,10 @@ msgstr ""
 msgid "More Info"
 msgstr "Más información"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Más enlaces"
 
@@ -4307,6 +4311,12 @@ msgstr ""
 
 msgctxt "maps_maps_module"
 msgid "View on Map"
+msgstr ""
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
 msgstr ""
 
 msgctxt "mobile promotion on desktop"

--- a/locales/es_UY/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_UY/LC_MESSAGES/duckduckgo.po
@@ -2284,6 +2284,10 @@ msgstr ""
 msgid "More Info"
 msgstr ""
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Más Enlaces"
 
@@ -4270,6 +4274,12 @@ msgstr ""
 
 msgctxt "maps_maps_module"
 msgid "View on Map"
+msgstr ""
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
 msgstr ""
 
 msgctxt "mobile promotion on desktop"

--- a/locales/es_VE/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_VE/LC_MESSAGES/duckduckgo.po
@@ -2294,6 +2294,10 @@ msgstr ""
 msgid "More Info"
 msgstr ""
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Mas enlaces"
 
@@ -4294,6 +4298,12 @@ msgstr ""
 
 msgctxt "maps_maps_module"
 msgid "View on Map"
+msgstr ""
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
 msgstr ""
 
 msgctxt "mobile promotion on desktop"

--- a/locales/et_EE/LC_MESSAGES/duckduckgo.po
+++ b/locales/et_EE/LC_MESSAGES/duckduckgo.po
@@ -2284,6 +2284,10 @@ msgstr "Rohkem pilte"
 msgid "More Info"
 msgstr "Rohkem teavet"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Rohkem linke"
 
@@ -4278,6 +4282,12 @@ msgstr "Vaata saidil %s"
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "Vaata kaardil"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/eu_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/eu_ES/LC_MESSAGES/duckduckgo.po
@@ -2279,6 +2279,10 @@ msgstr "Irudi gehiago"
 msgid "More Info"
 msgstr ""
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Esteka gehiago"
 
@@ -4264,6 +4268,12 @@ msgstr ""
 
 msgctxt "maps_maps_module"
 msgid "View on Map"
+msgstr ""
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
 msgstr ""
 
 msgctxt "mobile promotion on desktop"

--- a/locales/fa_IR/LC_MESSAGES/duckduckgo.po
+++ b/locales/fa_IR/LC_MESSAGES/duckduckgo.po
@@ -2372,6 +2372,10 @@ msgstr "عکس‌های بیشتر"
 msgid "More Info"
 msgstr "اطلاعات بیشتر"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "پیوندهای بیش‌تر"
 
@@ -4446,6 +4450,12 @@ msgstr "‫روی %s ببینید‬"
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "روی نقشه ببینید"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/fi_FI/LC_MESSAGES/duckduckgo.po
+++ b/locales/fi_FI/LC_MESSAGES/duckduckgo.po
@@ -2306,6 +2306,10 @@ msgstr "Lisää Kuvia"
 msgid "More Info"
 msgstr "Lisätietoja"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Lisää linkkejä"
 
@@ -4324,6 +4328,12 @@ msgstr "Näytä %s"
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "Näytä kartalla"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/fr_BE/LC_MESSAGES/duckduckgo.po
+++ b/locales/fr_BE/LC_MESSAGES/duckduckgo.po
@@ -2324,6 +2324,10 @@ msgstr "Davantage d'images"
 msgid "More Info"
 msgstr "Plus d'Info"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Plus de liens"
 
@@ -4369,6 +4373,12 @@ msgstr ""
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "Voir sur la carte"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/fr_CA/LC_MESSAGES/duckduckgo.po
+++ b/locales/fr_CA/LC_MESSAGES/duckduckgo.po
@@ -2320,6 +2320,10 @@ msgstr "Plus d'images"
 msgid "More Info"
 msgstr "Davantage d'info"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Plus de liens"
 
@@ -4369,6 +4373,12 @@ msgstr ""
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "Voir sur la carte"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/fr_CH/LC_MESSAGES/duckduckgo.po
+++ b/locales/fr_CH/LC_MESSAGES/duckduckgo.po
@@ -2321,6 +2321,10 @@ msgstr "Plus d'images"
 msgid "More Info"
 msgstr "Plus d'informations"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Plus de liens"
 
@@ -4351,6 +4355,12 @@ msgstr ""
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "Voir sur la carte"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/fr_FR/LC_MESSAGES/duckduckgo.po
+++ b/locales/fr_FR/LC_MESSAGES/duckduckgo.po
@@ -1590,11 +1590,14 @@ msgstr "Accéder aux liens Web"
 
 msgctxt "SERP footer content"
 msgid "Get official COVID-19 info and tips to help stop the spread."
-msgstr "Accédez aux informations officielles sur le COVID-19 et aux recommandations pour stopper la propagation du virus."
+msgstr ""
+"Accédez aux informations officielles sur le COVID-19 et aux recommandations "
+"pour stopper la propagation du virus."
 
 msgctxt "Homepage alert button "
 msgid "Get official COVID-19 info and tips."
-msgstr "Accédez aux informations officielles et aux recommandations sur le COVID-19."
+msgstr ""
+"Accédez aux informations officielles et aux recommandations sur le COVID-19."
 
 msgid "Get the non-JS version %s"
 msgstr "Accéder à la version %s sans JavaScript"
@@ -2354,6 +2357,10 @@ msgstr "Plus d'images"
 
 msgid "More Info"
 msgstr "Plus d'infos"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
 
 msgid "More Links"
 msgstr "Plus de liens"
@@ -4423,6 +4430,12 @@ msgstr "Voir sur %s"
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "Voir sur la carte"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/ga_IE/LC_MESSAGES/duckduckgo.po
+++ b/locales/ga_IE/LC_MESSAGES/duckduckgo.po
@@ -2364,6 +2364,10 @@ msgstr "Tuilleadh Íomhánna"
 msgid "More Info"
 msgstr "Tuilleadh Eolais"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Tuilleadh Naisc"
 
@@ -4435,6 +4439,12 @@ msgstr "Breathnaigh air ar %s"
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "Breathnaigh air ar an Léarscáil"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/gd_GB/LC_MESSAGES/duckduckgo.po
+++ b/locales/gd_GB/LC_MESSAGES/duckduckgo.po
@@ -2333,6 +2333,10 @@ msgstr "Barrachd dhealbhan"
 msgid "More Info"
 msgstr "Barrachd fiosrachaidh"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Barrachd cheanglaichean"
 
@@ -4363,6 +4367,12 @@ msgstr ""
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "Seall air mapa"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/gl_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/gl_ES/LC_MESSAGES/duckduckgo.po
@@ -2328,6 +2328,10 @@ msgstr "Máis imaxes"
 msgid "More Info"
 msgstr "Máis información"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Máis ligazóns"
 
@@ -4368,6 +4372,12 @@ msgstr "Ver en %s"
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "Ver no mapa"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/gu_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/gu_IN/LC_MESSAGES/duckduckgo.po
@@ -2274,6 +2274,10 @@ msgstr ""
 msgid "More Info"
 msgstr ""
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "વધારે કડીઓ"
 
@@ -4251,6 +4255,12 @@ msgstr ""
 
 msgctxt "maps_maps_module"
 msgid "View on Map"
+msgstr ""
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
 msgstr ""
 
 msgctxt "mobile promotion on desktop"

--- a/locales/he_IL/LC_MESSAGES/duckduckgo.po
+++ b/locales/he_IL/LC_MESSAGES/duckduckgo.po
@@ -2286,6 +2286,10 @@ msgstr "עוד תמונות"
 msgid "More Info"
 msgstr "מידע נוסף"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "עוד קישורים"
 
@@ -4278,6 +4282,12 @@ msgstr ""
 
 msgctxt "maps_maps_module"
 msgid "View on Map"
+msgstr ""
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
 msgstr ""
 
 msgctxt "mobile promotion on desktop"

--- a/locales/hi_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/hi_IN/LC_MESSAGES/duckduckgo.po
@@ -2290,6 +2290,10 @@ msgstr ""
 msgid "More Info"
 msgstr "अधिक जानकारी"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "और लिंक्स "
 
@@ -4281,6 +4285,12 @@ msgstr ""
 
 msgctxt "maps_maps_module"
 msgid "View on Map"
+msgstr ""
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
 msgstr ""
 
 msgctxt "mobile promotion on desktop"

--- a/locales/hr_HR/LC_MESSAGES/duckduckgo.po
+++ b/locales/hr_HR/LC_MESSAGES/duckduckgo.po
@@ -2316,6 +2316,10 @@ msgstr "Više slika"
 msgid "More Info"
 msgstr "Više informacija"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Više poveznica"
 
@@ -4342,6 +4346,12 @@ msgstr "Prikaži na %s"
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "Prikaži na karti"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/hu_HU/LC_MESSAGES/duckduckgo.po
+++ b/locales/hu_HU/LC_MESSAGES/duckduckgo.po
@@ -2327,6 +2327,10 @@ msgstr "További képek"
 msgid "More Info"
 msgstr "Több Információ"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "További találatok"
 
@@ -4379,6 +4383,12 @@ msgstr "Megtekintés itt: %s"
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "Megtekintés a térképen"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/hy_AM/LC_MESSAGES/duckduckgo.po
+++ b/locales/hy_AM/LC_MESSAGES/duckduckgo.po
@@ -2313,6 +2313,10 @@ msgstr ""
 msgid "More Info"
 msgstr ""
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Ավել հղումներ"
 
@@ -4314,6 +4318,12 @@ msgstr ""
 
 msgctxt "maps_maps_module"
 msgid "View on Map"
+msgstr ""
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
 msgstr ""
 
 msgctxt "mobile promotion on desktop"

--- a/locales/id_ID/LC_MESSAGES/duckduckgo.po
+++ b/locales/id_ID/LC_MESSAGES/duckduckgo.po
@@ -2318,6 +2318,10 @@ msgstr "Gambar Lainnya"
 msgid "More Info"
 msgstr "Info Lebih Banyak"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Tautan lainnya"
 
@@ -4347,6 +4351,12 @@ msgstr "Lihat di %s"
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "Lihat di Peta"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/io_XX/LC_MESSAGES/duckduckgo.po
+++ b/locales/io_XX/LC_MESSAGES/duckduckgo.po
@@ -2272,6 +2272,10 @@ msgstr "Plu imaji"
 msgid "More Info"
 msgstr ""
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Ligili plusa"
 
@@ -4253,6 +4257,12 @@ msgstr ""
 
 msgctxt "maps_maps_module"
 msgid "View on Map"
+msgstr ""
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
 msgstr ""
 
 msgctxt "mobile promotion on desktop"

--- a/locales/is_IS/LC_MESSAGES/duckduckgo.po
+++ b/locales/is_IS/LC_MESSAGES/duckduckgo.po
@@ -2263,6 +2263,10 @@ msgstr ""
 msgid "More Info"
 msgstr ""
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Fleiri tenglar"
 
@@ -4238,6 +4242,12 @@ msgstr ""
 
 msgctxt "maps_maps_module"
 msgid "View on Map"
+msgstr ""
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
 msgstr ""
 
 msgctxt "mobile promotion on desktop"

--- a/locales/it_IT/LC_MESSAGES/duckduckgo.po
+++ b/locales/it_IT/LC_MESSAGES/duckduckgo.po
@@ -1576,7 +1576,9 @@ msgstr "Ottieni link web"
 
 msgctxt "SERP footer content"
 msgid "Get official COVID-19 info and tips to help stop the spread."
-msgstr "Ottieni informazioni ufficiali sul COVID-19 e consigli su come contribuire a fermare il contagio. "
+msgstr ""
+"Ottieni informazioni ufficiali sul COVID-19 e consigli su come contribuire a "
+"fermare il contagio. "
 
 msgctxt "Homepage alert button "
 msgid "Get official COVID-19 info and tips."
@@ -2334,6 +2336,10 @@ msgstr "Altre immagini"
 
 msgid "More Info"
 msgstr "Maggiori Informazioni"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
 
 msgid "More Links"
 msgstr "Altri Link"
@@ -4387,6 +4393,12 @@ msgstr "Vedi su %s"
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "Vedi nella mappa"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/ja_JP/LC_MESSAGES/duckduckgo.po
+++ b/locales/ja_JP/LC_MESSAGES/duckduckgo.po
@@ -2321,6 +2321,10 @@ msgstr "画像をさらに表示"
 msgid "More Info"
 msgstr "詳細"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "その他のリンク"
 
@@ -4342,6 +4346,12 @@ msgstr "%s で表示"
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "マップで表示する"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/ka_GE/LC_MESSAGES/duckduckgo.po
+++ b/locales/ka_GE/LC_MESSAGES/duckduckgo.po
@@ -2272,6 +2272,10 @@ msgstr ""
 msgid "More Info"
 msgstr ""
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "მეტი ბმულები"
 
@@ -4251,6 +4255,12 @@ msgstr ""
 
 msgctxt "maps_maps_module"
 msgid "View on Map"
+msgstr ""
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
 msgstr ""
 
 msgctxt "mobile promotion on desktop"

--- a/locales/kab_DZ/LC_MESSAGES/duckduckgo.po
+++ b/locales/kab_DZ/LC_MESSAGES/duckduckgo.po
@@ -2294,6 +2294,10 @@ msgstr "Tugniwin nniḍen"
 msgid "More Info"
 msgstr "Ugar n talɣut"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Ugar n yiseɣwan"
 
@@ -4278,6 +4282,12 @@ msgstr "Wali deg %s"
 
 msgctxt "maps_maps_module"
 msgid "View on Map"
+msgstr ""
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
 msgstr ""
 
 msgctxt "mobile promotion on desktop"

--- a/locales/kn_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/kn_IN/LC_MESSAGES/duckduckgo.po
@@ -2287,6 +2287,10 @@ msgstr ""
 msgid "More Info"
 msgstr ""
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "ಇನ್ನಷ್ಟು ಲಿಂಕ್ಗಳು"
 
@@ -4270,6 +4274,12 @@ msgstr ""
 
 msgctxt "maps_maps_module"
 msgid "View on Map"
+msgstr ""
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
 msgstr ""
 
 msgctxt "mobile promotion on desktop"

--- a/locales/ko_KR/LC_MESSAGES/duckduckgo.po
+++ b/locales/ko_KR/LC_MESSAGES/duckduckgo.po
@@ -2305,6 +2305,10 @@ msgstr "이미지 더 보기"
 msgid "More Info"
 msgstr "더 많은 정보"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "더 보기"
 
@@ -4319,6 +4323,12 @@ msgstr "%s에서 보기"
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "지도에서 보기"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/kw_GB/LC_MESSAGES/duckduckgo.po
+++ b/locales/kw_GB/LC_MESSAGES/duckduckgo.po
@@ -2261,6 +2261,10 @@ msgstr ""
 msgid "More Info"
 msgstr ""
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Gorgevrennow moy"
 
@@ -4236,6 +4240,12 @@ msgstr ""
 
 msgctxt "maps_maps_module"
 msgid "View on Map"
+msgstr ""
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
 msgstr ""
 
 msgctxt "mobile promotion on desktop"

--- a/locales/ky_KG/LC_MESSAGES/duckduckgo.po
+++ b/locales/ky_KG/LC_MESSAGES/duckduckgo.po
@@ -2258,6 +2258,10 @@ msgstr ""
 msgid "More Info"
 msgstr ""
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Көбүрөөк Шилтемелер"
 
@@ -4233,6 +4237,12 @@ msgstr ""
 
 msgctxt "maps_maps_module"
 msgid "View on Map"
+msgstr ""
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
 msgstr ""
 
 msgctxt "mobile promotion on desktop"

--- a/locales/ln_CD/LC_MESSAGES/duckduckgo.po
+++ b/locales/ln_CD/LC_MESSAGES/duckduckgo.po
@@ -2257,6 +2257,10 @@ msgstr ""
 msgid "More Info"
 msgstr ""
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Bikangisele bisúsu"
 
@@ -4232,6 +4236,12 @@ msgstr ""
 
 msgctxt "maps_maps_module"
 msgid "View on Map"
+msgstr ""
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
 msgstr ""
 
 msgctxt "mobile promotion on desktop"

--- a/locales/lt_LT/LC_MESSAGES/duckduckgo.po
+++ b/locales/lt_LT/LC_MESSAGES/duckduckgo.po
@@ -2286,6 +2286,10 @@ msgstr ""
 msgid "More Info"
 msgstr ""
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Daugiau nuorodų"
 
@@ -4275,6 +4279,12 @@ msgstr ""
 
 msgctxt "maps_maps_module"
 msgid "View on Map"
+msgstr ""
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
 msgstr ""
 
 msgctxt "mobile promotion on desktop"

--- a/locales/lv_LV/LC_MESSAGES/duckduckgo.po
+++ b/locales/lv_LV/LC_MESSAGES/duckduckgo.po
@@ -2295,6 +2295,10 @@ msgstr "Vairāk attēlu"
 msgid "More Info"
 msgstr "Vairāk informācijas"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Vairāk saites"
 
@@ -4296,6 +4300,12 @@ msgstr ""
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "Skatīt Kartēs"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/ml_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/ml_IN/LC_MESSAGES/duckduckgo.po
@@ -2316,6 +2316,10 @@ msgstr ""
 msgid "More Info"
 msgstr "കൂടുതൽ വിവരങ്ങൾ"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "കൂടുതൽ കണ്ണികൾ "
 
@@ -4319,6 +4323,12 @@ msgstr ""
 
 msgctxt "maps_maps_module"
 msgid "View on Map"
+msgstr ""
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
 msgstr ""
 
 msgctxt "mobile promotion on desktop"

--- a/locales/mn_MN/LC_MESSAGES/duckduckgo.po
+++ b/locales/mn_MN/LC_MESSAGES/duckduckgo.po
@@ -2256,6 +2256,10 @@ msgstr ""
 msgid "More Info"
 msgstr ""
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr ""
 
@@ -4231,6 +4235,12 @@ msgstr ""
 
 msgctxt "maps_maps_module"
 msgid "View on Map"
+msgstr ""
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
 msgstr ""
 
 msgctxt "mobile promotion on desktop"

--- a/locales/mr_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/mr_IN/LC_MESSAGES/duckduckgo.po
@@ -2281,6 +2281,10 @@ msgstr ""
 msgid "More Info"
 msgstr "अधिक माहिती"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "आणखी दुवे"
 
@@ -4258,6 +4262,12 @@ msgstr ""
 
 msgctxt "maps_maps_module"
 msgid "View on Map"
+msgstr ""
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
 msgstr ""
 
 msgctxt "mobile promotion on desktop"

--- a/locales/ms_MY/LC_MESSAGES/duckduckgo.po
+++ b/locales/ms_MY/LC_MESSAGES/duckduckgo.po
@@ -2299,6 +2299,10 @@ msgstr ""
 msgid "More Info"
 msgstr "Maklumat Lanjut"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Lebih Pautan"
 
@@ -4303,6 +4307,12 @@ msgstr ""
 
 msgctxt "maps_maps_module"
 msgid "View on Map"
+msgstr ""
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
 msgstr ""
 
 msgctxt "mobile promotion on desktop"

--- a/locales/nb_NO/LC_MESSAGES/duckduckgo.po
+++ b/locales/nb_NO/LC_MESSAGES/duckduckgo.po
@@ -2318,6 +2318,10 @@ msgstr "Flere bilder"
 msgid "More Info"
 msgstr "Mer informasjon"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Flere Lenker"
 
@@ -4340,6 +4344,12 @@ msgstr "Se på %s"
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "Vis i kart"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/ne_NP/LC_MESSAGES/duckduckgo.po
+++ b/locales/ne_NP/LC_MESSAGES/duckduckgo.po
@@ -2278,6 +2278,10 @@ msgstr ""
 msgid "More Info"
 msgstr ""
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "थप लिङ्कहरू"
 
@@ -4255,6 +4259,12 @@ msgstr ""
 
 msgctxt "maps_maps_module"
 msgid "View on Map"
+msgstr ""
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
 msgstr ""
 
 msgctxt "mobile promotion on desktop"

--- a/locales/nl_BE/LC_MESSAGES/duckduckgo.po
+++ b/locales/nl_BE/LC_MESSAGES/duckduckgo.po
@@ -2299,6 +2299,10 @@ msgstr "Meer Afbeeldingen"
 msgid "More Info"
 msgstr "Meer Info"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Meer links"
 
@@ -4314,6 +4318,12 @@ msgstr ""
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "Bekijk op de kaart"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/nl_NL/LC_MESSAGES/duckduckgo.po
+++ b/locales/nl_NL/LC_MESSAGES/duckduckgo.po
@@ -2326,6 +2326,10 @@ msgstr "Meer Afbeeldingen"
 msgid "More Info"
 msgstr "Meer informatie"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Meer links"
 
@@ -4362,6 +4366,12 @@ msgstr "Bekijk op %s"
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "Weergeven op kaart"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/nn_NO/LC_MESSAGES/duckduckgo.po
+++ b/locales/nn_NO/LC_MESSAGES/duckduckgo.po
@@ -2294,6 +2294,10 @@ msgstr "Fleire bilde"
 msgid "More Info"
 msgstr "Meir info"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Fleire lenkjer"
 
@@ -4307,6 +4311,12 @@ msgstr "Vis på %s"
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "Vis på kart"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/od_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/od_IN/LC_MESSAGES/duckduckgo.po
@@ -2295,6 +2295,10 @@ msgstr "ଅଧିକ ଛବି"
 msgid "More Info"
 msgstr "ଅଧିକ ତଥ୍ୟ"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "ଅଧିକ କଡ଼ି"
 
@@ -4307,6 +4311,12 @@ msgstr "%sରେ ଦେଖନ୍ତୁ"
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "ମାନଚିତ୍ରରେ ଦେଖନ୍ତୁ"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/pl_PL/LC_MESSAGES/duckduckgo.po
+++ b/locales/pl_PL/LC_MESSAGES/duckduckgo.po
@@ -2322,6 +2322,10 @@ msgstr "Więcej obrazów"
 msgid "More Info"
 msgstr "Więcej informacji"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Więcej linków"
 
@@ -4353,6 +4357,12 @@ msgstr "Wyświetl na %s"
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "Pokaż na mapie"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/ps_AF/LC_MESSAGES/duckduckgo.po
+++ b/locales/ps_AF/LC_MESSAGES/duckduckgo.po
@@ -2256,6 +2256,10 @@ msgstr ""
 msgid "More Info"
 msgstr ""
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr ""
 
@@ -4231,6 +4235,12 @@ msgstr ""
 
 msgctxt "maps_maps_module"
 msgid "View on Map"
+msgstr ""
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
 msgstr ""
 
 msgctxt "mobile promotion on desktop"

--- a/locales/pt_BR/LC_MESSAGES/duckduckgo.po
+++ b/locales/pt_BR/LC_MESSAGES/duckduckgo.po
@@ -2332,6 +2332,10 @@ msgstr "Mais Imagens"
 msgid "More Info"
 msgstr "Mais Informações"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Mais links"
 
@@ -4375,6 +4379,12 @@ msgstr "Exibir em %s"
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "Visualizar no Mapa"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/pt_PT/LC_MESSAGES/duckduckgo.po
+++ b/locales/pt_PT/LC_MESSAGES/duckduckgo.po
@@ -2334,6 +2334,10 @@ msgstr "Mais Imagens"
 msgid "More Info"
 msgstr "Mais Informações"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Mais Ligações"
 
@@ -4382,6 +4386,12 @@ msgstr "Ver no %s"
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "Ver no mapa"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/ro_RO/LC_MESSAGES/duckduckgo.po
+++ b/locales/ro_RO/LC_MESSAGES/duckduckgo.po
@@ -2329,6 +2329,10 @@ msgstr "Mai Multe imagini"
 msgid "More Info"
 msgstr "Mai Multe Informații"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Mai Multe Linkuri"
 
@@ -4359,6 +4363,12 @@ msgstr "Vezi pe %s"
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "Vezi pe hartă"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/ru_RU/LC_MESSAGES/duckduckgo.po
+++ b/locales/ru_RU/LC_MESSAGES/duckduckgo.po
@@ -2327,6 +2327,10 @@ msgstr "Больше картинок"
 msgid "More Info"
 msgstr "Дополнительная информация"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Дополнительные ссылки"
 
@@ -4363,6 +4367,12 @@ msgstr "Смотреть на %s"
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "Посмотреть на карте"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/si_LK/LC_MESSAGES/duckduckgo.po
+++ b/locales/si_LK/LC_MESSAGES/duckduckgo.po
@@ -2308,6 +2308,10 @@ msgstr "පින්තූර තවත්"
 msgid "More Info"
 msgstr "දත්ත තවත්"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "තවත් සබැඳුම්"
 
@@ -4318,6 +4322,12 @@ msgstr "%s වෙතින් බලන්න"
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "සිතියමෙන් නරඹන්න"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/sk_SK/LC_MESSAGES/duckduckgo.po
+++ b/locales/sk_SK/LC_MESSAGES/duckduckgo.po
@@ -2296,6 +2296,10 @@ msgstr "Viac obrázkov"
 msgid "More Info"
 msgstr "Viac informácií"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Viac odkazov"
 
@@ -4308,6 +4312,12 @@ msgstr ""
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "Zobraziť na mape"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/sl_SI/LC_MESSAGES/duckduckgo.po
+++ b/locales/sl_SI/LC_MESSAGES/duckduckgo.po
@@ -2292,6 +2292,10 @@ msgstr ""
 msgid "More Info"
 msgstr "Več informacij"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Več povezav"
 
@@ -4292,6 +4296,12 @@ msgstr ""
 
 msgctxt "maps_maps_module"
 msgid "View on Map"
+msgstr ""
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
 msgstr ""
 
 msgctxt "mobile promotion on desktop"

--- a/locales/sq_AL/LC_MESSAGES/duckduckgo.po
+++ b/locales/sq_AL/LC_MESSAGES/duckduckgo.po
@@ -2301,6 +2301,10 @@ msgstr ""
 msgid "More Info"
 msgstr ""
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Më shumë Lidhje"
 
@@ -4303,6 +4307,12 @@ msgstr ""
 
 msgctxt "maps_maps_module"
 msgid "View on Map"
+msgstr ""
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
 msgstr ""
 
 msgctxt "mobile promotion on desktop"

--- a/locales/sr_RS/LC_MESSAGES/duckduckgo.po
+++ b/locales/sr_RS/LC_MESSAGES/duckduckgo.po
@@ -2319,6 +2319,10 @@ msgstr "Више слика"
 msgid "More Info"
 msgstr "Више информација"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Још веза"
 
@@ -4343,6 +4347,12 @@ msgstr "Види на %s "
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "Види на мапи"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/sv_SE/LC_MESSAGES/duckduckgo.po
+++ b/locales/sv_SE/LC_MESSAGES/duckduckgo.po
@@ -2318,6 +2318,10 @@ msgstr "Fler Bilder"
 msgid "More Info"
 msgstr "Mer Info"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Fler länkar"
 
@@ -4345,6 +4349,12 @@ msgstr "Visa på %s"
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "Visa på karta"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/ta_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/ta_IN/LC_MESSAGES/duckduckgo.po
@@ -2329,6 +2329,10 @@ msgstr ""
 msgid "More Info"
 msgstr ""
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "மேலும் இணைப்புகள்"
 
@@ -4334,6 +4338,12 @@ msgstr ""
 
 msgctxt "maps_maps_module"
 msgid "View on Map"
+msgstr ""
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
 msgstr ""
 
 msgctxt "mobile promotion on desktop"

--- a/locales/te_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/te_IN/LC_MESSAGES/duckduckgo.po
@@ -2287,6 +2287,10 @@ msgstr "మరిన్ని బొమ్మలు"
 msgid "More Info"
 msgstr ""
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "మరిన్ని లంకెలు"
 
@@ -4275,6 +4279,12 @@ msgstr "%s పై వీక్షించండి"
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "పటంలో చూడండి"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/th_TH/LC_MESSAGES/duckduckgo.po
+++ b/locales/th_TH/LC_MESSAGES/duckduckgo.po
@@ -2265,6 +2265,10 @@ msgstr "รูปภาพเพิ่มเติม"
 msgid "More Info"
 msgstr "ข้อมูลเพิ่มเติม"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "ลิงค์อื่น ๆ"
 
@@ -4244,6 +4248,12 @@ msgstr ""
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "ดูแผนที่"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/tl_PH/LC_MESSAGES/duckduckgo.po
+++ b/locales/tl_PH/LC_MESSAGES/duckduckgo.po
@@ -2287,6 +2287,10 @@ msgstr ""
 msgid "More Info"
 msgstr ""
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Karagdagang Links"
 
@@ -4276,6 +4280,12 @@ msgstr ""
 
 msgctxt "maps_maps_module"
 msgid "View on Map"
+msgstr ""
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
 msgstr ""
 
 msgctxt "mobile promotion on desktop"

--- a/locales/tokipona_XX/LC_MESSAGES/duckduckgo.po
+++ b/locales/tokipona_XX/LC_MESSAGES/duckduckgo.po
@@ -2318,6 +2318,10 @@ msgstr "sitelen mute"
 msgid "More Info"
 msgstr "sona sin"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "nimi tawa mute"
 
@@ -4339,6 +4343,12 @@ msgstr "lukin e ona lon %s"
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "lukin e ona lon sitelen ma"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/tpi_PG/LC_MESSAGES/duckduckgo.po
+++ b/locales/tpi_PG/LC_MESSAGES/duckduckgo.po
@@ -2256,6 +2256,10 @@ msgstr ""
 msgid "More Info"
 msgstr ""
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr ""
 
@@ -4231,6 +4235,12 @@ msgstr ""
 
 msgctxt "maps_maps_module"
 msgid "View on Map"
+msgstr ""
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
 msgstr ""
 
 msgctxt "mobile promotion on desktop"

--- a/locales/tr_TR/LC_MESSAGES/duckduckgo.po
+++ b/locales/tr_TR/LC_MESSAGES/duckduckgo.po
@@ -2324,6 +2324,10 @@ msgstr "Daha fazla görsel"
 msgid "More Info"
 msgstr "Daha fazla bilgi"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Diğer bağlantı"
 
@@ -4353,6 +4357,12 @@ msgstr "%s'da görüntüle"
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "Haritada görüntüle"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/uk_UA/LC_MESSAGES/duckduckgo.po
+++ b/locales/uk_UA/LC_MESSAGES/duckduckgo.po
@@ -2321,6 +2321,10 @@ msgstr "Більше зображень"
 msgid "More Info"
 msgstr "Більше Інформації"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Ще посилання"
 
@@ -4336,6 +4340,12 @@ msgstr ""
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "Показати на мапі"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/ur_PK/LC_MESSAGES/duckduckgo.po
+++ b/locales/ur_PK/LC_MESSAGES/duckduckgo.po
@@ -2280,6 +2280,10 @@ msgstr ""
 msgid "More Info"
 msgstr ""
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "مزید لینکس"
 
@@ -4267,6 +4271,12 @@ msgstr ""
 
 msgctxt "maps_maps_module"
 msgid "View on Map"
+msgstr ""
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
 msgstr ""
 
 msgctxt "mobile promotion on desktop"

--- a/locales/vi_VN/LC_MESSAGES/duckduckgo.po
+++ b/locales/vi_VN/LC_MESSAGES/duckduckgo.po
@@ -2294,6 +2294,10 @@ msgstr "Nhiều hình ảnh hơn"
 msgid "More Info"
 msgstr "Thông tin thêm"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "Thêm đường dẫn"
 
@@ -4306,6 +4310,12 @@ msgstr ""
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "Nhìn trên bản đồ "
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/zh_CN/LC_MESSAGES/duckduckgo.po
+++ b/locales/zh_CN/LC_MESSAGES/duckduckgo.po
@@ -2275,6 +2275,10 @@ msgstr "更多图片"
 msgid "More Info"
 msgstr "更多信息"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "更多链接"
 
@@ -4267,6 +4271,12 @@ msgstr "在 %s 中查看"
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "在地图上看"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/zh_TW/LC_MESSAGES/duckduckgo.po
+++ b/locales/zh_TW/LC_MESSAGES/duckduckgo.po
@@ -2270,6 +2270,10 @@ msgstr "更多圖片"
 msgid "More Info"
 msgstr "查看更多資訊"
 
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More Info"
+msgstr ""
+
 msgid "More Links"
 msgstr "更多連結"
 
@@ -4255,6 +4259,12 @@ msgstr "用 %s 檢視"
 msgctxt "maps_maps_module"
 msgid "View on Map"
 msgstr "在地圖檢視"
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/t/internal_translations.t
+++ b/t/internal_translations.t
@@ -17,7 +17,7 @@ sub wanted;
 
 sub translation_check {
     my ( $msgid, $msgstr ) = map { s/^"//r =~ s/"$//r } @_;
-    return 1 unless $msgstr eq "";
+    return 1 if $msgstr eq "";
 }
 
 File::Find::find({wanted => \&wanted}, 'locales');

--- a/t/internal_translations.t
+++ b/t/internal_translations.t
@@ -1,0 +1,36 @@
+use strict;
+use warnings;
+
+use Test::More;
+use File::Basename;
+use File::Find ();
+use Locale::PO;
+
+chdir dirname(__FILE__) . "/..";
+
+use vars qw/*name *dir *prune/;
+*name   = *File::Find::name;
+*dir    = *File::Find::dir;
+*prune  = *File::Find::prune;
+
+sub wanted;
+
+sub translation_check {
+    my ( $msgid, $msgstr ) = map { s/^"//r =~ s/"$//r } @_;
+    return 1 unless $msgstr eq "";
+}
+
+File::Find::find({wanted => \&wanted}, 'locales');
+done_testing;
+
+sub wanted {
+    /^.*\.po\z/s || return;
+    my $po = Locale::PO->load_file_asarray( $_ );
+    for ( @{ $po } ) {
+        next unless $_->msgctxt;
+        next unless $_->msgctxt =~ /Ads\sGDPR,\sinternal\suse\sonly\.\sDo\snot\schange/;
+        ok( translation_check( $_->msgid, $_->msgstr ),
+          'Translation for ' . $_->msgid . ' in ' . $name . ' should not be changed : ' . $_->msgstr )
+    }
+}
+


### PR DESCRIPTION
- Add the "more info" token to be used in the ad badge tooltip context only
- Add the ad badge tooltip text
- Unit tests (verify tokens haven't been translated yet)