### PR TITLE
Internal translations for the Ad Badge Tooltip

### DIFF
--- a/locales/bg_BG/LC_MESSAGES/duckduckgo.po
+++ b/locales/bg_BG/LC_MESSAGES/duckduckgo.po
@@ -2308,7 +2308,7 @@ msgstr "Повече информация"
 
 msgctxt "Ads GDPR, internal use only. Do not change"
 msgid "More Info"
-msgstr ""
+msgstr "sповече информация"
 
 msgid "More Links"
 msgstr "Повече Линкове"
@@ -4332,7 +4332,7 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr ""
+msgstr "Вашата поверителност при гледане на реклами е защитена от DuckDuckGo. Рекламните кликове се управляват от рекламната мрежа на Microsoft"
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/bg_BG/LC_MESSAGES/duckduckgo.po
+++ b/locales/bg_BG/LC_MESSAGES/duckduckgo.po
@@ -2308,7 +2308,7 @@ msgstr "Повече информация"
 
 msgctxt "Ads GDPR, internal use only. Do not change"
 msgid "More Info"
-msgstr "sповече информация"
+msgstr "повече информация"
 
 msgid "More Links"
 msgstr "Повече Линкове"

--- a/locales/cs_CZ/LC_MESSAGES/duckduckgo.po
+++ b/locales/cs_CZ/LC_MESSAGES/duckduckgo.po
@@ -2311,7 +2311,7 @@ msgstr "Více informací"
 
 msgctxt "Ads GDPR, internal use only. Do not change"
 msgid "More Info"
-msgstr ""
+msgstr "více informací"
 
 msgid "More Links"
 msgstr "Další odkazy"
@@ -4331,7 +4331,7 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr ""
+msgstr "Při zobrazení reklam společnost DuckDuckGo chrání vaše soukromí. Kliknutí na reklamy jsou spravována reklamní sítí společnosti Microsoft"
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/da_DK/LC_MESSAGES/duckduckgo.po
+++ b/locales/da_DK/LC_MESSAGES/duckduckgo.po
@@ -2321,7 +2321,7 @@ msgstr "Mere Info"
 
 msgctxt "Ads GDPR, internal use only. Do not change"
 msgid "More Info"
-msgstr ""
+msgstr "mere info"
 
 msgid "More Links"
 msgstr "Flere Links"
@@ -4351,7 +4351,7 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr ""
+msgstr "DuckDuckGo beskytter dine personoplysninger, når du ser annoncer. Annonceklik administreres af Microsofts annoncenetværk"
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/de_DE/LC_MESSAGES/duckduckgo.po
+++ b/locales/de_DE/LC_MESSAGES/duckduckgo.po
@@ -2343,7 +2343,7 @@ msgstr "Weitere Informationen"
 
 msgctxt "Ads GDPR, internal use only. Do not change"
 msgid "More Info"
-msgstr ""
+msgstr "Weitere Informationen"
 
 msgid "More Links"
 msgstr "Weitere Verweise"
@@ -4407,7 +4407,7 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr ""
+msgstr "Der Datenschutz beim Aufrufen von Anzeigen wird durch. DuckDuckGo gewährleistet. Die Anzeigen-Klicks werden durch das Microsoft-Werbenetzwerk verwaltet"
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/el_GR/LC_MESSAGES/duckduckgo.po
+++ b/locales/el_GR/LC_MESSAGES/duckduckgo.po
@@ -2353,7 +2353,7 @@ msgstr "Περισσότερες πληροφορίες"
 
 msgctxt "Ads GDPR, internal use only. Do not change"
 msgid "More Info"
-msgstr ""
+msgstr "περισσότερες πληροφορίες"
 
 msgid "More Links"
 msgstr "Περισσοτεροι σύνδεσμοι"
@@ -4412,7 +4412,7 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr ""
+msgstr "Στην προβολή διαφημίσεων υπάρχει προστασία απορρήτου από την DuckDuckGo. Η διαχείριση των κλικ διαφήμισης γίνεται από το δίκτυο διαφημίσεων της Microsoft"
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/es_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_ES/LC_MESSAGES/duckduckgo.po
@@ -2343,7 +2343,7 @@ msgstr "Más Información"
 
 msgctxt "Ads GDPR, internal use only. Do not change"
 msgid "More Info"
