### PR TITLE
Import new tokens - 2021-03-16-1454

### DIFF
--- a/duckduckgo.pot
+++ b/duckduckgo.pot
@@ -339,8 +339,20 @@ msgid "All Colors"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "image-layout"
 msgid "All Layouts"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -2111,6 +2123,30 @@ msgid "France"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr ""
@@ -2934,6 +2970,12 @@ msgid "Light green"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr ""
@@ -3626,6 +3668,10 @@ msgid "Open"
 msgstr ""
 
 # smartling.placeholder_format=C
+msgid "Open %s website"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 
@@ -4204,6 +4250,12 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
 msgstr ""
 
 # smartling.placeholder_format=C

--- a/locales/af_ZA/LC_MESSAGES/duckduckgo.po
+++ b/locales/af_ZA/LC_MESSAGES/duckduckgo.po
@@ -285,9 +285,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Alle Kleure"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Alle Uitlegte"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "Alle Plekke"
@@ -1785,6 +1795,26 @@ msgstr "Enkripsie op webwerwe afdwing"
 msgid "France"
 msgstr "Frankryk"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "30"
@@ -2473,6 +2503,11 @@ msgstr "Ligblou"
 msgid "Light green"
 msgstr "Lig groen"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Skakellettertipe:"
@@ -3037,6 +3072,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr "Maak oop"
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "Open %1$sKieslys > Instellings > Soek%2$s en kies DuckDuckGo!"
 
@@ -3511,6 +3549,11 @@ msgstr "Peskerm U Privaatheid!"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "Beskerm u data op elke toestel."
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5572,4 +5615,3 @@ msgstr "naspoorderblokkering"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "j"
-

--- a/locales/ar_DZ/LC_MESSAGES/duckduckgo.po
+++ b/locales/ar_DZ/LC_MESSAGES/duckduckgo.po
@@ -278,8 +278,18 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr ""
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
+msgstr ""
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
 msgstr ""
 
 msgid "All Places"
@@ -1685,6 +1695,26 @@ msgstr ""
 msgid "France"
 msgstr "فرنسا"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr ""
@@ -2349,6 +2379,11 @@ msgstr "الضوء الأزرق"
 msgid "Light green"
 msgstr "أخضر فاتح"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "بنط الرابط"
@@ -2904,6 +2939,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 
@@ -3365,6 +3403,11 @@ msgstr ""
 
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
+msgstr ""
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -5317,4 +5360,3 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/ar_EG/LC_MESSAGES/duckduckgo.po
+++ b/locales/ar_EG/LC_MESSAGES/duckduckgo.po
@@ -280,8 +280,18 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr ""
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
+msgstr ""
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
 msgstr ""
 
 msgid "All Places"
@@ -1710,6 +1720,26 @@ msgstr ""
 msgid "France"
 msgstr ""
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr ""
@@ -2375,6 +2405,11 @@ msgstr "أزرق فاتح"
 msgid "Light green"
 msgstr "أخضر فاتح"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "خط رابط:"
@@ -2936,6 +2971,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 
@@ -3393,6 +3431,11 @@ msgstr ""
 
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
+msgstr ""
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -5346,4 +5389,3 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/ar_JO/LC_MESSAGES/duckduckgo.po
+++ b/locales/ar_JO/LC_MESSAGES/duckduckgo.po
@@ -280,8 +280,18 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr ""
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
+msgstr ""
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
 msgstr ""
 
 msgid "All Places"
@@ -1705,6 +1715,26 @@ msgstr ""
 msgid "France"
 msgstr ""
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr ""
@@ -2365,6 +2395,11 @@ msgstr "أزرق فاتح"
 msgid "Light green"
 msgstr "أخضر فاتح"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "خط الرابط:"
@@ -2922,6 +2957,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 
@@ -3379,6 +3417,11 @@ msgstr ""
 
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
+msgstr ""
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -5327,4 +5370,3 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/ar_SA/LC_MESSAGES/duckduckgo.po
+++ b/locales/ar_SA/LC_MESSAGES/duckduckgo.po
@@ -282,9 +282,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "جميع الالوان"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "جميع الطبقات"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr ""
@@ -1702,6 +1712,26 @@ msgstr ""
 msgid "France"
 msgstr "فرنسا"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "صديق أو عائلة"
@@ -2366,6 +2396,11 @@ msgstr "ضوء أزرق"
 msgid "Light green"
 msgstr "أخضر فاتح"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "الخط المستخدم للروابط:"
@@ -2927,6 +2962,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 #  Marked fuzzy because of translated trademark
 #, fuzzy
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
@@ -3389,6 +3427,11 @@ msgstr ""
 
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
+msgstr ""
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -5360,4 +5403,3 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/ast_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/ast_ES/LC_MESSAGES/duckduckgo.po
@@ -277,8 +277,18 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Tolos colores"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
+msgstr ""
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
 msgstr ""
 
 msgid "All Places"
@@ -1680,6 +1690,26 @@ msgstr ""
 msgid "France"
 msgstr "Francia"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr ""
@@ -2340,6 +2370,11 @@ msgstr "Azul claro"
 msgid "Light green"
 msgstr "Verde claro"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr ""
@@ -2895,6 +2930,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 
@@ -3356,6 +3394,11 @@ msgstr "¡Protexi la to privacidá!"
 
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
+msgstr ""
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -5306,4 +5349,3 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/az_AZ/LC_MESSAGES/duckduckgo.po
+++ b/locales/az_AZ/LC_MESSAGES/duckduckgo.po
@@ -282,9 +282,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Bütün rənglər"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Bütün Düzülüşlər"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "Bütün Yerlər"
@@ -1691,6 +1701,26 @@ msgstr ""
 msgid "France"
 msgstr "Fransa"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Dost və ya ailə"
@@ -2355,6 +2385,11 @@ msgstr "Açıq mavi"
 msgid "Light green"
 msgstr "Açıq yaşıl"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Keçid yazı tipi:"
@@ -2914,6 +2949,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 
@@ -3375,6 +3413,11 @@ msgstr ""
 
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
+msgstr ""
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -5337,4 +5380,3 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/be_BY/LC_MESSAGES/duckduckgo.po
+++ b/locales/be_BY/LC_MESSAGES/duckduckgo.po
@@ -289,9 +289,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Усе колеры"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Усе макеты"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "Усе месцы"
@@ -1793,6 +1803,26 @@ msgstr "Прымусова пераключаць на шыфраванае зл
 msgid "France"
 msgstr "Францыя"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Сябар ці сям'я"
@@ -2486,6 +2516,11 @@ msgstr "Светлы блакітны"
 msgid "Light green"
 msgstr "Светла-зялены"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Шрыфт спасылкі:"
@@ -3050,6 +3085,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr "Адкрыта"
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "Адчыніце %1$sМеню> Налады> Пошук %2$s і абярыце DuckDuckGo!"
 
@@ -3525,6 +3563,11 @@ msgstr "Абараніце сваю прыватнасць!"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "Абараніце свае дадзеныя на кожнай прыладзе."
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5596,4 +5639,3 @@ msgstr "блакіроўка сродкаў адсочвання"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "г."
-

--- a/locales/bg_BG/LC_MESSAGES/duckduckgo.po
+++ b/locales/bg_BG/LC_MESSAGES/duckduckgo.po
@@ -288,9 +288,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Всички цветове"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Всички оформления"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "Всички места"
@@ -1796,6 +1806,26 @@ msgstr "Да наложи криптиране на уебсайтове"
 msgid "France"
 msgstr "Франция"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Приятел или член на семейството"
@@ -2493,6 +2523,11 @@ msgstr "светло синьо"
 msgid "Light green"
 msgstr "светло зелено"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Шрифт на линковете:"
@@ -3058,6 +3093,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr "Отваряне"
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "Отворете %1$sМеню > Настройки > Търсене %2$s и посочете DuckDuckGo!"
 
@@ -3535,6 +3573,11 @@ msgstr "Защитете Вашата поверителност!"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "Защитете Вашите данни на всяко устройство."
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5629,4 +5672,3 @@ msgstr "блокиране на проследяването"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "год"
-

--- a/locales/bn_BD/LC_MESSAGES/duckduckgo.po
+++ b/locales/bn_BD/LC_MESSAGES/duckduckgo.po
@@ -277,9 +277,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "সব রং"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "সব লেয়াউট"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "সব স্থান"
@@ -1699,6 +1709,26 @@ msgstr ""
 msgid "France"
 msgstr ""
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr ""
@@ -2363,6 +2393,11 @@ msgstr "হালকা নীল"
 msgid "Light green"
 msgstr "হালকা সবুজ"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "সংযোগ ফন্ট"
@@ -2925,6 +2960,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 
@@ -3382,6 +3420,11 @@ msgstr ""
 
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
+msgstr ""
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -5343,4 +5386,3 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/bn_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/bn_IN/LC_MESSAGES/duckduckgo.po
@@ -279,8 +279,18 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr ""
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
+msgstr ""
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
 msgstr ""
 
 msgid "All Places"
@@ -1696,6 +1706,26 @@ msgstr ""
 msgid "France"
 msgstr ""
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr ""
@@ -2356,6 +2386,11 @@ msgstr "আলোর বাল্ব"
 msgid "Light green"
 msgstr "হাল্কা সবুজ"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "লিংক ফন্ট:"
@@ -2911,6 +2946,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 
@@ -3368,6 +3406,11 @@ msgstr ""
 
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
+msgstr ""
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -5317,4 +5360,3 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/bo_CN/LC_MESSAGES/duckduckgo.po
+++ b/locales/bo_CN/LC_MESSAGES/duckduckgo.po
@@ -277,8 +277,18 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr ""
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
+msgstr ""
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
 msgstr ""
 
 msgid "All Places"
@@ -1674,6 +1684,26 @@ msgstr ""
 msgid "France"
 msgstr ""
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr ""
@@ -2332,6 +2362,11 @@ msgstr ""
 msgid "Light green"
 msgstr ""
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr ""
@@ -2887,6 +2922,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 
@@ -3344,6 +3382,11 @@ msgstr ""
 
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
+msgstr ""
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.

--- a/locales/br_FR/LC_MESSAGES/duckduckgo.po
+++ b/locales/br_FR/LC_MESSAGES/duckduckgo.po
@@ -279,8 +279,18 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr ""
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
+msgstr ""
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
 msgstr ""
 
 msgid "All Places"
@@ -1697,6 +1707,26 @@ msgstr ""
 msgid "France"
 msgstr ""
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr ""
@@ -2361,6 +2391,11 @@ msgstr "Glas sklaer"
 msgid "Light green"
 msgstr "Gwer sklaer"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Nodrezh an ere :"
@@ -2925,6 +2960,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 
@@ -3383,6 +3421,11 @@ msgstr ""
 
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
+msgstr ""
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -5355,4 +5398,3 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/bs_BA/LC_MESSAGES/duckduckgo.po
+++ b/locales/bs_BA/LC_MESSAGES/duckduckgo.po
@@ -279,8 +279,18 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr ""
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
+msgstr ""
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
 msgstr ""
 
 msgid "All Places"
