### PR TITLE
Update ja_JP translation

### DIFF
--- a/locales/ja_JP/LC_MESSAGES/duckduckgo.po
+++ b/locales/ja_JP/LC_MESSAGES/duckduckgo.po
@@ -14,7 +14,7 @@ msgstr ""
 
 # smartling.placeholder_format=C
 msgid "!Bang Search Shortcuts"
-msgstr "検索ショートカット（英語名：!Bang）"
+msgstr "検索ショートカット (英語名：!Bang)"
 
 # smartling.placeholder_format=C
 #. Heading for the table column indicating what percent of the population is fully vaccinated
@@ -435,19 +435,19 @@ msgstr "アルバム"
 
 # smartling.placeholder_format=C
 msgid "All"
-msgstr "全て"
+msgstr "すべて"
 
 # smartling.placeholder_format=C
 #. Button label for selecting to show the information from all Conferences, in American College Football
 msgctxt "Sports module"
 msgid "All"
-msgstr "全て"
+msgstr "すべて"
 
 # smartling.placeholder_format=C
 #. Button label for selecting chart showing all historical prices
 msgctxt "Stocks module"
 msgid "All"
-msgstr "全て"
+msgstr "すべて"
 
 # smartling.placeholder_format=C
 #. a filter for any image with a Creative Commons usage license
@@ -469,7 +469,7 @@ msgstr "すべてのライセンス"
 
 # smartling.placeholder_format=C
 msgid "All Places"
-msgstr "全ての場所"
+msgstr "すべての場所"
 
 # smartling.placeholder_format=C
 msgid "All Regions"
@@ -791,11 +791,11 @@ msgstr "ベルギー"
 
 # smartling.placeholder_format=C
 msgid "Belgium (fr)"
-msgstr "ベルギー（仏）"
+msgstr "ベルギー (仏)"
 
 # smartling.placeholder_format=C
 msgid "Belgium (nl)"
-msgstr "ベルギー（蘭）"
+msgstr "ベルギー (蘭)"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result BELOW the SNIPPET (description) of the result -- Example image: https://i.imgur.com/lnP77q4.png
@@ -987,7 +987,7 @@ msgstr "カナダ"
 
 # smartling.placeholder_format=C
 msgid "Canada (fr)"
-msgstr "カナダ（仏）"
+msgstr "カナダ (仏)"
 
 # smartling.placeholder_format=C
 msgid "Cancel"
@@ -1214,7 +1214,7 @@ msgstr "クリア"
 
 # smartling.placeholder_format=C
 msgid "Clear All"
-msgstr "全て消去"
+msgstr "すべて消去"
 
 # smartling.placeholder_format=C
 msgctxt "precise_user_location"
@@ -1352,7 +1352,7 @@ msgstr "下のほうの %1$sデフォルトに設定%2$s をクリックしま�
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
 msgid "Click on the %sSearch Providers%s under Add-on Types"
-msgstr "アドオンタイプセクションの下にある%1$sSearch Providers（検索プロバイダー）%2$sボタンを押してください"
+msgstr "アドオンタイプセクションの下にある%1$sSearch Providers (検索プロバイダー) %2$sボタンを押してください"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -1375,7 +1375,7 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
-msgstr "%1$s自分のデータを削除%2$sをクリックまたはタップします。この操作でデータはクラウド上から削除されますが、%3$s全ての設定をリセット%4$sをクリック/タップしない限り、お使いのブラウザに保存されたままとなります。"
+msgstr "%1$s自分のデータを削除%2$sをクリックまたはタップします。この操作でデータはクラウド上から削除されますが、%3$sすべての設定をリセット%4$sをクリック/タップしない限り、お使いのブラウザに保存されたままとなります。"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -1654,7 +1654,7 @@ msgstr "著作権侵害"
 # smartling.placeholder_format=C
 msgctxt "Covid 19 module"
 msgid "Coronavirus Disease (COVID-19)"
-msgstr "新型コロナウイルス感染症（COVID-19）"
+msgstr "新型コロナウイルス感染症 (COVID-19)"
 
 # smartling.placeholder_format=C
 #. Title of modal shown when user gets bot challenge correct
