### PR TITLE
update: korean translation (2021-01-09)

### DIFF
--- a/locales/ko_KR/LC_MESSAGES/duckduckgo.po
+++ b/locales/ko_KR/LC_MESSAGES/duckduckgo.po
@@ -16,7 +16,7 @@ msgstr "!Bang 바로 가기 기능"
 
 msgctxt "showcase_donations"
 msgid "$800,000 in privacy donations!"
-msgstr "개인정보 보호를 위해 약 9억원 기부"
+msgstr "사생활 보호를 위해 약 9억원 기부"
 
 msgctxt "SERP footer content"
 msgid "%s Billion Searches"
@@ -41,7 +41,7 @@ msgstr "%1$s시간 전"
 
 msgctxt "showcase_donations"
 msgid "%s in privacy donations!"
-msgstr "개인정보 보호를 위해 약 %1$s 기부!"
+msgstr "사생활 보호를 위해 약 %1$s 기부!"
 
 msgid "%s km"
 msgstr "%1$s km"
@@ -210,7 +210,7 @@ msgstr "경로를 찾기 위해 출발지와 도착지를 추가하세요."
 msgid ""
 "Add privacy protection to your browser. Search privately, block trackers, "
 "secure connections, and more — all for free."
-msgstr "브라우저에 개인정보 보호 기능을 추가하세요. 비공개 검색, 추적기 차단, 보안 연결 등의 다양한 기능을 무료로 사용하세요."
+msgstr "브라우저에 사생활 보호 기능을 추가하세요. 비공개 검색, 추적기 차단, 보안 연결 등의 다양한 기능을 무료로 사용하세요."
 
 #. In the top menu under Team Duck -- %s will be browser names, like Firefox.
 msgid "Add to %s"
@@ -303,7 +303,7 @@ msgstr "팬이신가요? %1$sDuckDuckGo를 알리는데 도와주세요!%2$s"
 
 msgctxt "mobile promotion on desktop"
 msgid "Also search privately on your iPad, iPhone, or Android!"
-msgstr "iPad, iPhone이나 Android에서도 개인정보 보호를 받으며 검색하세요!"
+msgstr "iPad, iPhone이나 Android에서도 사생활 보호를 받으며 검색하세요!"
 
 #. Instant Answer Tab Name
 msgid "Alternatives"
@@ -324,7 +324,7 @@ msgstr "위치 정보를 노출하지 않아도 됩니다."
 
 #. Instant Answer tab name
 msgid "Answer"
-msgstr "답"
+msgstr "답변"
 
 #. In feedback page, first box. https://duckduckgo.com/feedback
 msgid "Answers to most DuckDuckGo questions, like:"
@@ -381,7 +381,7 @@ msgstr "아르헨티나"
 msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
-msgstr "개인정보 보호 정책에 따라, 저희는 어떠한 개인정보도 수집하거나 공유하지 않습니다. 모든 개인정보 보호는 기기에서 수행됩니다."
+msgstr "개인 정보 보호 정책에 따라, 저희는 어떠한 개인 정보도 수집하거나 공유하지 않습니다. 모든 개인 정보 보호는 기기에서 수행됩니다."
 
 msgctxt "homepage ATB modal"
 msgid "At DuckDuckGo, we agree."
@@ -404,7 +404,7 @@ msgstr "자동 완성"
 #. http://i.imgur.com/OZIO1I9.png
 msgctxt "settings"
 msgid "Automatically open relevant Instant Answers"
-msgstr "자동으로 해당되는 빠른 답변을 열기"
+msgstr "관련성 있는 빠른 답변을 자동으로 열기"
 
 #. Used to show the numerical rating, when the user hovers over a visual star-rating. Sorry, this is hard to translate.
 msgctxt "homepage ATB social proof"
@@ -567,12 +567,12 @@ msgid "Brown"
 msgstr "갈색"
 
 msgid "Browse as Usual"
-msgstr "평소처럼 브라우저를 이용하세요"
+msgstr "기존과 동일하게 검색하세요"
 
 msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr "기존과 동일하게 검색하세요. 개인 정보는 저희가 보호해 드릴게요. 하나의 %1$s%2$s 확장 프로그램%3$s으로 검색 엔진, 추적 차단, 암호화 보호 강화 기능을 이용할 수 있습니다."
+msgstr "기존과 동일하게 검색하세요. 사생활은 저희가 보호해 드릴게요. 하나의 %1$s%2$s 확장 프로그램%3$s으로 검색 엔진, 추적 차단, 암호화 보호 강화 기능을 이용할 수 있습니다."
 
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
@@ -605,7 +605,7 @@ msgid ""
 "permanent way (on a remote server in the cloud). No personally identifiable "
 "information will be stored in the cloud, and your pass phrase will never "
 "leave your browser."
-msgstr "클라우드 저장을 사용하지 않는다면, 기본 설정은 컴퓨터의 브라우저 쿠키 내에 저장됩니다. 익명 클라우드 저장 기능을 사용하시면 현재 설정을 영구적으로, 클라우드의 원격 서버에 저장할 수 있습니다. 클라우드에 업로드되는 데이터에는 사용자의 개인정보가 절대로 저장되지 않으며,"
+msgstr "클라우드 저장을 사용하지 않는다면, 기본 설정은 컴퓨터의 브라우저 쿠키 내에 저장됩니다. 익명 클라우드 저장 기능을 사용하시면 현재 설정을 영구적으로, 클라우드의 원격 서버에 저장할 수 있습니다. 클라우드에 업로드되는 데이터에는 사용자의 개인 정보가 절대로 저장되지 않으며,"
 " 암호 또한 서버에 저장되지 않습니다."
 
 #. Instant Answer tab name
@@ -655,12 +655,12 @@ msgid "Center align the results page (instead of left aligned)"
 msgstr "검색 결과 페이지 가운데 정렬 (기본값은 왼쪽 정렬)"
 
 msgid "Change Region"
-msgstr "지역 바꾸기"
+msgstr "지역 변경하기"
 
 #. http://i.imgur.com/OntTi6e.png
 msgctxt "settings"
 msgid "Change the background color across the entire site"
-msgstr "전체 사이트에 적용하는 배경색 바꾸기"
+msgstr "전체 사이트에 적용하는 배경색 변경하기"
 
 #. http://i.imgur.com/oO0X6Pt.png
 msgctxt "settings"
@@ -672,67 +672,67 @@ msgstr "헤더가 차지하는 공간과 스크롤 했을 때의 동작을 설�
 #. http://i.imgur.com/mcZdcaF.png
 msgctxt "settings"
 msgid "Changes results to be region specific"
-msgstr "설정된 지역에 따라 검색 결과를 바꿉니다."
+msgstr "설정된 지역에 따라 검색 결과 변경하기"
 
 #. http://i.imgur.com/NdpkbY0.png
 msgctxt "settings"
 msgid "Changes the background color when hovering over a result"