-msgstr ""
+msgstr "más información"
 
 msgid "More Links"
 msgstr "Más Enlaces"
@@ -4387,7 +4387,7 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr ""
+msgstr "DuckDuckGo protege la privacidad de la visualización de anuncios. La red de anuncios de Microsoft gestiona los clics en los anuncios"
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/et_EE/LC_MESSAGES/duckduckgo.po
+++ b/locales/et_EE/LC_MESSAGES/duckduckgo.po
@@ -2286,7 +2286,7 @@ msgstr "Rohkem teavet"
 
 msgctxt "Ads GDPR, internal use only. Do not change"
 msgid "More Info"
-msgstr ""
+msgstr "lisateave"
 
 msgid "More Links"
 msgstr "Rohkem linke"
@@ -4287,7 +4287,7 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr ""
+msgstr "DuckDuckGo kaitseb reklaamide vaatamisel teie privaatsust. Reklaamiklõpse haldab Microsofti reklaamivõrgustik"
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/fi_FI/LC_MESSAGES/duckduckgo.po
+++ b/locales/fi_FI/LC_MESSAGES/duckduckgo.po
@@ -2308,7 +2308,7 @@ msgstr "Lisätietoja"
 
 msgctxt "Ads GDPR, internal use only. Do not change"
 msgid "More Info"
-msgstr ""
+msgstr "lisätietoa"
 
 msgid "More Links"
 msgstr "Lisää linkkejä"
@@ -4333,7 +4333,7 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr ""
+msgstr "Mainosten katselu on DuckDuckGo:n tietosuojaama. Mainosklikkauksia hallinnoi Microsoftin mainosverkosto"
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/fr_FR/LC_MESSAGES/duckduckgo.po
+++ b/locales/fr_FR/LC_MESSAGES/duckduckgo.po
@@ -2360,7 +2360,7 @@ msgstr "Plus d'infos"
 
 msgctxt "Ads GDPR, internal use only. Do not change"
 msgid "More Info"
-msgstr ""
+msgstr "plus d'informations"
 
 msgid "More Links"
 msgstr "Plus de liens"
@@ -4435,7 +4435,7 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr ""
+msgstr "La confidentialité des annonces est protégée par DuckDuckGo. Les clics sur les annonces sont gérés par le réseau publicitaire Microsoft de"
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/hr_HR/LC_MESSAGES/duckduckgo.po
+++ b/locales/hr_HR/LC_MESSAGES/duckduckgo.po
@@ -2318,7 +2318,7 @@ msgstr "Više informacija"
 
 msgctxt "Ads GDPR, internal use only. Do not change"
 msgid "More Info"
-msgstr ""
+msgstr "više informacija"
 
 msgid "More Links"
 msgstr "Više poveznica"
@@ -4351,7 +4351,7 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr ""
+msgstr "Pregledavanje oglasa je privatnost koju štiti DuckDuckGo. Klikovima na oglase upravlja Microsoftova oglasna mreža"
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/hu_HU/LC_MESSAGES/duckduckgo.po
+++ b/locales/hu_HU/LC_MESSAGES/duckduckgo.po
@@ -2329,7 +2329,7 @@ msgstr "Több Információ"
 
 msgctxt "Ads GDPR, internal use only. Do not change"
 msgid "More Info"
-msgstr ""
+msgstr "További információ"
 
 msgid "More Links"
 msgstr "További találatok"
@@ -4388,7 +4388,7 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr ""
+msgstr "A hirdetéseket a DuckDuckGo adatvédelme keretében tekintheted meg. A hirdetéskattintásokat a Microsoft hirdetési hálózata kezeli"
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/is_IS/LC_MESSAGES/duckduckgo.po
+++ b/locales/is_IS/LC_MESSAGES/duckduckgo.po
@@ -2265,7 +2265,7 @@ msgstr ""
 
 msgctxt "Ads GDPR, internal use only. Do not change"
 msgid "More Info"
-msgstr ""
+msgstr "frekari upplýsingar"
 
 msgid "More Links"
 msgstr "Fleiri tenglar"
