### PR TITLE
Update run-tests.yml

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,16 +2,12 @@ name: Run Tests
 
 on: pull_request
 
-env:
-  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
-  ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION: node16
-
 jobs:
   run_tests:
     name: Run Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     container:
-      image: perl:5.28.1
+      image: perl:5.40.0
     steps:
       - uses: actions/checkout@v3
       - name: Install system dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ jobs:
     container:
       image: perl:5.40.0
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install system dependencies
         run: |
           echo "deb http://archive.debian.org/debian stretch main contrib non-free" > /etc/apt/sources.list

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,6 +4,7 @@ on: pull_request
 
 env:
   ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+  ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION: node16
 
 jobs:
   run_tests:
@@ -12,7 +13,7 @@ jobs:
     container:
       image: perl:5.28.1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - name: Install system dependencies
         run: |
           echo "deb http://archive.debian.org/debian stretch main contrib non-free" > /etc/apt/sources.list

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -5,6 +5,7 @@ on: pull_request
 jobs:
   run_tests:
     name: Run Tests
+    # Becomes ubuntu-latest soon, required to run node20 actions.
     runs-on: ubuntu-24.04
     container:
       image: perl:5.40.0

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
     container:
       image: perl:5.28.1
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install system dependencies
         run: |
           echo "deb http://archive.debian.org/debian stretch main contrib non-free" > /etc/apt/sources.list


### PR DESCRIPTION
Fixes the issue that github deprecating node16 caused.  This updates both the version of perl we're using for the docker container and the version of ubuntu that we're using to the next latest one.  This makes node20 able to find the requisite glibc builds. 

https://github.blog/changelog/2024-09-25-end-of-life-for-actions-node16/
https://github.blog/changelog/2024-09-25-actions-new-images-and-ubuntu-latest-changes/