-msgstr "검색 결과에 마우스를 올렸을 때 배경 색상 바꾸기"
+msgstr "검색 결과에 마우스를 올렸을 때 배경 색상 변경하기"
 
 #. http://i.imgur.com/awVlAoo.png
 msgctxt "settings"
 msgid "Changes the color of the result URL"
-msgstr "검색 결과 URL의 색을 바꿉니다."
+msgstr "검색 결과 URL의 색상 변경하기"
 
 #. http://i.imgur.com/epUhcrA.png
 msgctxt "settings"
 msgid "Changes the color of the result description text"
-msgstr "검색 결과에서 설명 텍스트의 색상 바꾸기"
+msgstr "검색 결과 설명 텍스트의 색상 변경하기"
 
 #. http://i.imgur.com/kE1ZsM9.png
 msgctxt "settings"
 msgid "Changes the font across the entire site"
-msgstr "전체 사이트에 적용할 글꼴 바꾸기"
+msgstr "사이트 전체에 적용할 글꼴 변경하기"
 
 #. http://i.imgur.com/ftpln8q.png
 msgctxt "settings"
 msgid "Changes the font size across the entire site"
-msgstr "모든 사이트에서 글꼴 크기를 바꿉니다."
+msgstr "사이트 전체에 적용할 글꼴 크기 변경하기"
 
 #. http://i.imgur.com/4AG1u9Q.png
 #. Setting to change the color of the top of DuckDuckGo: http://i.imgur.com/A1Nh20m.png
 msgctxt "settings"
 msgid "Changes the header color across the entire site"
-msgstr "사이트 전체에 걸쳐 상단부에 적용될 색깔을 바꿀 수 있습니다."
+msgstr "사이트 상단부에 적용될 색상 변경하기"
 
 #. http://i.imgur.com/w4XN6Fj.png
 msgctxt "settings"
 msgid "Changes the language across the entire site"
-msgstr "사이트에서 사용할 언어 바꾸기"
+msgstr "사이트 전체에서 사용할 언어 변경하기"
 
 msgctxt "settings"
 msgid "Changes the result hover, module, and dropdown background color"
-msgstr "검색 결과의 마우스 강조 및 드롭다운 메뉴 색상 바꾸기"
+msgstr "검색 결과의 마우스 강조 및 드롭다운 메뉴 색상 변경하기"
 
 #. http://i.imgur.com/f1bLTY1.png
 #. Description for "Result Title Color" which changes the color of the results.
 msgctxt "settings"
 msgid "Changes the title link color for each result"
-msgstr "검색 결과 제목의 링크 색상 바꾸기"
+msgstr "검색 결과 제목의 링크 색상 변경하기"
 
 #. http://i.imgur.com/5IQda6g.png
 msgctxt "settings"
 msgid "Changes the title link font for each result"
-msgstr "각 결과에 따른 제목 링크 글꼴 바꾸기"
+msgstr "각 결과에 따른 제목 링크 글꼴 변경하기"
 
 #. http://i.imgur.com/auITACf.png
 msgctxt "settings"
 msgid "Changes what happens when you click on a video thumbnail"
-msgstr "동영상 미리보기를 클릭했을 때 동작 설정"
+msgstr "동영상 미리보기를 클릭했을 때의 동작 설정하기"
 
 msgctxt "settings"
 msgid "Changes whether the visited check mark is visible"
-msgstr "방문 확인 마크가 보이는 것을 변경"
+msgstr "사이트 방문 확인 마크의 표시 여부 변경하기"
 
 msgid "Chat"
 msgstr "대화"
@@ -742,11 +742,11 @@ msgstr "%1$s이 검색 엔진을 사용%2$s에 체크하세요"
 
 msgctxt "SERP footer content"
 msgid "Check out our privacy device guides."
-msgstr "기기별 개인정보 보호 가이드를 확인해 보세요."
+msgstr "기기별 사생활 보호 가이드를 확인해 보세요."
 
 msgctxt "showcase_privacy"
 msgid "Check out our privacy device guides."
-msgstr "기기별 개인정보 보호 가이드를 확인해 보세요."
+msgstr "기기별 사생활 보호 가이드를 확인해 보세요."
 
 msgctxt "showcase_aria_label"
 msgid "Check out the list of things that we've also made."
@@ -852,7 +852,7 @@ msgstr "%1$s열기%2$s를 눌러 DuckDuckGo Safari 확장 기능을 다운로드
 
 #  Edge default search engine instruction
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr "왼쪽 사이드바에서 %1$s개인 정보 및 서비스%2$s를 클릭하세요."
+msgstr "왼쪽 사이드바에서 %1$s개인 정보, 검색 및 서비스%2$s를 클릭하세요."
 
 #  Safari homepage instruction
 msgid ""
@@ -988,19 +988,19 @@ msgid "Close window."
 msgstr "창 닫기"
 
 msgid "Closed"
-msgstr "닫힘"
+msgstr "영업 종료"
 
 msgctxt "maps_places"
 msgid "Closed"
-msgstr "닫힘"
+msgstr "영업 종료"
 
 msgctxt "maps_places"
 msgid "Closes"
-msgstr "종료"
+msgstr "영업 종료 시간"
 
 msgctxt "maps_places"
 msgid "Closes soon"
-msgstr "종료 예정"
+msgstr "곧 영업 종료"
 
 #. Title for the bottom part of  the <a href="https://duckduckgo.com/settings.html">main settings page</a> about saving anonymously in the cloud.
 msgid "Cloud Save"
@@ -1169,15 +1169,15 @@ msgstr "체코 공화국"
 #. A theme name in the theme menu:
 #. https://duck.co/media/files/theme.png
 msgid "Dark"
-msgstr "어두움"
+msgstr "어둡게"
 
 #. http://i.imgur.com/07cZIPc.png
 msgctxt "theme"
 msgid "Dark"
-msgstr "어두움"
+msgstr "어둡게"
 
 msgid "Data Privacy Day 2018"
-msgstr "2018년 개인정보 보호의 날"
+msgstr "2018년 개인 정보 보호의 날"
 
 #. Instant Answer tab name
 msgid "Date"
@@ -1289,14 +1289,14 @@ msgstr "체크 박스가 보이지 않는다고요? %1$s아래의 방법을 따�
 
 msgctxt "showcase_donate"
 msgid "Donate and support online privacy."
-msgstr "기부해서 온라인 개인정보 보호에 도움을 주세요."
+msgstr "기부해서 온라인 개인 정보 보호에 도움을 주세요."
 
 msgid "Donating for Privacy"
-msgstr "개인정보을 위한 기부"
+msgstr "개인 정보을 위한 기부"
 
 msgctxt "SERP footer content"
 msgid "Donating for Privacy"
-msgstr "개인정보 보호를 위한 기부"
+msgstr "개인 정보 보호를 위한 기부"
 
 msgctxt "precise_user_location"
 msgid "Done"