@@ -4248,7 +4248,7 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr ""
+msgstr "Að skoða auglýsingar fellur undir persónuvernd frá DuckDuckGo. Auglýsingasmellum er stjórnað af auglýsinganeti Microsoft"
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/it_IT/LC_MESSAGES/duckduckgo.po
+++ b/locales/it_IT/LC_MESSAGES/duckduckgo.po
@@ -2339,7 +2339,7 @@ msgstr "Maggiori Informazioni"
 
 msgctxt "Ads GDPR, internal use only. Do not change"
 msgid "More Info"
-msgstr ""
+msgstr "Maggiori Informazioni"
 
 msgid "More Links"
 msgstr "Altri Link"
@@ -4398,7 +4398,7 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr ""
+msgstr "La privacy della visualizzazione degli annunci è protetta da DuckDuckGo. I clic sugli annunci sono gestiti dalla rete pubblicitaria di Microsoft"
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/lt_LT/LC_MESSAGES/duckduckgo.po
+++ b/locales/lt_LT/LC_MESSAGES/duckduckgo.po
@@ -2288,7 +2288,7 @@ msgstr ""
 
 msgctxt "Ads GDPR, internal use only. Do not change"
 msgid "More Info"
-msgstr ""
+msgstr "daugiau informacijos"
 
 msgid "More Links"
 msgstr "Daugiau nuorodų"
@@ -4285,7 +4285,7 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr ""
+msgstr "Peržiūrimų skelbimų privatumą saugo „DuckDuckGo“. Skelbimų spustelėjimus tvarko „Microsoft“ skelbimų tinklas"
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/lv_LV/LC_MESSAGES/duckduckgo.po
+++ b/locales/lv_LV/LC_MESSAGES/duckduckgo.po
@@ -2297,7 +2297,7 @@ msgstr "Vairāk informācijas"
 
 msgctxt "Ads GDPR, internal use only. Do not change"
 msgid "More Info"
-msgstr ""
+msgstr "papildu informācija"
 
 msgid "More Links"
 msgstr "Vairāk saites"
@@ -4305,7 +4305,7 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr ""
+msgstr "Reklāmu skatīšanu aizsargā DuckDuckGo konfidencialitāte. Klikšķus uz reklāmām pārvalda Microsoft reklāmu tīkls"
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/nb_NO/LC_MESSAGES/duckduckgo.po
+++ b/locales/nb_NO/LC_MESSAGES/duckduckgo.po
@@ -2320,7 +2320,7 @@ msgstr "Mer informasjon"
 
 msgctxt "Ads GDPR, internal use only. Do not change"
 msgid "More Info"
-msgstr ""
+msgstr "mer info"
 
 msgid "More Links"
 msgstr "Flere Lenker"
@@ -4349,7 +4349,7 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr ""
+msgstr "Visningsannonser er personvernbeskyttet av DuckDuckGo. Annonseklikk administreres av Microsofts annonsenettverk"
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/nl_NL/LC_MESSAGES/duckduckgo.po
+++ b/locales/nl_NL/LC_MESSAGES/duckduckgo.po
@@ -2328,7 +2328,7 @@ msgstr "Meer informatie"
 
 msgctxt "Ads GDPR, internal use only. Do not change"
 msgid "More Info"
-msgstr ""
+msgstr "meer informatie"
 
 msgid "More Links"
 msgstr "Meer links"
@@ -4371,7 +4371,7 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr ""
+msgstr "De weergave van advertenties wordt beschermd door DuckDuckGo. Advertentieklikken worden beheerd door het advertentienetwerk van Microsoft"
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/pl_PL/LC_MESSAGES/duckduckgo.po
+++ b/locales/pl_PL/LC_MESSAGES/duckduckgo.po
@@ -2324,7 +2324,7 @@ msgstr "Więcej informacji"
 
 msgctxt "Ads GDPR, internal use only. Do not change"
 msgid "More Info"
-msgstr ""
+msgstr "więcej informacji"
 
 msgid "More Links"
 msgstr "Więcej linków"
@@ -4362,7 +4362,7 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr ""
+msgstr "DuckDuckGo chroni prywatność użytkowników przeglądających reklamy. Klikanie reklam zarządzane jest przez sieć reklamową Microsoft"
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/pt_PT/LC_MESSAGES/duckduckgo.po
+++ b/locales/pt_PT/LC_MESSAGES/duckduckgo.po
@@ -2336,7 +2336,7 @@ msgstr "Mais Informações"
 
 msgctxt "Ads GDPR, internal use only. Do not change"
 msgid "More Info"
