### PR TITLE
Fix error in nl_NL-translation

### DIFF
--- a/locales/nl_NL/LC_MESSAGES/duckduckgo.po
+++ b/locales/nl_NL/LC_MESSAGES/duckduckgo.po
@@ -4136,13 +4136,13 @@ msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Stap over naar de zoekmachine die je niet volgt. Nooit."
 
 msgid "Switzerland (de)"
-msgstr "Zwisterland (Duits)"
+msgstr "Zwitserland (Duits)"
 
 msgid "Switzerland (fr)"
-msgstr "Switzerland"
+msgstr "Zwitserland (Frans)"
 
 msgid "Switzerland (it)"
-msgstr "Switzerland"
+msgstr "Zwitserland (Italiaans)"
 
 msgid "TV"
 msgstr "Televisie"


### PR DESCRIPTION
Fix translation error in nl_NL-translation: Switzerland.
This fixes #366 