@@ -1685,6 +1695,26 @@ msgstr ""
 msgid "France"
 msgstr ""
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr ""
@@ -2348,6 +2378,11 @@ msgstr "Svijetlo plavo"
 msgid "Light green"
 msgstr "Svijetlo zeleno"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Linkza font:"
@@ -2908,6 +2943,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 
@@ -3365,6 +3403,11 @@ msgstr ""
 
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
+msgstr ""
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -5317,4 +5360,3 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/ca_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/ca_ES/LC_MESSAGES/duckduckgo.po
@@ -291,9 +291,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Tots els colors"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Totes les capes"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "Tots els llocs"
@@ -1729,6 +1739,26 @@ msgstr "Força el xifratge en llocs web"
 msgid "France"
 msgstr "França"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Amic o família"
@@ -2414,6 +2444,11 @@ msgstr "Blau clar"
 msgid "Light green"
 msgstr "Verd clar"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Font de l'enllaç:"
@@ -2976,6 +3011,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr "Obert"
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "Obriu %sMenú  > Preferències  > Cerca %s i seleccioneu DuckDuckGo!"
 
@@ -3445,6 +3483,11 @@ msgstr "Protegeix la vostra privadesa!"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "Protegiu les vostres dades a cada dispositiu."
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5473,4 +5516,3 @@ msgstr "bloqueig de rastrejadors"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/cs_CZ/LC_MESSAGES/duckduckgo.po
+++ b/locales/cs_CZ/LC_MESSAGES/duckduckgo.po
@@ -285,9 +285,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Všechny barvy"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Všechny formáty"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "Všechna Místa"
@@ -1782,6 +1792,26 @@ msgstr "Vynutit šifrování na webových stránkách"
 msgid "France"
 msgstr "Francie"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Přítel nebo rodina"
@@ -2476,6 +2506,11 @@ msgstr "Světle modrá"
 msgid "Light green"
 msgstr "Světle zelená"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Font odkazu:"
@@ -3039,6 +3074,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr "Otevřít"
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "Otevřete %1$sMenu > Nastavení > Vyhledávání %2$s a vyberte DuckDuckGo!"
 
@@ -3514,6 +3552,11 @@ msgstr "Chraňte své soukromí!"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "Chraňte svá data na všech zařízeních."
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5593,4 +5636,3 @@ msgstr "blokování trackerů"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "r"
-

--- a/locales/cy_GB/LC_MESSAGES/duckduckgo.po
+++ b/locales/cy_GB/LC_MESSAGES/duckduckgo.po
@@ -289,9 +289,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Pob Lliw"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Pob Cynllun"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "Pob Lle"
@@ -1716,6 +1726,26 @@ msgstr ""
 msgid "France"
 msgstr "Ffrainc"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr ""
@@ -2383,6 +2413,11 @@ msgstr "Glas golau"
 msgid "Light green"
 msgstr "Gwyrdd golau"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Ffont dolen:"
@@ -2949,6 +2984,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 
@@ -3419,6 +3457,11 @@ msgstr "Amddiffyn Eich Preifatrwydd!"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "Amddiffyn eich ddata ar pob dyfais."
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"

--- a/locales/da_DK/LC_MESSAGES/duckduckgo.po
+++ b/locales/da_DK/LC_MESSAGES/duckduckgo.po
@@ -284,9 +284,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Alle farver"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Alle Layouts"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "Alle steder"
@@ -1780,6 +1790,26 @@ msgstr "Tvinge kryptering på websteder"
 msgid "France"
 msgstr "Frankrig"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Ven eller familie"
@@ -2468,6 +2498,11 @@ msgstr "Lyseblå"
 msgid "Light green"
 msgstr "Lysegrøn"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Link skrifttype:"
@@ -3031,6 +3066,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr "Åben"
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "Åbn %1$sMenu > Indstillinger > Søg på %2$s og vælg DuckDuckGo!"
 
@@ -3504,6 +3542,11 @@ msgstr "Beskyt Dit Privatliv!"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "Beskyt dine data på alle enheder."
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5569,4 +5612,3 @@ msgstr "tracker blokering"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "år"
-

--- a/locales/de_CH/LC_MESSAGES/duckduckgo.po
+++ b/locales/de_CH/LC_MESSAGES/duckduckgo.po
@@ -287,9 +287,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Alle Farben"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Alle Dimensionen"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "Alle Ort"
@@ -1726,6 +1736,26 @@ msgstr "Erzwinge Verschlüsselung auf Webseiten"
 msgid "France"
 msgstr "Frankreich"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Freunde oder Familie"
@@ -2404,6 +2434,11 @@ msgstr "Hellblau"
 msgid "Light green"
 msgstr "Hellgrün"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Link-Schriftart"
@@ -2968,6 +3003,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr "Öffnen"
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "Öffne %sMenu > Einstellungen > Suche %s und wähle DuckDuckGo."
 
@@ -3436,6 +3474,11 @@ msgstr "Schütze deine Privatsphäre!"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "Schütze deine Daten auf allen Geräten"
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5466,4 +5509,3 @@ msgstr "Trackerblockierung"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/de_DE/LC_MESSAGES/duckduckgo.po
+++ b/locales/de_DE/LC_MESSAGES/duckduckgo.po
@@ -287,9 +287,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Alle Farben"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Alle Bildformate"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "Alle Orte"
@@ -1807,6 +1817,26 @@ msgstr "Eine Verschlüsselung auf Websites erzwingen"
 msgid "France"
 msgstr "Frankreich"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Freunde oder Familie"
@@ -2503,6 +2533,11 @@ msgstr "Hellblau"
 msgid "Light green"
 msgstr "Hellgrün"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Verweisschrift:"
@@ -3068,6 +3103,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr "Offen"
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "%1$sMenü → Einstellungen → Suche %2$s und dann DuckDuckGo auswählen!"
 
@@ -3549,6 +3587,11 @@ msgstr "Schütze deine Privatsphäre!"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "Schütze Deine Daten, egal auf welchem Gerät."
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5651,4 +5694,3 @@ msgstr "tracker blocking"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "J"
-

--- a/locales/el_GR/LC_MESSAGES/duckduckgo.po
+++ b/locales/el_GR/LC_MESSAGES/duckduckgo.po
@@ -287,9 +287,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Όλα τα Χρώματα"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Όλες οι μορφές"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "Όλες οι τοποθεσίες"
@@ -1825,6 +1835,26 @@ msgstr "Εξαναγκάσει την κρυπτογράφηση σε ιστότ
 msgid "France"
 msgstr "Γαλλία"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Φίλος ή Οικογένεια"
@@ -2534,6 +2564,11 @@ msgstr "Απαλό μπλε"
 msgid "Light green"
 msgstr "Απαλό πράσινο"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Γραμματοσειρά συνδέσμου"
@@ -3102,6 +3137,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr "΄Άνοιγμα"
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 "Ανοίξτε το %1$sΜενού > Ρυθμίσεις > Αναζήτηση %2$s και επιλέξτε DuckDuckGo!"
@@ -3585,6 +3623,11 @@ msgstr "Προστατέψτε την ιδιωτικότητά σας!"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "Προστατέψτε τα δεδομένα σας σε κάθε συσκευή."
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5726,4 +5769,3 @@ msgstr "αποκλεισμός παρακολούθησης"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "έτ"
-

--- a/locales/en_AU/LC_MESSAGES/duckduckgo.po
+++ b/locales/en_AU/LC_MESSAGES/duckduckgo.po
@@ -280,9 +280,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "All Colours"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "All Layouts"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "All Places"
@@ -1695,6 +1705,26 @@ msgstr ""
 msgid "France"
 msgstr "France"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Mate or relo"
@@ -2361,6 +2391,11 @@ msgstr "Light blue"
 msgid "Light green"
 msgstr "Light green"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Link font:"
@@ -2922,6 +2957,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 
@@ -3385,6 +3423,11 @@ msgstr "Protect Your Privacy!"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "Protect your data on every device."
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5363,4 +5406,3 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/en_CA/LC_MESSAGES/duckduckgo.po
+++ b/locales/en_CA/LC_MESSAGES/duckduckgo.po
@@ -280,9 +280,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "All Colours"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "All Layouts"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "All Places"
@@ -1695,6 +1705,26 @@ msgstr ""
 msgid "France"
 msgstr "France"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Friend or family"
@@ -2361,6 +2391,11 @@ msgstr " Light blue"
 msgid "Light green"
 msgstr " Light green"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr " Link font:"
@@ -2922,6 +2957,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "Open %sMenu > Settings > Search %s and select DuckDuckGo! "
 
@@ -3385,6 +3423,11 @@ msgstr "Protect Your Privacy!"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "Protect your data on every device."
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5363,4 +5406,3 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/en_GB/LC_MESSAGES/duckduckgo.po
+++ b/locales/en_GB/LC_MESSAGES/duckduckgo.po
@@ -280,9 +280,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "All Colours"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "All Layouts"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "All Places"
@@ -1695,6 +1705,26 @@ msgstr ""
 msgid "France"
 msgstr "France"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Friend or family"
@@ -2361,6 +2391,11 @@ msgstr "Light blue"
 msgid "Light green"
 msgstr "Light green"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Link font:"
@@ -2922,6 +2957,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 
@@ -3385,6 +3423,11 @@ msgstr "Protect Your Privacy!"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "Protect your data on every device."
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5363,4 +5406,3 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/en_US/LC_MESSAGES/duckduckgo.po
+++ b/locales/en_US/LC_MESSAGES/duckduckgo.po
@@ -277,8 +277,18 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr ""
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
+msgstr ""
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
 msgstr ""
 
 msgid "All Places"
@@ -1674,6 +1684,26 @@ msgstr ""
 msgid "France"
 msgstr ""
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr ""
@@ -2332,6 +2362,11 @@ msgstr ""
 msgid "Light green"
 msgstr ""
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr ""
@@ -2887,6 +2922,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 
@@ -3344,6 +3382,11 @@ msgstr ""
 
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
+msgstr ""
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.

--- a/locales/eo_XX/LC_MESSAGES/duckduckgo.po
+++ b/locales/eo_XX/LC_MESSAGES/duckduckgo.po
@@ -287,9 +287,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Ĉiuj koloroj"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Ĉiuj aranĝoj"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "Ĉiuj pozicioj"
@@ -1708,6 +1718,26 @@ msgstr "Devigi ĉifradon en retejoj"
 msgid "France"
 msgstr "Francio"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Amiko aŭ familio"
@@ -2377,6 +2407,11 @@ msgstr "Helblua"
 msgid "Light green"
 msgstr "Helverda"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Tiparo de ligiloj:"
@@ -2938,6 +2973,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr "Malfermita"
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "Malfermu %sMenu > Settings > Search %s kaj elektu DuckDuckGo!"
 
@@ -3400,6 +3438,11 @@ msgstr "Protektu vian privatecon!"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "Protekti viajn datumojn sur ĉiu aparato."
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5395,4 +5438,3 @@ msgstr "blokado de spuriloj"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/es_AR/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_AR/LC_MESSAGES/duckduckgo.po
@@ -281,9 +281,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Todos los colores"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Todos los diseños"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "Todos los lugares"
@@ -1718,6 +1728,26 @@ msgstr ""
 msgid "France"
 msgstr "Francia"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Amigo o familiar"