@@ -1335,17 +1335,17 @@ msgstr "DuckDuckGo 빠른 답변 API"
 
 #. by opening https://duckduckgo.com/newbang it shows in the window title
 msgid "DuckDuckGo New !Bang"
-msgstr "DuckDuckGo의 새로운 !Bang​"
+msgstr "DuckDuckGo의 새로운 !Bang"
 
 #. Inside your browser title bar or tab title when visiting the <a href="https://duckduckgo.com/privacy.html">privacy page</a>.
 msgid "DuckDuckGo Privacy"
-msgstr "DuckDuckGo 개인정보 처리방침"
+msgstr "DuckDuckGo 개인 정보 처리방침"
 
 #. 'DuckDuckGo Privacy Essentials' is a trademark and should NOT be translated.
 msgid ""
 "DuckDuckGo Privacy Essentials protects your privacy, wherever the Internet "
 "takes you."
-msgstr "DuckDuckGo Privacy Essentials은 인터넷 어디서나 사용자의 개인정보를 보호합니다."
+msgstr "DuckDuckGo Privacy Essentials은 인터넷 어디서나 사용자의 사생활을 보호합니다."
 
 #. Inside your browser title bar or tab title when visiting the <a href="https://duckduckgo.com/search_box.html">search box page</a>.
 msgid "DuckDuckGo Search Box"
@@ -1380,7 +1380,7 @@ msgid ""
 "away, such that you remain anonymous. Learn more about how we designed this "
 "technology to protect your privacy %shere%s."
 msgstr "DuckDuckGo는 사생활 보호를 위한 검색 엔진입니다. 위치 정보 사용 설정 시 정보는 로컬 기기에만 저장됩니다. 여러분이 검색을 하면 여러분의 기기는 우리에게 검색 정보를 보냅니다. 우리는 그것을 검색 결과를 향상시키기 위해 사용한 후 즉시 폐기하여 여러분의 검색"
-" 기록을 남기지 않습니다. %1$s여기%2$s에서 개인 정보 보호를 위해 개발된 DuckDuckGo의 기술에 대해 자세히 알아보세요."
+" 기록을 남기지 않습니다. %1$s여기%2$s에서 사생활 보호를 위해 개발된 DuckDuckGo의 기술에 대해 자세히 알아보세요."
 
 msgid "DuckDuckGo search"
 msgstr "DuckDuckGo 검색"
@@ -1591,7 +1591,7 @@ msgstr "여러분과 보다 관련있는 결과를 찾아보세요."
 
 msgctxt "showcase_privacy"
 msgid "Find useful privacy advice on our blog."
-msgstr "DuckDuckGo 블로그에서 유용한 개인정보 보호 팁을 찾아보세요."
+msgstr "DuckDuckGo 블로그에서 유용한 사생활 보호 팁을 찾아보세요."
 
 msgctxt "SERP footer content"
 msgid "Fine-tune Your Search"
@@ -1606,7 +1606,7 @@ msgstr "항공편"
 
 msgctxt "new user poll"
 msgid "Following us on Twitter"
-msgstr "트위터 팔로우 중"
+msgstr "Twitter 팔로우 중"
 
 #. http://i.imgur.com/JWnlmmo.png
 msgctxt "settings"
@@ -1677,7 +1677,7 @@ msgstr "앱 및 확장 기능 설치하기"
 
 msgctxt "showcase_privacy"
 msgid "Get Privacy Tips"
-msgstr "개인정보 보호 팁 얻기"
+msgstr "사생활 보호 팁 얻기"
 
 msgctxt "SERP footer content"
 msgid "Get Started at Duck.com"
@@ -1696,10 +1696,10 @@ msgstr "코로나19 관련 공식 정보 및 지침을 확인하세요."
 
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
-msgstr "다운로드 한 번으로 브라우저에서 개인 정보를 완벽하게 보호하세요:"
+msgstr "다운로드 한 번으로 브라우저에서 사생활을 완벽하게 보호하세요:"
 
 msgid "Get the non-JS version %s"
-msgstr "자바스크립트를 쓰지 않는 %1$s 사용하기"
+msgstr "Javascript를 쓰지 않는 %1$s 사용하기"
 
 msgctxt "access_song"
 msgid "Get this song on:"
@@ -1800,7 +1800,7 @@ msgid "Help Spread DuckDuckGo"
 msgstr "DuckDuckGo를 더 많은 사람들에게 알려주세요"
 
 msgid "Help Spread Privacy"
-msgstr "개인정보 보호의 중요성 알리기"
+msgstr "사생활 보호의 중요성 알리기"
 
 msgctxt "SERP footer content"
 msgid "Help us raise the standard of trust online."
@@ -1852,7 +1852,7 @@ msgstr "키보드의 %1$sReturn%2$s을 눌러 %3$sDuckDuckGo를 목록에 저장
 
 msgctxt "settings"
 msgid "Homepage Privacy Tips"
-msgstr "홈페이지 개인정보 보호 팁"
+msgstr "홈페이지 사생활 보호 팁"
 
 msgid "Hong Kong"
 msgstr "홍콩"
@@ -1888,7 +1888,7 @@ msgstr "이것은 어떻게 동작하나요?"
 #. You have to click the "What is this?" link to display it.
 msgctxt "cloudsave"
 msgid "How does passphrase generation work?"
-msgstr "암호 추천은 어떻게 작동하나요?"
+msgstr "암호 추천 기능은 어떤 원리로 작동하나요?"
 
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
 #. Title for a small paragraph about how DuckDuckGo doesn't store <strong>ANY</strong> personal informations (including your username). How are you BTW for asking this???
@@ -1910,18 +1910,18 @@ msgstr "헝가리"
 
 msgctxt "feedback form"
 msgid "I don't want this type of result"
-msgstr "나는 이러한 종류의 결과를 원하지 않습니다"
+msgstr "저는 이러한 종류의 결과를 원하지 않습니다"
 
 msgctxt "feedback form"
 msgid "I don't want this type of results"
-msgstr "나는 이러한 종류의 결과를 원하지 않습니다"
+msgstr "저는 이러한 종류의 결과를 원하지 않습니다"
 
 #. Title for the stuff explaining <em>how DuckDuckGo <strong>REALLY doesn't</strong> track you</em>.
 #. From the <a href="https://duckduckgo.com/settings.html">settings page</a>.
 #. You have to click the "What is this?" link to display it.
 msgctxt "cloudsave"
 msgid "I forgot my passphrase. Can you recover it?"
-msgstr "암호를 잊어버렸어요. 찾을 수 있죠?"
+msgstr "암호를 잊어버렸는데, 혹시 찾을 수 있나요?"
 
 msgid "I need to report a bug!"
 msgstr "버그를 신고하고 싶어요!"
