### PR TITLE
New Irish translation

### DIFF
--- a/locales/ga_IE/LC_MESSAGES/duckduckgo.po
+++ b/locales/ga_IE/LC_MESSAGES/duckduckgo.po
@@ -2728,7 +2728,7 @@ msgstr "Tuilleadh eolais"
 
 msgctxt "Ads GDPR, internal use only. Do not change"
 msgid "More Info"
-msgstr "Tuilleadh eolais"
+msgstr ""
 
 msgid "More Links"
 msgstr "Tuilleadh Naisc"

--- a/locales/ga_IE/LC_MESSAGES/duckduckgo.po
+++ b/locales/ga_IE/LC_MESSAGES/duckduckgo.po
@@ -4999,9 +4999,6 @@ msgstr "Físeáin"
 msgid "Vietnam"
 msgstr "Vítneam"
 
-msgid "View File"
-msgstr "Féach ar an gcomhad"
-
 #. The name of the Vietnamese language
 msgctxt "language_name"
 msgid "Vietnamese"

--- a/locales/ga_IE/LC_MESSAGES/duckduckgo.po
+++ b/locales/ga_IE/LC_MESSAGES/duckduckgo.po
@@ -226,7 +226,7 @@ msgstr "Barra seoladh:"
 
 #. as in multiple advertisements
 msgid "Ads"
-msgstr ""
+msgstr "Fógraí"
 
 msgctxt "feedback form"
 msgid "Advertisements"
@@ -261,7 +261,7 @@ msgstr ""
 #. 'license' as in 'permission to use, share, or modify a work'
 msgctxt "image-licence"
 msgid "All Licenses"
-msgstr ""
+msgstr "Gach ceadúnas"
 
 msgid "All Places"
 msgstr "Gach Áit"
@@ -278,30 +278,30 @@ msgstr "Gach Socrú"
 
 msgctxt "settings pages"
 msgid "All Settings"
-msgstr ""
+msgstr "Gach socrú"
 
 #. This is shown in an image filter. This option only shows images in colors, excluding black and white images. https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-color"
 msgid "All colors"
-msgstr ""
+msgstr "Gach dath"
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
 msgctxt "image-layout"
 msgid "All layouts"
-msgstr ""
+msgstr "Gach leagan amach"
 
 msgctxt "settingsvalue"
 msgid "All regions"
-msgstr ""
+msgstr "Gach réigiún"
 
 msgctxt "size"
 msgid "All sizes"
-msgstr ""
+msgstr "Gach méid"
 
 #. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
 msgctxt "image-type"
 msgid "All types"
-msgstr ""
+msgstr "Gach cineál"
 
 msgctxt "settings"
 msgid ""
@@ -353,20 +353,20 @@ msgstr "Am ar bith"
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
 msgctxt "video-duration"
 msgid "Any duration"
-msgstr ""
+msgstr "Aga ar bith"
 
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
 msgctxt "video-license"
 msgid "Any license"
-msgstr ""
+msgstr "Ceadúnas ar bith"
 
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
 msgctxt "video-resolution"
 msgid "Any resolution"
-msgstr ""
+msgstr "Taifeachh ar bith"
 
 msgid "Any time"
-msgstr ""
+msgstr "Am ar bith"
 
 msgid "Anywhere"
 msgstr "Áit ar bith"
@@ -375,7 +375,7 @@ msgid "App"
 msgstr "Feidhmchláirín"
 
 msgid "App and Extension"
-msgstr "Aip agus Breiseán"
+msgstr "Feidhmchláirín agus Breiseán"
 
 msgid "Appearance"
 msgstr "Cuma"
@@ -387,7 +387,7 @@ msgstr "Cuma"
 
 msgctxt "Custom date range filer"
 msgid "Apply"
-msgstr ""
+msgstr "Cuir i bhfeidhm é"
 
 #. Instant Answer Tab Name
 msgid "Apps"
@@ -432,7 +432,7 @@ msgstr "Moladh uathoibríoch"
 
 msgctxt "settings"
 msgid "Autocomplete Suggestions"
-msgstr ""
+msgstr "Moltaí uathchríochnaithe"
 
 #. http://i.imgur.com/OZIO1I9.png
 msgctxt "settings"
@@ -481,7 +481,7 @@ msgstr "An Bheilg (nl)"
 
 msgctxt "settingsvalue"
 msgid "Best available"