@@ -2394,6 +2424,11 @@ msgstr "Azul claro"
 msgid "Light green"
 msgstr "Verde claro"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Fuente del link:"
@@ -2957,6 +2992,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "¡Abrí %sMenú > Configuración > Búsqueda %s y seleccioná DuckDuckGo!"
 
@@ -3422,6 +3460,11 @@ msgstr "¡Protege tu privacidad!"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "Protegé tus datos en cada dispositivo."
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5433,4 +5476,3 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/es_CL/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_CL/LC_MESSAGES/duckduckgo.po
@@ -279,8 +279,18 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr ""
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
+msgstr ""
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
 msgstr ""
 
 msgid "All Places"
@@ -1703,6 +1713,26 @@ msgstr ""
 msgid "France"
 msgstr "Francia"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr ""
@@ -2367,6 +2397,11 @@ msgstr "Azul claro"
 msgid "Light green"
 msgstr "Verde Claro"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Fuente del enlace:"
@@ -2930,6 +2965,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 
@@ -3394,6 +3432,11 @@ msgstr ""
 
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
+msgstr ""
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -5382,4 +5425,3 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/es_CO/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_CO/LC_MESSAGES/duckduckgo.po
@@ -281,9 +281,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Todos los colores"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Todos los Diseños"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr ""
@@ -1713,6 +1723,26 @@ msgstr ""
 msgid "France"
 msgstr "Francia"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Amigo o Familia"
@@ -2379,6 +2409,11 @@ msgstr "Azul claro"
 msgid "Light green"
 msgstr "Verde claro"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Fuente del link:"
@@ -2942,6 +2977,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "Abra %sMenu  > Configuraciones > Busqueda %s y selecccione DuckDuckGo!"
 
@@ -3408,6 +3446,11 @@ msgstr "¡Protege Tu Privacidad!"
 
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
+msgstr ""
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -5407,4 +5450,3 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/es_CR/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_CR/LC_MESSAGES/duckduckgo.po
@@ -277,8 +277,18 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr ""
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
+msgstr ""
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
 msgstr ""
 
 msgid "All Places"
@@ -1684,6 +1694,26 @@ msgstr ""
 msgid "France"
 msgstr ""
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr ""
@@ -2346,6 +2376,11 @@ msgstr "Azul Claro"
 msgid "Light green"
 msgstr "Verde Claro"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Fuente del enlace"
@@ -2903,6 +2938,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 
@@ -3361,6 +3399,11 @@ msgstr ""
 
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
+msgstr ""
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -5321,4 +5364,3 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/es_EC/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_EC/LC_MESSAGES/duckduckgo.po
@@ -277,8 +277,18 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr ""
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
+msgstr ""
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
 msgstr ""
 
 msgid "All Places"
@@ -1691,6 +1701,26 @@ msgstr ""
 msgid "France"
 msgstr ""
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr ""
@@ -2353,6 +2383,11 @@ msgstr "Azul claro"
 msgid "Light green"
 msgstr "Verde claro"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Fuente del enlace:"
@@ -2913,6 +2948,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 
@@ -3372,6 +3410,11 @@ msgstr ""
 
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
+msgstr ""
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -5353,4 +5396,3 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/es_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_ES/LC_MESSAGES/duckduckgo.po
@@ -287,9 +287,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "color de la imagen"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Todos los diseños"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "Todos los Lugares"
@@ -1803,6 +1813,26 @@ msgstr "Forzar la encriptación en los sitios web"
 msgid "France"
 msgstr "Francia"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Amigo o familia"
@@ -2497,6 +2527,11 @@ msgstr "Azul claro"
 msgid "Light green"
 msgstr "Verde claro"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Fuente para enlaces:"
@@ -3061,6 +3096,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr "Abrir"
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "¡Abre %1$sMenú > Ajustes > Búsqueda %2$s y selecciona DuckDuckGo!"
 
@@ -3540,6 +3578,11 @@ msgstr "¡Protege tu privacidad!"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "Protege tus datos en todos tus dispositivos."
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5645,4 +5688,3 @@ msgstr "bloqueo de rastreadores"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "a"
-

--- a/locales/es_MX/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_MX/LC_MESSAGES/duckduckgo.po
@@ -284,9 +284,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Todos los Colores"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Todos los Diseños"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "Todos los Lugares"
@@ -1725,6 +1735,26 @@ msgstr "Forzar cifrado en sitios web"
 msgid "France"
 msgstr "Francia"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Amigo o familiar"
@@ -2403,6 +2433,11 @@ msgstr "Azúl claro"
 msgid "Light green"
 msgstr "Verde claro"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Fuente del enlace:"
@@ -2969,6 +3004,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr "Abierto"
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "Abrir %sMenú > Ajustes > Busqueda %s ¡y selecciona DuckDuckGo!"
 
@@ -3438,6 +3476,11 @@ msgstr "¡Proteja su Privacidad!"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "Protege tu información en cada dispositivo."
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5470,4 +5513,3 @@ msgstr "bloqueador de rastreadores"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/es_PE/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_PE/LC_MESSAGES/duckduckgo.po
@@ -279,8 +279,18 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr ""
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
+msgstr ""
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
 msgstr ""
 
 msgid "All Places"
@@ -1696,6 +1706,26 @@ msgstr ""
 msgid "France"
 msgstr ""
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr ""
@@ -2359,6 +2389,11 @@ msgstr "Azul claro"
 msgid "Light green"
 msgstr "Luz verde"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Fuente del link:"
@@ -2918,6 +2953,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 
@@ -3377,6 +3415,11 @@ msgstr ""
 
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
+msgstr ""
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -5349,4 +5392,3 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/es_UY/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_UY/LC_MESSAGES/duckduckgo.po
@@ -277,8 +277,18 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr ""
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
+msgstr ""
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
 msgstr ""
 
 msgid "All Places"
@@ -1681,6 +1691,26 @@ msgstr ""
 msgid "France"
 msgstr ""
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr ""
@@ -2341,6 +2371,11 @@ msgstr "Azul claro"
 msgid "Light green"
 msgstr "Verde claro"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Fuente de vínculos"
@@ -2898,6 +2933,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 
@@ -3355,6 +3393,11 @@ msgstr ""
 
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
+msgstr ""
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -5308,4 +5351,3 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/es_VE/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_VE/LC_MESSAGES/duckduckgo.po
@@ -279,8 +279,18 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr ""
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
+msgstr ""
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
 msgstr ""
 
 msgid "All Places"
@@ -1693,6 +1703,26 @@ msgstr ""
 msgid "France"
 msgstr ""
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr ""
@@ -2355,6 +2385,11 @@ msgstr "Luz azul"
 msgid "Light green"
 msgstr "Luz verde"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Enlace fuente:"
@@ -2915,6 +2950,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 
@@ -3376,6 +3414,11 @@ msgstr ""
 
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
+msgstr ""
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -5340,4 +5383,3 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/et_EE/LC_MESSAGES/duckduckgo.po
+++ b/locales/et_EE/LC_MESSAGES/duckduckgo.po
@@ -286,9 +286,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Kõik värvid"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Kõik paigutused"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "Kõik kohad"
@@ -1778,6 +1788,26 @@ msgstr "Blokeerida ohtlikke jälgijaid"
 msgid "France"
 msgstr "Prantsusmaa"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Sõber või pere"
@@ -2463,6 +2493,11 @@ msgstr "Helesinine"
 msgid "Light green"
 msgstr "Heleroheline"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Lingi font:"
@@ -3026,6 +3061,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr "Avatud"
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "Ava %1$sMenüü > Seaded > Otsi %2$s ja vali DuckDuckGo!"
 
@@ -3498,6 +3536,11 @@ msgstr "Kaitse oma privaatsust!"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "Kaitse oma andmeid igas seadmes."
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5553,4 +5596,3 @@ msgstr "jälgija blokeerimine"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "a"
-

--- a/locales/eu_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/eu_ES/LC_MESSAGES/duckduckgo.po
@@ -277,8 +277,18 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr ""
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
+msgstr ""
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
 msgstr ""
 
 msgid "All Places"
@@ -1680,6 +1690,26 @@ msgstr ""
 msgid "France"
 msgstr ""
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr ""
@@ -2340,6 +2370,11 @@ msgstr "Urdin argia"
 msgid "Light green"
 msgstr "Berde argia"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Esteken letra-tipoa:"
@@ -2897,6 +2932,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 
@@ -3356,6 +3394,11 @@ msgstr ""
 
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
+msgstr ""
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -5309,4 +5352,3 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/fa_IR/LC_MESSAGES/duckduckgo.po
+++ b/locales/fa_IR/LC_MESSAGES/duckduckgo.po
@@ -289,9 +289,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "همه رنگها"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "همه چیدمانها"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "همه مکانها"
@@ -1743,6 +1753,26 @@ msgstr ""
 msgid "France"
 msgstr "فرانسه"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "دوست یا خانواده"
@@ -2429,6 +2459,11 @@ msgstr "آبی روشن"
 msgid "Light green"
 msgstr "سبز روشن"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "فونت پیوند ها:"
@@ -2996,6 +3031,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 "‫منوی %sMenu > Settings > Search %s را باز کنید و DuckDuckGo! را انتخاب "
@@ -3469,6 +3507,11 @@ msgstr "حفاظت از حریم خصوصی شما!"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "از داده‌های خود در هر دستگاهی محافظت کنید"
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5492,4 +5535,3 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/fi_FI/LC_MESSAGES/duckduckgo.po
+++ b/locales/fi_FI/LC_MESSAGES/duckduckgo.po
@@ -286,9 +286,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Kaikki värit"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Kaikki ulkoasut"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "Kaikki Paikat"
@@ -1778,6 +1788,26 @@ msgstr "Pakottaa verkkosivustot käyttämään salausta"
 msgid "France"
 msgstr "Ranska"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Ystävä vai perhe"
@@ -2465,6 +2495,11 @@ msgstr "Vaaleansininen"
 msgid "Light green"
 msgstr "Vaaleanvihreä"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Linkkien fontti:"
@@ -3029,6 +3064,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr "Avaa"
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "Avaa %1$sValikko > Asetukset > Haku %2$s ja valitse DuckDuckGo!"
 
@@ -3503,6 +3541,11 @@ msgstr "Suojele Yksityisyyttäsi!"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "Suojaa datasi kaikilla laitteilla."
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5571,4 +5614,3 @@ msgstr "seurannan esto"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "v"
-

--- a/locales/fr_BE/LC_MESSAGES/duckduckgo.po
+++ b/locales/fr_BE/LC_MESSAGES/duckduckgo.po
@@ -279,9 +279,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Toutes les couleurs"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Toutes les mises en page"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr ""
@@ -1708,6 +1718,26 @@ msgstr ""
 msgid "France"
 msgstr ""
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Ami ou famille"
@@ -2378,6 +2408,11 @@ msgstr "Bleu clair"
 msgid "Light green"
 msgstr "Vert clair"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Police des liens :"