-msgstr ""
+msgstr "mais informações"
 
 msgid "More Links"
 msgstr "Mais Ligações"
@@ -4391,7 +4391,7 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr ""
+msgstr "A visualização de anúncios tem proteção de privacidade pelo DuckDuckGo. Os cliques em anúncios são geridos pela rede de publicidade da Microsoft"
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/ro_RO/LC_MESSAGES/duckduckgo.po
+++ b/locales/ro_RO/LC_MESSAGES/duckduckgo.po
@@ -2331,7 +2331,7 @@ msgstr "Mai Multe Informații"
 
 msgctxt "Ads GDPR, internal use only. Do not change"
 msgid "More Info"
-msgstr ""
+msgstr "mai multe informații"
 
 msgid "More Links"
 msgstr "Mai Multe Linkuri"
@@ -4368,7 +4368,7 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr ""
+msgstr "Vizualizarea reclamelor este protejată de confidențialitatea DuckDuckGo. Clicurile pe reclame  sunt gestionate de rețeaua publicitară Microsoft"
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/ru_RU/LC_MESSAGES/duckduckgo.po
+++ b/locales/ru_RU/LC_MESSAGES/duckduckgo.po
@@ -2329,7 +2329,7 @@ msgstr "Дополнительная информация"
 
 msgctxt "Ads GDPR, internal use only. Do not change"
 msgid "More Info"
-msgstr ""
+msgstr "подробнее"
 
 msgid "More Links"
 msgstr "Дополнительные ссылки"
@@ -4372,7 +4372,7 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr ""
+msgstr "DuckDuckGo обеспечивает защиту конфиденциальности пользователей при просмотре рекламных объявлений. Управление переходами по рекламным объявлениям осуществляется рекламной сетью «Майкрософт»"
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/sk_SK/LC_MESSAGES/duckduckgo.po
+++ b/locales/sk_SK/LC_MESSAGES/duckduckgo.po
@@ -2298,7 +2298,7 @@ msgstr "Viac informácií"
 
 msgctxt "Ads GDPR, internal use only. Do not change"
 msgid "More Info"
-msgstr ""
+msgstr "ďalšie informácie"
 
 msgid "More Links"
 msgstr "Viac odkazov"
@@ -4317,7 +4317,7 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr ""
+msgstr "Zobrazenie reklám je chránené ochranou osobných údajov DuckDuckGo. Kliknutia na reklamy spravuje reklamná sieť spoločnosti Microsoft"
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/sl_SI/LC_MESSAGES/duckduckgo.po
+++ b/locales/sl_SI/LC_MESSAGES/duckduckgo.po
@@ -2294,7 +2294,7 @@ msgstr "Več informacij"
 
 msgctxt "Ads GDPR, internal use only. Do not change"
 msgid "More Info"
-msgstr ""
+msgstr "več informacij"
 
 msgid "More Links"
 msgstr "Več povezav"
@@ -4302,7 +4302,7 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr ""
+msgstr "DuckDuckGo ščiti vašo zasebnost pri ogledu oglasov. S kliki na oglase upravlja Microsoftovo oglaševalsko omrežje"
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/sv_SE/LC_MESSAGES/duckduckgo.po
+++ b/locales/sv_SE/LC_MESSAGES/duckduckgo.po
@@ -2320,7 +2320,7 @@ msgstr "Mer Info"
 
 msgctxt "Ads GDPR, internal use only. Do not change"
 msgid "More Info"
-msgstr ""
+msgstr "mer info"
 
 msgid "More Links"
 msgstr "Fler länkar"
@@ -4354,7 +4354,7 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr ""
+msgstr "Visning av annonser är sekretessskyddat av DuckDuckGo. Annonsklick hanteras av Microsofts annonsnätverk"
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/locales/tr_TR/LC_MESSAGES/duckduckgo.po
+++ b/locales/tr_TR/LC_MESSAGES/duckduckgo.po
@@ -2326,7 +2326,7 @@ msgstr "Daha fazla bilgi"
 
 msgctxt "Ads GDPR, internal use only. Do not change"
 msgid "More Info"
-msgstr ""
+msgstr "daha fazla bilgi"
 
 msgid "More Links"
 msgstr "Diğer bağlantı"
