### PR TITLE
Update zh_CN translation

### DIFF
--- a/locales/zh_CN/LC_MESSAGES/duckduckgo.po
+++ b/locales/zh_CN/LC_MESSAGES/duckduckgo.po
@@ -17,12 +17,12 @@ msgstr "叹号搜索"
 #. Heading for the table column indicating what percent of the population is fully vaccinated
 msgctxt "Covid 19 module"
 msgid "% Fully Vaccinated"
-msgstr "% 已完全接种疫苗"
+msgstr "疫苗完全接种率"
 
 #. Heading for the table column indicating what percent of the population is partially vaccinated
 msgctxt "Covid 19 module"
 msgid "% Vaccinated"
-msgstr "% 已接种疫苗"
+msgstr "疫苗接种率"
 
 msgctxt "SERP footer content"
 msgid "%s Billion Searches"
@@ -1340,7 +1340,7 @@ msgstr "暗色"
 #. Attribution text for the sports module
 msgctxt "Sports module"
 msgid "Data from Sportradar"
-msgstr "来自 Sportradar 的数据"
+msgstr "数据来自 Sportradar"
 
 #. Attribution text for the stocks module
 msgctxt "Stocks module"
@@ -1797,7 +1797,7 @@ msgstr "最终"
 #. Used to indicate the game is over and the score shown is the final score, e.g. 10-5 Final
 msgctxt "Sports module"
 msgid "Final"
-msgstr "最终"
+msgstr "最终比分"
 
 #  IE < 11 default search engine instruction
 msgid "Finally, click %sAdd%s"
@@ -1915,7 +1915,7 @@ msgstr "游戏"
 #. Title of a tab that displays a list of games for a sports league
 msgctxt "Sports module"
 msgid "Games"
-msgstr "游戏"
+msgstr "赛事"
 
 msgid "General"
 msgstr "常规"
@@ -2263,12 +2263,14 @@ msgctxt "language_name"
 msgid "Icelandic"
 msgstr "冰岛语"
 
+#  Single sentence instruction, iOS
 msgctxt "precise_user_location"
 msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
 msgstr "如果仍然无法使用浏览器定位，请前往%1$s“设置” > “通用” > “还原” > “还原位置与隐私”%2$s。"
 
+#  Single sentence instruction, Android
 msgctxt "precise_user_location"
 msgid ""
 "If the browser location remains unavailable, then in your browser go to %s⋮ "
@@ -2479,7 +2481,7 @@ msgid ""
 "Items are ranked based on relevance to your search terms and are delivered "
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
-msgstr "根据与搜索词的相关性对项目进行排名，并通过 Microsoft 的广告网络提供。点击直接指向商户登陆页面，与广告不同，DuckDuckGo 不会因这些结果而获得补偿。"
+msgstr "结果根据与搜索词的相关程度排序，并通过 Microsoft 的广告网络提供。链接直接指向商户页面，与广告不同，DuckDuckGo 不会通过这些搜索结果获得收益。"
 
 #. https://duckduckgo.com/settings near the bottom, under "Cloud Save", by clicking "What's this", under "How does passphrase generation work?"
 msgctxt "cloudsave"
@@ -2571,7 +2573,7 @@ msgstr "北库尔德语"
 #. Indicates this is the number of losses for this team
 msgctxt "Sports module"
 msgid "L"
-msgstr "L"
+msgstr "负"
 
 #. http://i.imgur.com/L74c87B.png
 #. Adjusts the displayed language of DuckDuckGo (translations)
@@ -2889,7 +2891,7 @@ msgstr "马拉地语"
 #. Indicates this is a list of matchups (games) between two teams
 msgctxt "Sports module"
 msgid "Matchups"
-msgstr "比赛"
+msgstr "战绩"
 
 msgctxt "precise_user_location"
 msgid "Maybe later"
@@ -3260,7 +3262,7 @@ msgstr "好的"
 #. Abbreviation indicating this is the score for a game that is in overtime
 msgctxt "Sports module"
 msgid "OT"
-msgstr "OT"
+msgstr "加时"
 
 #. The name of the Odia language
 msgctxt "language_name"
@@ -3496,12 +3498,12 @@ msgstr "市盈率"
 #. Indicates this is the total points scored against this team
 msgctxt "Sports module"
 msgid "PA"
-msgstr "PA"
+msgstr "失分"
 
 #. Indicates this is the total 'points for' (i.e. scored by) this team
 msgctxt "Sports module"
 msgid "PF"
-msgstr "PF"
+msgstr "得分"
 
 #. Instant Answer Tab Name
 msgid "Packages"
@@ -3563,7 +3565,7 @@ msgstr "一天内"
 #. Indicates this is a list of past games for this team
 msgctxt "Sports module"
 msgid "Past Games"
-msgstr "过去的比赛"
+msgstr "战绩"
 
 #. Option for the filter-by-date search.
 msgid "Past Month"
@@ -3592,7 +3594,7 @@ msgstr "一年内"
 #. Indicates this is the percentage of wins for this team
 msgctxt "Sports module"
 msgid "Pct"
-msgstr "百分比"
+msgstr "胜率"
 
 #. The name of the Persian language
 msgctxt "language_name"
@@ -4160,7 +4162,7 @@ msgstr "告别 Google"
 #. Title of a tab that displays a list of the season schedule for a team
 msgctxt "Sports module"
 msgid "Schedule"
-msgstr "日程表"
+msgstr "赛程"
 
 #. Needs Context
 msgid "Score"
@@ -4293,7 +4295,7 @@ msgstr "安全问题（前往另一页面反馈）"
 
 msgctxt "expand_text"
 msgid "See More"
-msgstr "查看更多"
+msgstr "查看详情"
 
 msgid "See Photos"
 msgstr "查看照片"
@@ -4867,7 +4869,7 @@ msgstr "症状"
 #. Indicates this is the number of ties for this team
 msgctxt "Sports module"
 msgid "T"
-msgstr "万亿"
+msgstr "平"
 
 #. Abbreviate trillions in a number. E.g. 1,000,000,000,000 becomes 1T
 msgctxt "Stocks module"
@@ -5449,7 +5451,7 @@ msgstr "已查看的链接："
 #. Indicates this is the number of wins for this team
 msgctxt "Sports module"
 msgid "W"
-msgstr "西风"
+msgstr "胜"
 
 msgctxt "forecast"
 msgid "W"
@@ -5608,7 +5610,7 @@ msgstr "缺失网站"
 #. Used to indicate which week the game belongs to, e.g. Week 2
 msgctxt "Sports module"
 msgid "Week"
-msgstr "周"
+msgstr "周次:"
 
 msgctxt "settings"
 msgid "Welcome Message"
@@ -5721,7 +5723,7 @@ msgstr "风速"
 #. Indicates this is the percentage of wins for this team
 msgctxt "Sports module"
 msgid "Winning Percentage"
-msgstr "获胜率"
+msgstr "获胜场次百分比"
 
 #. Indicates this is the number of wins for this team
 msgctxt "Sports module"


### PR DESCRIPTION
Incorrect translations introduced by 00d4367d0ec025bff45dd8c902cc8072bd1862be are fixed in this patch.

By the way, please always use placeholders like `Week %d` in the following circumstance, as reordering words is often necessary for a proper translation.

https://github.com/duckduckgo/duckduckgo-locales/blob/32428cae21635a84ed78a405a999624952abbeda/duckduckgo.pot#L6920-L6924