@@ -2943,6 +2978,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 "Ouvrez %sMenu > Paramètres > Recherche %s et sélectionnez DuckDuckGo ! "
@@ -3412,6 +3450,11 @@ msgstr "Protégez Votre Vie Privée !"
 
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
+msgstr ""
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -5423,4 +5466,3 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/fr_CA/LC_MESSAGES/duckduckgo.po
+++ b/locales/fr_CA/LC_MESSAGES/duckduckgo.po
@@ -280,9 +280,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Toutes les couleurs"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Toutes les dispositions"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr ""
@@ -1707,6 +1717,26 @@ msgstr ""
 msgid "France"
 msgstr ""
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Ami ou parent"
@@ -2378,6 +2408,11 @@ msgstr "Bleu pâle"
 msgid "Light green"
 msgstr "Vert pâle"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Police des liens:"
@@ -2944,6 +2979,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "Ouvrez %sMenu > Paramètres > Recherche%s et sélectionnez DuckDuckGo !"
 
@@ -3412,6 +3450,11 @@ msgstr "Protégez votre vie privée!"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "Protégez vos informations sur tous vos appareils."
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5430,4 +5473,3 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/fr_CH/LC_MESSAGES/duckduckgo.po
+++ b/locales/fr_CH/LC_MESSAGES/duckduckgo.po
@@ -279,9 +279,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Toutes les couleurs"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Tous les formats"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr ""
@@ -1713,6 +1723,26 @@ msgstr ""
 msgid "France"
 msgstr ""
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Amis ou famille"
@@ -2378,6 +2408,11 @@ msgstr "Bleu clair"
 msgid "Light green"
 msgstr "Vert clair"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Police des liens :"
@@ -2942,6 +2977,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "Ouvrez %sMenu > Réglages > Recherche %s et sélectionnez DuckDuckGo !"
 
@@ -3406,6 +3444,11 @@ msgstr ""
 
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
+msgstr ""
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -5404,4 +5447,3 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/fr_FR/LC_MESSAGES/duckduckgo.po
+++ b/locales/fr_FR/LC_MESSAGES/duckduckgo.po
@@ -290,9 +290,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Toutes les couleurs"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Toutes les dispositions"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "Partout"
@@ -1821,6 +1831,26 @@ msgstr "Forçage du chiffrement sur les sites web"
 msgid "France"
 msgstr "France"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Ami(e) ou famille"
@@ -2522,6 +2552,11 @@ msgstr "Bleu clair"
 msgid "Light green"
 msgstr "Vert clair"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Police des liens :"
@@ -3089,6 +3124,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr "Ouvert"
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 "Accéder à %1$sMenu > Paramètres > Recherche %2$s et sélectionner DuckDuckGo !"
@@ -3572,6 +3610,11 @@ msgstr "Protégez Votre Vie Privée !"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "Protégez vos données sur chaque appareil."
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5699,4 +5742,3 @@ msgstr "blocage des traqueurs"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "an"
-

--- a/locales/ga_IE/LC_MESSAGES/duckduckgo.po
+++ b/locales/ga_IE/LC_MESSAGES/duckduckgo.po
@@ -290,9 +290,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Gach Dath"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Gach Leagan Amach"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "Gach Áit"
@@ -1735,6 +1745,26 @@ msgstr "Éignigh criptiú ar shuíomhanna gréasáin"
 msgid "France"
 msgstr "An Fhrainc"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Cara nó duine muinteartha"
@@ -2416,6 +2446,11 @@ msgstr "Gealghorm"
 msgid "Light green"
 msgstr "Fionnghlas"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Clófhoireann an naisc:"
@@ -2982,6 +3017,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr "Oscail"
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 "Oscail %sRoghchlár > Socruithe > Cuardaigh %s agus roghnaigh DuckDuckGo!"
@@ -3448,6 +3486,11 @@ msgstr "Cosain Do Phríobháideachas!"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "Cosain do chuid sonraí ar gach gléas."
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5489,4 +5532,3 @@ msgstr "bac ar lorgairí"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/gd_GB/LC_MESSAGES/duckduckgo.po
+++ b/locales/gd_GB/LC_MESSAGES/duckduckgo.po
@@ -282,9 +282,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Dath sam bith"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Co-dhealbhachd sam bith"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr ""
@@ -1714,6 +1724,26 @@ msgstr ""
 msgid "France"
 msgstr "An Fhraing"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Caraid no teaghlach"
@@ -2383,6 +2413,11 @@ msgstr "Soilleir-ghorm"
 msgid "Light green"
 msgstr "Soilleir-uaine"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Cruth-clò nan ceangal:"
@@ -2947,6 +2982,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "Fosgail %sClàr-taice » Roghainnean » Lorg%s is tagh DuckDuckGo!"
 
@@ -3410,6 +3448,11 @@ msgstr ""
 
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
+msgstr ""
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -5419,4 +5462,3 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/gl_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/gl_ES/LC_MESSAGES/duckduckgo.po
@@ -290,9 +290,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Todas as cores"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Todos os deseños"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "Todos os sitios"
@@ -1724,6 +1734,26 @@ msgstr ""
 msgid "France"
 msgstr "Francia"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Amizades ou familia"
@@ -2398,6 +2428,11 @@ msgstr "Azul claro"
 msgid "Light green"
 msgstr "Verde claro"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Tipo de letra da ligazón:"
@@ -2959,6 +2994,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "Abra %sMenú > Axustes >  Busca %s e seleccione DuckDuckGo!"
 
@@ -3427,6 +3465,11 @@ msgstr "Protexa a súa privacidade!"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "Protexa a súa información en calquera dispositivo."
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5439,4 +5482,3 @@ msgstr "bloqueo de rastrexadores"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/gu_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/gu_IN/LC_MESSAGES/duckduckgo.po
@@ -279,8 +279,18 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "બધા રંગો"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
+msgstr ""
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
 msgstr ""
 
 msgid "All Places"
@@ -1686,6 +1696,26 @@ msgstr ""
 msgid "France"
 msgstr ""
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr ""
@@ -2344,6 +2374,11 @@ msgstr "accho vadali"
 msgid "Light green"
 msgstr "aacho lilo (આછો લીલો)"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "કડી અક્ષર:"
@@ -2899,6 +2934,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 
@@ -3356,6 +3394,11 @@ msgstr ""
 
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
+msgstr ""
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -5301,4 +5344,3 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/he_IL/LC_MESSAGES/duckduckgo.po
+++ b/locales/he_IL/LC_MESSAGES/duckduckgo.po
@@ -279,9 +279,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "כל הצבעים"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "כל הפריסות"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "כל המקומות"
@@ -1688,6 +1698,26 @@ msgstr ""
 msgid "France"
 msgstr "צרפת"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr ""
@@ -2350,6 +2380,11 @@ msgstr "כחלחל"
 msgid "Light green"
 msgstr "ירקרק"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "גופן לינקים:"
@@ -2909,6 +2944,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr "פתח"
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 
@@ -3371,6 +3409,11 @@ msgstr "הגן על הפרטיות שלך!"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "הגן על הנתונים שלך בכל מכשיר."
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"

--- a/locales/hi_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/hi_IN/LC_MESSAGES/duckduckgo.po
@@ -281,9 +281,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "सब रंग"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "सब आकार"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "सब जगह"
@@ -1764,6 +1774,26 @@ msgstr "वेबसाइटों पर एन्क्रिप्शन ल
 msgid "France"
 msgstr "फ़्रांस"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "दोस्त या परिवार"
@@ -2447,6 +2477,11 @@ msgstr "हल्का नीला"
 msgid "Light green"
 msgstr "हल्का हरा"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "फॉण्ट जोड़े"
@@ -3008,6 +3043,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr "खोलें"
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "%1$sमेनू > सेटिंग > खोज %2$s खोलें और DuckDuckGo चुनें!"
 
@@ -3481,6 +3519,11 @@ msgstr "अपनी गोपनीयता सुरक्षित करे
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "प्रत्येक उपकरण पर अपना डेटा सुरक्षित करें।"
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5522,4 +5565,3 @@ msgstr "ट्रैकर ब्लॉकिंग"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "सा"
-

--- a/locales/hr_HR/LC_MESSAGES/duckduckgo.po
+++ b/locales/hr_HR/LC_MESSAGES/duckduckgo.po
@@ -287,9 +287,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Sve boje"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Svi oblici"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "Sva mjesta"
@@ -1789,6 +1799,26 @@ msgstr "Nametnuti šifriranje na web-mjestima"
 msgid "France"
 msgstr "Francuska"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Prijatelj ili obitelj"
@@ -2479,6 +2509,11 @@ msgstr "Svjetlo plava"
 msgid "Light green"
 msgstr "Svijetlo zelena"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Font poveznica:"
@@ -3044,6 +3079,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr "Otvorena"
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 "Otvorite %1$sIzbornik > Postavke > Pretraživanje %2$s i odaberite DuckDuckGo!"
@@ -3521,6 +3559,11 @@ msgstr "Zaštitite Vašu privatnost!"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "Zaštitite svoju privatnost na svakom uređaju."
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5603,4 +5646,3 @@ msgstr "blokiranje tragača"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "god"
-

--- a/locales/hu_HU/LC_MESSAGES/duckduckgo.po
+++ b/locales/hu_HU/LC_MESSAGES/duckduckgo.po
@@ -294,9 +294,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Minden szín"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Minden elrendezés"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "Minden hely"
@@ -1817,6 +1827,26 @@ msgstr "Titkosítás kényszerítése weboldalakon"
 msgid "France"
 msgstr "Franciaország"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Barát vagy család"
@@ -2519,6 +2549,11 @@ msgstr "Világoskék"
 msgid "Light green"
 msgstr "Világoszöld"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Hivatkozás betűtípus:"
@@ -3085,6 +3120,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr "Megnyitás"
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 "Menj a %1$sMenü > Beállítások > Keresés %2$s menüpontba és válaszd ki a "
@@ -3569,6 +3607,11 @@ msgstr "Védd a magánszférádat!"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "Óvd meg az adataidat minden eszközödön."
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5684,4 +5727,3 @@ msgstr "követésvédelem"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "év"
-

--- a/locales/hy_AM/LC_MESSAGES/duckduckgo.po
+++ b/locales/hy_AM/LC_MESSAGES/duckduckgo.po
@@ -283,8 +283,18 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Բոլոր գույները"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
+msgstr ""
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
 msgstr ""
 
 msgid "All Places"
@@ -1706,6 +1716,26 @@ msgstr ""
 msgid "France"
 msgstr "Ֆրանսիա"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr ""
@@ -2372,6 +2402,11 @@ msgstr "Բաց կապույտ"
 msgid "Light green"
 msgstr "Բաց կանաչ"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Հղման տառատեսակ"
@@ -2939,6 +2974,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr "Բացել"
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 
@@ -3396,6 +3434,11 @@ msgstr "Պաշտպանիր քո անվտանգությունը"
 
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
+msgstr ""
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -5362,4 +5405,3 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/id_ID/LC_MESSAGES/duckduckgo.po
+++ b/locales/id_ID/LC_MESSAGES/duckduckgo.po
@@ -285,9 +285,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Semua Warna"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Semua Layout"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "Semua tempat"
@@ -1787,6 +1797,26 @@ msgstr "Wajib enkripsi di semua situs"
 msgid "France"
 msgstr "Perancis"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Teman atau keluarga"
