### PR TITLE
Update AI Chat localization for pt-BR and others

### DIFF
--- a/locales/pt_BR/LC_MESSAGES/duckduckgo.po
+++ b/locales/pt_BR/LC_MESSAGES/duckduckgo.po
@@ -59,7 +59,7 @@ msgstr ""
 #. Text describing available AI models when onboarding. Example: 'GPT-3.5 and Claude AI models'
 msgctxt "Onboarding welcome screen feature"
 msgid "%s and %s AI models"
-msgstr ""
+msgstr "Modelos de IA %s e %s"
 
 #. Message that appears above the search results encouraging them to filter results by domain. The placeholder string would include a the name of a website. E.g. 'Reddit appears in some of the top results for this search.'
 msgctxt "Site filter message"
@@ -113,6 +113,8 @@ msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
 msgstr ""
+"%s está temporariamente indisponível. Por favor, mude para um modelo "
+"diferente ou tente novamente mais tarde."
 
 #. Distance in kilometers. Placeholder is a number. For example: '100 km'
 msgid "%s km"
@@ -121,7 +123,7 @@ msgstr "%s km"
 #. Disclaimer text shown bellow chat input on mobile, avoid long text if possible. Example: 'GPT-3 may display inaccurate or offensive information.'
 msgctxt "Disclaimer bellow chat input - mobile"
 msgid "%s may display inaccurate or offensive information."
-msgstr ""
+msgstr "%s pode exibir informações imprecisas ou ofensivas."
 
 #. Distance measured in miles. Placeholder is a number. For example: '100 mi'
 msgid "%s mi"
@@ -389,11 +391,11 @@ msgstr "Uma sequência de caracteres para identificar a fonte."
 #. Page title for a ChatGPT-like chat bot feature. Translation should include the equivalent term for AI (Artificial Intelligence). It's ok to leave it in English if that's the expectation in your language.
 msgctxt "Page title in browser tab"
 msgid "AI Chat"
-msgstr ""
+msgstr "AI Chat"
 
 msgctxt "settings"
 msgid "AI Chat <sup>BETA</sup>"
-msgstr ""
+msgstr "AI Chat <sup>BETA</sup>"
 
 msgctxt "settings"
 msgid ""
@@ -448,7 +450,7 @@ msgstr "Sobre"
 #. A link to a page that provides information about the DuckDuckGo Browser (https://duckduckgo.com/app/)
 msgctxt "SERP footer content"
 msgid "About Browser"
-msgstr ""
+msgstr "Sobre o Navegador"
 
 #. at least in:
 #. * https://duckduckgo.com/about. Appears in the window title when you open the link
@@ -457,7 +459,7 @@ msgstr "Sobre o DuckDuckGo"
 
 #. Link label for DuckDuckGo 'App' page (https://duckduckgo.com/app)
 msgid "About Our Browser"
-msgstr ""
+msgstr "Sobre Nosso Navegador"
 
 #. Link to a page with more information about the company.
 msgid "About Us"
@@ -598,7 +600,7 @@ msgstr "Africâner"
 
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid "After it downloads and opens, click %sInstall%s"
-msgstr "Depois de baixar e abrir, clique %sInstalar%s"
+msgstr "Depois de baixar e abrir, clique em %sInstalar%s"
 
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
@@ -615,7 +617,7 @@ msgstr "Albanês"
 #. Label for the song's album name e.g. 'Album: A Night At The Opera'
 msgctxt "lyrics_module"
 msgid "Album"
-msgstr ""
+msgstr "Álbum"
 
 msgid "All"
 msgstr "Todos"
@@ -785,6 +787,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
+"Acesso anônimo a modelos de IA populares, incluindo %s, %s, e os de "
+"código-aberto %s e %s."
 
 #. Confirmation message after location service is enabled.
 msgctxt "precise_user_location"
