### PR TITLE
Remove 2-year-old note about language review

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,6 @@ The following languages will be affected:
 - Turkish
 - Ukrainian
 
-Soon, we plan to launch a complete review of all translations to ensure even more consistency across languages.
-
 We're very grateful for all the translation contributions that have helped support users around the world up to now, and we still welcome comments to help us improve translations. Please [open an Issue](https://github.com/duckduckgo/duckduckgo-locales/issues/new) and let us know what you think.
 
 ## About PO files


### PR DESCRIPTION
> Soon, we plan to launch a complete review of all translations to ensure even more consistency across languages.

This review has probably already happened, right? Either way, probably best to remove so the readme is current.