@@ -1955,7 +1955,7 @@ msgstr "만약 %1$sDuckDuckGo%2$s가 보이지 않는다면 %3$sOther Search Eng
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "계속 저희를 지원하고 싶으시다면, %1$sDuckDuckGo를 더 많은 사람들에게 소개해주세요%2$s"
+msgstr "저희를 계속 지원하고 싶으시다면, %1$sDuckDuckGo를 더 많은 사람들에게 소개해주세요%2$s"
 
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
 #. Message displayed at the bottom of the page, informing you that you can't use the settings page without Java Script activated into your browser. <em>%s</em> and <em>%s</em> are respectively for (raw) <em>HTML</em> and <em>lite</em> versions.
@@ -2100,7 +2100,7 @@ msgstr "인터페이스 설정"
 
 msgctxt "homepage onboarding"
 msgid "Invite friends to the Duck Side!"
-msgstr "Duck Side에 친구들을 초대해 보세요!"
+msgstr "친구들을 '오리 편'으로 만들어보세요!"
 
 msgid "Ireland"
 msgstr "아일랜드"
@@ -2110,7 +2110,7 @@ msgstr "아일랜드"
 #. You have to click the "What is this?" link to display it.
 msgctxt "cloudsave"
 msgid "Is deleted data really deleted?"
-msgstr "삭제 버튼 누르면 진짜 삭제되는 거 맞죠?"
+msgstr "삭제 버튼을 누르면 진짜 삭제되는 거 맞죠?"
 
 #. in https://duckduckgo.com/feedback under "DuckDuckHack" header
 msgid "Is someone working on your zero-click plugin?"
@@ -2154,7 +2154,7 @@ msgstr "저희와 함께 일하세요!"
 
 msgctxt "showcase_donate"
 msgid "Join our $500,000 Privacy Challenge"
-msgstr "$500,000 개인 정보 챌린지에 동참하세요"
+msgstr "$500,000 사생활 보호 챌린지에 동참하세요"
 
 msgid "Just a few clicks to install, and you're ready to go. It's that easy."
 msgstr "클릭 몇 번만 하면 설치해서 바로 사용할 수 있습니다. 간단합니다."
@@ -2245,11 +2245,11 @@ msgstr "Bang에 대해 알아보기"
 
 msgctxt "showcase_newsletter"
 msgid "Learn about online privacy right in your inbox."
-msgstr "메일로 개인정보 보호와 관련된 정보를 받아보세요."
+msgstr "메일로 사생활 보호와 관련된 정보를 받아보세요."
 
 msgctxt "SERP footer content"
 msgid "Learn how to protect your privacy."
-msgstr "어떻게 개인정보를 보호할 수 있는지 확인하세요."
+msgstr "어떻게 사생활을 보호할 수 있는지 확인하세요."
 
 msgctxt "SERP footer content"
 msgid "Learn how to search like the pros."
@@ -2351,7 +2351,7 @@ msgstr "스크롤할 때 더 많은 이미지 결과 보여주기"
 #. http://i.imgur.com/WTkvs9I.png
 msgctxt "settings"
 msgid "Loads more results when scrolling"
-msgstr "스크롤 할 때 더 많은 결과 열기"
+msgstr "스크롤할 때 더 많은 결과 보여주기"
 
 msgctxt "settings"
 msgid "Location"
@@ -2785,7 +2785,7 @@ msgstr "꺼짐"
 
 msgctxt "settingsvalue"
 msgid "Off"
-msgstr "끔"
+msgstr "꺼짐"
 
 #. Used in 0-click box for product results, e.g. <a href="https://duckduckgo.com/?q=9780061353246">https://duckduckgo.com/?q=9780061353246</a>
 msgid "Offers"
@@ -2794,7 +2794,7 @@ msgstr "제공"
 #. http://i.imgur.com/zQWKLIm.png
 msgctxt "settings"
 msgid "Omits objectionable (mostly adult) material"
-msgstr "거부감이 있는 (주로 성인물) 컨텐츠 생략"
+msgstr "거부감이 있는 (주로 성인물) 컨텐츠 생략하기"
 
 msgid "On"
 msgstr "켜짐"
@@ -2840,7 +2840,7 @@ msgctxt "cloudsave"
 msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
-msgstr "사용자가 변경한 설정만 저장됩니다. 자세한 내용은 %1$sURL 매개 변수%2$s페이지를 참고하세요."
+msgstr "사용자가 변경한 설정만 저장됩니다. 자세한 내용은 %1$sURL 매개 변수%2$s 페이지를 참고하세요."
 
 msgctxt "maps_places"
 msgid "Open"
@@ -2963,7 +2963,7 @@ msgctxt "homepage onboarding"
 msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
-msgstr "어떠한 개인정보도 수집하거나 공유하지 않습니다."
+msgstr "어떠한 개인 정보도 수집하거나 공유하지 않습니다."
 
 msgid ""
 "Our private browser for mobile comes equipped with our search engine, "
@@ -2977,7 +2977,7 @@ msgstr "%1$s0억개 이상의 익명 검색"
 
 msgctxt "SERP footer content"
 msgid "Over %s in DuckDuckGo privacy donations."
-msgstr "개인정보 보호를 위해 DuckDuckGo에 %1$s 이상의 기부금이 모였습니다."
+msgstr "사생활 보호를 위해 DuckDuckGo에 %1$s 이상의 기부금이 모였습니다."
 
 msgctxt "showcase_traffic"
 msgid "Over 15 Billion anonymous searches."
@@ -3009,11 +3009,11 @@ msgstr "페이지 모양"
 #. indica o número de páxina de resultados na que estamos
 msgctxt "settings"
 msgid "Page Break #'s"
-msgstr "페이지 나누기 #'s"
+msgstr "페이지 구분 #"
 
 msgctxt "settings"
 msgid "Page Break Lines"
-msgstr "페이지 나누기 선"
+msgstr "페이지 구분 선"
 
 #. http://i.imgur.com/nyTQ3ki.png
 msgctxt "settings"
@@ -3148,7 +3148,7 @@ msgstr "포르투갈"
 
 msgctxt "settings"
 msgid "Preferred units of measure"
-msgstr "측정 단위"
+msgstr "선호하는 측정 단위 선택하기"
 
 #. Main page under "More"
 msgid "Press"
@@ -3178,15 +3178,15 @@ msgstr "이전 지역"
 
 #. In the top menu under Settings ("More" > "Privacy")
 msgid "Privacy"
-msgstr "개인정보 보호"
+msgstr "개인 정보 보호"
 
 #. http://i.imgur.com/squ02on.png
 msgctxt "settings"
 msgid "Privacy"
-msgstr "개인정보 보호"
+msgstr "개인 정보 보호"
 
 msgid "Privacy Blog"
-msgstr "개인정보 보호 안내 블로그"
+msgstr "사생활 보호 안내 블로그"
 
 msgid "Privacy Browser App"
 msgstr "비공개 브라우저 앱"