@@ -933,6 +937,10 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
+"Automaticamente exibe o DuckAssist para pesquisas relevantes. O DuckAssist "
+"pode procurar e resumir informações anonimamente em resposta a algumas "
+"pesquisas. Por enquanto, o DuckAssist está disponível apenas em regiões em"
+" Inglês."
 
 #. Used to show the numerical rating, when the user hovers over a visual star-rating. Sorry, this is hard to translate.
 msgctxt "homepage ATB social proof"
@@ -1061,7 +1069,7 @@ msgstr ""
 #. DuckDuckGo Email Protection offers the ability to generate random email addresses to protect your personal email address
 msgctxt "SERP footer content"
 msgid "Block email trackers and hide your address."
-msgstr ""
+msgstr "Bloqueia rastreadores de email e esconde seu endereço."
 
 msgctxt "homepage ATB modal"
 msgid "Block most trackers as you browse."
@@ -1226,7 +1234,7 @@ msgstr "Idioma preferido do navegador"
 #. Text that indicates which source an AI Model was built with, such as 'Built with Meta Llama 3'. Note that 'built' is used in the context of software, not of e.g. construction.
 msgctxt "Label copy indicating the source of an AI Model"
 msgid "Built with %s"
-msgstr ""
+msgstr "Feito com %s"
 
 msgid "Bulgaria"
 msgstr "Bulgária"
@@ -1526,7 +1534,7 @@ msgstr ""
 #. Message shown when we have no data from upstream to display
 msgctxt "Single Place Hotel Offers Module"
 msgid "Check %s for rates and availability."
-msgstr ""
+msgstr "Verificar %s para avaliações e disponibilidade."
 
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Check %sMake this the current search engine%s"
@@ -2112,7 +2120,7 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
-msgstr ""
+msgstr "Criado por %s"
 
 #. Label below a video that's available under the Creative Commons license.
 msgctxt "video-license"
@@ -2472,6 +2480,8 @@ msgid ""
 "Draft a few options for a title of a post I’m writing about strategies to "
 "increase team collaboration."
 msgstr ""
+"Escreva algumas opções para um título de um post que estou escrevendo "
+"sobre estratégias para aumentar a colaboração de equipe."
 
 #. Short string representing a prompt suggestion for drafting a social media post.
 msgctxt "Brief for drafting a social media post"
@@ -2563,6 +2573,8 @@ msgid ""
 "DuckDuckGo AI Chat is in Beta, it may display inaccurate or offensive "
 "information."
 msgstr ""
+"O DuckDuckGo AI Chat está em Beta, e pode exibir informações imprecisas "
+"ou ofensivas."
 
 #. Displayed when there is an error in the chat making it unavailable, and asking the user to send an email with a specific code if the error persists. E.g. 'DuckDuckGo AI Chat is temporarily unavailable. If this persists, please email this anonymous code abcdefg12345 to aichat-error@duckduckgo.com'
 msgctxt "Error message for BOTNET limit."
@@ -2736,12 +2748,12 @@ msgstr "E-mail"
 
 #. Refers to the DuckDuckGo Email Protection product.
 msgid "Email Protection"
-msgstr ""
+msgstr "Proteção de Email"
 
 #. A link that takes the user to the Email Protection product page (https://duckduckgo.com/email/)
 msgctxt "SERP footer content"
 msgid "Email Protection"
-msgstr ""
+msgstr "Proteção de Email"
 
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
@@ -2957,6 +2969,8 @@ msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
 msgstr ""
+"Me explique os conceitos fundamentais de buracos negros em um nível de ensino"
+" médio."
 
 #. Label to show if song lyrics contain explicit content
 msgctxt "lyrics_module"
@@ -3658,7 +3672,7 @@ msgstr "Cabeçalho:"
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Heavy Rain"
-msgstr ""
+msgstr "Chuva Forte"
 
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
@@ -3913,7 +3927,7 @@ msgstr ""
 
 #. Feedback option for when customer dislikes AI
 msgid "I dislike AI"
-msgstr ""
+msgstr "Eu não gosto de IA"
 
 #. Category of feedback a user can select on a feedback form.
 msgctxt "feedback form"
