### PR TITLE
Removing double colons from 2 translations

### DIFF
--- a/locales/tr_TR/LC_MESSAGES/duckduckgo.po
+++ b/locales/tr_TR/LC_MESSAGES/duckduckgo.po
@@ -4216,10 +4216,10 @@ msgid "Showing"
 msgstr "Görünür"
 
 msgid "Showing results excluding"
-msgstr "Gösterilen sonuçlar şunları içermiyor:"
+msgstr "Gösterilen sonuçlar şunları içermiyor"
 
 msgid "Showing results from"
-msgstr "Şuradan sonuçlar gösteriliyor:"
+msgstr "Şuradan sonuçlar gösteriliyor"
 
 msgid "Showing results without %s."
 msgstr "%1$s hariç sonuçlar gösteriliyor."


### PR DESCRIPTION
Removed extra colons from 2 places I noticed. As I removed the extra one from locales, it's now left with a single colon as it supposed to be.

![Demonstration](https://i.imgur.com/DLTl3j6.png)

To test, visit this link with Turkish language set: https://duckduckgo.com/?q=site%3Agithub.com+foo