-msgstr ""
+msgstr "An ceann is fearr atá le fáil"
 
 #. In the right menu panel of the homepage.
 msgid "Beta"
@@ -501,7 +501,7 @@ msgstr "Dubh"
 
 msgctxt "image-color"
 msgid "Black and white"
-msgstr ""
+msgstr "Dubh agus bán"
 
 msgid "Block Trackers"
 msgstr "Cuir Bac ar Lorgairí"
@@ -570,7 +570,7 @@ msgstr "Teanga Ansa an Líonléitheora"
 
 msgctxt "settingsvalue"
 msgid "Browser preferred language"
-msgstr ""
+msgstr "Teanga an líonléitheora"
 
 msgid "Bulgaria"
 msgstr "An Bhulgáir"
@@ -770,10 +770,10 @@ msgstr "Glan Gach Rud"
 
 msgctxt "precise_user_location"
 msgid "Clear Location"
-msgstr ""
+msgstr "Glan an suíomh"
 
 msgid "Clear all filters"
-msgstr ""
+msgstr "Glan gach scagaire"
 
 #. Part of a list of what our app can do. The app can: …
 msgctxt "welcome message eu search preference android"
@@ -835,7 +835,7 @@ msgid "Click %sSettings%s"
 msgstr "Brúigh %sSocruithe%s"
 
 msgid "Click %sSettings%s in the dropdown."
-msgstr ""
+msgstr "Brúigh %sSocruithe%s sa roghchlár anuas."
 
 msgid "Click %sUse current pages%s then %sClick OK%s."
 msgstr ""
@@ -1023,7 +1023,7 @@ msgstr "Socruithe na nDathanna"
 
 msgctxt "image-color"
 msgid "Color only"
-msgstr ""
+msgstr "Dath amháin"
 
 #. In the top menu under Settings
 msgid "Colors"
@@ -1067,7 +1067,7 @@ msgstr "Comhshó"
 #. http://i.imgur.com/fd7EjAN.png
 msgctxt "settings"
 msgid "Cookie data:"
-msgstr ""
+msgstr "Sonraí fianáin:"
 
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
 msgstr "Cóipeáil &amp; greamaigh %sabout:preferences#search%s sa bharra seolta"
@@ -1115,7 +1115,7 @@ msgid "Custom %s"
 msgstr "%s saincheaptha"
 
 msgid "Custom date range"
-msgstr ""
+msgstr "Raon saincheaptha dáta"
 
 msgid "Czech Republic"
 msgstr "An tSeicia"
@@ -1140,7 +1140,7 @@ msgstr "Scagairí an Dáta"
 
 msgctxt "feedback form"
 msgid "Date filters"
-msgstr ""
+msgstr "Scagairí dáta"
 
 #. A theme name in the theme menu:
 #. https://duck.co/media/files/theme.png
@@ -1159,7 +1159,7 @@ msgstr "Sainmhíniú"
 #. When anonymous cloud save is enabled, a box is available with a <em>delete your data</em> button at the bottom of <a href="https://duckduckgo.com/settings.html">settings page<a/>.
 #. This token is displayed as a button, so keep it short!
 msgid "Delete My Data"
-msgstr ""
+msgstr "Scrios Mo Chuid Sonraí"
 
 msgid "Denmark"
 msgstr "An Danmhairg"
@@ -1182,7 +1182,7 @@ msgstr "An %s a bhí ar intinn agat?"
 
 msgctxt "directions"
 msgid "Directions"
-msgstr ""
+msgstr "Eolas an Bhealaigh"
 
 #. Non lle poño "enderezos" pois non se refire aos enderezos se non as instruccións para chegar a un lugar
 msgctxt "maps_places"
@@ -1248,7 +1248,7 @@ msgstr "Deochanna"
 
 msgctxt "directions"
 msgid "Driving"
-msgstr ""
+msgstr "Ag tiomáint"
 
 #. This is the DDG version of "Google it", meaning "search it".
 msgid "Duck it"
@@ -1304,7 +1304,7 @@ msgid ""
 msgstr ""
 
 msgid "DuckDuckGo search"
