### PR TITLE
Fix small grammatical error in Croatian (hr-hr) translation

### DIFF
--- a/locales/hr_HR/LC_MESSAGES/duckduckgo.po
+++ b/locales/hr_HR/LC_MESSAGES/duckduckgo.po
@@ -3456,10 +3456,10 @@ msgstr "Privatnost u tvojoj ulaznoj pošti"
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid "Privacy, simplified"
-msgstr "Zaštita privatnosti, pojednostavljeno"
+msgstr "Zaštita privatnosti, pojednostavljena"
 
 msgid "Privacy, simplified."
-msgstr "Zaštita privatnosti, pojednostavljeno."
+msgstr "Zaštita privatnosti, pojednostavljena."
 
 msgid "Private Search"
 msgstr "Privatno pretraživanje"


### PR DESCRIPTION
Fixed translation of "simplified", considering the grammatical gender of the noun "privacy" in Croatian.