### PR TITLE
Update zh_CN translation

### DIFF
--- a/locales/zh_CN/LC_MESSAGES/duckduckgo.po
+++ b/locales/zh_CN/LC_MESSAGES/duckduckgo.po
@@ -120,7 +120,7 @@ msgstr "打开%1$s下载%2$s"
 #. Disclaimer text for the stocks module
 msgctxt "Stocks module"
 msgid "15 minutes delayed"
-msgstr "延迟了 15 分钟"
+msgstr "数据延迟 15 分钟"
 
 #. Button label for selecting chart of today's prices (needs to be short on mobile devices)
 msgctxt "Stocks module"
@@ -233,7 +233,7 @@ msgid "Add DuckDuckGo as a search engine"
 msgstr "添加 DuckDuckGo 搜索引擎"
 
 msgid "Add DuckDuckGo to %s"
-msgstr "添加 DuckDuckGo 到 %1$s"
+msgstr "将 DuckDuckGo 添加至 %1$s"
 
 #. https://duckduckgo.com/search_box near the top
 #. e.g.: Add a DuckDuckGo search box to your site!
@@ -1196,11 +1196,11 @@ msgstr "音乐会"
 #. Heading for the table column indicating how many confirmed cases there have been in that location
 msgctxt "Covid 19 module"
 msgid "Confirmed"
-msgstr "已确诊"
+msgstr "确诊人数"
 
 msgctxt "Covid 19 module"
 msgid "Confirmed Cases"
-msgstr "确诊病例"
+msgstr "确诊病例数"
 
 msgid "Congratulations!"
 msgstr "恭喜！"
@@ -2106,7 +2106,7 @@ msgstr "印地语"
 #. Indicate that we have no chart data for prices of the current stock
 msgctxt "Stocks module"
 msgid "Historical prices not available"
-msgstr "暂无历史价格"
+msgstr "暂无历史股价"
 
 #  Chrome default search engine instruction
 msgid ""
@@ -2138,11 +2138,11 @@ msgstr "营业时间"
 
 msgctxt "feedback form"
 msgid "Hours are incorrect"
-msgstr "时间有误"
+msgstr "营业时间有误"
 
 msgctxt "feedback form"
 msgid "Hours are missing"
-msgstr "缺失时间"
+msgstr "缺失营业时间"
 
 #. This is the name of a user setting
 msgctxt "settings"
@@ -2214,12 +2214,14 @@ msgctxt "language_name"
 msgid "Icelandic"
 msgstr "冰岛语"
 
+#  Single sentence instruction, iOS
 msgctxt "precise_user_location"
 msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
-msgstr "如果仍然无法使用浏览器定位，请转到%1$s“设置” > “常规设置” > “重置” > “重置位置和隐私”%2$s。"
+msgstr "如果仍然无法使用浏览器定位，请前往%1$s“设置” > “通用” > “还原” > “还原位置与隐私”%2$s。"
 
+#  Single sentence instruction, Android
 msgctxt "precise_user_location"
 msgid ""
 "If the browser location remains unavailable, then in your browser go to %s⋮ "
@@ -2712,7 +2714,7 @@ msgstr "随页面滚动不断显示更多搜索结果"
 #. Heading for the table column indicating the country or region for which the data applies
 msgctxt "Covid 19 module"
 msgid "Location"
-msgstr "定位"
+msgstr "地区"
 
 msgctxt "settings"
 msgid "Location"
@@ -2747,7 +2749,7 @@ msgstr "最低价"
 #. Abbreviate millions in a number. E.g. 1,000,000 becomes 1M
 msgctxt "Stocks module"
 msgid "M"
-msgstr "分钟"
+msgstr "百万"
 
 msgctxt "noresults"
 msgid "Make sure all words are spelled correctly."
@@ -2863,7 +2865,7 @@ msgstr "居中"
 #. The market capitalization of the currently selected stock
 msgctxt "Stocks module"
 msgid "Mkt Cap"
-msgstr "总市值"
+msgstr "市值"
 
 msgctxt "settings"
 msgid "Mobile Instructions (not displayed on settings page)"
@@ -3255,7 +3257,7 @@ msgstr "抱歉！翻译此文本时发生意外错误。请稍后再试。"
 #. The price the markets opens at
 msgctxt "Stocks module"
 msgid "Open"
-msgstr "正在营业"
+msgstr "开盘价"
 
 msgctxt "maps_places"
 msgid "Open"
@@ -3401,7 +3403,7 @@ msgstr "简介"
 #. Placeholder can be Apple Maps, TripAdvisor, or Foursquare
 msgctxt "feedback form"
 msgid "Own this business? Manage on %s"
-msgstr "拥有该企业？在 %1$s 上管理"
+msgstr "此商户在您名下？可前往 %1$s 予以管理"
 
 #. The price / earnings multiple for the currently selected stock
 msgctxt "Stocks module"
@@ -3579,7 +3581,7 @@ msgstr "请提供正确的电话号码"
 
 msgctxt "feedback form"
 msgid "Please suggest the correct website URL"
-msgstr "请提供正确的网站 URL"
+msgstr "请提供正确网址"
 
 msgctxt "feedback form"
 msgid "Please suggest the hours of operation"
@@ -3591,7 +3593,7 @@ msgstr "请提供电话号码"
 
 msgctxt "feedback form"
 msgid "Please suggest the website URL"
-msgstr "请提供网站 URL"
+msgstr "请提供网址"
 
 #  https://duckduckgo.com/?e=1
 msgid "Please try again"
@@ -3640,7 +3642,7 @@ msgstr "媒体资源"
 #. The price the stock previously closed at
 msgctxt "Stocks module"
 msgid "Prev Close"
-msgstr "之前收盘价"
+msgstr "前收盘价"
 
 msgid "Preview"
 msgstr "预览"
@@ -3901,7 +3903,7 @@ msgid ""
 "Reports are anonymous and sent to DuckDuckGo to help improve our search "
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
-msgstr "匿名报告会发送至 DuckDuckGo，以帮助改进我们的搜索服务。您的匿名反馈意见也会与 %1$s 分享，以帮助他们改善服务。"
+msgstr "您的反馈将以匿名方式发送至 DuckDuckGo，帮助我们改进搜索服务，同时也将匿名提供给 %1$s，以便共同提高服务质量。"
 
 msgctxt "settings dropdown"
 msgid "Reset"
@@ -5406,7 +5408,7 @@ msgid ""
 "We use feedback like this to improve DuckDuckGo. Suggestions will be "
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
-msgstr "我们会利用此类反馈意见来改进 DuckDuckGo。%1$s 将酌情采纳相关建议。更正可能不会立即显示在结果中。"
+msgstr "您的反馈意见能帮助我们改进 DuckDuckGo。%1$s 将酌情采纳您的建议，但搜索结果更正可能需要一段时间。"
 
 msgctxt "new user poll"
 msgid "We're honored to have you on the Duck Side"
@@ -5533,7 +5535,7 @@ msgstr "风速"
 
 msgctxt "Covid 19 module"
 msgid "World"
-msgstr "世界"
+msgstr "全球"
 
 msgctxt "Covid 19 module"
 msgid "Worldwide Coverage Map"


### PR DESCRIPTION
Some of the latest ‘professional’ translations are plain wrong (e.g. by translating M from ‘millions’ to ‘minutes’). This patch fixs the errors and makes a few further improvements.