### PR TITLE
Remove unexpected Smartling directive

### DIFF
--- a/smartling-config.json
+++ b/smartling-config.json
@@ -153,7 +153,6 @@
             "translationPathExpression": "locales/${locale}/LC_MESSAGES/duckduckgo.po",
             "translationCommitMessage": "Translate ${originalFile.baseName} to ${locale}",
             "smartlingDirectives": [
-                "gettext_line_width=normalized",
                 "placeholder_format:C"
             ]
         }


### PR DESCRIPTION
Not sure why it's unexpected, it's in the docs. Possibly a version mismatch. Will check later.