@@ -3195,53 +3195,53 @@ msgid "Privacy Browser Extension"
 msgstr "비공개 브라우저 확장 프로그램"
 
 msgid "Privacy Crash Course"
-msgstr "개인정보 보호 특강"
+msgstr "사생활 보호 특강"
 
 msgid "Privacy Essentials"
-msgstr "개인정보 보호 지침"
+msgstr "사생활 보호 지침"
 
 msgid "Privacy Essentials for %s"
 msgstr "%1$s Privacy Essentials"
 
 msgctxt "SERP footer content"
 msgid "Privacy Newsletter"
-msgstr "개인정보 관련 뉴스레터"
+msgstr "사생활 관련 뉴스레터"
 
 msgctxt "settings"
 msgid "Privacy Newsletter"
-msgstr "개인정보 보호 뉴스레터"
+msgstr "사생활 보호 뉴스레터"
 
 msgid "Privacy Policy"
-msgstr "개인정보 처리 방침"
+msgstr "개인 정보 처리 방침"
 
 msgid "Privacy Protection For Any Device"
-msgstr "모든 기기에서 개인 정보 보호"
+msgstr "모든 기기에서 사생활 보호"
 
 #. https://duckduckgo.com/params. it is a bold header
 msgid "Privacy Settings"
-msgstr "개인정보 설정"
+msgstr "개인 정보 설정"
 
 msgid "Privacy for %s"
-msgstr "%1$s 개인 정보 보호"
+msgstr "%1$s 사생활 보호"
 
 msgctxt "SERP footer content"
 msgid "Privacy in Your Inbox"
-msgstr "개인정보 보호 뉴스레터 받기"
+msgstr "사생활 보호 뉴스레터 받기"
 
 msgctxt "showcase_newsletter"
 msgid "Privacy in Your Inbox"
-msgstr "개인정보 보호 뉴스레터 받기"
+msgstr "사생활 보호 뉴스레터 받기"
 
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid "Privacy, simplified"
-msgstr "개인정보 보호, 쉬워졌네요."
+msgstr "사생활 보호, 쉬워졌네요."
 
 msgid "Privacy, simplified."
-msgstr "개인정보 보호, 쉬워졌네요."
+msgstr "사생활 보호, 쉬워졌네요."
 
 msgid "Private Search"
-msgstr "개인정보 보호 검색"
+msgstr "사생활 보호 검색"
 
 msgid "Private Search Engine"
 msgstr "비공개 검색 엔진"
@@ -3257,19 +3257,19 @@ msgstr "제품"
 #. http://i.imgur.com/KT5S1TR.png
 msgctxt "settingsvalue"
 msgid "Prompt me"
-msgstr "팝업 표시"
+msgstr "재생하기 전에 물어보기"
 
 msgctxt "settings"
 msgid "Prompt me to anonymously use browser location for better results."
-msgstr "더 나은 검색 결과를 위해 브라우저 위치를 익명으로 설정하는 기능을 제공합니다."
+msgstr "더 나은 검색 결과를 위해 브라우저 위치 정보를 익명으로 사용할 것인지 물어보기"
 
 msgctxt "settings"
 msgid "Prompt me to customize my DuckDuckGo experience."
-msgstr "DuckDuckGo 경험을 프롬프트하여 사용자 정의하겠습니다."
+msgstr "DuckDuckGo 사용자 경험을 맞춤 설정할 것인지 물어보기"
 
 msgctxt "settings"
 msgid "Prompt me to personalize my DuckDuckGo experience."
-msgstr "DuckDuckGo 경험을 프롬프트하여 사용자 개인화하겠습니다."
+msgstr "DuckDuckGo 사용자 경험을 개인 설정할 것인지 물어보기"
 
 msgctxt "SERP footer content"
 msgid "Protect Your Devices"
@@ -3280,7 +3280,7 @@ msgid "Protect Your Devices"
 msgstr "여러분의 기기를 보호하세요"
 
 msgid "Protect Your Privacy!"
-msgstr "여러분의 개인정보를 보호하세요!"
+msgstr "여러분의 사생활을 보호하세요!"
 
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
@@ -3344,7 +3344,7 @@ msgid "Red"
 msgstr "빨간색"
 
 msgid "Reddit"
-msgstr "레딧"
+msgstr "Reddit"
 
 msgctxt "settings"
 msgid "Redirect (when necessary)"
@@ -3382,7 +3382,7 @@ msgid "Related Topics"
 msgstr "연관된 주제"
 
 msgid "Remember my choice (this can be changed in %sSettings%s)"
-msgstr "이 선택을 유지합니다. (%1$s설정%2$s에서도 바꿀 수 있습니다.)"
+msgstr "이 선택을 유지합니다. (%1$s설정%2$s에서도 변경할 수 있습니다)"
 
 msgctxt "ads"
 msgid "Report Ad"
@@ -3419,7 +3419,7 @@ msgstr "검색 결과 내용의 색상"
 
 msgctxt "settings"
 msgid "Result Full URLs"
-msgstr "모든 URL 결과"
+msgstr "검색 결과 전체 URL"
 
 #. http://i.imgur.com/kqN8dPT.png
 msgctxt "settings"
@@ -3428,7 +3428,7 @@ msgstr "검색 결과 강조 색상"
 
 msgctxt "settings"
 msgid "Result Hover, Module, and Dropdown Background Color"
-msgstr "검색 결과의 마우스 강조 및 드롭다운 메뉴 색상 바꾸기"
+msgstr "검색 결과의 마우스 강조 및 드롭다운 메뉴 색상"
 
 #. in https://duckduckgo.com/params in the top. it is the first header
 msgid "Result Settings"
@@ -3453,20 +3453,20 @@ msgstr "검색 결과의 제목 밑줄"
 #. http://i.imgur.com/fsnijIZ.png
 msgctxt "settings"
 msgid "Result URL Color"
-msgstr "검색 결과 URL의 색상"
+msgstr "검색 결과 URL 색상"
 
 msgctxt "settings"
 msgid "Result URLs above snippet"
-msgstr "미리보기 위에 URL 표시"
+msgstr "검색 결과 URL 위치"
 
 msgctxt "settings"
 msgid "Result Visited Check Mark"
-msgstr "방문 확인 마크의 결과"
+msgstr "검색 결과의 방문 확인 마크"
 
 #. http://i.imgur.com/nRnQruy.png
 msgctxt "settings"
 msgid "Result Visited Title Color"
-msgstr "검색 결과에서 방문한 사이트 색상"
+msgstr "검색 결과의 방문한 사이트 제목 색상"
 
 #. In the top menu under Settings
 msgid "Results"
@@ -3563,7 +3563,7 @@ msgstr "저장하고 나가기"
 #. http://i.imgur.com/2X1kTSf.png
 msgctxt "settings"
 msgid "Save your settings anonymously to the cloud"