@@ -2393,7 +2393,7 @@ msgstr "最後に、%1$s追加%2$sをクリック"
 #  Chrome default search engine instruction
 # smartling.placeholder_format=C
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr "%1$sDuckDuckGo%2$s を検索し、%3$sMake default（デフォルトに設定する）%4$sをクリックしてください。"
+msgstr "%1$sDuckDuckGo%2$s を検索し、%3$sMake default (デフォルトに設定する) %4$sをクリックしてください。"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -2491,7 +2491,7 @@ msgstr "フランス語"
 #. The name of the French (Canada) language
 msgctxt "language_name"
 msgid "French (Canada)"
-msgstr "フランス語(カナダ)"
+msgstr "フランス語 (カナダ)"
 
 # smartling.placeholder_format=C
 msgctxt "new user poll"
@@ -2502,13 +2502,13 @@ msgstr "友達か家族"
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
 msgctxt "settingsvalue"
 msgid "Full URLs (Breadcrumbs)"
-msgstr "完全なURL（パンくずリスト）"
+msgstr "完全なURL (パンくずリスト)"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path (e.g. website.com/this/is/this/path) -- Example image: https://i.imgur.com/SxYWf9o.png
 msgctxt "settingsvalue"
 msgid "Full URLs (Slashes)"
-msgstr "完全なURL（スラッシュ）"
+msgstr "完全なURL (スラッシュ)"
 
 # smartling.placeholder_format=C
 #. Indicates this is the total goals scored against this team
@@ -3169,7 +3169,7 @@ msgstr "インドネシア"
 
 # smartling.placeholder_format=C
 msgid "Indonesia (en)"
-msgstr "インドネシア（英）"
+msgstr "インドネシア (英)"
 
 # smartling.placeholder_format=C
 #. The name of the Indonesian language
@@ -3293,7 +3293,7 @@ msgstr "イスラエル"
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr "DuckDuckGoを使った感想について、（非常に稀に）私に尋ねても大丈夫です"
+msgstr "DuckDuckGoを使った感想について、(非常に稀に) 私に尋ねても大丈夫です"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -3569,7 +3569,7 @@ msgstr "オンライントラッキングの削減が重要な理由を説明し
 # smartling.placeholder_format=C
 msgctxt "showcase_tracking"
 msgid "Learn why reducing tracking is important."
-msgstr "なぜトラッキング（追跡）を減らすことが重要なのか学んでみましょう。"
+msgstr "なぜトラッキング (追跡) を減らすことが重要なのか学んでみましょう。"
 
 # smartling.placeholder_format=C
 #. Discontinued, don't translate
@@ -3796,7 +3796,7 @@ msgstr "マレーシア"
 
 # smartling.placeholder_format=C
 msgid "Malaysia (en)"
-msgstr "マレーシア（英）"
+msgstr "マレーシア (英)"
 
 # smartling.placeholder_format=C
 #. The name of the Maltese language
@@ -3915,12 +3915,12 @@ msgstr "メニュー"
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
 msgid "Metric (Kilograms, Meters, Celsius)"
-msgstr "メートル法(キログラム・メートル・セ氏温度)"
+msgstr "メートル法 (キログラム・メートル・セ氏温度)"
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
 msgid "Metric (kilograms, meters, Celsius)"
-msgstr "メートル法(キログラム・メートル・摂氏温度)"
+msgstr "メートル法 (キログラム・メートル・摂氏温度)"
 
 # smartling.placeholder_format=C
 msgid "Mexico"
@@ -4797,7 +4797,7 @@ msgstr "フィリピン"
 
 # smartling.placeholder_format=C
 msgid "Philippines (tl)"
-msgstr "フィリピン（タガログ語）"
+msgstr "フィリピン (タガログ語)"
 
 # smartling.placeholder_format=C
 msgctxt "maps_places"
@@ -5317,7 +5317,7 @@ msgstr "リリース年"
 
 # smartling.placeholder_format=C
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr "選択を記憶する（この選択は%1$s%2$s%3$s設定%4$sから変更できます)"
+msgstr "選択を記憶する (この選択は%1$s%2$s%3$s設定%4$sから変更できます)"
 
 # smartling.placeholder_format=C
 msgctxt "ads"
