### PR TITLE
Update duckduckgo.po ja_JP translation

### DIFF
--- a/locales/ja_JP/LC_MESSAGES/duckduckgo.po
+++ b/locales/ja_JP/LC_MESSAGES/duckduckgo.po
@@ -248,7 +248,7 @@ msgid ""
 msgstr "ダウンロード後は拡張ファイルの場所に行き、ダブルクリックしてインストールしてください"
 
 msgid "All"
-msgstr "全て"
+msgstr "すべて"
 
 msgctxt "image-color"
 msgid "All Colors"
@@ -259,7 +259,7 @@ msgid "All Layouts"
 msgstr "すべてのレイアウト"
 
 msgid "All Places"
-msgstr "全ての場所"
+msgstr "すべての場所"
 
 msgid "All Regions"
 msgstr "全地域"
@@ -4013,7 +4013,7 @@ msgstr "プライバシーニュースレターで、最新情報を入手して
 
 #. Instant Answer tab name - eg. https://duckduckgo.com/?q=Energy+Transfer+Equity&ia=stock
 msgid "Stock"
-msgstr "在庫"
+msgstr "株価"
 
 msgid "Store"
 msgstr "ストア"


### PR DESCRIPTION
Stock market is "株価" and not "在庫" which means stock in term of inventory.
"全て" is not Joyo Kanji (常用漢字), thus "すべて" is appropriate.