-msgstr ""
+msgstr "Cuardach DuckDuckGo"
 
 #. Used as a link to your personal settings  into the sentence <em>You can change *DuckDuckGo settings* via URL parameters by adding them after the search query</em>. See the <a href="https://duckduckgo.com/params.html">params page</a>.
 msgid "DuckDuckGo settings"
@@ -1312,7 +1312,7 @@ msgstr "Socruithe DuckDuckGo"
 
 msgctxt "forecast"
 msgid "E"
-msgstr "E"
+msgstr "O"
 
 msgctxt "settings"
 msgid "EU Android Welcome Message"
@@ -1430,7 +1430,7 @@ msgstr ""
 
 msgctxt "maps_directions"
 msgid "Enter your destination"
-msgstr ""
+msgstr "Cuir isteach do cheann scríbe"
 
 msgctxt "email newsletter"
 msgid "Enter your email address."
@@ -1466,7 +1466,7 @@ msgstr "Ollmhór"
 
 msgctxt "directions"
 msgid "Fastest route"
-msgstr ""
+msgstr "An bealach is tapúla"
 
 #. <em>kf</em>'s label into <a href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Favicons:"
@@ -1481,7 +1481,7 @@ msgstr "Seoladh an t-aiseolas"
 
 msgctxt "feedback form"
 msgid "Feedback Sent Successfully"
-msgstr ""
+msgstr "Seoladh an t-aiseolas go rathúil"
 
 #. https://duckduckgo.com/search_box
 msgid ""
@@ -1495,14 +1495,14 @@ msgid "Fill in the last form field with %s"
 msgstr "Líon an réimse deiridh san fhoirm le %s"
 
 msgid "Filter by Date"
-msgstr ""
+msgstr "Scag de réir dáta"
 
 msgid "Filter by Region"
-msgstr ""
+msgstr "Scag de réir an réigiúin"
 
 msgctxt "feedback form"
 msgid "Filters aren't working"
-msgstr ""
+msgstr "Níl na scagairí ag feidhmiú"
 
 msgid "Final"
 msgstr "Críochnúil"
@@ -1520,7 +1520,7 @@ msgstr ""
 
 msgctxt "precise_user_location"
 msgid "Find results closer to you"
-msgstr ""
+msgstr "Aimsigh torthaí níos giorra duit"
 
 msgctxt "precise_user_location"
 msgid "Find results closer to you."
@@ -1586,7 +1586,7 @@ msgstr "Cara nó duine muinteartha"
 #. http://i.imgur.com/tGau0Vx.png
 msgctxt "settings"
 msgid "GET Requests"
-msgstr ""
+msgstr "Iarratais GET"
 
 msgid "Game ended"
 msgstr "Tá an cluiche thart"
@@ -1651,7 +1651,7 @@ msgstr "Áitigh ar do chairde tiontú chuig DuckDuckGo agus cabhraigh linn fás!
 
 msgctxt "precise_user_location"
 msgid "Go to 'Site Settings'."
-msgstr ""
+msgstr "Téigh chuig 'Socruithe an tSuímh'."
 
 msgid "Go to Options."
 msgstr "Téigh chuig Roghanna."
@@ -1667,7 +1667,7 @@ msgstr "Dea-rudaí"
 #. Option selected by user to acknowledge understanding of information
 msgctxt "precise_user_location"
 msgid "Got it"
-msgstr ""
+msgstr "Tuigim"
 
 msgctxt "color"
 msgid "Gray"
@@ -1773,7 +1773,7 @@ msgstr ""
 #. Hides details of a step-by-step navigation route
 msgctxt "directions"
 msgid "Hide Steps"
-msgstr ""
+msgstr "Cuir na céimeanna i bhfolach"
 
 msgctxt "settings"
 msgid "Hides search term from being shown in browser tab/history"
@@ -1783,7 +1783,7 @@ msgstr ""
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
 msgctxt "video-resolution"
 msgid "High definition"
-msgstr ""
+msgstr "Ardghléine"
 
 msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
@@ -1851,7 +1851,7 @@ msgstr "An Ungáir"
 
 msgctxt "feedback form"
 msgid "I don't want this type of result"
-msgstr ""
+msgstr "Ní mian liom an cineál torthaí seo"
 
 msgctxt "feedback form"
 msgid "I expected to see results from more sellers"
@@ -1908,7 +1908,7 @@ msgstr ""
 
 msgctxt "settingsvalue"
 msgid "Image tiles"