@@ -4007,6 +4021,9 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
+"Se você tiver preocupações sobre nossos fornecedores ou a resposta "
+"de algum chat específico, você também pode falar conosco diretamente "
+"pelas páginas de suporte %s e %s."
 
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
@@ -4139,7 +4156,7 @@ msgstr ""
 
 #. Feedback option when AI response is not accurate
 msgid "Information is inaccurate"
-msgstr ""
+msgstr "Informação imprecisa"
 
 #. Feedback option when AI response is not up to date
 msgid "Information is outdated"
@@ -4492,7 +4509,7 @@ msgstr ""
 
 #. Link to a documentation page to learn more about how duckassist (an instant answer based on generative AI) works
 msgid "Learn more about how it works"
-msgstr ""
+msgstr "Aprenda mais sobre como funciona"
 
 msgctxt "SERP footer content"
 msgid "Learn why reducing online tracking is important."
@@ -4637,7 +4654,7 @@ msgstr "Configurações de aparência e comportamento"
 #. Short string representing a prompt suggestion for looking up basic facts.
 msgctxt "Brief for looking up basic facts"
 msgid "Lookup basic facts"
-msgstr ""
+msgstr "Procurar fatos básicos"
 
 #. Text indicating the loser of a World Cup game when that team is not yet known
 msgctxt "Sports module"
@@ -5039,7 +5056,7 @@ msgstr "Etapa de integração para adicionar ao navegador em várias etapas"
 #. Text when onboarding users, describing that AI Chat supports multiple AI models, all in one place.
 msgctxt "Onboarding welcome screen feature"
 msgid "Multiple AI models, all in one place"
-msgstr ""
+msgstr "Vários modelos de IA, tudo em um lugar"
 
 msgid "Music"
 msgstr "Música"
@@ -5207,7 +5224,7 @@ msgstr ""
 #. Text describing feature highlighted on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen feature"
 msgid "No AI training on your conversations"
-msgstr ""
+msgstr "Sem treinamento de IA em suas conversas"
 
 #. Indicates that driving directions aren't available between two locations on a map.
 msgctxt "directions"
@@ -5532,7 +5549,7 @@ msgstr "Abrir configurações"
 #. Text that indicates that an AI Model is open source. Please stick to a short translation as this is used in a small label.
 msgctxt "Label copy indicating that an AI Model is open source"
 msgid "Open Source"
-msgstr ""
+msgstr "Código Aberto"
 
 #. Prompts users to open a new browser tab or window.
 msgid "Open a new tab or window"
@@ -5934,7 +5951,7 @@ msgstr "Locais"
 #. Short string representing a prompt suggestion for planning a trip.
 msgctxt "Brief for planning a trip"
 msgid "Plan a trip"
-msgstr ""
+msgstr "Planejar uma viagem"
 
 #. Bot challenge explanation
 msgctxt "Anomaly modal"
@@ -5954,6 +5971,8 @@ msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
 msgstr ""
+"Aviso: iniciar uma nova conversa com qualquer modelo irá deletar sua "
+"sessão de conversa atual."
 
 #. Title on a feedback form.
 msgctxt "feedback form"
@@ -6016,12 +6035,12 @@ msgstr "Por favor, tente novamente"
 #. Title of modal shown when user gets bot challenge incorrect
 msgctxt "Anomaly modal"
 msgid "Please try again"
-msgstr ""
+msgstr "Por favor, tente novamente"
 
 #. A link that will allow users to reload the page.
 msgctxt "noresults"
 msgid "Please try again."
-msgstr ""
+msgstr "Por favor, tente novamente."
 
 #. Indicates these are the total points of this team, in e.g. the soccer World Cup
 msgctxt "Sports module"
@@ -6241,7 +6260,7 @@ msgstr "Ferramenta de busca privada"
 #. Text describing that chats are private and anonymized by us.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Private chats, anonymized by us"
-msgstr ""
+msgstr "Chats privados, anonimizados por nós"
 
 #. Text describing feature highlighted on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen feature"