@@ -2478,6 +2508,11 @@ msgstr "Biru terang"
 msgid "Light green"
 msgstr "Hijau terang"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Fon tautan:"
@@ -3043,6 +3078,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr "Buka"
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "Buka %1$sMenu > Pengaturan > Pencarian %2$s dan pilih DuckDuckGo!"
 
@@ -3517,6 +3555,11 @@ msgstr "Lindungi Privasi Anda!"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "lindungi data anda pada setiap perangkat"
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5593,4 +5636,3 @@ msgstr "pemblokiran pelacak"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "th"
-

--- a/locales/io_XX/LC_MESSAGES/duckduckgo.po
+++ b/locales/io_XX/LC_MESSAGES/duckduckgo.po
@@ -277,8 +277,18 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr ""
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
+msgstr ""
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
 msgstr ""
 
 msgid "All Places"
@@ -1680,6 +1690,26 @@ msgstr ""
 msgid "France"
 msgstr ""
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr ""
@@ -2340,6 +2370,11 @@ msgstr "Klarblua"
 msgid "Light green"
 msgstr "Klarverda"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Ligilo-tipo:"
@@ -2897,6 +2932,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 
@@ -3354,6 +3392,11 @@ msgstr ""
 
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
+msgstr ""
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -5304,4 +5347,3 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/is_IS/LC_MESSAGES/duckduckgo.po
+++ b/locales/is_IS/LC_MESSAGES/duckduckgo.po
@@ -278,9 +278,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Allir litir"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Allar skipanir"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "Allir staðir"
@@ -1680,6 +1690,26 @@ msgstr "Þvinga dulritun vefsíðna"
 msgid "France"
 msgstr "Frakkland"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Kunningi eða ættingi"
@@ -2342,6 +2372,11 @@ msgstr "Ljósblátt"
 msgid "Light green"
 msgstr "Ljósgrænt"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Fontur tengils:"
@@ -2897,6 +2932,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr "Opið"
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 
@@ -3359,6 +3397,11 @@ msgstr "Verndum friðhelgina!"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "Verndum upplýsingar þínar í öllum þínum tækjum."
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5314,4 +5357,3 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/it_IT/LC_MESSAGES/duckduckgo.po
+++ b/locales/it_IT/LC_MESSAGES/duckduckgo.po
@@ -289,9 +289,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Tutti i colori"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Tutte le disposizioni"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "Tutti i Luoghi"
@@ -1797,6 +1807,26 @@ msgstr "Forzare la crittografia sui siti web"
 msgid "France"
 msgstr "Francia"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Amico o famiglia"
@@ -2489,6 +2519,11 @@ msgstr "Azzurro"
 msgid "Light green"
 msgstr "Verde chiaro"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Carattere dei link:"
@@ -3058,6 +3093,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr "Aperto"
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "Apri %1$sMenu > Impostazioni > Ricerca %2$s e seleziona DuckDuckGo!"
 
@@ -3536,6 +3574,11 @@ msgstr "Proteggi la tua privacy!"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "Proteggi i tuoi dati su ogni dispositivo."
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5640,4 +5683,3 @@ msgstr "blocco dei tracker"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "anno"
-

--- a/locales/ja_JP/LC_MESSAGES/duckduckgo.po
+++ b/locales/ja_JP/LC_MESSAGES/duckduckgo.po
@@ -287,9 +287,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "すべての色"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "すべてのレイアウト"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "全ての場所"
@@ -1797,6 +1807,26 @@ msgstr "ウェブサイトで暗号化を強制適用"
 msgid "France"
 msgstr "フランス"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "友達か家族"
@@ -2487,6 +2517,11 @@ msgstr "ライトブルー"
 msgid "Light green"
 msgstr "ライトグリーン"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "リンクのフォント:"
@@ -3048,6 +3083,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr "営業中"
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "%1$sメニュー > 設定 > 検索 %2$sを開いてDuckDuckGoを選択してください。"
 
@@ -3527,6 +3565,11 @@ msgstr "プライバシーを守る！"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "すべてのデバイスであなたのデータを保護しましょう。"
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5598,4 +5641,3 @@ msgstr "トラッカーブロック"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "年"
-

--- a/locales/ka_GE/LC_MESSAGES/duckduckgo.po
+++ b/locales/ka_GE/LC_MESSAGES/duckduckgo.po
@@ -277,8 +277,18 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr ""
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
+msgstr ""
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
 msgstr ""
 
 msgid "All Places"
@@ -1680,6 +1690,26 @@ msgstr ""
 msgid "France"
 msgstr ""
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr ""
@@ -2340,6 +2370,11 @@ msgstr "ღია ლურჯი"
 msgid "Light green"
 msgstr "ღია მწვანე"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "ბმულის ფონტი"
@@ -2897,6 +2932,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 
@@ -3354,6 +3392,11 @@ msgstr ""
 
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
+msgstr ""
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.

--- a/locales/kab_DZ/LC_MESSAGES/duckduckgo.po
+++ b/locales/kab_DZ/LC_MESSAGES/duckduckgo.po
@@ -281,9 +281,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Akk initen"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Akk tinerufin"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "Meṛṛa idigan"
@@ -1705,6 +1715,26 @@ msgstr ""
 msgid "France"
 msgstr "Fransa"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Imeddukal d yimawlan"
@@ -2371,6 +2401,11 @@ msgstr "Anili afessas"
 msgid "Light green"
 msgstr "Amumad afessas"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Tasefsit n yiseɣwan:"
@@ -2931,6 +2966,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr "Ldi"
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "Ldi %sUmuɣ > Iɣewwaren > Nadi %s daɣen fren DuckDuckGo!"
 
@@ -3394,6 +3432,11 @@ msgstr "Mmesten tabadnit-ik!"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "Mmesten isefka-iw deg yal ibenk."
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5387,4 +5430,3 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/kn_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/kn_IN/LC_MESSAGES/duckduckgo.po
@@ -279,8 +279,18 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr ""
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
+msgstr ""
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
 msgstr ""
 
 msgid "All Places"
@@ -1689,6 +1699,26 @@ msgstr ""
 msgid "France"
 msgstr ""
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr ""
@@ -2350,6 +2380,11 @@ msgstr "ತಿಳಿ ನೀಲಿ"
 msgid "Light green"
 msgstr "ಬೆಳಕಿನ ಹಸಿರು"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "ಲಿಂಕ್ ಫಾಂಟ್:"
@@ -2907,6 +2942,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 
@@ -3364,6 +3402,11 @@ msgstr ""
 
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
+msgstr ""
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -5317,4 +5360,3 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/ko_KR/LC_MESSAGES/duckduckgo.po
+++ b/locales/ko_KR/LC_MESSAGES/duckduckgo.po
@@ -283,9 +283,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "모든 색상"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "모든 레이아웃"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "모든 곳"
@@ -1774,6 +1784,26 @@ msgstr "웹사이트에서 암호화 강제 실행"
 msgid "France"
 msgstr "프랑스"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "친구 또는 가족"
@@ -2456,6 +2486,11 @@ msgstr "하늘색"
 msgid "Light green"
 msgstr "밝은 녹색"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "링크 글꼴:"
@@ -3020,6 +3055,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr "영업 중"
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "%1$s메뉴  > 설정 > 검색%2$s으로 들어가서 DuckDuckGo를 선택하세요!"
 
@@ -3490,6 +3528,11 @@ msgstr "여러분의 사생활을 보호하세요!"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "모든 기기에서 정보를 보호하세요"
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5541,4 +5584,3 @@ msgstr "추적 차단"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "년"
-

--- a/locales/kw_GB/LC_MESSAGES/duckduckgo.po
+++ b/locales/kw_GB/LC_MESSAGES/duckduckgo.po
@@ -278,8 +278,18 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr ""
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
+msgstr ""
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
 msgstr ""
 
 msgid "All Places"
@@ -1675,6 +1685,26 @@ msgstr ""
 msgid "France"
 msgstr ""
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr ""
@@ -2335,6 +2365,11 @@ msgstr "Glas wann"
 msgid "Light green"
 msgstr "Gwyrdh skav"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Kevren font:"
@@ -2890,6 +2925,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 
@@ -3347,6 +3385,11 @@ msgstr ""
 
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
+msgstr ""
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -5290,4 +5333,3 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/ky_KG/LC_MESSAGES/duckduckgo.po
+++ b/locales/ky_KG/LC_MESSAGES/duckduckgo.po
@@ -277,8 +277,18 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr ""
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
+msgstr ""
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
 msgstr ""
 
 msgid "All Places"
@@ -1676,6 +1686,26 @@ msgstr ""
 msgid "France"
 msgstr ""
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr ""
@@ -2334,6 +2364,11 @@ msgstr "Ачык көк"
 msgid "Light green"
 msgstr "Ачык жашыл"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Шилтеменин ариби:"
@@ -2889,6 +2924,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 
@@ -3346,6 +3384,11 @@ msgstr ""
 
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
+msgstr ""
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.

--- a/locales/ln_CD/LC_MESSAGES/duckduckgo.po
+++ b/locales/ln_CD/LC_MESSAGES/duckduckgo.po
@@ -278,8 +278,18 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr ""
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
+msgstr ""
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
 msgstr ""
 
 msgid "All Places"
@@ -1675,6 +1685,26 @@ msgstr ""
 msgid "France"
 msgstr ""
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr ""
@@ -2333,6 +2363,11 @@ msgstr ""
 msgid "Light green"
 msgstr ""
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr ""
@@ -2888,6 +2923,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 
@@ -3345,6 +3383,11 @@ msgstr ""
 
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
+msgstr ""
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.

--- a/locales/lt_LT/LC_MESSAGES/duckduckgo.po
+++ b/locales/lt_LT/LC_MESSAGES/duckduckgo.po
@@ -288,9 +288,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Visos spalvos"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Visi maketai"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "Visos vietos"
@@ -1793,6 +1803,26 @@ msgstr "Priverstinai šifruoti svetainėse"
 msgid "France"
 msgstr "Prancūzija"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Draugas arba artimasis"
@@ -2484,6 +2514,11 @@ msgstr "Šviesiai mėlyna"
 msgid "Light green"
 msgstr "Šviesiai žalia"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Nuorodos šriftas:"
@@ -3048,6 +3083,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr "Atviras"
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 "Atidarykite %1$sMeniu > Parametrai > Ieškoti %2$s ir pasirinkite "
@@ -3526,6 +3564,11 @@ msgstr "Apsaugokite privatumą!"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "Apsaugokite duomenis kiekviename įrenginyje."
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5619,4 +5662,3 @@ msgstr "sekimo blokavimas"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "m."
-

--- a/locales/lv_LV/LC_MESSAGES/duckduckgo.po
+++ b/locales/lv_LV/LC_MESSAGES/duckduckgo.po
@@ -287,9 +287,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Visas krāsas"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Visi izkārtojumi"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "Visas vietas"
@@ -1801,6 +1811,26 @@ msgstr "Uzspiest vietnēm šifrēšanu"
 msgid "France"
 msgstr "Francija"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Draugs vai ģimenes loceklis"
@@ -2494,6 +2524,11 @@ msgstr "Gaiši zils"
 msgid "Light green"
 msgstr "Gaiši zaļš"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Saites fonts:"