-msgstr ""
+msgstr "Leacáin íomhá"
 
 #. Used in the !bang dropdown.
 msgid "Images"
@@ -1952,7 +1952,7 @@ msgstr "Sa roghchlár ar an taobh, roghnaigh %sCuardach Idirlín%s"
 
 #. e.g., 'Including results for Mozart' (when the user searched for 'Mozar')
 msgid "Including results for %s"
-msgstr ""
+msgstr "Lena n-áirítear torthaí i gcomhair %s"
 
 msgid "India"
 msgstr "An India"
@@ -1982,7 +1982,7 @@ msgstr "Scrollú gan chríoch i gcomhair Íomhánna agus Físeáin"
 
 msgctxt "settings"
 msgid "Infinite Scroll for Images, Videos, and Shopping"
-msgstr ""
+msgstr "Scrollú gan chríoch i gcomhair Íomhánna, Físeáin, agus Siopadóireacht"
 
 msgid "Install"
 msgstr "Suiteáil"
@@ -2036,7 +2036,7 @@ msgstr "Dáiríre, an scriostar go hiomlán sonraí a scriosadh?"
 
 msgctxt "feedback form"
 msgid "Is this video helpful?"
-msgstr ""
+msgstr "An bhfuil an físeán seo acrach?"
 
 msgid "Israel"
 msgstr "Iosrael"
@@ -2305,7 +2305,7 @@ msgstr ""
 
 msgctxt "directions"
 msgid "Make sure your search is spelled correctly."
-msgstr ""
+msgstr "Cinntigh go bhfuil do chuardach litrithe i gceart."
 
 msgid "Malaysia"
 msgstr "An Mhalaeisia"
@@ -2330,11 +2330,11 @@ msgstr "Léarscáileanna"
 
 msgctxt "feedback form"
 msgid "Maps / location info"
-msgstr ""
+msgstr "Léarscáileanna / eolas faoi shuíomh"
 
 msgctxt "precise_user_location"
 msgid "Maybe later"
-msgstr ""
+msgstr "Ar ball b'fhéidir"
 
 #. In 0-click box -- for disambiguation.
 msgid "Meanings"
@@ -2367,7 +2367,7 @@ msgstr "Méadrach (Cileagraim, Méadair, Celsius)"
 
 msgctxt "settingsvalue"
 msgid "Metric (kilograms, meters, Celsius)"
-msgstr ""
+msgstr "Méadrach (ciligreaim, méadair, Celsius)"
 
 msgid "Mexico"
 msgstr "Meicsiceo"
@@ -2409,11 +2409,11 @@ msgid "More Images"
 msgstr "Tuilleadh Íomhánna"
 
 msgid "More Info"
-msgstr "Tuilleadh Eolais"
+msgstr "Tuilleadh eolais"
 
 msgctxt "Ads GDPR, internal use only. Do not change"
 msgid "More Info"
-msgstr ""
+msgstr "Tuilleadh eolais"
 
 msgid "More Links"
 msgstr "Tuilleadh Naisc"
@@ -2436,7 +2436,7 @@ msgstr "Tuilleadh Ábhair Ghaolmhara"
 #. e.g., 'More Reviews on Tripadvisor'
 msgctxt "more_reviews_on_external_website"
 msgid "More Reviews on %s "
-msgstr ""
+msgstr "Tuilleadh léirmheasanna ar %s"
 
 msgid "More Themes"
 msgstr "Tuilleadh Téamanna"
@@ -2489,7 +2489,7 @@ msgstr "Tuilleadh bealaí chun DuckDuckGo a chur le %s"
 
 msgctxt "precise_user_location"
 msgid "Move map to set current location"
-msgstr ""
+msgstr "Bog an léarscáil chun an áit mar a bhfuil tú faoi láthair a shocrú"
 
 #. Instant Answer Tab Name
 msgid "Movies"
@@ -2598,7 +2598,7 @@ msgstr ""
 
 msgctxt "settingsvalue"
 msgid "No preference (default)"
-msgstr ""
+msgstr "Ní miste (réamhshocrú)"
 
 msgid "No results"
 msgstr "Gan toradh"
@@ -2609,7 +2609,7 @@ msgstr "Níor aimsíodh aon torthaí i gcomhair %s%s%s."
 
 msgctxt "directions"
 msgid "No results found."