@@ -6357,7 +6376,7 @@ msgstr "Rádio ou podcast"
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Rain"
-msgstr ""
+msgstr "Chuva"
 
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
@@ -6417,7 +6436,7 @@ msgctxt "Tooltip for redo action"
 msgid "Redo"
 msgstr ""
 
-#. Button that refreshes the user's current location on a map. 
+#. Button that refreshes the user's current location on a map.
 msgctxt "precise_user_location"
 msgid "Refresh Location"
 msgstr ""
@@ -6705,7 +6724,7 @@ msgstr "Salve as suas configurações anonimamente na nuvem"
 #. Title displayed on the welcome screen of the onboarding.
 msgctxt "Onboarding welcome screen title"
 msgid "Say hello to DuckDuckGo AI Chat!"
-msgstr ""
+msgstr "Diga oi para o DuckDuckGo AI Chat!"
 
 #. Title of a tab that displays a list of the season schedule for a team
 msgctxt "Sports module"
@@ -7090,7 +7109,7 @@ msgstr "Selecione Configurações > Localização."
 #. Bot challenge instructions
 msgctxt "Anomaly modal"
 msgid "Select all squares containing a duck:"
-msgstr ""
+msgstr "Selecione todos os quadros contendo um pato:"
 
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
@@ -7201,17 +7220,17 @@ msgstr ""
 #. Text displayed on a button that opens a feedback modal when clicked.
 msgctxt "Share Feedback button text"
 msgid "Share Feedback"
-msgstr ""
+msgstr "Compartilhar Comentários"
 
 #. Link to a feedback form.
 msgctxt "feedback form"
 msgid "Share Feedback"
-msgstr "Compartilhar comentários"
+msgstr "Compartilhar Comentários"
 
 #. Link to a feedback form.
 msgctxt "feedback form"
 msgid "Share feedback for these results."
-msgstr ""
+msgstr "Compartilhe comentários para estes resultados."
 
 #. Link to a feedback form.
 msgctxt "feedback form"
@@ -8149,6 +8168,7 @@ msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
 msgstr ""
+"Para continuar, você deve concordar com os %s e %s do DuckDuckGo AI Chat"
 
 #. Instructions for how to print driving directions.
 msgctxt "directions"
@@ -8192,7 +8212,7 @@ msgstr ""
 #. Indicates this is the total points scored against this team
 msgctxt "Sports module"
 msgid "Total Points Against"
-msgstr ""
+msgstr "Pontos Totais Contra"
 
 #. Indicates this is the total 'points for' (i.e. scored by) this team
 msgctxt "Sports module"
@@ -8282,7 +8302,7 @@ msgstr ""
 #. Text of button allowing users to try the bot challenge again
 msgctxt "Anomaly modal"
 msgid "Try Again"
-msgstr ""
+msgstr "Tente Novamente"
 
 #. Alternate header text for front page
 msgid "Try a search!"
@@ -8349,7 +8369,7 @@ msgstr "Experimente o aplicativo do DuckDuckGo"
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
-msgstr ""
+msgstr "Experimente estas ideias para começar ou escreva o seu pedido abaixo"
 
 #. Message displayed sometimes at top of results (for bang syntax), e.g. <a href="https://duckduckgo.com/?q=twitter+test">https://duckduckgo.com/?q=twitter+test</a>
 msgid "Try: %s"
@@ -8540,7 +8560,7 @@ msgstr "Sublinha os títulos dos resultados"
 #. Short string representing a prompt suggestion for understanding a topic.
 msgctxt "Brief for understanding a topic"
 msgid "Understand a topic"
-msgstr ""
+msgstr "Entender um tópico"
 
 #. Label on the button that allows the previous action to be undone. For example, after removing a website this is shown.
 msgctxt "new tab page"
@@ -9000,6 +9020,9 @@ msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
 msgstr ""
+"Bem-vindo ao DuckDuckGo AI Chat! Todas as suas conversas aqui "
+"são privadas, anonimizadas por nós e não utilizadas para treinar modelos "
+"de IA."
 
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
 msgctxt "Welcome message in chat"