@@ -3060,6 +3095,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr "Atvērt"
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 "Atver %1$sIzvēlne > Iestatījumi > Meklēšana %2$s un izvēlies DuckDuckGo!"
@@ -3539,6 +3577,11 @@ msgstr "Aizsargā savu privātumu!"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "Aizsargā datus visās savās ierīcēs."
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5619,4 +5662,3 @@ msgstr "izsekotāju bloķēšana"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "g."
-

--- a/locales/ml_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/ml_IN/LC_MESSAGES/duckduckgo.po
@@ -285,9 +285,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "എല്ലാ വർണ്ണങ്ങളും"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "എല്ലാ ക്രമീകരണങ്ങളും"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "എല്ലാ സ്ഥലങ്ങളും"
@@ -1785,6 +1795,26 @@ msgstr "വെബ്സൈറ്റുകളിൽ നിർബന്ധിത �
 msgid "France"
 msgstr "ഫ്രാൻസ്"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "സുഹൃത്ത് അല്ലെങ്കിൽ കുടുംബം"
@@ -2478,6 +2508,11 @@ msgstr "ഇളം നീല"
 msgid "Light green"
 msgstr "ഇളം പച്ച"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "കണ്ണികളുടെ ലിപി"
@@ -3045,6 +3080,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr "തുറക്കുക"
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "%1$sമെനു > ക്രമീകരണം > തിരയുക%2$s തുറന്ന് DuckDuckGo തിരഞ്ഞെടുക്കുക!"
 
@@ -3521,6 +3559,11 @@ msgstr "നിങ്ങളുടെ സ്വകാര്യത പരിരക�
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "എല്ലാ ഉപകരണത്തിലും നിങ്ങളുടെ ഡാറ്റ പരിരക്ഷിക്കുക."
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5592,4 +5635,3 @@ msgstr "ട്രാക്കർ തടയൽ"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "വർഷം"
-

--- a/locales/mn_MN/LC_MESSAGES/duckduckgo.po
+++ b/locales/mn_MN/LC_MESSAGES/duckduckgo.po
@@ -277,8 +277,18 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr ""
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
+msgstr ""
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
 msgstr ""
 
 msgid "All Places"
@@ -1674,6 +1684,26 @@ msgstr ""
 msgid "France"
 msgstr ""
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr ""
@@ -2332,6 +2362,11 @@ msgstr ""
 msgid "Light green"
 msgstr ""
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr ""
@@ -2887,6 +2922,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 
@@ -3344,6 +3382,11 @@ msgstr ""
 
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
+msgstr ""
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.

--- a/locales/mr_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/mr_IN/LC_MESSAGES/duckduckgo.po
@@ -279,8 +279,18 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr ""
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
+msgstr ""
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
 msgstr ""
 
 msgid "All Places"
@@ -1687,6 +1697,26 @@ msgstr ""
 msgid "France"
 msgstr ""
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr ""
@@ -2346,6 +2376,11 @@ msgstr "फिकट निळा"
 msgid "Light green"
 msgstr "फिकट हिरवा"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "दुवा शैली:"
@@ -2901,6 +2936,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 
@@ -3358,6 +3396,11 @@ msgstr ""
 
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
+msgstr ""
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -5305,4 +5348,3 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/ms_MY/LC_MESSAGES/duckduckgo.po
+++ b/locales/ms_MY/LC_MESSAGES/duckduckgo.po
@@ -279,8 +279,18 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr ""
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
+msgstr ""
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
 msgstr ""
 
 msgid "All Places"
@@ -1695,6 +1705,26 @@ msgstr ""
 msgid "France"
 msgstr ""
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr ""
@@ -2358,6 +2388,11 @@ msgstr "Biru muda"
 msgid "Light green"
 msgstr "Hijau muda"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Fon pautan:"
@@ -2922,6 +2957,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 
@@ -3379,6 +3417,11 @@ msgstr ""
 
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
+msgstr ""
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -5345,4 +5388,3 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/nb_NO/LC_MESSAGES/duckduckgo.po
+++ b/locales/nb_NO/LC_MESSAGES/duckduckgo.po
@@ -286,9 +286,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Alle farger"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Alle visninger"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "Alle steder"
@@ -1782,6 +1792,26 @@ msgstr "Tvinge kryptering på nettsider"
 msgid "France"
 msgstr "Frankrike"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Venn eller familie"
@@ -2470,6 +2500,11 @@ msgstr "Lyseblå"
 msgid "Light green"
 msgstr "Lysegrønn"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Skrifttype for lenke:"
@@ -3033,6 +3068,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr "Åpen"
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "Åpne %1$sMeny > Innstillinger > Søk %2$s og velg DuckDuckGo!"
 
@@ -3506,6 +3544,11 @@ msgstr "Beskytt ditt personvern!"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "Beskytt dataen din på alle enheter."
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5570,4 +5613,3 @@ msgstr "sporingsblokkering"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "år"
-

--- a/locales/ne_NP/LC_MESSAGES/duckduckgo.po
+++ b/locales/ne_NP/LC_MESSAGES/duckduckgo.po
@@ -279,8 +279,18 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr ""
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
+msgstr ""
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
 msgstr ""
 
 msgid "All Places"
@@ -1692,6 +1702,26 @@ msgstr ""
 msgid "France"
 msgstr ""
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr ""
@@ -2354,6 +2384,11 @@ msgstr "आकाशे रङ"
 msgid "Light green"
 msgstr "हल्का हरियो"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "लिङ्क फन्ट:"
@@ -2909,6 +2944,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 
@@ -3366,6 +3404,11 @@ msgstr ""
 
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
+msgstr ""
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.

--- a/locales/nl_BE/LC_MESSAGES/duckduckgo.po
+++ b/locales/nl_BE/LC_MESSAGES/duckduckgo.po
@@ -279,9 +279,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Alle kleuren"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Alle lay-outs"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr ""
@@ -1695,6 +1705,26 @@ msgstr ""
 msgid "France"
 msgstr "Frankrijk"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Vriend of familielid"
@@ -2357,6 +2387,11 @@ msgstr "Lichtblauw"
 msgid "Light green"
 msgstr "Lichtgroen"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Link lettertype:"
@@ -2918,6 +2953,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "Open %sMenu > Instellingen > Zoek %s en kies DuckDuckGo!"
 
@@ -3379,6 +3417,11 @@ msgstr "Bescherm je privacy!"
 
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
+msgstr ""
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -5369,4 +5412,3 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/nl_NL/LC_MESSAGES/duckduckgo.po
+++ b/locales/nl_NL/LC_MESSAGES/duckduckgo.po
@@ -285,9 +285,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Alle kleuren"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Alle Lay-outs"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "Alle locaties"
@@ -1787,6 +1797,26 @@ msgstr "Versleuteling op websites afdwingen"
 msgid "France"
 msgstr "Frankrijk"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Vriend of familie"
@@ -2478,6 +2508,11 @@ msgstr "Lichtblauw"
 msgid "Light green"
 msgstr "Lichtgroen"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Lettertype voor links:"
@@ -3043,6 +3078,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr "Open"
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "Open %1$sMenu > Instellingen > Zoeken %2$s en selecteer DuckDuckGo!"
 
@@ -3517,6 +3555,11 @@ msgstr "Bescherm je privacy!"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "Bescherm je gegevens op elk apparaat."
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5600,4 +5643,3 @@ msgstr "blokkeer trackers"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "jr"
-

--- a/locales/nn_NO/LC_MESSAGES/duckduckgo.po
+++ b/locales/nn_NO/LC_MESSAGES/duckduckgo.po
@@ -279,9 +279,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Alle fargar"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Alle versjonar"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "Alle stadar"
@@ -1693,6 +1703,26 @@ msgstr ""
 msgid "France"
 msgstr "Frankrike"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Ven eller familie"
@@ -2353,6 +2383,11 @@ msgstr "Lyseblå"
 msgid "Light green"
 msgstr "Lysegrøn"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Lenkjeskrift:"
@@ -2915,6 +2950,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "Opne %sMeny > Innstillingar > Søk %s og vel DuckDuckGo!"
 
@@ -3377,6 +3415,11 @@ msgstr ""
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "Vern dine data på alle einingar."
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5362,4 +5405,3 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/od_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/od_IN/LC_MESSAGES/duckduckgo.po
@@ -282,9 +282,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "ସବୁ ରଙ୍ଗ"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "ସମସ୍ତ ଲେଆଉଟ"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "ସବୁ ସ୍ଥାନ"
@@ -1692,6 +1702,26 @@ msgstr ""
 msgid "France"
 msgstr "ଫ୍ରାନ୍ସ"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "ବନ୍ଧୁ କିମ୍ବା ପରିବାର"
@@ -2356,6 +2386,11 @@ msgstr "ହାଲୁକା ନୀଳ"
 msgid "Light green"
 msgstr "ହାଲୁକା ସବୁଜ"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "ଫଣ୍ଟ ଯୋଡ଼ନ୍ତୁ:"
@@ -2916,6 +2951,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr "ଖୋଲା"
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "ଖୋଲନ୍ତୁ %sମେନୁ > ସେଟିଙ୍ଗ > ଖୋଜାଖୋଜି %s ଏବଂ DuckDuckGo  ଚୟନ କରନ୍ତୁ!"
 
@@ -3375,6 +3413,11 @@ msgstr "ନିଜର ଗୋପନୀୟତାକୁ ସୁରକ୍ଷା ପ୍
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "ଆପଣଙ୍କର ତଥ୍ୟକୁ ପ୍ରତ୍ୟେକ ଯନ୍ତ୍ରରେ ସୁରକ୍ଷିତ ରଖନ୍ତୁ ।"
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5368,4 +5411,3 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/pl_PL/LC_MESSAGES/duckduckgo.po
+++ b/locales/pl_PL/LC_MESSAGES/duckduckgo.po
@@ -286,9 +286,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Wszystkie kolory"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Wszystkie formaty"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "Wszystkie lokalizacje"
@@ -1794,6 +1804,26 @@ msgstr "Wymuszać szyfrowanie na stronach"
 msgid "France"
 msgstr "Francja"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Przyjaciel lub rodzina"
@@ -2485,6 +2515,11 @@ msgstr "Jasnoniebieski"
 msgid "Light green"
 msgstr "Jasnozielony"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Czcionka linków:"
@@ -3049,6 +3084,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr "Otwórz"
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "Otwórz %1$sMenu > Ustawienia > Wyszukiwanie %2$s i wybierz DuckDuckGo!"
 
@@ -3525,6 +3563,11 @@ msgstr "Chroń swoją prywatność!"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "Chroń swoje dane na wszystkich urządzeniach."
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5618,4 +5661,3 @@ msgstr "blokowanie skryptów śledzących"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "rok"
-

--- a/locales/ps_AF/LC_MESSAGES/duckduckgo.po
+++ b/locales/ps_AF/LC_MESSAGES/duckduckgo.po
@@ -277,8 +277,18 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr ""
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
+msgstr ""
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
 msgstr ""
 
 msgid "All Places"