-msgstr ""
+msgstr "Níor aimsíodh aon torthaí."
 
 msgctxt "new user poll"
 msgid "No thanks."
@@ -2642,7 +2642,7 @@ msgstr "An Iorua"
 
 msgctxt "precise_user_location"
 msgid "Not getting nearby results?"
-msgstr ""
+msgstr "Nach bhfuil torthaí in aice leat á bhfáil agat?"
 
 #. Not many results contain '<query>' (<query> is the query that the user sent to the search engine)
 msgid "Not many results contain %s"
@@ -2654,7 +2654,7 @@ msgstr "Níl sé ábhartha"
 
 msgctxt "settingsvalue"
 msgid "Not set"
-msgstr ""
+msgstr "Níl sé socraithe"
 
 #. Instant Answer tab name
 msgid "Nutrition"
@@ -2739,7 +2739,7 @@ msgstr "Oscail"
 
 #. The placeholder is a business name, e.g. 'Open Ikea website'.
 msgid "Open %s website"
-msgstr ""
+msgstr "Oscail suíomh gréasáin %s"
 
 msgctxt "mobile homepage banner"
 msgid "Open %sMenu%s"
@@ -2805,7 +2805,7 @@ msgstr ""
 
 msgctxt "maps_places"
 msgid "Opens"
-msgstr ""
+msgstr "Osclaíonn sé"
 
 #. http://i.imgur.com/iCNwHqR.png
 #. This setting controls how results open when you click on them.
@@ -2940,16 +2940,16 @@ msgid "Past Year"
 msgstr "Bhliain Seo Caite"
 
 msgid "Past day"
-msgstr ""
+msgstr "An lá inné"
 
 msgid "Past month"
-msgstr ""
+msgstr "An mhí seo caite"
 
 msgid "Past week"
-msgstr ""
+msgstr "An tseachtain seo caite"
 
 msgid "Past year"
-msgstr ""
+msgstr "An bhliain seo caite"
 
 msgid "Peru"
 msgstr "Peiriú"
@@ -2977,7 +2977,7 @@ msgstr "Grianghraif ar %s"
 
 msgctxt "precise_user_location"
 msgid "Pick Custom Location"
-msgstr ""
+msgstr "Roghnaigh suíomh saincheaptha"
 
 msgctxt "feedback form"
 msgid "Pick a category"
@@ -3008,7 +3008,7 @@ msgstr "Cuir isteach nath faire le do thoil"
 
 msgctxt "feedback form"
 msgid "Please provide feedback"
-msgstr ""
+msgstr "Tabhair aiseolas le do thoil"
 
 msgctxt "new user poll"
 msgid "Please select one option."
@@ -3057,14 +3057,14 @@ msgid "Price shown doesn't reflect merchant site"
 msgstr ""
 
 msgid "Print"
-msgstr ""
+msgstr "Clóbhuail"
 
 msgctxt "directions"
 msgid "Print Directions"
-msgstr ""
+msgstr "Clóbhuail eolas an bhealaigh"
 
 msgid "Print Preview"
-msgstr ""
+msgstr "Réamhamharc clóbhuailte"
 
 #. In the top menu under Settings ("More" > "Privacy")
 msgid "Privacy"
@@ -3159,7 +3159,7 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Product ads aren't relevant"
-msgstr ""
+msgstr "Níl fógraí an táirge ábhartha"
 
 #. Instant Answer Tab Name
 msgid "Products"
@@ -3189,7 +3189,7 @@ msgstr "Cosain do chuid sonraí ar gach gléas."
 #. a filter for images with the CC0 usage license
 msgctxt "image-licence"
 msgid "Public Domain"
-msgstr ""
+msgstr "Fearann Poiblí"
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
 msgid "Purple"
@@ -3525,7 +3525,7 @@ msgstr "Torthaí Cuardaigh"
 
 msgctxt "map"
 msgid "Search This Area"
-msgstr ""
+msgstr "Cuardaigh an Ceantar Seo"
 
 msgctxt "settings"
 msgid "Search Visibility"
@@ -3536,7 +3536,7 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Search box"
-msgstr ""
+msgstr "Bosca cuardaigh"
 
 #. Le terme apparait en survolant le terme "More from ..." sur la page de résultats.
 msgid "Search domain %s"