@@ -5778,7 +5778,7 @@ msgstr "%1$sDuckDuckGo%2$sを選択しよう!"
 #  Chrome default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr "ドロップダウンの中にある%1$sEdit Search Engines...（検索エンジンを編集）%2$sボタンを選択してください。"
+msgstr "ドロップダウンの中にある%1$sEdit Search Engines... (検索エンジンを編集) %2$sボタンを選択してください。"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6271,7 +6271,7 @@ msgstr "スペイン"
 
 # smartling.placeholder_format=C
 msgid "Spain (ca)"
-msgstr "スペイン（カタルーニャ語）"
+msgstr "スペイン (カタルーニャ語)"
 
 # smartling.placeholder_format=C
 #. The name of the Spanish language
@@ -6458,15 +6458,15 @@ msgstr "スイス"
 
 # smartling.placeholder_format=C
 msgid "Switzerland (de)"
-msgstr "スイス（独）"
+msgstr "スイス (独)"
 
 # smartling.placeholder_format=C
 msgid "Switzerland (fr)"
-msgstr "スイス（仏）"
+msgstr "スイス (仏)"
 
 # smartling.placeholder_format=C
 msgid "Switzerland (it)"
-msgstr "スイス（伊）"
+msgstr "スイス (伊)"
 
 # smartling.placeholder_format=C
 #. Label for symptoms tab
@@ -6655,7 +6655,7 @@ msgstr "テーマ"
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
 msgid "Thesaurus"
-msgstr "類語辞書（シソーラス）"
+msgstr "類語辞書 (シソーラス)"
 
 # smartling.placeholder_format=C
 msgid ""
@@ -6728,7 +6728,7 @@ msgstr "このウェブページでは「暗号化された安全な接続(HTTPS
 #. In spanish: Esto borrará todos los ajustes. ¿Desea continuar?
 msgctxt "settings"
 msgid "This will erase all settings. Continue?"
-msgstr "全ての設定が消去されます。続けますか?"
+msgstr "すべての設定が消去されます。続けますか?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7006,12 +7006,12 @@ msgstr "アメリカ合衆国"
 
 # smartling.placeholder_format=C
 msgid "US (Spanish)"
-msgstr "アメリカ合衆国（西）"
+msgstr "アメリカ合衆国 (西)"
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
 msgid "US based (Pounds, Feet, Fahrenheit)"
-msgstr "アメリカ合衆国の単位系(ポンド・フィート・華氏温度)"
+msgstr "アメリカ合衆国の単位系 (ポンド・フィート・華氏温度)"
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -7708,7 +7708,7 @@ msgstr "設定を別のパスフレーズで保存してください。それま
 #. In the cloud save box - http://i.imgur.com/pVjCXmw.png
 msgctxt "cloudsave"
 msgid "You can restore your settings after deleting cookies."
-msgstr "Cookie（クッキー）を削除した後でも、設定を復元することができます。"
+msgstr "Cookie (クッキー) を削除した後でも、設定を復元することができます。"
 
 # smartling.placeholder_format=C
 #. Click "What is this?" - http://i.imgur.com/KhmRHth.png
@@ -7823,7 +7823,7 @@ msgctxt "newsletter email collection"
 msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
-msgstr "あなたの電子メールアドレスが他人に共有されることはありませし、%1$s匿名での検索に紐づけられることもありません。（%2$s例文のサンプル%3$s）"
+msgstr "あなたの電子メールアドレスが他人に共有されることはありませし、%1$s匿名での検索に紐づけられることもありません。(%2$s例文のサンプル%3$s)"
 
 # smartling.placeholder_format=C
 msgctxt "cloudsave"
@@ -7944,7 +7944,7 @@ msgstr "%1$sのエンコーディングではない"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr "あるいはカラーコードを指定してください。例：%1$s （%2$s は %3$s をエンコードしたものです）"
+msgstr "あるいはカラーコードを指定してください。例：%1$s (%2$s は %3$s をエンコードしたものです)"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "


### PR DESCRIPTION
"全て" → "すべて" - Corrected variation in Japanese translation of "all"
"（）" → "()" - Corrected variation in Japanese translation of parentheses