@@ -4362,7 +4362,7 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr ""
+msgstr "Reklam görüntüleme, DuckDuckGo’nun gizlilik koruması altındadır. Reklam tıklamaları, Microsoft’un reklam ağı tarafından yönetilir"
 
 msgctxt "mobile promotion on desktop"
 msgid ""

--- a/t/internal_translations.t
+++ b/t/internal_translations.t
@@ -8,16 +8,128 @@ use Locale::PO;
 
 chdir dirname(__FILE__) . "/..";
 
-use vars qw/*name *dir *prune/;
+use vars qw/*name *dir *prune %european_languages/;
 *name   = *File::Find::name;
 *dir    = *File::Find::dir;
 *prune  = *File::Find::prune;
 
+%european_languages = (
+    bg_BG => {
+      more_info => "повече информация",
+      ad_badge => "Вашата поверителност при гледане на реклами е защитена от DuckDuckGo. Рекламните кликове се управляват от рекламната мрежа на Microsoft"
+    },
+    hr_HR => {
+      more_info => "više informacija",
+      ad_badge => "Pregledavanje oglasa je privatnost koju štiti DuckDuckGo. Klikovima na oglase upravlja Microsoftova oglasna mreža"
+    },
+    cs_CZ => {
+      more_info => "více informací",
+      ad_badge => "Při zobrazení reklam společnost DuckDuckGo chrání vaše soukromí. Kliknutí na reklamy jsou spravována reklamní sítí společnosti Microsoft"
+    },
+    da_DK => {
+      more_info => "mere info",
+      ad_badge => "DuckDuckGo beskytter dine personoplysninger, når du ser annoncer. Annonceklik administreres af Microsofts annoncenetværk"
+    },
+    nl_NL => {
+      more_info => "meer informatie",
+      ad_badge => "De weergave van advertenties wordt beschermd door DuckDuckGo. Advertentieklikken worden beheerd door het advertentienetwerk van Microsoft"
+    },
+    et_EE => {
+      more_info => "lisateave",
+      ad_badge => "DuckDuckGo kaitseb reklaamide vaatamisel teie privaatsust. Reklaamiklõpse haldab Microsofti reklaamivõrgustik"
+    },
+    de_DE => {
+      more_info => "Weitere Informationen",
+      ad_badge => "Der Datenschutz beim Aufrufen von Anzeigen wird durch. DuckDuckGo gewährleistet. Die Anzeigen-Klicks werden durch das Microsoft-Werbenetzwerk verwaltet"
+    },
+    fi_FI => {
+      more_info => "lisätietoa",
+      ad_badge => "Mainosten katselu on DuckDuckGo:n tietosuojaama. Mainosklikkauksia hallinnoi Microsoftin mainosverkosto"
+    },
+    fr_FR => {
+      more_info => "plus d'informations",
+      ad_badge => "La confidentialité des annonces est protégée par DuckDuckGo. Les clics sur les annonces sont gérés par le réseau publicitaire Microsoft de"
+    },
+    el_GR => {
+      more_info => "περισσότερες πληροφορίες",
+      ad_badge => "Στην προβολή διαφημίσεων υπάρχει προστασία απορρήτου από την DuckDuckGo. Η διαχείριση των κλικ διαφήμισης γίνεται από το δίκτυο διαφημίσεων της Microsoft"
+    },
+    es_ES => {
+      more_info => "más información",
+      ad_badge => "DuckDuckGo protege la privacidad de la visualización de anuncios. La red de anuncios de Microsoft gestiona los clics en los anuncios"
+    },
+    hu_HU => {
+      more_info => "További információ",
+      ad_badge => "A hirdetéseket a DuckDuckGo adatvédelme keretében tekintheted meg. A hirdetéskattintásokat a Microsoft hirdetési hálózata kezeli"
+    },
+    is_IS => {
+      more_info => "frekari upplýsingar",
+      ad_badge => "Að skoða auglýsingar fellur undir persónuvernd frá DuckDuckGo. Auglýsingasmellum er stjórnað af auglýsinganeti Microsoft"
+    },
+    it_IT => {
+      more_info => "Maggiori Informazioni",
+      ad_badge => "La privacy della visualizzazione degli annunci è protetta da DuckDuckGo. I clic sugli annunci sono gestiti dalla rete pubblicitaria di Microsoft"
+    },
+    lt_LT => {
+      more_info => "daugiau informacijos",
+      ad_badge => "Peržiūrimų skelbimų privatumą saugo „DuckDuckGo“. Skelbimų spustelėjimus tvarko „Microsoft“ skelbimų tinklas"
+    },
+    lv_LV => {
+      more_info => "papildu informācija",
+      ad_badge => "Reklāmu skatīšanu aizsargā DuckDuckGo konfidencialitāte. Klikšķus uz reklāmām pārvalda Microsoft reklāmu tīkls"
+    },
+    nb_NO => {
+      more_info => "mer info",
+      ad_badge => "Visningsannonser er personvernbeskyttet av DuckDuckGo. Annonseklikk administreres av Microsofts annonsenettverk"
+    },
+    pl_PL => {
+      more_info => "więcej informacji",
+      ad_badge => "DuckDuckGo chroni prywatność użytkowników przeglądających reklamy. Klikanie reklam zarządzane jest przez sieć reklamową Microsoft"
+    },
+    pt_PT => {
+      more_info => "mais informações",
+      ad_badge => "A visualização de anúncios tem proteção de privacidade pelo DuckDuckGo. Os cliques em anúncios são geridos pela rede de publicidade da Microsoft"
+    },
+    ro_RO => {
+      more_info => "mai multe informații",
+      ad_badge => "Vizualizarea reclamelor este protejată de confidențialitatea DuckDuckGo. Clicurile pe reclame  sunt gestionate de rețeaua publicitară Microsoft"
+    },
+    ru_RU => {
+      more_info => "подробнее",
+      ad_badge => "DuckDuckGo обеспечивает защиту конфиденциальности пользователей при просмотре рекламных объявлений. Управление переходами по рекламным объявлениям осуществляется рекламной сетью «Майкрософт»"
+    },
+    sk_SK => {
+      more_info => "ďalšie informácie",
+      ad_badge => "Zobrazenie reklám je chránené ochranou osobných údajov DuckDuckGo. Kliknutia na reklamy spravuje reklamná sieť spoločnosti Microsoft"
+    },
+    sl_SI => {
+      more_info => "več informacij",
+      ad_badge => "DuckDuckGo ščiti vašo zasebnost pri ogledu oglasov. S kliki na oglase upravlja Microsoftovo oglaševalsko omrežje"
+    },
+    sv_SE => {
+      more_info => "mer info",
+      ad_badge => "Visning av annonser är sekretessskyddat av DuckDuckGo. Annonsklick hanteras av Microsofts annonsnätverk"
+    },
+    tr_TR => {
+      more_info => "daha fazla bilgi",
+      ad_badge => "Reklam görüntüleme, DuckDuckGo’nun gizlilik koruması altındadır. Reklam tıklamaları, Microsoft’un reklam ağı tarafından yönetilir"
+    }
+);
+
 sub wanted;
 
 sub translation_check {
-    my ( $msgid, $msgstr ) = map { s/^"//r =~ s/"$//r } @_;
-    return 1 if $msgstr eq "";
+    my ( $name, $msgid, $msgstr ) = map { s/^"//r =~ s/"$//r } @_;
+    # We only need the locale code
+    my $locale = (split "/", $name)[1];
+
+    if ( exists( $european_languages{$locale} )) {
+        my $which_msg = ( $msgid =~ /More\sInfo/ ) ? "more_info" : "ad_badge";
+        my $msg_expected = $european_languages{$locale}{$which_msg}; 
+        return 1 if $msgstr eq $msg_expected;
+    } else {
+        return 1 if $msgstr eq "";
+    }
 }
 
 File::Find::find({wanted => \&wanted}, 'locales');
@@ -29,7 +141,7 @@ sub wanted {
     for ( @{ $po } ) {
         next unless $_->msgctxt;
         next unless $_->msgctxt =~ /Ads\sGDPR,\sinternal\suse\sonly\.\sDo\snot\schange/;
-        ok( translation_check( $_->msgid, $_->msgstr ),
+        ok( translation_check( $name, $_->msgid, $_->msgstr ),
           'Translation for ' . $_->msgid . ' in ' . $name . ' should not be changed : ' . $_->msgstr )
     }
 }


### PR DESCRIPTION
Following up from #296:

- Add internally approved translations for the ad badge tooltip context
- Update tests to check the internal translation for those hasn't been changed