-msgstr "클라우드에 익명으로 설정 저장"
+msgstr "클라우드에 익명으로 설정 저장하기"
 
 msgctxt "SERP footer content"
 msgid "Say Goodbye To Google"
@@ -3623,7 +3623,7 @@ msgstr "검색 버튼 배경"
 #. search for a place within the map area currently shown in expanded map
 msgctxt "vertical_map"
 msgid "Search Current Map Area"
-msgstr "현재 지도 영역 검색"
+msgstr "현재 지도 영역 검색하기"
 
 msgid "Search DuckDuckGo"
 msgstr "DuckDuckGo 검색"
@@ -3658,7 +3658,7 @@ msgstr "DuckDuckGo 앱 또는 확장 프로그램을 이용하거나, 자주 사
 msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
-msgstr "URL에 검색 요청문 (search queries)을 포함합니다. ('꺼짐'으로 설정할 경우, 검색할 때 POST 요청 방식을 사용합니다)"
+msgstr "URL에 검색 요청문 (search queries)을 포함합니다 ('꺼짐'으로 설정할 경우, 검색할 때 POST 요청 방식을 사용합니다)"
 
 msgctxt "search input box"
 msgid "Search the web without being tracked"
@@ -3873,7 +3873,7 @@ msgstr "매개변수 설정 (JSON 형식)"
 
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "DuckDuckGo를 더 많은 친구들에게 알려서 개인정보를 되찾을 수 있게 도와주세요!"
+msgstr "DuckDuckGo를 더 많은 친구들에게 알려서 사생활을 되찾을 수 있게 도와주세요!"
 
 msgctxt "feedback form"
 msgid "Share feedback for this result."
@@ -3898,7 +3898,7 @@ msgstr "DuckDuckGo 외 타 사이트로 바로 가기"
 #. Clicking will show you your Settings as a URL and JSON like this http://i.imgur.com/59sqEFU.png
 msgctxt "setting"
 msgid "Show Bookmarklet and Settings Data"
-msgstr "북마크와 설정값 보이기"
+msgstr "북마크와 설정값 보여주기"
 
 msgctxt "mobile expanded map"
 msgid "Show Detail"
@@ -3955,11 +3955,11 @@ msgstr "기기에서 DuckDuckGo 사용을 추천하는 메시지 가끔 보여�
 msgctxt "settings"
 msgid ""
 "Show occasional reminders to sign up for the DuckDuckGo privacy newsletter"
-msgstr "DuckDuckGo 개인정보 보호 뉴스레터 구독 추천 메시지 보여주기"
+msgstr "DuckDuckGo 사생활 보호 뉴스레터 구독 추천 메시지 보여주기"
 
 msgctxt "settings"
 msgid "Show page numbers at result page breaks"
-msgstr "페이지 결과를 나눌 때 페이지 번호 보이기"
+msgstr "페이지 결과를 나눌 때 페이지 번호 보여주기"
 
 #. Click "Load Settings" - http://i.imgur.com/cii6KqL.png
 #. Then - http://i.imgur.com/nOvjdKb.png
@@ -3972,7 +3972,7 @@ msgstr "암호 보여주기"
 
 msgctxt "settings"
 msgid "Show sign up form for the DuckDuckGo privacy newsletter"
-msgstr "DuckDuckGo 개인정보 보호 뉴스레터 등록 양식 표시"
+msgstr "DuckDuckGo 사생활 보호 뉴스레터 등록 양식 표시"
 
 msgctxt "directions"
 msgid "Show steps"
@@ -3985,15 +3985,15 @@ msgstr "검색 상자 밑에 검색어 제안 내용 보여주기"
 
 msgctxt "settings"
 msgid "Show the Result URL line above the snippet text"
-msgstr "찾은 URL 토막글 위에 표시하기"
+msgstr "검색 결과 URL을 설명 텍스트 바로 위에 표시하기"
 
 msgctxt "settings"
 msgid "Show the full URL for each result"
-msgstr "각 검색 결과에 전체 URL 보이기"
+msgstr "검색 결과의 전체 URL 보여주기"
 
 msgctxt "settings"
 msgid "Show the privacy benefits of using DuckDuckGo on the homepage"
-msgstr "DuckDuckGo가 개인정보 보호에 어떻게 도움이 되는지 홈페이지에 보여주기"
+msgstr "DuckDuckGo가 사생활 보호에 어떻게 도움이 되는지 홈페이지에서 보여주기"
 
 msgctxt "video-duration"
 msgid "Show videos of any length"
@@ -4036,7 +4036,7 @@ msgstr "공연"
 #. Discontinued, don't translate
 msgctxt "settings"
 msgid "Shows the search button background"
-msgstr "뒤에 검색 버튼 보이기"
+msgstr "뒤에 검색 버튼 보여주기"
 
 #. Used in 0-click box for product results, e.g. <a href="https://duckduckgo.com/?q=9780061353246">https://duckduckgo.com/?q=9780061353246</a>
 msgid "Similar"
@@ -4143,11 +4143,11 @@ msgstr "최신 정보 확인하기"
 
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "뉴스레터를 통해 개인정보를 보호할 수 있는 방법을 알아보세요."
+msgstr "뉴스레터를 통해 사생활을 보호할 수 있는 방법을 알아보세요."
 
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "뉴스레터를 통해 개인정보를 보호할 수 있는 방법을 알아보세요."
+msgstr "뉴스레터를 통해 사생활을 보호할 수 있는 방법을 알아보세요."
 
 #. Instant Answer tab name - eg. https://duckduckgo.com/?q=Energy+Transfer+Equity&ia=stock
 msgid "Stock"
@@ -4193,7 +4193,7 @@ msgstr "구독하기"
 
 msgctxt "showcase_newsletter"
 msgid "Subscribe to our Privacy Crash Course"
-msgstr "개인정보 보호 특강을 구독하세요"
+msgstr "사생활 보호 특강을 구독하세요"
 
 #. http://i.imgur.com/BMM6X3h.png
 msgctxt "settings"
@@ -4237,7 +4237,7 @@ msgstr "DuckDuckGo로 변경"
 
 msgctxt "homepage onboarding"
 msgid "Switch to DuckDuckGo and take back your privacy!"
-msgstr "DuckDuckGo로 갈아타고 개인정보을 되찾으세요!"
+msgstr "DuckDuckGo로 갈아타고 사생활을 되찾으세요!"
 
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "절대 사용자를 추적하지 않는 검색 엔진으로 바꾸세요."
@@ -4259,18 +4259,18 @@ msgstr "대만"
 
 #. Recupera Tu Privacidad!
 msgid "Take Back Your Privacy!"
-msgstr "개인정보를 완벽하게 보호하세요!"
+msgstr "사생활을 완벽하게 보호하세요!"
 
 msgid "Take back your privacy!"