@@ -1674,6 +1684,26 @@ msgstr ""
 msgid "France"
 msgstr ""
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr ""
@@ -2332,6 +2362,11 @@ msgstr ""
 msgid "Light green"
 msgstr ""
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr ""
@@ -2887,6 +2922,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 
@@ -3344,6 +3382,11 @@ msgstr ""
 
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
+msgstr ""
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.

--- a/locales/pt_BR/LC_MESSAGES/duckduckgo.po
+++ b/locales/pt_BR/LC_MESSAGES/duckduckgo.po
@@ -288,9 +288,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Todas as Cores"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Todos os Layouts"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "Todos os Lugares"
@@ -1723,6 +1733,26 @@ msgstr "Forçar criptografia em sites"
 msgid "France"
 msgstr "França"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Amigo ou familiar"
@@ -2402,6 +2432,11 @@ msgstr "Azul claro"
 msgid "Light green"
 msgstr "Verde claro"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Fonte do link:"
@@ -2967,6 +3002,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr "Abrir"
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "Abrir %sMenu > Configurações > Procura %s e selecione DuckDuckGo!"
 
@@ -3435,6 +3473,11 @@ msgstr "Proteja Sua Privacidade!"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "Proteja seus dados em todos os dispositivos."
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5459,4 +5502,3 @@ msgstr "bloqueio de rastreador"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/pt_PT/LC_MESSAGES/duckduckgo.po
+++ b/locales/pt_PT/LC_MESSAGES/duckduckgo.po
@@ -287,9 +287,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Qualquer cor"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Qualquer formato"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "Todos os Locais"
@@ -1792,6 +1802,26 @@ msgstr "Forçar a encriptação em sítios Web"
 msgid "France"
 msgstr "França"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Amigo ou familiar"
@@ -2482,6 +2512,11 @@ msgstr "Azul claro"
 msgid "Light green"
 msgstr "Vede claro"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Código fonte:"
@@ -3048,6 +3083,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr "Abrir"
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 "Abrir %1$sMenu > Configurações > Pesquisa %2$s e seleccione DuckDuckGo!"
@@ -3528,6 +3566,11 @@ msgstr "Proteja a Sua Privacidade!"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "Proteja os seus dados em todos os dispositivos."
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5620,4 +5663,3 @@ msgstr "bloqueador de rastreio"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "ano"
-

--- a/locales/ro_RO/LC_MESSAGES/duckduckgo.po
+++ b/locales/ro_RO/LC_MESSAGES/duckduckgo.po
@@ -288,9 +288,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Toate Culorile"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Toate Layouturile"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "Toate Locațiile"
@@ -1794,6 +1804,26 @@ msgstr "Să forțeze criptarea pe site-uri web"
 msgid "France"
 msgstr "Franța"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Prieten sau familie"
@@ -2482,6 +2512,11 @@ msgstr "Albastru deschis"
 msgid "Light green"
 msgstr "Verde deschis"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Fontul linkurilor:"
@@ -3046,6 +3081,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr "Deschideți"
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "Deschide %1$sMeniu > Setări > Caută %2$s și selectează DuckDuckGo!"
 
@@ -3524,6 +3562,11 @@ msgstr "Protejează-ți Intimitatea!"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "Protejează-ți datele pe fiecare dispozitiv."
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5610,4 +5653,3 @@ msgstr "blocarea urmăririi"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "an"
-

--- a/locales/ru_RU/LC_MESSAGES/duckduckgo.po
+++ b/locales/ru_RU/LC_MESSAGES/duckduckgo.po
@@ -289,9 +289,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Все Цвета"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Все Макеты"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "Все места"
@@ -1799,6 +1809,26 @@ msgstr "Принудительно шифровать данные на сайт
 msgid "France"
 msgstr "Франция"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Друзья или семья"
@@ -2487,6 +2517,11 @@ msgstr "Светло-синий"
 msgid "Light green"
 msgstr "Светло-зелёный"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Шрифт ссылки:"
@@ -3050,6 +3085,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr "Открыто"
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "Откройте %1$sМеню > Настройки > Поиск %2$s и выберите DuckDuckGo!"
 
@@ -3528,6 +3566,11 @@ msgstr "Защитите свою приватность!"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "Защитите свои данные на каждом устройстве."
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5619,4 +5662,3 @@ msgstr "блокировка трекеров"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "г."
-

--- a/locales/sc_IT/LC_MESSAGES/duckduckgo.po
+++ b/locales/sc_IT/LC_MESSAGES/duckduckgo.po
@@ -282,9 +282,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Totu is colores"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Totu is dispositziones"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "Totu is logos"
@@ -1709,6 +1719,26 @@ msgstr "Imprea tzifradu in sitos web"
 msgid "France"
 msgstr "Frantza"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Amistade o famìlia"
@@ -2388,6 +2418,11 @@ msgstr "Biaitu craru"
 msgid "Light green"
 msgstr "Birde craru"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Orìgine de su ligàmene:"
@@ -2953,6 +2988,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr "Aberi"
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "Aberi %sMenù > Cunfiguratziones > Chirca %s e seletziona DuckDuckGo."
 
@@ -3422,6 +3460,11 @@ msgstr "Ampara sa riservadesa tua!"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "Ampara is datos tuos in totu is dispositivos."
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5444,4 +5487,3 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/si_LK/LC_MESSAGES/duckduckgo.po
+++ b/locales/si_LK/LC_MESSAGES/duckduckgo.po
@@ -283,9 +283,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "සියළු වර්ණ"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "සියලුම පිරිසැලසුම්"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "සියළු ස්ථාන"
@@ -1765,6 +1775,26 @@ msgstr "වෙබ් අඩවි වල බලහත්කාරයෙන් �
 msgid "France"
 msgstr "ප්‍රංශය"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "යහළුවා හෝ පවුල"
@@ -2446,6 +2476,11 @@ msgstr "ලා නිල්"
 msgid "Light green"
 msgstr "ලා කොළ"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "සබැඳි සඳහා අකුරු වර්ගය:"
@@ -3007,6 +3042,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr "විවෘත"
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "%1$sMenu > Settings > Search %2$s විවෘත කර DuckDuckGo තෝරන්න!"
 
@@ -3478,6 +3516,11 @@ msgstr "ඔබගේ පෞද්ගලිකත්වය ආරක්ශා ක
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "සෑම උපාංගයකම ඇති ඔබ්ගේ දත්ත ආරක්ෂා කරගන්න."
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5516,4 +5559,3 @@ msgstr "නිරික්සුව අවහිර කිරීම"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "වර්ෂ"
-

--- a/locales/sk_SK/LC_MESSAGES/duckduckgo.po
+++ b/locales/sk_SK/LC_MESSAGES/duckduckgo.po
@@ -283,9 +283,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Všetky farby"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Všetky rozloženia"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "Všetky miesta"
@@ -1794,6 +1804,26 @@ msgstr "Vynútiť šifrovanie na webových stránkach"
 msgid "France"
 msgstr "Francúzsko"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Priateĺ alebo rodina"
@@ -2488,6 +2518,11 @@ msgstr "Svetlomodrá"
 msgid "Light green"
 msgstr "Svetlozelená"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Font pre odkazy:"
@@ -3052,6 +3087,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr "Otvorené"
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "Otvorte %1$sMenu > Nastavenia > Vyhľadávať %2$s a vyberte DuckDuckGo!"
 
@@ -3526,6 +3564,11 @@ msgstr "Chráňte si súkromie!"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "Chráňte svoje údaje an každom zariadení."
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5621,4 +5664,3 @@ msgstr "blokovanie sledovacích zariadení"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "r"
-

--- a/locales/sl_SI/LC_MESSAGES/duckduckgo.po
+++ b/locales/sl_SI/LC_MESSAGES/duckduckgo.po
@@ -285,9 +285,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Vse barve"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Vse razporeditve"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "Vsa mesta"
@@ -1779,6 +1789,26 @@ msgstr "Prisilno šifrira spletna mesta"
 msgid "France"
 msgstr "Francija"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Prijatelj ali družina"
@@ -2467,6 +2497,11 @@ msgstr "Svetlo modra"
 msgid "Light green"
 msgstr "Svetlo zelena"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Pisava povezave:"
@@ -3031,6 +3066,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr "Odpri"
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "Odprite %1$sMeni > Nastavitve > Iskanje %2$s in izberite DuckDuckGo!"
 
@@ -3506,6 +3544,11 @@ msgstr "Zaščitite svojo zasebnost!"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "Zaščitite svoje podatke na vsaki napravi."
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5565,4 +5608,3 @@ msgstr "blokiranje sledenja"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "leto"
-

--- a/locales/sq_AL/LC_MESSAGES/duckduckgo.po
+++ b/locales/sq_AL/LC_MESSAGES/duckduckgo.po
@@ -282,9 +282,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Të gjitha ngjyrat"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Të gjitha skemat"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "Të gjitha vendet"
@@ -1705,6 +1715,26 @@ msgstr ""
 msgid "France"
 msgstr ""
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr ""
@@ -2367,6 +2397,11 @@ msgstr "Blu e hapur"
 msgid "Light green"
 msgstr "E gjelbër e çelur"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Shkrimi i lidhjes:"
@@ -2930,6 +2965,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 
@@ -3388,6 +3426,11 @@ msgstr ""
 
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
+msgstr ""
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -5352,4 +5395,3 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/sr_RS/LC_MESSAGES/duckduckgo.po
+++ b/locales/sr_RS/LC_MESSAGES/duckduckgo.po
@@ -281,9 +281,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Све боје"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Сви распореди"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "Сва места"
@@ -1701,6 +1711,26 @@ msgstr ""
 msgid "France"
 msgstr "Француска"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Пријатељ или породица"
@@ -2373,6 +2403,11 @@ msgstr "Светло плава"
 msgid "Light green"
 msgstr "Светло зелена"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Фонт везе"
@@ -2936,6 +2971,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "Отвори %sМени > Подешавања > Претрага %s и изабери DuckDuckGo!"
 
@@ -3401,6 +3439,11 @@ msgstr "Заштитите вашу приватност!"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "Заштитите ваше податке на сваком уређају."
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5391,4 +5434,3 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/sv_SE/LC_MESSAGES/duckduckgo.po
+++ b/locales/sv_SE/LC_MESSAGES/duckduckgo.po
@@ -286,9 +286,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Alla färger"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Alla layouter"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "Alla platser"
@@ -1787,6 +1797,26 @@ msgstr "Tvinga kryptering på webbplatser"
 msgid "France"
 msgstr "Frankrike"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Vän eller familj"
@@ -2475,6 +2505,11 @@ msgstr "Ljusblå"
 msgid "Light green"
 msgstr "Ljusgrön"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Länkteckensnitt:"
@@ -3038,6 +3073,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr "Öppna"
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "Öppna %1$sMeny > Inställningar > Sök %2$s och välj DuckDuckGo!"
 
@@ -3510,6 +3548,11 @@ msgstr "Skydda din integritet!"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "Skydda din information på alla enheter."
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5574,4 +5617,3 @@ msgstr "blockerar trackers"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "år"
-