@@ -3565,7 +3565,7 @@ msgstr "Cuardaigh an gréasán gan daoine á do lorg"
 #. Search this area for hotels, restaurants, bars, parks, banks etc.
 msgctxt "map"
 msgid "Search this area for..."
-msgstr ""
+msgstr "Déan cuardach sa cheantar seo i gcomhair..."
 
 #. Message displayed sometimes at top of results (for bang syntax), e.g. <a href="https://duckduckgo.com/?q=twitter+test">https://duckduckgo.com/?q=twitter+test</a>
 msgid "Searches %s using our %s"
@@ -3576,7 +3576,7 @@ msgstr "Cuarduithe gaolta le \"%s\""
 
 msgctxt "feedback form"
 msgid "Security issue (opens in new tab)"
-msgstr ""
+msgstr "Fadhb slándála (osclófar cluaisín nua)"
 
 msgid "See Photos"
 msgstr "Féach ar Ghrianghraif"
@@ -3585,7 +3585,7 @@ msgstr "Féach ar Ghrianghraif"
 #. Then at the bottom of the cloud save box - http://i.imgur.com/4Jo3jAf.png
 msgctxt "cloudsave"
 msgid "See also"
-msgstr ""
+msgstr "Féach freisin"
 
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
@@ -3695,7 +3695,7 @@ msgstr "Roghnaigh DuckDuckGo!"
 
 msgctxt "precise_user_location"
 msgid "Select Settings > Location."
-msgstr ""
+msgstr "Roghnaigh Socruithe > Suíomh"
 
 msgid "Selected %sDuckDuckGo%s"
 msgstr "%sDuckDuckGo%s roghnaithe"
@@ -3745,7 +3745,7 @@ msgid "Settings in JSON:"
 msgstr "Socruithe i JSON:"
 
 msgid "Settings updated"
-msgstr ""
+msgstr "Nuashonraíodh na socruithe"
 
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
@@ -3755,7 +3755,7 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share Feedback"
-msgstr ""
+msgstr "Roinn aiseolas linn"
 
 msgctxt "feedback form"
 msgid "Share feedback for this result."
@@ -3778,12 +3778,12 @@ msgstr "Aicearraí chuig suíomhanna eile chun cuardach as DuckDuckGo"
 #. button to show X>1 more options in a list
 msgctxt "shopping_vertical"
 msgid "Show %s more"
-msgstr ""
+msgstr "Taispeáin %s eile"
 
 #. button to show 1 more option in a list
 msgctxt "shopping_vertical"
 msgid "Show 1 more"
-msgstr ""
+msgstr "Taispeáin 1 amháin eile"
 
 #. http://i.imgur.com/msbR8Xk.png
 #. Clicking will show you your Settings as a URL and JSON like this http://i.imgur.com/59sqEFU.png
@@ -3820,15 +3820,15 @@ msgstr ""
 #. Shows details of a step-by-step navigation route
 msgctxt "directions"
 msgid "Show Steps"
-msgstr ""
+msgstr "Taispeáin na céimeanna"
 
 msgctxt "noresults"
 msgid "Show Web Results"
-msgstr ""
+msgstr "Taispeáin na torthaí gréasáin"
 
 msgctxt "directions"
 msgid "Show map"
-msgstr ""
+msgstr "Taispeáin an léarscáil"
 
 msgctxt "video-duration"
 msgid "Show videos of any length"
@@ -4307,7 +4307,7 @@ msgid "Try setting your location manually."
 msgstr ""
 
 msgid "Try the DuckDuckGo app"
-msgstr ""
+msgstr "Bain feidhm as feidhmchláirín DuckDuckGo"
 
 #. Message displayed sometimes at top of results (for bang syntax), e.g. <a href="https://duckduckgo.com/?q=twitter+test">https://duckduckgo.com/?q=twitter+test</a>
 msgid "Try: %s"
@@ -4355,7 +4355,7 @@ msgstr "SAM-bunaithe (Puint, Troithe, Fahrenheit)"
 
 msgctxt "settingsvalue"
 msgid "US-based (pounds, feet, Fahrenheit)"
-msgstr ""
+msgstr "SAM-bhunaithe (puint, troithe, Fahrenheit)"
 
 #. I haven't Translated the links under %s because that will come from Chrome Browser...
 msgid ""