-msgstr "개인정보를 완벽하게 보호하세요!"
+msgstr "사생활을 완벽하게 보호하세요!"
 
 msgctxt "reasons-to-use-duckduckgo"
 msgid "Take control of your personal data."
-msgstr "개인정보를 관리하세요."
+msgstr "개인 정보를 원하는 대로 관리하세요."
 
 msgctxt "SERP footer content"
 msgid "Take our Privacy Crash Course and learn about online privacy."
-msgstr "개인 정보 보호 특강 코스를 통해 온라인 개인 정보에 대해 자세히 알아보세요."
+msgstr "사생활 보호 특강 코스를 통해 온라인 사생활에 대해 자세히 알아보세요."
 
 msgctxt "image-layout"
 msgid "Tall"
@@ -4364,7 +4364,7 @@ msgstr "이 검색 엔진은 사용자를 추적하지 않습니다. %1$s더 알
 
 msgctxt "SERP footer content"
 msgid "The world needs an alternative to the collect-it-all business model."
-msgstr "허락도 없이 개인정보를 수집하는 다른 검색 엔진과의 차이를 확인하세요."
+msgstr "허락도 없이 개인 정보를 수집하는 다른 검색 엔진과의 차이를 확인하세요."
 
 #. Title for the theme menu:
 #. https://duck.co/media/files/theme.png
@@ -4391,7 +4391,7 @@ msgid ""
 "These browser permissions are used to add privacy protection on websites you "
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
-msgstr "이 브라우저 권한은 사용자를 추적하는 히든 트래커들을 차단해 개인정보를 보호하고 DuckDuckGo를 기본 검색 엔진으로 변경하는 데 사용됩니다."
+msgstr "이 브라우저 권한은 사용자를 추적하는 히든 트래커들을 차단해 사생활을 보호하고 DuckDuckGo를 기본 검색 엔진으로 변경하는 데 사용됩니다."
 
 #. Click "What is this?" - http://i.imgur.com/KhmRHth.png
 #. Then in the cloud save box - http://i.imgur.com/d2RxxQ8.png
@@ -4427,14 +4427,14 @@ msgstr "이 웹사이트는 사용자를 안전하게 보호하고 통신을 암
 #. In spanish: Esto borrará todos los ajustes. ¿Desea continuar?
 msgctxt "settings"
 msgid "This will erase all settings. Continue?"
-msgstr "모든 설정이 삭제됩니다. 계속하시겠습니까?"
+msgstr "모든 설정이 삭제됩니다. 계속하시겠어요?"
 
 msgctxt "settings"
 msgid "This will reset your saved settings to default values. Continue?"
-msgstr "저장된 설정을 기본값으로 초기화시킵니다. 계속하시겠습니까?"
+msgstr "저장된 설정을 기본값으로 초기화시킵니다. 계속하시겠어요?"
 
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr "온라인에서 개인 정보를 보호하고 싶으세요? %1$sDuckDuckGo와 함께 하세요.%2$s"
+msgstr "개인 정보를 추적하는 웹사이트가 지긋지긋하시다고요? %1$s저희가 도와드리겠습니다.%2$s"
 
 msgid "Today"
 msgstr "오늘"
@@ -4519,7 +4519,7 @@ msgid "Turn off:"
 msgstr "끄기:"
 
 msgid "Twitter"
-msgstr "트위터"
+msgstr "Twitter"
 
 #  Chrome default search engine instruction
 msgid "Type %sDuckDuckGo%s in the first %sform field"
@@ -4631,7 +4631,7 @@ msgstr "사용"
 
 msgctxt "mobile homepage"
 msgid "Use DuckDuckGo Private Search"
-msgstr "DuckDuckGo 개인정보 보호 모드 사용하기"
+msgstr "DuckDuckGo 사생활 보호 모드 사용하기"
 
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
@@ -4733,7 +4733,7 @@ msgstr "YouTube에서 보기"
 
 msgctxt "SERP footer content"
 msgid "We Protect Your Privacy"
-msgstr "저희는 개인정보를 보호합니다"
+msgstr "저희는 개인 정보를 보호합니다"
 
 #. Click "What is this?" - http://i.imgur.com/KhmRHth.png
 #. Then in the cloud save box - http://i.imgur.com/vBsbibl.png
@@ -4772,11 +4772,11 @@ msgstr "위치 정보는 서버에 저장되지 않으며, 사용자의 기기�
 
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr "저희는 사용자의 개인정보를 저장하거나 추적하지 않습니다. 절대로요."
+msgstr "저희는 사용자의 개인 정보를 저장하거나 추적하지 않습니다. 절대로요."
 
 msgctxt "reasons-to-use-duckduckgo"
 msgid "We don't store your personal info."
-msgstr "저희는 사용자의 개인정보를 저장하지 않습니다."
+msgstr "저희는 사용자의 개인 정보를 저장하지 않습니다."
 
 msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
@@ -4785,7 +4785,7 @@ msgstr "DuckDuckGo는 개인 정보를 저장하지 않습니다. DuckDuckGo는 
 
 msgctxt "reasons-to-use-duckduckgo"
 msgid "We don't store your personal information."
-msgstr "저희는 사용자의 개인정보를 저장하지 않습니다."
+msgstr "저희는 사용자의 개인 정보를 저장하지 않습니다."
 
 msgctxt "SERP footer content"
 msgid "We don't store your search history or follow you around the web."
@@ -4797,7 +4797,7 @@ msgstr "DuckDuckGo는 사용자를 추적하지 않지만, 다른 검색 엔진�
 
 msgctxt "reasons-to-use-duckduckgo"
 msgid "We don't track you, including private browsing mode."
-msgstr "개인정보 보호 모드를 사용하든 안하든 사용자를 추적하지 않습니다."
+msgstr "개인 정보 보호 모드의 사용 여부와 관계없이 사용자를 추적하지 않습니다."
 
 msgctxt "new user poll"
 msgid ""
@@ -4824,11 +4824,11 @@ msgstr "저희는 위치나 이용 기록 등을 추적해 광고를 보여주�
 
 msgctxt "homepage onboarding"
 msgid "We don’t store your personal info. Ever."
-msgstr "어떠한 개인정보도 저장하지 않습니다. 절대로요."
+msgstr "어떠한 개인 정보도 저장하지 않습니다. 절대로요."
 
 msgctxt "homepage onboarding"
 msgid "We don’t store your personal information. Ever."
-msgstr "어떠한 개인정보도 저장하지 않습니다. 절대로요."
+msgstr "어떠한 개인 정보도 저장하지 않습니다. 절대로요."
 
 msgctxt "homepage onboarding"
 msgid ""
@@ -4838,7 +4838,7 @@ msgstr "검색 기록은 절대로 서버에 저장되지 않으며, 광고주�
 
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr "개인정보 보호 모드 사용 여부에 관계없이 절대로 사용자를 추적하지 않습니다."
+msgstr "사생활 보호 모드 사용 여부에 관계없이 절대로 사용자를 추적하지 않습니다."
 
 msgctxt "SERP footer content"
 msgid "We get a ton of searches, and all of them are anonymous."
