### PR TITLE
Update duckduckgo.po (Update Japanese translation)

### DIFF
--- a/locales/ja_JP/LC_MESSAGES/duckduckgo.po
+++ b/locales/ja_JP/LC_MESSAGES/duckduckgo.po
@@ -371,11 +371,11 @@ msgstr "アプリ"
 
 msgctxt "feedback form"
 msgid "Are these ads helpful?"
-msgstr ""
+msgstr "この広告は役に立っていますか？"
 
 msgctxt "feedback form"
 msgid "Are these links helpful?"
-msgstr ""
+msgstr "このリンクは役に立っていますか？"
 
 msgid "Argentina"
 msgstr "アルゼンチン"
@@ -2403,7 +2403,7 @@ msgstr "標準"
 
 msgctxt "settingsvalue"
 msgid "Moderate"
-msgstr "適度"
+msgstr "標準"
 
 #. Used to point to additional social networking profiles (in results).
 msgid "More"
@@ -2619,7 +2619,7 @@ msgstr "追跡しません。どんなときでも。"
 
 msgctxt "safe search"
 msgid "No adult content"
-msgstr "アダルトコンテンツを排除する"
+msgstr "成人向けコンテンツを排除する"
 
 msgctxt "safe search"
 msgid "No explicit images or videos"
@@ -2713,7 +2713,7 @@ msgstr "提供"
 #. http://i.imgur.com/zQWKLIm.png
 msgctxt "settings"
 msgid "Omits objectionable (mostly adult) material"
-msgstr "大人向けの好ましくない検索結果を省く"
+msgstr "成人向け等の好ましくない検索結果を除外"
 
 msgid "On"
 msgstr "オン"
@@ -2876,7 +2876,7 @@ msgstr ""
 
 msgctxt "precise_user_location"
 msgid "Other."
-msgstr ""
+msgstr "その他"
 
 msgctxt "SERP footer content"
 msgid "Our Crash Course"
@@ -3451,7 +3451,7 @@ msgstr "セーフサーチが %s の検索結果を一部ブロックしまし�
 #. For a button that shows satellite imagery on a map
 msgctxt "map-mode"
 msgid "Satellite"
-msgstr "衛星"
+msgstr "衛星画像"
 
 msgid "Saudi Arabia"
 msgstr "サウジアラビア"
@@ -4062,7 +4062,7 @@ msgstr "送信"
 
 msgctxt "precise_user_location"
 msgid "Submit"
-msgstr ""
+msgstr "送信"
 
 msgctxt "email newsletter"
 msgid "Subscribe"
@@ -4578,7 +4578,7 @@ msgstr "即席回答 (IA) を作りたいですか？"
 
 msgctxt "feedback form"
 msgid "Want to tell us a bit more?"
-msgstr ""
+msgstr "何か私たちに伝えたいことはありますか？"
 
 #. e.g. Video search viewing options: http://i.imgur.com/ofZeLRn.png
 msgid "Watch Here"


### PR DESCRIPTION
Add some translations
en:adult = ja:成人向け
...

複数の翻訳を追加。
「adult」の日本語訳を「成人向け」に統一。
など