### PR TITLE
Add AGENTS.md with Cursor Cloud dev environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repository (`duckduckgo-locales`) is a translation catalog, not a running
+service. It contains gettext PO files under `locales/<code>/LC_MESSAGES/duckduckgo.po`,
+a source template `duckduckgo.pot`, locale metadata in `locales.json`, and a
+Perl-based validation test suite in `t/`. There is no web server or daemon to run.
+
+### Prerequisites (baked into the VM image, not the update script)
+- `gettext` (provides `msgfmt`/`msgunfmt`) — required by `t/00-build.t`.
+- `cpanminus` (`cpanm`) — used to install the Perl module dependencies.
+
+These system packages are installed via `apt-get` during environment setup and
+are captured in the VM snapshot, so the startup update script only refreshes the
+Perl module dependencies from `cpanfile`.
+
+### Lint / Test / Build / Run
+- Test (this is the primary workflow, mirrors `.github/workflows/run-tests.yml`):
+  `prove -r t`
+  - The suite runs ~450k assertions across all locale files and takes ~30-40s.
+- Lint: there is no dedicated linter. For quick syntax checks use `perl -c t/<file>.t`
+  for the tests and `node --check adapt-translations-from-smartling.js` for the JS helper.
+- Build: "building" here means compiling a PO catalog to a binary `.mo`, e.g.
+  `msgfmt locales/it_IT/LC_MESSAGES/duckduckgo.po -o /tmp/it.mo`. Compiled `.mo`
+  files are git-ignored.
+- Run (the only executable "application"): `node ./adapt-translations-from-smartling.js`
+  imports Smartling exports into `locales/`. It is interactive and prompts for a
+  folder path (pipe the path via stdin to run non-interactively). Note: it only
+  picks up locale subfolders named with a dash, e.g. `it-IT` (not `it_IT`), and
+  writes them to the underscore-named `locales/<code>/LC_MESSAGES/duckduckgo.po`.
+
+### Gotchas
+- `msgfmt` must be on `PATH` or `t/00-build.t` fails silently-looking (it checks `$?`).
+- Perl module deps (`Locale::PO`, `Test::Fatal`, `Cpanel::JSON::XS`) come from
+  `cpanfile`; install with `cpanm --installdeps .`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for this repository and documents it for future cloud agents. `duckduckgo-locales` is a gettext PO translation catalog validated by a Perl test suite — there is no long-running service.

Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering prerequisites, lint/test/build/run commands, and non-obvious gotchas.

## Environment setup

- **System deps** (installed via `apt-get`, baked into the VM snapshot): `gettext` (`msgfmt`/`msgunfmt`), `cpanminus`.
- **Perl module deps** (from `cpanfile`, refreshed by the startup update script): `Locale::PO`, `Test::Fatal`, `Cpanel::JSON::XS` via `cpanm --installdeps .`.
- **Update script**: `if [ -f cpanfile ]; then sudo cpanm --installdeps --notest .; fi`

## Verification

- **Lint / syntax**: `perl -c t/*.t` and `node --check adapt-translations-from-smartling.js` — all OK.
- **Test**: `prove -r t` — all 5 files pass (454,471 assertions, ~34s).
- **Build**: `msgfmt <locale>/duckduckgo.po -o out.mo` compiles a binary catalog.
- **Run (hello world)**: ran the Smartling import script `node ./adapt-translations-from-smartling.js` against a mock `it-IT` export, confirmed it wrote `locales/it_IT/LC_MESSAGES/duckduckgo.po`, compiled it to `.mo`, and looked the translation back up. Reverted the demo change (working tree clean).

```
t/00-build.t ............... ok
t/01-meta.t ................ ok
t/02-format.t .............. ok
t/internal_translations.t .. ok
t/trademark.t .............. ok
All tests successful.
Files=5, Tests=454471
Result: PASS
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d1655ec-375e-4e28-9345-0fb4d08f5bc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d1655ec-375e-4e28-9345-0fb4d08f5bc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