@@ -4461,7 +4461,7 @@ msgstr ""
 #. User clicks this button to share their device's location
 msgctxt "precise_user_location"
 msgid "Use Location"
-msgstr ""
+msgstr "Bain feidhm as an suíomh"
 
 msgid "Use in Firefox"
 msgstr "Bain feidhm as in Firefox"
@@ -4471,7 +4471,7 @@ msgstr "Bain feidhm as i Safari"
 
 msgctxt "directions"
 msgid "Via"
-msgstr ""
+msgstr "Trí"
 
 #. http://i.imgur.com/BF3gZsZ.png
 msgctxt "settings"
@@ -4486,7 +4486,7 @@ msgid "Vietnam"
 msgstr "Vítneam"
 
 msgid "View File"
-msgstr ""
+msgstr "Féach ar an gcomhad"
 
 msgid "View on %s"
 msgstr "Breathnaigh air ar %s"
@@ -4524,7 +4524,7 @@ msgstr ""
 
 msgctxt "directions"
 msgid "Walking"
-msgstr ""
+msgstr "Ag siúl"
 
 msgctxt "size"
 msgid "Wallpaper"
@@ -4532,7 +4532,7 @@ msgstr "Cúlbhrat"
 
 msgctxt "feedback form"
 msgid "Want to tell us a bit more?"
-msgstr ""
+msgstr "An mian leat tuilleadh a rá linn?"
 
 #. e.g. Video search viewing options: http://i.imgur.com/ofZeLRn.png
 msgid "Watch Here"
@@ -4682,7 +4682,7 @@ msgstr "Cad ar thaitin leat?"
 
 msgctxt "feedback form"
 msgid "What do you think of the information shown?"
-msgstr ""
+msgstr "Cad é do mheas faoin eolas atá á thaispeáint?"
 
 #. Click "What is this?" - http://i.imgur.com/KhmRHth.png
 #. Then in the cloud save box - http://i.imgur.com/ta4V0Xy.png
@@ -4708,7 +4708,7 @@ msgstr "Cad a thug chuig DuckDuckGo thú?"
 
 msgctxt "maps_places"
 msgid "What people say:"
-msgstr ""
+msgstr "Cad atá á rá ag daoine:"
 
 msgid "Where it says Homepage click %sSet to Current Page%s."
 msgstr ""
@@ -4775,7 +4775,7 @@ msgstr "Sea, úsáideoir nua!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr ""
+msgstr "Caithimid uainn sonraí an tráth a bhíonn tú críochnaithe leo, agus ní féidir iad a fháil ar ais arís"
 
 #. Option for the filter-by-date search.
 msgid "Yesterday"
@@ -4853,7 +4853,7 @@ msgstr "Caighdeán YouTube"
 
 msgctxt "directions"
 msgid "Your Location"
-msgstr ""
+msgstr "Mar a bhfuil tú"
 
 #. Floating text over a tick next to search results which indicates if a link has been visited.
 msgid "Your browser indicates if you've visited this link"
@@ -4906,7 +4906,7 @@ msgstr "le %s"
 #. An abbreviated form of "day" that can be displayed in a small space e.g. "1d"
 msgctxt "published date for videos"
 msgid "d"
-msgstr ""
+msgstr "l"
 
 #. https://duckduckgo.com/params under "Color Settings" under all
 #. under "Look & Feel Settings"  under "Size:" and "Text link: "
@@ -4924,7 +4924,7 @@ msgstr "i gcomhair"
 #. An abbreviated form of "hour" that can be displayed in a small space e.g. "1h"
 msgctxt "published date for videos"
 msgid "h"
-msgstr ""
+msgstr "u"
 
 msgctxt "nonjsversion"
 msgid "here"
@@ -4933,12 +4933,12 @@ msgstr "anseo"
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
-msgstr ""
+msgstr "n"
 
 #. An abbreviated form of "month" that can be displayed in a small space e.g. "1mo"
 msgctxt "published date for videos"
 msgid "mo"
-msgstr ""
+msgstr "mí"
 
 #. https://duckduckgo.com/50x.html?e=2
 #. p.s.(tsester): i found it out by searching "  "
@@ -5004,4 +5004,4 @@ msgstr "bac ar lorgairí"
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
-msgstr ""
+msgstr "bl"


### PR DESCRIPTION
Updated Irish translation to get DuckDuckGo in Irish up to date.