### PR TITLE
Fix chrome counter message msg in Fr

### DIFF
--- a/locales/fr_FR/LC_MESSAGES/duckduckgo.po
+++ b/locales/fr_FR/LC_MESSAGES/duckduckgo.po
@@ -819,7 +819,7 @@ msgstr "Chinois traditionnel"
 
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr "Choisissez %1$sGarder%2$s pour continuer à protéger votre confidentialité."
+msgstr "Choisissez %1$sConserver%2$s pour continuer à protéger votre confidentialité."
 
 #. http://i.imgur.com/f8Ae6jo.png
 msgctxt "cloudsave"


### PR DESCRIPTION
This is so that we use the same word as the Chrome popup proper (see screenshot).

![DDG counter popup_wrong french translation](https://user-images.githubusercontent.com/1141327/146982480-b29587a3-9dd6-4f7f-9be7-d2b87d4706a0.png)