@@ -4853,15 +4853,15 @@ msgstr "설정 파일은 생성된 키를 파일 이름으로 하여 클라우�
 
 msgctxt "feedback form"
 msgid "We use feedback like this to improve DuckDuckGo. It really helps."
-msgstr "우리는 DuckDuckGo를 개선하기 위해 이와 같은 피드백을 사용합니다. 도움을 주셔서 감사합니다."
+msgstr "저희는 DuckDuckGo를 개선하기 위해 이러한 피드백을 사용합니다. 도움을 주셔서 감사합니다."
 
 msgid ""
 "We'll block hidden trackers and encrypt connections to keep you more private."
-msgstr "숨겨진 추적기를 차단하고 연결을 암호화하여 개인정보 보호를 강화합니다."
+msgstr "숨겨진 추적기를 차단하고 연결을 암호화하여 사생활 보호를 강화합니다."
 
 msgctxt "new user poll"
 msgid "We're honored to have you on the Duck Side"
-msgstr "같이 'Duck'을 쌓을 수 있게 되어서 영광이에요."
+msgstr "'오리 편'으로 오시게 되어 정말 영광이에요."
 
 msgctxt "SERP footer content"
 msgid "We've got some more links for you!"
@@ -4885,11 +4885,11 @@ msgstr "환영 메시지"
 
 msgctxt "new user poll"
 msgid "Welcome back!"
-msgstr "다시 온 것을 환영해요!"
+msgstr "다시 오신 것을 환영합니다!"
 
 msgctxt "homepage onboarding"
 msgid "Welcome to the Duck Side!"
-msgstr "Duck Side에 오신 것을 환영합니다!"
+msgstr "'오리 편'에 들어오신 것을 환영합니다!"
 
 msgctxt "maps_places"
 msgid "What People Say"
@@ -4927,7 +4927,7 @@ msgstr "클라우드 저장 북마클릿이 뭐죠? 그리고 이게 URL 파라�
 
 #. http://i.imgur.com/fDEZ8XN.png
 msgid "What is this?"
-msgstr "이게 뭔가요?"
+msgstr "이건 무슨 기능인가요?"
 
 msgctxt "new user poll"
 msgid "What led you to DuckDuckGo?"
@@ -4953,7 +4953,7 @@ msgid "Who We Are"
 msgstr "회사 정보"
 
 msgid "Why Privacy"
-msgstr "개인정보 보호의 중요성"
+msgstr "사생활 보호의 중요성"
 
 msgctxt "image-layout"
 msgid "Wide"
@@ -5039,7 +5039,7 @@ msgstr "DuckDuckGo 확장 설치가 완료되었습니다!"
 msgid ""
 "You now have the tools you need to control your online footprint and take "
 "back your privacy!"
-msgstr "이제 온라인 흔적을 제어하고 개인정보를 보호하는 데 필요한 도구가 생겼습니다!"
+msgstr "이제 온라인 흔적을 제어하고 개인 정보를 보호하는 데 필요한 도구가 생겼습니다!"
 
 msgctxt "SERP footer content"
 msgid "You're in control. Customize the look-and-feel of DuckDuckGo."
@@ -5050,15 +5050,15 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
-msgstr "이제 Chrome에서 개인 정보 노출 없이 검색할 수 있습니다. 크롬 대신 DuckDuckGo 앱도 사용해 보세요. 이미 설치되어 있으며 다음 기능이 제공됩니다."
+msgstr "이제 Chrome에서 사생활 노출 없이 검색할 수 있습니다. 크롬 대신 DuckDuckGo 앱도 사용해 보세요. 이미 설치되어 있으며 다음과 같은 기능이 제공됩니다:"
 
 msgid "You're now searching with privacy!"
-msgstr "현재 개인정보 보호 모드로 검색하고 있습니다!"
+msgstr "현재 사생활 보호 모드로 검색하고 있습니다!"
 
 msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
-msgstr "현재 개인정보 보호 모드로 검색하고 있습니다. %1$s더욱 더 비밀스러워지고 싶다면, 팁을 받아보세요."
+msgstr "현재 사생활 보호 모드로 검색하고 있습니다. %1$s더욱 더 비밀스러워지고 싶다면, 팁을 받아보세요."
 
 msgctxt "precise_user_location"
 msgid "You've chosen not to set your location."
@@ -5070,7 +5070,7 @@ msgid ""
 msgstr "YouTube에서는 동영상을 익명으로 볼 수 없습니다.따라서, 여기서 YouTube 동영상을 볼 경우 YouTube나 Google의 추적을 받게 됩니다."
 
 msgid "YouTube Privacy Warning"
-msgstr "YouTube 개인정보 보호 관련 주의"
+msgstr "YouTube 개인 정보 관련 주의"
 
 msgctxt "video-license"
 msgid "YouTube Standard"

--- a/locales/ko_KR/LC_MESSAGES/duckduckgo.po
+++ b/locales/ko_KR/LC_MESSAGES/duckduckgo.po
@@ -1292,7 +1292,7 @@ msgid "Donate and support online privacy."
 msgstr "기부해서 온라인 개인 정보 보호에 도움을 주세요."
 
 msgid "Donating for Privacy"
-msgstr "개인 정보을 위한 기부"
+msgstr "개인 정보 보호를 위한 기부"
 
 msgctxt "SERP footer content"
 msgid "Donating for Privacy"


### PR DESCRIPTION
I'm also reverting some of the changes I made related to https://github.com/duckduckgo/duckduckgo-locales/pull/247 and https://github.com/duckduckgo/duckduckgo-locales/pull/249.

Here is a list of major changes and the reasons why I believe these changes are necessary.

## `개인정보` -> `개인 정보`

The proper spacing for `개인정보` is `개인 정보`, check out [this comment written by National Institute of the Korean Language](https://www.korean.go.kr/front/onlineQna/onlineQnaView.do?mn_id=84&qna_seq=152068&pageIndex=12) for more information.

## `개인 정보` -> `사생활`

All translations that contain the word `개인 정보` (personal data) have been updated to include the word `사생활` (privacy) which makes more sense, considering there could be privacy-sensitive information that aren't personal data such as sensitive information about companies and organizations.

## `바꾸기` -> `변경하기`

`변경하기` is a more formal version of `바꾸기` and is used in major Korean search engines such as [NAVER](https://www.naver.com/) and [Daum](https://www.daum.net/).

## `Duck Side` -> `오리 편`

I'll admit that this is a *bad* play on words considering `오리` means 'duck' and `우리 편` means 'our side' in Korean, but I decided that it is probably better to update translations than leaving 'Duck Side' untranslated. Let me know what you think about this one.