### PR TITLE
Fixed Japanese "stock" translation

### DIFF
--- a/locales/ja_JP/LC_MESSAGES/duckduckgo.po
+++ b/locales/ja_JP/LC_MESSAGES/duckduckgo.po
@@ -4150,7 +4150,7 @@ msgstr "プライバシーニュースレターで、最新情報を入手して
 
 #. Instant Answer tab name - eg. https://duckduckgo.com/?q=Energy+Transfer+Equity&ia=stock
 msgid "Stock"
-msgstr "在庫"
+msgstr "株価"
 
 msgid "Store"
 msgstr "ストア"


### PR DESCRIPTION
The current text (在庫) means stock as in inventory, whereas in this context it should be stock market price (株価).