@@ -9008,6 +9031,9 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
+"Bem-vindo ao DuckDuckGo AI Chat! Esta sessão de conversa conta com o %2$s da "
+" %1$s. Todas as suas conversas aqui são privadas, anonimizadas por nós e não "
+"utilizadas para treinar modelos de IA."
 
 #. Welcome message for new DuckDuckGo users.
 msgctxt "homepage onboarding"
@@ -9282,7 +9308,7 @@ msgstr ""
 #. Short string representing a prompt suggestion for writing an email.
 msgctxt "Brief for writing an email"
 msgid "Write an email"
-msgstr ""
+msgstr "Escrever um email"
 
 #. Short string representing a prompt suggestion for writing code.
 msgctxt "Brief for writing code"
@@ -9339,6 +9365,8 @@ msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
 msgstr ""
+"Você está conversando com o %s. Conversas de IA podem exibir informações "
+"imprecisas ou ofensivas."
 
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
 msgctxt "noresults"
@@ -9351,6 +9379,8 @@ msgid ""
 "You can also use %sDuckDuckGo AI Chat%s to answer questions or summarize "
 "text."
 msgstr ""
+"Você também pode usar o %sDuckDuckGo AI Chat para responder perguntas ou "
+"resumir texto."
 
 #. Text explaning how to change a passphrase.
 msgctxt "cloudsave"
@@ -9459,7 +9489,7 @@ msgstr "Sua localização"
 #. Disclaimer telling users their precise geolocation remains private. More at https://help.duckduckgo.com/duckduckgo-help-pages/privacy/anonymous-localized-results/
 msgctxt "maps_places"
 msgid "Your actual location remains private"
-msgstr ""
+msgstr "Sua localização real permanece privada"
 
 #. Floating text over a tick next to search results which indicates if a link has been visited.
 msgid "Your browser indicates if you've visited this link"
@@ -9489,18 +9519,24 @@ msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
+"Suas conversas são privadas, anonimizadas por nós, e não são usadas para"
+" treinar modelos de IA."
 
 #. Text for a menu item that describes the privacy protection feature.
 msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
+"Suas conversas são privadas, nunca salvas por nós, e não são usadas para"
+" treinar modelos de IA."
 
 #. Body text of the modal that provides information about the active privacy protection.
 msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
+"Suas conversas são privadas, nunca salvas por nós, e não são usadas para"
+" treinar modelos de IA."
 
 msgctxt "homepage ATB modal"
 msgid "Your data shouldn’t be for sale."
@@ -9543,6 +9579,8 @@ msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
 msgstr ""
+"Você excedeu o tamanho máximo de mensagem. Por favor, encurte sua mensagem "
+"e tente novamente."
 
 #. Displayed when the user has reached the maximum chat length in a conversation.
 msgctxt "Error message for conversation limit"
@@ -9577,7 +9615,7 @@ msgstr "por %s"
 #. Label of which AI provider the current AI Model comes from. Example: 'by OpenAI'
 msgctxt "AI provider label in the side menu item"
 msgid "by %s"
-msgstr ""
+msgstr "por %s"
 
 #. Label indicating something is made by a specific brand. The placeholder value is a brand name. For example 'by Microsoft'
 msgctxt "made_by"
@@ -9726,12 +9764,12 @@ msgstr "bloqueio de rastreador"
 #. Inform the users that "something" went wrong and discourage the user from immediately reloading the page.
 msgctxt "noresults"
 msgid "try again later"
-msgstr ""
+msgstr "tente novamente mais tarde"
 
 #. A link that will allow users to reload the page, show when no search results loaded due to an error
 msgctxt "noresults"
 msgid "try your search again"
-msgstr ""
+msgstr "tente pesquisar novamente"
 
 #. Used to indicate a matchup between teams, e.g. Team A vs Team B
 msgctxt "Sports module"
@@ -9922,3 +9960,4 @@ msgstr "ano"
 
 #~ msgid "not %s encoding"
 #~ msgstr "sem codificação %s"
+


### PR DESCRIPTION
Adds a few missing strings that could be seen in pt-PT from the AI Chat page and others I bothered translating.