### PR TITLE
[L10n] Update duckduckgo.po: "Thailand": "ประเทศไทย" -> "ไทย"

### DIFF
--- a/locales/th_TH/LC_MESSAGES/duckduckgo.po
+++ b/locales/th_TH/LC_MESSAGES/duckduckgo.po
@@ -8453,7 +8453,7 @@ msgstr "ไทย"
 
 # smartling.placeholder_format=C
 msgid "Thailand"
-msgstr "ประเทศไทย"
+msgstr "ไทย"
 
 # smartling.placeholder_format=C
 msgid "Thank you!"


### PR DESCRIPTION
Change "Thailand" translation from "ประเทศไทย" to "ไทย".

Based on the translation of other country names, like:

```
msgid "Italy"
msgstr "อิตาลี"
```

https://github.com/duckduckgo/duckduckgo-locales/blob/324156b01a34f8150e1cda839a68408521daca10/locales/th_TH/LC_MESSAGES/duckduckgo.po#L4411C1-L4412C16

and

```
msgid "Malaysia"
msgstr "มาเลเซีย"
```

https://github.com/duckduckgo/duckduckgo-locales/blob/324156b01a34f8150e1cda839a68408521daca10/locales/th_TH/LC_MESSAGES/duckduckgo.po#L4928C1-L4929C18

which don't include the prefix "ประเทศ" ("country"),
so the translation of "Thailand" should not include "ประเทศ" as well.

This will make it consistent for the user and make it easier to find country names.