--- a/locales/ta_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/ta_IN/LC_MESSAGES/duckduckgo.po
@@ -285,9 +285,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "அனைத்து வண்ணகள்"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "அனைத்து தளவமைப்புகள்"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "அனைத்து இடங்கள்"
@@ -1725,6 +1735,26 @@ msgstr ""
 msgid "France"
 msgstr ""
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr ""
@@ -2389,6 +2419,11 @@ msgstr " வெளிர் நீலம்"
 msgid "Light green"
 msgstr "வெளிர் பச்சை"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "இணைப்பு எழுத்துரு:"
@@ -2956,6 +2991,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 
@@ -3413,6 +3451,11 @@ msgstr ""
 
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
+msgstr ""
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -5378,4 +5421,3 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/te_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/te_IN/LC_MESSAGES/duckduckgo.po
@@ -282,9 +282,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "అన్ని రంగులు"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "అన్ని లేఔట్ లు"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "అన్ని ప్రాంతాలు"
@@ -1690,6 +1700,26 @@ msgstr ""
 msgid "France"
 msgstr ""
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "స్నేహితులు లేదా కుటుంబం"
@@ -2351,6 +2381,11 @@ msgstr "లేత నీలం"
 msgid "Light green"
 msgstr "లేత ఆకుపచ్చ"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "లంకె ఖతి:"
@@ -2912,6 +2947,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 
@@ -3369,6 +3407,11 @@ msgstr ""
 
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
+msgstr ""
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -5332,4 +5375,3 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/th_TH/LC_MESSAGES/duckduckgo.po
+++ b/locales/th_TH/LC_MESSAGES/duckduckgo.po
@@ -281,9 +281,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "ทุกสี"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "เค้าโครงทั้งหมด"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "ทุกสถานที่"
@@ -1757,6 +1767,26 @@ msgstr "บังคับใช้การเข้ารหัสบนเว
 msgid "France"
 msgstr "ฝรั่งเศส"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "เพื่อนหรือครอบครัว"
@@ -2436,6 +2466,11 @@ msgstr "สีฟ้าอ่อน"
 msgid "Light green"
 msgstr "สีเขียวอ่อน"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "ตัวอักษรลิงค์ :"
@@ -2996,6 +3031,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr "เปิด"
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "เปิด %1$sเมนู > การตั้งค่า > ค้นหา %2$s และเลือก DuckDuckGo!"
 
@@ -3466,6 +3504,11 @@ msgstr "ปกป้องความเป็นส่วนตัว"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "ปกป้องข้อมูลของคุณบนอุปกรณ์ทุกเครื่อง"
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5487,4 +5530,3 @@ msgstr "การบล็อกตัวติดตาม"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "ป"
-

--- a/locales/tl_PH/LC_MESSAGES/duckduckgo.po
+++ b/locales/tl_PH/LC_MESSAGES/duckduckgo.po
@@ -277,8 +277,18 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr ""
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
+msgstr ""
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
 msgstr ""
 
 msgid "All Places"
@@ -1683,6 +1693,26 @@ msgstr ""
 msgid "France"
 msgstr ""
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr ""
@@ -2345,6 +2375,11 @@ msgstr "Maaliwalas na asul"
 msgid "Light green"
 msgstr "Maaliwalas na berde"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Link font"
@@ -2902,6 +2937,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 
@@ -3359,6 +3397,11 @@ msgstr ""
 
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
+msgstr ""
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -5314,4 +5357,3 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/tokipona_XX/LC_MESSAGES/duckduckgo.po
+++ b/locales/tokipona_XX/LC_MESSAGES/duckduckgo.po
@@ -283,9 +283,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "kule ale"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "ale"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "ma ale"
@@ -1706,6 +1716,26 @@ msgstr ""
 msgid "France"
 msgstr "ma Kanse"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "jan pona anu kulupu tomo"
@@ -2378,6 +2408,11 @@ msgstr "laso walo"
 msgid "Light green"
 msgstr "laso walo"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "sitelen nimi pi nimi tawa:"
@@ -2939,6 +2974,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "open %s”Menu” > ”Settings” > ”Search”%s li pali e ”DuckDuckGo”!"
 
@@ -3401,6 +3439,11 @@ msgstr "o awen e len sina!"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "o awen e sitelen walo sin lon ijo ale."
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5390,4 +5433,3 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/tpi_PG/LC_MESSAGES/duckduckgo.po
+++ b/locales/tpi_PG/LC_MESSAGES/duckduckgo.po
@@ -277,8 +277,18 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr ""
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
+msgstr ""
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
 msgstr ""
 
 msgid "All Places"
@@ -1674,6 +1684,26 @@ msgstr ""
 msgid "France"
 msgstr ""
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr ""
@@ -2332,6 +2362,11 @@ msgstr ""
 msgid "Light green"
 msgstr ""
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr ""
@@ -2887,6 +2922,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 
@@ -3344,6 +3382,11 @@ msgstr ""
 
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
+msgstr ""
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.

--- a/locales/tr_TR/LC_MESSAGES/duckduckgo.po
+++ b/locales/tr_TR/LC_MESSAGES/duckduckgo.po
@@ -285,9 +285,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Tüm Renkler"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Tüm Düzenler"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "Tüm Yerler"
@@ -1788,6 +1798,26 @@ msgstr "Web sitelerini şifreleme kullanmaya zorlayabilir"
 msgid "France"
 msgstr "Fransa"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Arkadaş ya da aile"
@@ -2479,6 +2509,11 @@ msgstr "Açık mavi"
 msgid "Light green"
 msgstr "Açık yeşil"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Bağlantı yazı tipi:"
@@ -3045,6 +3080,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr "Aç"
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 "%1$sMenüyü açın > Ayarlar > %2$s aramasını yapın ve DuckDuckGo'yu seçin"
@@ -3519,6 +3557,11 @@ msgstr "Gizliliğinizi koruyun!"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "Verilerinizi her cihazda koruyun."
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5596,4 +5639,3 @@ msgstr "izleyici engelleme"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "y"
-

--- a/locales/uk_UA/LC_MESSAGES/duckduckgo.po
+++ b/locales/uk_UA/LC_MESSAGES/duckduckgo.po
@@ -289,9 +289,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Усі кольори"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Усі шаблони"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "Усі місця"
@@ -1804,6 +1814,26 @@ msgstr "Примусове шифрування на вебсайтах"
 msgid "France"
 msgstr "Франція"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Друг або сім'я"
@@ -2496,6 +2526,11 @@ msgstr "Cвітло-блакитний"
 msgid "Light green"
 msgstr "Cвітло-зелений"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Шрифт посилання:"
@@ -3066,6 +3101,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr "Відкрити"
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "Відкрийте %1$s Меню > Налаштування > Пошук %2$s і оберіть DuckDuckGo!"
 
@@ -3544,6 +3582,11 @@ msgstr "Захистіть свою приватність!"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "Захистіть свої дані на кожному пристрої."
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5634,4 +5677,3 @@ msgstr "блокування стеження"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "р"
-

--- a/locales/ur_PK/LC_MESSAGES/duckduckgo.po
+++ b/locales/ur_PK/LC_MESSAGES/duckduckgo.po
@@ -279,8 +279,18 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr ""
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
+msgstr ""
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
 msgstr ""
 
 msgid "All Places"
@@ -1680,6 +1690,26 @@ msgstr ""
 msgid "France"
 msgstr ""
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr ""
@@ -2346,6 +2376,11 @@ msgstr "ہلکا نیلا"
 msgid "Light green"
 msgstr "ہلکی سبز"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "لنک فونٹ:"
@@ -2905,6 +2940,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr ""
 
@@ -3362,6 +3400,11 @@ msgstr ""
 
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
+msgstr ""
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -5312,4 +5355,3 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/vi_VN/LC_MESSAGES/duckduckgo.po
+++ b/locales/vi_VN/LC_MESSAGES/duckduckgo.po
@@ -277,9 +277,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "Tất cả các màu "
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "Tất cả giao diện "
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr ""
@@ -1693,6 +1703,26 @@ msgstr ""
 msgid "France"
 msgstr "Pháp"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "Bạn bè hoặc Gia đình "
@@ -2353,6 +2383,11 @@ msgstr "Xanh dương nhạt"
 msgid "Light green"
 msgstr "Xanh nhạt"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Phông chữ đường liên kết"
@@ -2915,6 +2950,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr ""
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "Mở %sMenu > Settings > Search %s và lựa chọn DuckDuckGo!"
 
@@ -3376,6 +3414,11 @@ msgstr ""
 
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
+msgstr ""
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -5360,4 +5403,3 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr ""
-

--- a/locales/zh_CN/LC_MESSAGES/duckduckgo.po
+++ b/locales/zh_CN/LC_MESSAGES/duckduckgo.po
@@ -280,9 +280,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "不限颜色"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "不限形状"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "所有地点"
@@ -1742,6 +1752,26 @@ msgstr "自动采用加密连接"
 msgid "France"
 msgstr "法国"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "亲朋好友"
@@ -2416,6 +2446,11 @@ msgstr "浅蓝色"
 msgid "Light green"
 msgstr "浅绿色"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "链接字体："
@@ -2976,6 +3011,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr "正在营业"
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "打开 %1$s菜单 > 设置 > 搜索%2$s 然后选择 DuckDuckGo！"
 
@@ -3444,6 +3482,11 @@ msgstr "保护你的隐私！"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "将隐私保护普及到所有设备上。"
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5450,4 +5493,3 @@ msgstr "屏蔽追踪脚本"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "年"
-

--- a/locales/zh_TW/LC_MESSAGES/duckduckgo.po
+++ b/locales/zh_TW/LC_MESSAGES/duckduckgo.po
@@ -278,9 +278,19 @@ msgctxt "image-color"
 msgid "All Colors"
 msgstr "所有顏色"
 
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
 msgctxt "image-layout"
 msgid "All Layouts"
 msgstr "所有佈局"
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
 
 msgid "All Places"
 msgstr "每個地方"
@@ -1747,6 +1757,26 @@ msgstr "強制加密網站"
 msgid "France"
 msgstr "法國"
 
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
 msgctxt "new user poll"
 msgid "Friend or family"
 msgstr "朋友或是家人"
@@ -2421,6 +2451,11 @@ msgstr "淺藍色"
 msgid "Light green"
 msgstr "淺綠色"
 
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "連結字體："
@@ -2981,6 +3016,9 @@ msgctxt "maps_places"
 msgid "Open"
 msgstr "營業中"
 
+msgid "Open %s website"
+msgstr ""
+
 msgid "Open %sMenu > Settings > Search %s and select DuckDuckGo!"
 msgstr "打開 %1$s 選單 ＞ 設定 ＞ 搜尋 %2$s 然後選擇 DuckDuckGo！"
 
@@ -3449,6 +3487,11 @@ msgstr "保護你的隱私！"
 msgctxt "showcase_app"
 msgid "Protect your data on every device."
 msgstr "保護你在每台裝置上的資料"
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -5448,4 +5491,3 @@ msgstr "追蹤器封鎖"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "年"
-


### PR DESCRIPTION
Hey @GioSensation, here's a redux of #447 with comments. Some of the strings' meanings are relatively technical in nature, so I've offered the names of the specific Creative Commons licenses they are describing. The localizers can search for that license to help understand what the string describes.

CC @morgajp; it looks like this picked up the `OPEN_SITE_STRING` string that you recently added.