### PR TITLE
Adding South-Tyrol German (from Bolzano/Bozen)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,12 @@ Find the locale code for your language in the list below. The file can be found 
 - cy_GB: Cymraeg
 - da_DK: Dansk (Danmark)
 - de_CH: Deutsch (Schweiz)
-- de_DE: Deutsch (Deutschland)
+- 
+ de_IT: Deutsch (Südtirol)
+ 
+-
+
+de_DE: Deutsch (Deutschland)
 - el_GR: Ελληνικά (Ελλάδα)
 - en_AU: English (Australia)
 - en_CA: English (Canada)

--- a/locales.json
+++ b/locales.json
@@ -121,7 +121,7 @@
       "name_in_local" : "Deutsch (Deutschland)",
       "rtl" : 0
    },
-   "de_IT": {
+   "de_IT": 
    "locale": "de_IT",
    "name_in_english": "German (South Tyrol)",
    "name_in_local": "Deutsch (Südtirol)",
@@ -132,12 +132,8 @@
       "locale" : "el_GR",
       "name_in_english" : "Greek (Greece)",
       "name_in_local" : "Ελληνικά (Ελλάδα)",
-      "rtl" : 0},"de_IT": {
-       "locale": "de_IT",
-        "name_in_english": "German (South Tyrol)",
-        "name_in_local": "Deutsch (Südtirol)",
-        "rtl": 0
- },
+      "rtl" : 0},
+}
 
    "en_AU" : {
       "locale" : "en_AU",

--- a/locales.json
+++ b/locales.json
@@ -121,12 +121,24 @@
       "name_in_local" : "Deutsch (Deutschland)",
       "rtl" : 0
    },
+   "de_IT": {
+   "locale": "de_IT",
+   "name_in_english": "German (South Tyrol)",
+   "name_in_local": "Deutsch (Südtirol)",
+   "rtl": 0
+},
+
    "el_GR" : {
       "locale" : "el_GR",
       "name_in_english" : "Greek (Greece)",
       "name_in_local" : "Ελληνικά (Ελλάδα)",
-      "rtl" : 0
-   },
+      "rtl" : 0},"de_IT": {
+       "locale": "de_IT",
+        "name_in_english": "German (South Tyrol)",
+        "name_in_local": "Deutsch (Südtirol)",
+        "rtl": 0
+ },
+
    "en_AU" : {
       "locale" : "en_AU",
       "name_in_english" : "English (Australia)",

--- a/locales/de_IT/LC_MESSAGES/duckduckgo.po
+++ b/locales/de_IT/LC_MESSAGES/duckduckgo.po
@@ -1,0 +1,21137 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: DuckDuckGo-Translation-0.000\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:51-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"Language: Deutsch in der Schweiz (German in Switzerland)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+msgid "!Bang Search Shortcuts"
+msgstr "!Bang Suchkürzel"
+
+#. Names the device being revoked. %s is the decrypted device name (falls back to a 'Device N' placeholder when the name can't be decrypted).
+msgctxt ""
+"Body copy for the Remove Device confirmation modal; %s is the device name"
+msgid "\"%s\" will no longer be able to access your synced data."
+msgstr ""
+
+#. Used to specify the rank of a team/player in a specific ranking in short form. This should be interpreted as 'Ranked number <rankNumber> in the <rankingName> ranking. Here you only need to translate the # symbol for ranked number. If your language doesn't provide a single-letter convention, please leave #.
+msgctxt "Sports module"
+msgid "#%s %s"
+msgstr ""
+
+#. Heading for the table column indicating what percent of the population is fully vaccinated
+msgctxt "Covid 19 module"
+msgid "% Fully Vaccinated"
+msgstr ""
+
+#. Heading for the table column indicating what percent of the population is partially vaccinated
+msgctxt "Covid 19 module"
+msgid "% Vaccinated"
+msgstr ""
+
+#. In the context of an NHL (hockey) game, indicates in which intermission (break between game periods) an in-progress game is currently in. The number is in ordinal form (e.g. 1st), localized separately. The combination results in e.g. 1st Intermission, 4th Intermission
+msgctxt "Sports module"
+msgid "%s Intermission"
+msgstr ""
+
+#. Indicates the number of players who are out in Baseball, e.g. '3 Out'
+msgctxt "Sports module"
+msgid "%s Out"
+msgstr ""
+
+#. Displaying the number of reviews in plural for a website
+msgid "%s Reviews"
+msgstr ""
+
+#. Used to indicate the season year, e.g. '2020 Season'
+msgctxt "Sports module"
+msgid "%s Season"
+msgstr ""
+
+#. Header for the Search Assist settings modal. %s is replaced with the product name (Search Assist).
+msgctxt "duckassist"
+msgid "%s Settings"
+msgstr ""
+
+#. Plural form for user feedback, when displaying the number of adults selected (e.g. 3 adults).
+msgctxt "Single Place Hotel Offers Module"
+msgid "%s adults"
+msgstr ""
+
+#. Text describing available AI models when onboarding. Example: 'GPT-3.5 and Claude AI models'
+msgctxt "Onboarding welcome screen feature"
+msgid "%s and %s AI models"
+msgstr ""
+
+#. Message that appears above the search results encouraging them to filter results by domain. The placeholder string would include a the name of a website. E.g. 'Reddit appears in some of the top results for this search.'
+msgctxt "Site filter message"
+msgid "%s appears in some of the top results for this search."
+msgstr ""
+
+#. Number of tracking attempts blocked, when there is more than 1. Eg: '2 attempts' or '302 attempts'
+msgctxt "tracker_stats"
+msgid "%s attempts"
+msgstr ""
+
+#. A summary description of how many tracking attempts where blocked, when there was more than 1. Eg: '1,028 attempts blocked by DuckDuckGo in the last 24 hours'
+msgid "%s attempts blocked by DuckDuckGo in the last 24 hours"
+msgstr ""
+
+#. A label that indicates a specific search result has been blocked by the safe search filter. The placeholder value is the name of the search result that was blocked.
+msgid "%s blocked by safe search."
+msgstr "%s durch die sichere Suche blockierte Inhalte."
+
+#. Label that's displayed next to a calories count below a web search result.
+msgctxt "Rich Facts label"
+msgid "%s calories"
+msgstr ""
+
+#. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
+msgctxt "published dates for organic results"
+msgid "%s days ago"
+msgstr "vor %s Tagen"
+
+#. An indication that inputted text was detected to be in this language. E.g.: Italian detected.
+msgctxt "translations_module"
+msgid "%s detected"
+msgstr ""
+
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
+#. Label that's displayed next to a follower count below a web search result.
+msgctxt "Rich Facts label"
+msgid "%s followers"
+msgstr ""
+
+#. in https://duckduckgo.com/params. multiple fors
+msgid "%s for %s"
+msgstr "%s für %s"
+
+#. States the title of an article and the website on which the article appears. The placeholder values are the title of the article and the name of the website. Example: 'How to Wash a Car from wikihow.com'
+msgid "%s from %s"
+msgstr ""
+
+#. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
+msgctxt "published dates for organic results"
+msgid "%s hours ago"
+msgstr "vor %s Stunden"
+
+#. The total amount DuckDuckGo has donated to privacy-related causes. The placeholder value is a number. For example '$1,000,000 in privacy donations!'
+msgctxt "showcase_donations"
+msgid "%s in privacy donations!"
+msgstr "%s an Privatsphärenspenden"
+
+#. Link used to find out more about the specified country in the Olympics in the given year. Placeholders are for Country and Year. i.e. Germany in the Olympics 1996
+msgid "%s in the Olympics %s"
+msgstr ""
+
+msgctxt ""
+"A string used to find out more about the specified country in the Olympics "
+"in the given year."
+msgid "%s in the Olympics %s"
+msgstr ""
+
+#. Text for a promotional card that encourages users to try the recently added AI model. The placeholder is the name of AI model like 'GPT-5 mini is here!'
+msgctxt "Promotional text for a single new AI model"
+msgid "%s is here!"
+msgstr ""
+
+#. Displayed when a Plus subscriber tries to use a Pro-only AI model. Example: 'GPT 4o mini is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.'
+msgctxt "Error message when a Plus subscriber tries to use a Pro-only model"
+msgid ""
+"%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
+"browser again to continue the chat, or switch to a Plus or free model."
+msgstr ""
+
+#. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
+msgctxt ""
+"Text for the model not available without a Pro subscription disclaimer"
+msgid ""
+"%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
+"browser again to continue the chat, or switch to a Plus or free model."
+msgstr ""
+
+#. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
+msgctxt "Error message for model unavailability"
+msgid "%s is only available with a DuckDuckGo subscription."
+msgstr ""
+
+#. Text for the disclaimer message that appears when a model is not available to the user without a subscription. This is part of a sentence containing also the model name. Example: GPT-4.1 is only available with a DuckDuckGo subscription. Activate your subscription in this browser again to continue the chat, or switch to a free model.
+msgctxt "Text for the model not available without a subscription disclaimer"
+msgid ""
+"%s is only available with a DuckDuckGo subscription. Activate your "
+"subscription in this browser again to continue the chat, or switch to a free "
+"model."
+msgstr ""
+
+#. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
+msgctxt "Error message for model unavailability"
+msgid ""
+"%s is temporarily unavailable. Please switch to a different model or try "
+"again later."
+msgstr ""
+
+#. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
+msgctxt "Discussions IA"
+msgid "%s karma"
+msgstr ""
+
+#. Distance in kilometers. Placeholder is a number. For example: '100 km'
+msgid "%s km"
+msgstr "%s km"
+
+#. Label that's displayed next to a like count below a web search result.
+msgctxt "Rich Facts label"
+msgid "%s likes"
+msgstr ""
+
+#. Disclaimer text shown bellow chat input on mobile, avoid long text if possible. Example: 'GPT-3 may display inaccurate or offensive information.'
+msgctxt "Disclaimer bellow chat input - mobile"
+msgid "%s may display inaccurate or offensive information."
+msgstr ""
+
+#. Label showing how many members a discussion has. To be displayed on a card about that discussion.
+msgctxt "Discussions IA"
+msgid "%s members"
+msgstr ""
+
+#. Distance measured in miles. Placeholder is a number. For example: '100 mi'
+msgid "%s mi"
+msgstr "%s mi"
+
+#. Displayed in the Duck.ai usage limit banner for subscribers. %s is the formatted used percentage of the 6-hour usage limit, including the percent sign, e.g., '75% of 6-hour usage limit'.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "%s of 6-hour usage limit."
+msgstr ""
+
+#. Displayed in the Duck.ai usage limit banner for subscribers. %s is the formatted used percentage of the daily usage limit, including the percent sign, e.g., '75% of daily limit'.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "%s of daily limit"
+msgstr ""
+
+#. Displayed in the Duck.ai usage limit banner for subscribers. %s is the formatted used percentage of the monthly usage limit, including the percent sign, e.g., '75% of monthly limit'.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "%s of monthly limit"
+msgstr ""
+
+#. Displayed in the Duck.ai usage limit banner for subscribers. %s is the formatted used percentage of the weekly usage limit, including the percent sign, e.g., '75% of weekly limit'.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "%s of weekly limit"
+msgstr ""
+
+#. Label next to a user review. The placeholders are the user name and the review website. For example: 'John on TripAdvisor'
+msgctxt "maps_places"
+msgid "%s on %s"
+msgstr "%s auf %s"
+
+#. Empty state message to indicate that there are no rankings for a particular ranking yet. For example, for college football, the CFP ranking is typically not released until halfway through the season.
+msgctxt "Sports module"
+msgid "%s rankings are not yet available"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
+msgstr ""
+
+#. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
+msgid "%s remaining"
+msgstr ""
+
+#. Label for a single result being hidden
+msgctxt "Organic result context menu"
+msgid "%s results hidden"
+msgstr ""
+
+#. Description explaining that the model runs in an encrypted environment so neither DuckDuckGo nor the model provider can access user prompts or responses. %s is replaced with the full model name (e.g. 'GPT-OSS 120B').
+msgctxt "Privacy claim description in Duck.ai chat for encrypted models"
+msgid ""
+"%s runs in a Trusted Execution Environment. This means not even the model "
+"provider can see your prompts or the model’s responses, or save this chat on "
+"their servers."
+msgstr ""
+
+#. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
+msgctxt ""
+"Label for selected chats count in the selection toolbar when exactly one is "
+"selected"
+msgid "%s selected"
+msgstr ""
+
+#. Label shown in the batch selection toolbar when two or more chats are selected. %s is replaced with the number of selected chats. Use plural agreement where the language requires it.
+msgctxt ""
+"Label for selected chats count in the selection toolbar when more than one "
+"is selected"
+msgid "%s selected"
+msgstr ""
+
+#. Label shown in the batch selection toolbar when zero chats are selected. %s is replaced with 0. Use grammatical forms appropriate for zero in this language (which may differ from singular or plural).
+msgctxt ""
+"Label for selected chats count in the selection toolbar when none are "
+"selected"
+msgid "%s selected"
+msgstr ""
+
+#. Shown to Plus subscribers when they hit a usage limit error. The variable is a link with text 'Upgrade to Pro' that takes the user to the Pro plans page. Example: Upgrade to Pro to unlock 2x higher limits.
+msgctxt "Text promoting Pro upgrade for Plus subscribers who hit usage limits"
+msgid "%s to unlock 2x higher limits."
+msgstr ""
+
+#. The main headline indicating that more than 1 attempt has been blocked. Eg: '2 tracking attempts blocked'
+msgid "%s tracking attempts blocked"
+msgstr ""
+
+#. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
+msgctxt "Duck.ai settings usage section"
+msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
+msgstr ""
+
+#. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
+msgid "%s view"
+msgstr ""
+
+#. Label to add to describe the number of views of a video (e.g., 100 views). This is for the plural case (> 1 view). The placeholder indicates the number of view (e.g., 100).
+msgid "%s views"
+msgstr ""
+
+#. Label that's displayed next to a views count below a web search result.
+msgctxt "Rich Facts label"
+msgid "%s views"
+msgstr ""
+
+#. Message that appears when a site is blocked successfully
+msgctxt "Organic result context menu"
+msgid "%s will be hidden from your search results from now on."
+msgstr ""
+
+#. Message that appears when a site is blocked successfully
+msgctxt "Organic result context menu"
+msgid "%s will be hidden from your search results."
+msgstr ""
+
+#. Displayed in a saved chat when its AI model is scheduled to be retired in more than one day. First placeholder is the friendly model name, second placeholder is the number of days remaining (integer >= 2), third placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Plural-day form.
+msgctxt ""
+"AI Chat: Pre-deprecation notice shown in a saved chat with the number of "
+"days remaining until the model is retired"
+msgid ""
+"%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
+"models to continue this chat."
+msgstr ""
+
+#. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
+msgctxt ""
+"AI Chat: Pre-deprecation notice shown in a saved chat exactly one day before "
+"the model is retired"
+msgid ""
+"%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
+"to continue this chat."
+msgstr ""
+
+#. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
+msgctxt "Word count for an attached text selection"
+msgid "%s words"
+msgstr ""
+
+#. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
+msgctxt "install-duckduckgo"
+msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
+msgstr ""
+
+#. Instructions on what buttons the user has to click in order to add the DuckDuckGo extension to their browser.
+msgctxt "install-duckduckgo"
+msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
+msgstr ""
+"%sKlicke %serlauben%sKlicke %shinzufügen%sWähle %sZulassen%s, dann klicke "
+"auf %sOkay%s"
+
+#. Instructions on which buttons the user has to click in order to add the DuckDuckGo extension to their browser.
+msgctxt "install-duckduckgo"
+msgid ""
+"%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
+"%sOkay%s"
+msgstr ""
+
+#. A button that reloads search results when an error occurs.
+msgctxt "noresults"
+msgid ""
+"%sClick here%s to try again, if you think there should be results for this "
+"search."
+msgstr ""
+"%sKlicke hier%s, um es erneut zu versuchen, wenn du der Meinung bist, dass "
+"es Ergebnisse für diese Suche geben sollte."
+
+#. Header for a page with information about sharing DuckDuckGo.
+msgctxt "frontpage"
+msgid "%sHelp Spread DuckDuckGo!%s"
+msgstr "%sHilf bei der Verbreitung von DuckDuckGo!%s "
+
+#. Link to more information
+msgctxt "frontpage"
+msgid "%sLearn More%s."
+msgstr "%sMehr erfahren%s."
+
+#. Link to a page with more information about how anonymous location works.
+msgctxt "precise_user_location"
+msgid "%sLearn how we keep your location private%s."
+msgstr ""
+
+#. Footer text with a Learn more link explaining where to find more information about chat privacy.
+msgctxt "Footer text for About Sync modal"
+msgid ""
+"%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
+msgstr ""
+
+#. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
+msgctxt "Information about adjusting recent chat storage settings"
+msgid "%sLearn more%s about how chats are stored privately on your device."
+msgstr ""
+
+#. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
+msgctxt "precise_user_location"
+msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
+msgstr ""
+
+#. A message displayed when there is an error loading content or no results on requery
+msgctxt "Error or no results message"
+msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
+msgstr ""
+
+#. Tagline in a popover encouraging the user to download the DuckDuckGo browser
+msgctxt "Browser Promo Popover"
+msgid "%sProtection. Privacy.%s Peace of mind."
+msgstr ""
+
+#. Prompts the user to reload the webpage.
+msgctxt "precise_user_location"
+msgid "%sReload%s DuckDuckGo, and try again"
+msgstr ""
+
+#. Prompts the user to reload the webpage.
+msgctxt "precise_user_location"
+msgid "%sReload%s DuckDuckGo, and try again."
+msgstr ""
+
+#. A button that clears any filters that have been applied to search results.
+msgctxt "noresults"
+msgid "%sReset filters %s"
+msgstr ""
+
+#. Tells users where to click in their browser to change the default search engine.
+msgid "%sRight click%s in the search bar"
+msgstr "%sRechts klick%s im Suchfeld"
+
+#. Conjunction between two inline links, e.g. 'Podcast & Newsletter'
+msgctxt "SERP footer content"
+msgid "&"
+msgstr ""
+
+msgctxt "settings"
+msgid "'Always private' Reminder"
+msgstr ""
+
+msgctxt "settings"
+msgid "'Always protected' Reminder"
+msgstr ""
+
+msgctxt "settings"
+msgid "'Protected' Reminder"
+msgstr ""
+
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "(Current Tab)"
+msgstr ""
+
+#. A suffix on a filter option indicating it is the one that is in effect if no other filter is chosen
+msgid "(Default)"
+msgstr ""
+
+#. Renders to the right of the device name for the row that matches this device's id.
+msgctxt "Suffix marking the current device in the synced devices list"
+msgid "(This device)"
+msgstr ""
+
+#. Shorter mobile placeholder for the AI Chat prompt input shown inline next to the 'Show More' button on the short answer, where the narrow width would otherwise wrap the longer copy (Duck.ai entry-point experiment, variant f only)
+msgid "... or ask a follow-up"
+msgstr ""
+
+#. A placeholder for the AI Chat prompt input shown inline next to the 'Show More' button on the short answer (Duck.ai entry-point experiment, variant f only)
+msgid "... or ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Displaying 1 review for a website
+msgid "1 Review"
+msgstr ""
+
+#. Singular form when displaying the number of adults staying at a hotel.
+msgctxt "Single Place Hotel Offers Module"
+msgid "1 adult"
+msgstr ""
+
+#. Number of tracking attempts blocked, when there's only 1
+msgctxt "tracker_stats"
+msgid "1 attempt"
+msgstr ""
+
+#. A summary description of how many tracking attempts where blocked, when only one exists.
+msgid "1 attempt blocked by DuckDuckGo in the last 24 hours"
+msgstr ""
+
+#. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
+msgctxt "published dates for organic results"
+msgid "1 day ago"
+msgstr "Vor einem Tag"
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
+
+#. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
+msgctxt "published dates for organic results"
+msgid "1 hour ago"
+msgstr "Vor einer Stunde"
+
+#. Label for a single result being hidden
+msgctxt "Organic result context menu"
+msgid "1 result hidden"
+msgstr ""
+
+#. The main headline indicating that 1 tracker was blocked
+msgid "1 tracking attempt blocked"
+msgstr ""
+
+#. Shown in a text selection chip when the selection contains exactly one word.
+msgctxt "Word count for an attached text selection"
+msgid "1 word"
+msgstr ""
+
+#. Tells users where they can find the DuckDuckGo browser extension file downloaded to their computer.
+msgctxt "install-extension"
+msgid "1. Open %sDownloads%s"
+msgstr "1. Öffne %sDownloads%s"
+
+#. Numbers that indicate the position in a series
+msgctxt "Sports module"
+msgid "10th"
+msgstr ""
+
+#. Numbers that indicate the position in a series
+msgctxt "Sports module"
+msgid "11th"
+msgstr ""
+
+#. Numbers that indicate the position in a series
+msgctxt "Sports module"
+msgid "12th"
+msgstr ""
+
+#. Numbers that indicate the position in a series
+msgctxt "Sports module"
+msgid "13th"
+msgstr ""
+
+#. Numbers that indicate the position in a series
+msgctxt "Sports module"
+msgid "14th"
+msgstr ""
+
+#. Disclaimer text for the stocks module
+msgctxt "Stocks module"
+msgid "15 minutes delayed"
+msgstr ""
+
+#. Numbers that indicate the position in a series
+msgctxt "Sports module"
+msgid "15th"
+msgstr ""
+
+#. Button label for selecting chart of today's prices (needs to be short on mobile devices)
+msgctxt "Stocks module"
+msgid "1D"
+msgstr ""
+
+#. Button label for selecting chart of prices over the last month
+msgctxt "Stocks module"
+msgid "1M"
+msgstr ""
+
+#. Button label for selecting chart of prices over the last year
+msgctxt "Stocks module"
+msgid "1Y"
+msgstr ""
+
+#. Numbers that indicate the position in a series
+msgctxt "Sports module"
+msgid "1st"
+msgstr ""
+
+#. Tennis match stats: first serve percentage
+msgctxt "Sports module"
+msgid "1st Serve %"
+msgstr ""
+
+#. Tennis match stats
+msgctxt "Sports module"
+msgid "1st Serve Pts Won"
+msgstr ""
+
+#. Text indicating the winner of a World Cup group when that team is not yet known
+msgctxt "Sports module"
+msgid "1st in Group %s"
+msgstr ""
+
+#. Instructions on how to install the DuckDuckGo browser extension.
+msgctxt "install-extension"
+msgid "2. Double-click %sduckduckgo.safariextz%s"
+msgstr "2. Klicke doppelt auf %sduckduckgo.safariextz%s"
+
+#. Title of a module related to the United States presidential election.
+msgctxt "Elections IA"
+msgid "2024 US Presidential Election"
+msgstr ""
+
+#. Title of a module related to the United States presidential election.
+msgctxt "Elections IA"
+msgid "2024 United States Presidential Election"
+msgstr ""
+
+#. Numbers that indicate the position in a series
+msgctxt "Sports module"
+msgid "2nd"
+msgstr ""
+
+#. Tennis match stats
+msgctxt "Sports module"
+msgid "2nd Serve Pts Won"
+msgstr ""
+
+#. Text indicating the runner-up of a World Cup group when that team is not yet known
+msgctxt "Sports module"
+msgid "2nd in Group %s"
+msgstr ""
+
+#. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. '3 premium protections' refers to the three bundled features (VPN, advanced Duck.ai AI, and Identity Theft Restoration).
+msgctxt "DuckDuckGo Subscription instant answer"
+msgid "3 premium protections. 1 subscription."
+msgstr ""
+
+#. Numbers that indicate the position in a series
+msgctxt "Sports module"
+msgid "3rd"
+msgstr ""
+
+#. Text indicating the 3rd place team of a World Cup group when that team is not yet known
+msgctxt "Sports module"
+msgid "3rd in Group %s"
+msgstr ""
+
+#. US-only heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. '4 premium protections' refers to the four bundled features (VPN, advanced AI, Personal Information Removal, and Identity Theft Restoration).
+msgctxt "DuckDuckGo Subscription instant answer"
+msgid "4 premium protections. 1 subscription."
+msgstr ""
+
+#. Cricket scorecard: fours abbreviation
+msgctxt "Sports module"
+msgid "4s"
+msgstr ""
+
+#. Numbers that indicate the position in a series
+msgctxt "Sports module"
+msgid "4th"
+msgstr ""
+
+#. The highest price over the previous 52 weeks
+msgctxt "Stocks module"
+msgid "52wk High"
+msgstr ""
+
+#. The lowest price over the previous 52 weeks
+msgctxt "Stocks module"
+msgid "52wk Low"
+msgstr ""
+
+#. Button label for selecting chart of prices over the last 5 days
+msgctxt "Stocks module"
+msgid "5D"
+msgstr ""
+
+#. Button label for selecting chart of prices over the last five years
+msgctxt "Stocks module"
+msgid "5Y"
+msgstr ""
+
+#. Numbers that indicate the position in a series
+msgctxt "Sports module"
+msgid "5th"
+msgstr ""
+
+#. Label for the 6-hour usage limit row in the Usage section of Duck.ai settings.
+msgctxt "Duck.ai settings usage section"
+msgid "6-hour limit"
+msgstr ""
+
+#. Displayed in the Duck.ai usage limit banner for subscribers when the 6-hour usage limit has been reached.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "6-hour usage limit reached."
+msgstr ""
+
+#. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
+msgctxt "Error message for fixed-window Duck.ai usage limit"
+msgid "6-hour usage limit reached. You can continue this chat after %s."
+msgstr ""
+
+#. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
+msgctxt "Error message for fixed-window Duck.ai usage limit"
+msgid ""
+"6-hour usage limit reached. You can keep chatting by using your daily limit."
+msgstr ""
+
+#. Cricket scorecard: sixes abbreviation
+msgctxt "Sports module"
+msgid "6s"
+msgstr ""
+
+#. Numbers that indicate the position in a series
+msgctxt "Sports module"
+msgid "6th"
+msgstr ""
+
+#. Numbers that indicate the position in a series
+msgctxt "Sports module"
+msgid "7th"
+msgstr ""
+
+#. Numbers that indicate the position in a series
+msgctxt "Sports module"
+msgid "8th"
+msgstr ""
+
+#. Numbers that indicate the position in a series
+msgctxt "Sports module"
+msgid "9th"
+msgstr ""
+
+#. Text for the query that is displayed in the Search Assist introduction. For example: Get an answer for 'How to wash a car'.
+msgid "<strong>Generate answer for</strong> %s"
+msgstr ""
+
+#. Label inside the compact Search Assist button at the top of search results. The bold prefix precedes the user's query and the text is ellipsized to a single line. For example: 'Show answer for How to wash a car'.
+msgid "<strong>Show answer for</strong> %s"
+msgstr ""
+
+#. Indicates the Win-Loss record of a team when playing away
+msgctxt "Sports module"
+msgid "A"
+msgstr ""
+
+#. Error message for the duckassist instant answer (based on generative AI) whenever there is a network issue.
+msgid ""
+"A network issue is preventing Search Assist from generating an answer. "
+"Please check your connection and try again."
+msgstr ""
+
+#. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
+msgctxt "Body text for new version available modal"
+msgid ""
+"A new version of AI Chat is available! Please refresh this page to continue."
+msgstr ""
+
+#. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
+msgctxt "Body text for new version available modal"
+msgid ""
+"A new version of Duck.ai is available! Please refresh this page to continue."
+msgstr ""
+
+#. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
+msgctxt "Stale version banner in Duck.ai (Electron desktop app)"
+msgid "A new version of Duck.ai is available. "
+msgstr ""
+
+#. https://duckduckgo.com/params in the end under " Source:"
+msgid "A string to identify the source."
+msgstr "Ein Text, um die Quelle zu identifizieren."
+
+#. Abbreviation for 'after extra time'. Shown in parentheses after 'FT' (e.g. 'FT (AET)') when a soccer match was decided in extra time or on penalties (which follow extra time).
+msgctxt "Sports module"
+msgid "AET"
+msgstr ""
+
+#. Page title for a ChatGPT-like chat bot feature. Translation should include the equivalent term for AI (Artificial Intelligence). It's ok to leave it in English if that's the expectation in your language.
+msgctxt "Page title in browser tab"
+msgid "AI Chat"
+msgstr ""
+
+msgctxt "settings"
+msgid "AI Chat <sup>BETA</sup>"
+msgstr ""
+
+#. Title of the modal that contains settings for AI Chat.
+msgctxt "Modal header for AI Chat settings"
+msgid "AI Chat Settings"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"AI Chat lets you have anonymous conversations with 3rd-party AI chat models. "
+"Turning this off will hide the AI Chat feature on DuckDuckGo Search. You can "
+"still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
+"aichat%s."
+msgstr ""
+
+#. A label for a setting that appears on a menu, used to control global AI features settings.
+msgctxt "Label for AI Features setting"
+msgid "AI Features"
+msgstr ""
+
+msgctxt "settings"
+msgid "AI Features"
+msgstr ""
+
+#. Title for filter to hide or include AI-generated images in image results
+msgid "AI images"
+msgstr ""
+
+#. Title for filter to hide or include AI-generated images in image results
+msgid "AI images:"
+msgstr ""
+
+#. Disclaimer text shown bellow chat input.
+msgctxt "Disclaimer bellow chat input"
+msgid "AI may display inaccurate or offensive information."
+msgstr ""
+
+#. Disclaimer text displayed at the bottom of the voice chat dialog informing the user that the AI (Artificial Intelligence) may provide inaccurate or offensive information.
+msgctxt "voice chat"
+msgid "AI may provide inaccurate or offensive information."
+msgstr ""
+
+#. Label for the input field where user can specify how the AI assistant should refer to itself. Example: 'AI nickname (is): Fred'
+msgctxt "Label for assistant name input"
+msgid "AI nickname"
+msgstr ""
+
+#. Label indicating the assistant's role. Example: 'AI role (is a): travel guide'
+msgctxt "Label for assistant role selection"
+msgid "AI role"
+msgstr ""
+
+#. The title for the learn more modal about AI-Assisted Answers.
+msgctxt "duckassist"
+msgid "AI-Assisted Answers"
+msgstr ""
+
+#. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
+msgid ""
+"AI-assisted answers do not currently support follow-up questions directly. "
+"However, we also offer and often link to %sDuck.ai%s for follow-up "
+"questions, which is our private AI-powered chat service that supports chat "
+"models from OpenAI, and Anthropic, and more."
+msgstr ""
+
+#. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
+msgctxt "duckassist"
+msgid "AI-assisted answers have been turned off!"
+msgstr ""
+
+#. Negative feedback suggestion for when user dislikes AI-generated content
+msgctxt "Feedback prompt"
+msgid "AI-generated"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "AI-generated recipe"
+msgstr ""
+
+#. Shortened title for filter to hide or include AI-generated images in image results
+msgid "AI:"
+msgstr ""
+
+#. Abbreviation for 'American League Championship Series', the title of the divisional championship series for the American League division of Major League Baseball
+msgctxt "Sports module"
+msgid "ALCS"
+msgstr ""
+
+#. Abbreviation for 'American League Division Series', the title of the divisional semi-final series for the American League division of Major League Baseball
+msgctxt "Sports module"
+msgid "ALDS"
+msgstr ""
+
+#. Abbreviation for 'American League Wild Card Series', the title of the divisional runner-up series for the American League Division in Major League Baseball.
+msgctxt "Sports module"
+msgid "ALWC"
+msgstr ""
+
+msgctxt "settings"
+msgid "ATB Dismiss"
+msgstr "ATB Verwerfen"
+
+msgctxt "settings"
+msgid "ATB related (not displayed on settings page)"
+msgstr "ATB bezogen (nicht auf der Einstellungsseite angezeigt)"
+
+#. Golf rankings column: average points
+msgctxt "Sports module"
+msgid "AVG"
+msgstr ""
+
+#. In the new DDG website, this token appears as the Tab name for Instant Answers that give general information about a subject. eg. https://duckduckgo.com/?q=Sony
+#. It is not "About DuckDuckGo".
+msgid "About"
+msgstr "Über"
+
+#. Label for the 'About' item in the Search Assist overflow menu. Opens the 'About AI-Assisted Answers' explainer modal.
+msgctxt "duckassist"
+msgid "About"
+msgstr ""
+
+#. Link to a page with more information about the company.
+msgctxt "static_page"
+msgid "About"
+msgstr "Über"
+
+#. Sidebar navigation label for the About & Legal section of the Duck.ai settings page, which contains general information about Duck.ai as well as legal links such as the privacy policy and terms of service.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "About & Legal"
+msgstr ""
+
+#. A link to a page that provides information about the DuckDuckGo Browser (https://duckduckgo.com/app/)
+msgctxt "SERP footer content"
+msgid "About Browser"
+msgstr ""
+
+#. Title of the modal that provides information about Chat History, shown when the user clicks 'How it works'.
+msgctxt "Modal header for chat history information"
+msgid "About Chat History"
+msgstr ""
+
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+#. at least in:
+#. * https://duckduckgo.com/about. Appears in the window title when you open the link
+msgid "About DuckDuckGo"
+msgstr "Über DuckDuckGo"
+
+#. Title displayed at the top of the modal that explains the Encrypted Storage feature for 3rd party browsers.
+msgctxt "Title for the About Encrypted Storage modal"
+msgid "About Encrypted Storage"
+msgstr ""
+
+#. Link label for DuckDuckGo 'App' page (https://duckduckgo.com/app)
+msgid "About Our Browser"
+msgstr ""
+
+#. Title of the modal that provides information about Recent Chats.
+msgctxt "Modal header for recent chats information"
+msgid "About Recent Chats"
+msgstr ""
+
+#. Title displayed at the top of the modal that explains the Sync & Backup feature for native DDG browsers.
+msgctxt "Title for the About Sync modal"
+msgid "About Sync & Backup"
+msgstr ""
+
+#. Link to a page with more information about the company.
+msgid "About Us"
+msgstr "Über uns"
+
+#. A title for the ads tooltip
+msgid "About our ads"
+msgstr ""
+
+#. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
+msgctxt "settingsvalue"
+msgid "Above Title"
+msgstr ""
+
+#. Description explaining that synced chats can be accessed from any device.
+msgctxt "Sync feature benefit description"
+msgid "Access from any device."
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Accurate"
+msgstr ""
+
+#. Tennis match stats: aces count
+msgctxt "Sports module"
+msgid "Aces"
+msgstr ""
+
+#. Label indicating the assistant's role. Example: 'Act like a travel guide'
+msgctxt "Label for assistant role selection"
+msgid "Act like"
+msgstr ""
+
+#. Text for the button that opens the subscription modal.
+msgctxt "Button on the model not available disclaimer"
+msgid "Activate Subscription"
+msgstr ""
+
+#. Will be used in the sentence, 'Activate your DuckDuckGo subscription in this browser again to continue the chat, or switch to a free model.' but needs to be a separate token so we can make DuckDuckGo subscription a link
+msgctxt ""
+"Error message informing the user they need to activate their subscription to "
+"keep using the same AI model"
+msgid ""
+"Activate your %s in this browser again to continue the chat, or switch to a "
+"free model."
+msgstr ""
+
+#. Label indicating that the user has an active DuckDuckGo subscription.
+msgctxt "Text for the active subscription label on the settings modal"
+msgid "Active"
+msgstr ""
+
+#. Label for a menu item for the active privacy protection feature.
+msgctxt "Menu item label"
+msgid "Active Privacy Protection"
+msgstr ""
+
+#. Title that informs users that their chats have an active privacy protection feature.
+msgctxt "Modal header for active privacy protection"
+msgid "Active Privacy Protection"
+msgstr ""
+
+#. Title of the modal about the active privacy protection.
+msgctxt "Modal title for privacy"
+msgid "Active Privacy Protection"
+msgstr ""
+
+#. A label that appears on an advertisement. 'Ad' is an abbreviation for 'Advertisement'
+msgid "Ad"
+msgstr "Werbung"
+
+#. An item in the ads tooltip that explains that ad clicks are managed by the ad network and are not used to profile you. The placeholder is the name of the ad network. For example: Microsoft
+msgid ""
+"Ad clicks are managed by %s’s ad network and are not used to profile you."
+msgstr ""
+
+#. Information that ad clicks are managed by Microsoft.
+msgid ""
+"Ad clicks are managed by Microsoft’s ad network and are not used to profile "
+"you."
+msgstr ""
+
+#. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
+msgid "Ad clicks aren’t used to profile you"
+msgstr ""
+
+#. Category of problem a user can select on a feedback form.
+msgctxt "feedback form"
+msgid "Ad is annoying"
+msgstr "Werbung ist nervig"
+
+#. Category of problem a user can select on a feedback form.
+msgctxt "feedback form"
+msgid "Ad is inappropriate"
+msgstr "Werbig ist unangebracht"
+
+#. Category of problem a user can select on a feedback form.
+msgctxt "feedback form"
+msgid "Ad is irrelevant"
+msgstr "Werbung ist irrelevant"
+
+#. Category of problem a user can select on a feedback form.
+msgctxt "feedback form"
+msgid "Ad is malware"
+msgstr "Werbung ist Schadsoftware"
+
+#. Category of problem a user can select on a feedback form.
+msgctxt "feedback form"
+msgid "Ad is suspicious"
+msgstr "Werbung ist verdächtig"
+
+#. Link to add the DuckDuckGo extension to the user's web browser.
+msgid "Add DuckDuckGo"
+msgstr "Füge DuckDuckGo an"
+
+msgctxt "homepage ATB modal"
+msgid "Add DuckDuckGo Extension"
+msgstr ""
+
+msgid ""
+"Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
+msgstr ""
+"Füge DuckDuckGo Privacy Essentials mit einem einzelnen Download gratis zu "
+"deinem Browser hinzu:"
+
+#. Tells users how to add DuckDuckGo to the list of search engines in their browser.
+msgid "Add DuckDuckGo as a search engine"
+msgstr "Füge DuckDuckGo als Suchmaschine hinzu"
+
+#. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
+msgid "Add DuckDuckGo to %s"
+msgstr "Füge DuckDuckGo zu %s hinzu"
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Images"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Images or PDFs"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add PDFs"
+msgstr ""
+
+#. Sentence-case tooltip and accessible label for the upload button when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Attach PDF files to the Duck.ai chat conversation (upload button tooltip and "
+"aria-label)"
+msgid "Add PDFs"
+msgstr ""
+
+#. Title-case label for the page-context option in the attach dropdown menu and its submenu aria-label.
+msgctxt ""
+"Add page context from the current tab to the AI chat message (attach "
+"dropdown menu item)"
+msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the standalone page-context CTA button and the icon-only toggle button's tooltip/aria-label.
+msgctxt ""
+"Attach page context from the current tab to the AI chat message (standalone "
+"CTA button and icon toggle tooltip)"
+msgid "Add Page Content"
+msgstr ""
+
+#. https://duckduckgo.com/search_box near the top
+#. e.g.: Add a DuckDuckGo search box to your site!
+msgid "Add a %s search box to your site!"
+msgstr "Füge deiner Seite eine %s-Suchbox hinzu!"
+
+#. Prompt to add locations on a map in order to get directions.
+msgctxt "directions"
+msgid "Add a starting point and destination to find a route."
+msgstr "Füge einen Startpunkt und ein Ziel hinzu, um eine Route zu finden."
+
+#. Label on the AI model card indicating the model supports file uploads.
+msgctxt "duck.ai model card"
+msgid "Add files"
+msgstr ""
+
+#. Label on the AI model card indicating the model supports both file and image uploads.
+msgctxt "duck.ai model card"
+msgid "Add files and photos"
+msgstr ""
+
+#. Sentence-case tooltip and accessible label for the upload button when only image upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add an image to the AI chat conversation (upload button tooltip and aria-"
+"label)"
+msgid "Add images"
+msgstr ""
+
+#. Sentence-case tooltip and accessible label for the upload button when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (upload button tooltip "
+"and aria-label)"
+msgid "Add images or PDFs"
+msgstr ""
+
+#. Prompt to install the DuckDuckGo browser extension.
+msgctxt "homepage ATB modal"
+msgid "Add our extension to help protect personal data"
+msgstr ""
+
+#. Tooltip for the upload button when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt "Add photos or PDF files to the Duck.ai chat conversation"
+msgid "Add photos or PDF files"
+msgstr ""
+
+#. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; shown in every market.
+msgctxt "DuckDuckGo Subscription instant answer"
+msgid "Add premium protections today"
+msgstr ""
+
+#. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add to Chrome'
+msgid "Add to %s"
+msgstr "Zu %s hinzufügen"
+
+#. Button that creates a shortcut to the current page on the home screen of the user's phone.
+msgid "Add to Home Screen"
+msgstr "Zu Homescreen hinzufügen"
+
+#. In the top menu under Goodies
+msgid "Add-ons"
+msgstr "Erweiterungen"
+
+#. Loading message shown when the image generation is nearing completion.
+msgctxt "Loading state message"
+msgid "Adding finishing touches"
+msgstr ""
+
+#. Label that's displayed next to an address below a web search result.
+msgctxt "Rich Facts label"
+msgid "Address"
+msgstr ""
+
+#. Refers to a street address.
+msgctxt "maps_places"
+msgid "Address"
+msgstr "Adresse"
+
+#. https://duckduckgo.com/params near the top under "Privacy Settings"
+msgid "Address bar:"
+msgstr "Adressleiste:"
+
+#. Category of feedback a user can select on a feedback form.
+msgctxt "feedback form"
+msgid "Address is incorrect"
+msgstr ""
+
+#. Page-suggestion chip label "Adjust the servings", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Adjust the servings"
+msgstr ""
+
+#. as in multiple advertisements
+msgid "Ads"
+msgstr "Werbungen"
+
+#. An item in the ads tooltip that explains that ads are only based on the current search.
+msgid "Ads are only based on your current search"
+msgstr ""
+
+#. A call-to-action to subscribe to unlock access to advanced AI models. Please keep translations to 50 characters or less.
+msgctxt "Text promotion"
+msgid "Advanced AI in DuckDuckGo subscription!"
+msgstr ""
+
+#. Displayed above the fixed-window limit error when the user can continue by switching to a configured free/degraded model.
+msgctxt "Error label for fixed-window Duck.ai usage limit."
+msgid "Advanced AI models limit reached"
+msgstr ""
+
+#. Displayed when the user's advanced-model Duck.ai usage limit has been reached but they can continue the current conversation by switching to a configured free/degraded model.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Advanced AI models limit reached"
+msgstr ""
+
+#. Text for a promotional card that encourages DuckDuckGo Subscription users to try the advanced AI models that the subscription unlocks.
+msgctxt "Promotional text for advanced AI models for subscribed Duck.ai users"
+msgid "Advanced AI models unlocked!"
+msgstr ""
+
+#. Title for the welcome modal displayed after the user subscribes to DuckDuckGo.
+msgctxt "Title for the subscription welcome modal"
+msgid "Advanced AI models unlocked!"
+msgstr ""
+
+#. Text displayed on the models list as a title for the advanced AI (Artificial Intelligence) models section.
+msgctxt "Label for the advanced AI models"
+msgid "Advanced Models"
+msgstr ""
+
+#. Shown in the desktop electron app for logged-in users in place of 'DuckDuckGo Subscription'.
+msgctxt ""
+"Title of the account/models setting on the settings modal (electron desktop "
+"app variant)"
+msgid "Advanced Models"
+msgstr ""
+
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid ""
+"Advanced models can reach usage limits 2–5x sooner than other models. %s"
+msgstr ""
+
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
+#. Link to a page with resources for advertisers who want to place ads on the search results page.
+msgid "Advertise on Search"
+msgstr ""
+
+msgctxt "feedback form"
+msgid "Advertisements"
+msgstr "Werbung"
+
+#. http://i.imgur.com/ZG0Mz3R.png
+msgctxt "settings"
+msgid "Advertisements"
+msgstr "Werbung"
+
+#. https://duckduckgo.com/params near the top under "Interface Settings"
+msgid "Advertisements:"
+msgstr "Werbung:"
+
+msgid "Afghanistan"
+msgstr ""
+
+#. The name of the Afrikaans language
+msgctxt "language_name"
+msgid "Afrikaans"
+msgstr ""
+
+#. Instructions on how to install the DuckDuckGo browser extension after it downloads.
+msgid "After it downloads and opens, click %sInstall%s"
+msgstr ""
+"Nachdem es heruntergeladen und geöffnet wurde, klicke auf %sInstallieren%s"
+
+#. Instructions on how to install the DuckDuckGo browser extension after it downloads.
+msgid ""
+"After it downloads, locate the extension file and double-click it to install"
+msgstr ""
+"Öffne die Datei nach dem Herunterladen per Doppelklick um sie zu installieren"
+
+#. Label that's displayed next to an age below a web search result.
+msgctxt "Rich Facts label"
+msgid "Age"
+msgstr ""
+
+#. Primary button on the inline terms-of-service decision card. Clicking it accepts the terms and submits the user's pending prompt.
+msgctxt "Agree button on terms-of-service decision card on Duck.ai"
+msgid "Agree"
+msgstr ""
+
+#. Text displayed on the button on the onboarding modal where the user agrees to the Terms of Use and Privacy Policy.
+msgctxt "Modal onboarding terms screen button text"
+msgid "Agree and Continue"
+msgstr ""
+
+msgid "Albania"
+msgstr ""
+
+#. The name of the Albanian language
+msgctxt "language_name"
+msgid "Albanian"
+msgstr ""
+
+#. Label for the song's album name e.g. 'Album: A Night At The Opera'
+msgctxt "lyrics_module"
+msgid "Album"
+msgstr ""
+
+msgid "Algeria"
+msgstr ""
+
+msgid "All"
+msgstr "Alle"
+
+#. Button label for selecting to show the information from all Conferences, in American College Football
+msgctxt "Sports module"
+msgid "All"
+msgstr ""
+
+#. Button label for selecting chart showing all historical prices
+msgctxt "Stocks module"
+msgid "All"
+msgstr ""
+
+#. Dropdown label for showing games from all competitions in the team module
+msgctxt "Sports module"
+msgid "All Competitions"
+msgstr ""
+
+#. a filter for any image with a Creative Commons usage license
+msgctxt "image-licence"
+msgid "All Creative Commons"
+msgstr ""
+
+#. Button label for selecting to show the information from all Groups, in e.g. the soccer World Cup
+msgctxt "Sports module"
+msgid "All Groups"
+msgstr ""
+
+#. 'license' as in 'permission to use, share, or modify a work'
+msgctxt "image-licence"
+msgid "All Licenses"
+msgstr ""
+
+#. Links back to a list of all search results from a page with information on a single result.
+msgid "All Places"
+msgstr "Alle Ort"
+
+#. A filter that shows search results from all countries.
+msgid "All Regions"
+msgstr "Alle Regionen"
+
+#. A label that appears above search results.
+msgid "All Results"
+msgstr "Alle Resultate"
+
+#. Text for a link to the settings page with all search settings available.
+msgctxt "link to settings page"
+msgid "All Search Settings"
+msgstr ""
+
+#. Link that shows all settings.
+msgid "All Settings"
+msgstr "Alle Einstellungen"
+
+msgctxt "settings pages"
+msgid "All Settings"
+msgstr ""
+
+#. Heading shown on the empty chat screen. %s is replaced with an interactive privacy button containing a shield icon and the word 'private'.
+msgctxt "Empty state heading in Duck.ai chat mode"
+msgid "All chats are %s"
+msgstr ""
+
+#. Disclaimer text shown below chat input. %s is replaced with a clickable underlined 'private' link that opens the privacy protection modal.
+msgctxt "Disclaimer below chat input in Duck.ai"
+msgid "All chats are %s. AI can make mistakes."
+msgstr ""
+
+#. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
+msgctxt "Empty state heading in Duck.ai chat mode"
+msgid "All chats are %sprivate%s"
+msgstr ""
+
+#. Paragraph in the Privacy & Terms section of the About & Legal page in Duck.ai settings, summarizing how chats are anonymized and are not stored or used to train chat models.
+msgctxt "Privacy & Terms section description on the Duck.ai settings page"
+msgid ""
+"All chats are anonymized by DuckDuckGo, and your conversations are not used "
+"to train chat models by DuckDuckGo or the model providers"
+msgstr ""
+
+#. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
+msgctxt "Privacy modal header in Duck.ai chat"
+msgid "All chats are private"
+msgstr ""
+
+#. This is shown in an image filter. This option only shows images in colors, excluding black and white images. https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
+msgctxt "image-color"
+msgid "All colors"
+msgstr ""
+
+#. Title shown to the host device (the one that is logged in) after the pair completes.
+msgctxt "Title for the host-device success screen"
+msgid "All done!"
+msgstr ""
+
+#. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
+msgctxt "image-layout"
+msgid "All layouts"
+msgstr ""
+
+#. Description explaining that all AI model providers are contractually prevented from using user conversations to train their AI models.
+msgctxt "Privacy claim description in Duck.ai chat"
+msgid ""
+"All model providers are prevented from training their AI on your "
+"conversations."
+msgstr ""
+
+#. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
+msgctxt "Modal subheader text"
+msgid "All models are anonymously provided by DuckDuckGo"
+msgstr ""
+
+#. Explains that all metadata including personal info like IP address is removed before a chat reaches the AI provider. Pairs with a mask pictogram.
+msgctxt "Body copy for the anonymized card in the How Duck.ai Works panel"
+msgid ""
+"All personal metadata (for example, your IP address) is removed before "
+"sending a chat to the AI provider."
+msgstr ""
+
+#. A filter that shows search results from all countries.
+msgctxt "settingsvalue"
+msgid "All regions"
+msgstr ""
+
+#. Filters the size of images in search results.
+msgctxt "size"
+msgid "All sizes"
+msgstr ""
+
+#. Shown in an image type selector. Other options are: photograph, clipart, animated gif, etc.  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images
+msgctxt "image-type"
+msgid "All types"
+msgstr ""
+
+#. Button to approve file/image uploads for the current conversation, shown inside an in-chat permission card in Duck.ai
+msgctxt "DuckChat upload consent prompt for encrypted models"
+msgid "Allow"
+msgstr ""
+
+#. Message shown to the user when microphone access is denied.
+msgctxt "voice chat"
+msgid ""
+"Allow DuckDuckGo microphone access in System Settings to use voice chat."
+msgstr ""
+
+#. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
+msgctxt "precise_user_location"
+msgid "Allow DuckDuckGo to use your location."
+msgstr ""
+
+#. Label of a button that opens instructions on how to turn off the user's ad blocker
+msgid "Allow Privacy-Respecting Ads"
+msgstr ""
+
+#. Title of the upload consent prompt shown before the first image/file upload in a chat with a zero-provider-visibility model, shown inside an in-chat permission card in Duck.ai
+msgctxt "DuckChat upload consent prompt for encrypted models"
+msgid "Allow anonymous file review for this chat?"
+msgstr ""
+
+#. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
+msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
+msgstr ""
+
+#. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
+msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid ""
+"Allows %s to search the web to improve responses to relevant prompts. Only "
+"sends AI-generated queries to a search engine with limited data retention. "
+"Prompts and responses with %s still have %szero provider visibility%s."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Allows Cloud Save key to be stored locally on device (required to use Cloud "
+"Save)"
+msgstr ""
+
+#. Pending title indicating near completion.
+msgctxt "duckai_migration"
+msgid "Almost there!"
+msgstr ""
+
+#. A title on a page that let's users know they're almost done with the process of installing DuckDuckGo in their browser
+msgctxt "install-duckduckgo"
+msgid "Almost there!"
+msgstr "Fast fertig!"
+
+msgctxt "homepage onboarding"
+msgid "Already a fan?"
+msgstr "Schon ein Fan?"
+
+#. Shown when the user tries to pair a device that is already connected to this Sync & Backup account (same_account). Dismissing returns the user to the device management screen.
+msgctxt ""
+"Title for the screen shown when both devices are already on the same account"
+msgid "Already synced."
+msgstr ""
+
+#. Explains that DuckDuckGo is available for multiple devices.
+msgctxt "mobile promotion on desktop"
+msgid "Also search privately on your iPad, iPhone, or Android!"
+msgstr "Suche auch anonym mit deinem iPad, iPhone oder Android!"
+
+#. Keyboard shortcut for Duck.ai
+msgctxt "Search form"
+msgid "Alt+Enter"
+msgstr ""
+
+#. Instant Answer Tab Name
+msgid "Alternatives"
+msgstr "Alternativen"
+
+#. https://i.imgur.com/89c3nJI.png
+msgctxt "settingsvalue"
+msgid "Always play on DuckDuckGo"
+msgstr "Immer auf DuckDuckGo abspielen "
+
+#. Refers to the DuckDuckGo search engine, on which your searches are always private.
+msgid "Always private"
+msgstr ""
+
+#. Refers to the DuckDuckGo search engine, on which your searches are always protected.
+msgid "Always protected"
+msgstr ""
+
+#. Text displayed next to the Active Privacy Protection icon in an empty chat, stating that conversations with Duck.ai are always protected.
+msgctxt ""
+"Text displayed next to the Active Privacy Protection icon in an empty chat"
+msgid "Always protected"
+msgstr ""
+
+#. Title of the divisional championship series for the American League division of Major League Baseball
+msgctxt "Sports module"
+msgid "American League Championship Series"
+msgstr ""
+
+#. Title of the divisional semi-final series for the American League division of Major League Baseball
+msgctxt "Sports module"
+msgid "American League Division Series"
+msgstr ""
+
+#. Title of the divisional runner-up series for the American League Division in Major League Baseball.
+msgctxt "Sports module"
+msgid "American League Wild Card Series"
+msgstr ""
+
+msgid "American Samoa"
+msgstr ""
+
+#. The name of the Amharic language
+msgctxt "language_name"
+msgid "Amharic"
+msgstr ""
+
+msgid "Andorra"
+msgstr ""
+
+#. Refers to the DuckDuckGo browser for Android.
+msgid "Android Browser"
+msgstr ""
+
+msgid "Angola"
+msgstr ""
+
+#. Filters the type of images in search results.
+msgctxt "image-type"
+msgid "Animated GIF"
+msgstr "Animiertes GIF"
+
+#. Title for the privacy claim that explains user prompts are anonymized before being sent to AI model providers.
+msgctxt "Privacy claim title in Duck.ai chat"
+msgid "Anonymized by DuckDuckGo"
+msgstr ""
+
+#. Tells the user the location being used to show search results. e.g. Anonymizing your location in London, UK.
+msgctxt "precise_user_location"
+msgid "Anonymizing your location in"
+msgstr ""
+
+#. Confirmation message after location service is enabled.
+msgctxt "precise_user_location"
+msgid "Anonymous Location Enabled"
+msgstr ""
+
+#. Text with information about AI Chat and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
+msgctxt "AI Chat description"
+msgid ""
+"Anonymous access to popular AI models, including %s, %s, and open-source %s "
+"and %s."
+msgstr ""
+
+#. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
+msgctxt "Duck.ai description"
+msgid ""
+"Anonymous access to popular AI models, including %s, %s, and open-source %s "
+"and %s."
+msgstr ""
+
+#. Confirmation message after location service is enabled.
+msgctxt "precise_user_location"
+msgid "Anonymous location enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Anonymously generates answers for search queries based on web content. "
+"Choose how often you want it to appear, or disable it completely."
+msgstr ""
+
+#. Instant Answer tab name
+msgid "Answer"
+msgstr "Antwort"
+
+#. Button text that appears during AI reasoning to allow users to skip the thinking phase and get an immediate answer without reasoning.
+msgctxt "Button text to skip reasoning and get an answer immediately"
+msgid "Answer Faster"
+msgstr ""
+
+#. Toast message shown briefly after the user copies the Search Assist answer to their clipboard via the overflow menu's Copy action. Confirms the copy succeeded since the menu closes immediately on click and there is no inline checkmark feedback to rely on.
+msgctxt "Search Assist"
+msgid "Answer copied!"
+msgstr ""
+
+#. Positive feedback category a user can select on the Search Assist feedback form, meaning the answer was relevant to their question.
+msgctxt "feedback form"
+msgid "Answered my question"
+msgstr ""
+
+#. Description text shown below the Fast option in the reasoning mode dropdown.
+msgctxt "Description for fast reasoning mode in Duck.ai"
+msgid "Answers right away"
+msgstr ""
+
+msgid "Antigua and Barbuda"
+msgstr ""
+
+#. Option for the filter-by-date search.
+msgid "Any Time"
+msgstr "Jederzeit"
+
+#. Placeholder text for the textarea where users can provide additional instructions for the AI assistant. Example: 'Any additional instructions you want Duck.ai to follow. e.g. Always tell me facts about ducks'
+msgctxt "Placeholder for additional instructions textarea"
+msgid ""
+"Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
+"facts about ducks"
+msgstr ""
+
+#. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
+msgctxt "video-duration"
+msgid "Any duration"
+msgstr ""
+
+#. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
+msgctxt "video-license"
+msgid "Any license"
+msgstr ""
+
+#. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
+msgctxt "video-resolution"
+msgid "Any resolution"
+msgstr ""
+
+msgid "Any time"
+msgstr ""
+
+msgid "Anywhere"
+msgstr "Überall"
+
+msgid "App"
+msgstr "App"
+
+msgid "App and Extension"
+msgstr "App und Erweiterung"
+
+#. Header above a list of settings that effect the appearance of the search engine.
+msgid "Appearance"
+msgstr "Auftritt"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Appearance"
+msgstr ""
+
+#. Sidebar navigation label for the Appearance section of the Duck.ai settings page, where users can adjust visual preferences such as theme.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Appearance"
+msgstr ""
+
+#. https://i.imgur.com/HWCiPDW.png
+msgctxt "settings"
+msgid "Appearance"
+msgstr "Aussehen"
+
+#. Button that applies a filter to search results.
+msgctxt "Custom date range filer"
+msgid "Apply"
+msgstr ""
+
+#. Instant Answer Tab Name
+msgid "Apps"
+msgstr "Apps"
+
+#. The name of the Arabic language
+msgctxt "language_name"
+msgid "Arabic"
+msgstr ""
+
+#. Question on a feedback form.
+msgctxt "feedback form"
+msgid "Are these ads helpful?"
+msgstr "Sind diese Werbungen hilfreich?"
+
+#. Question on a feedback form.
+msgctxt "feedback form"
+msgid "Are these links helpful?"
+msgstr "Sind diese Links hilfreich?"
+
+#. Message shown when the user has been inactive/idle for a while during voice chat, and show this message to indicate they have not been active in the chat for a while.
+msgctxt "voice chat"
+msgid "Are you still there?"
+msgstr ""
+
+#. Text asking the user to confirm if they want to clear all chats, with a warning that this action cannot be undone.
+msgctxt "Body text for clear all chats confirmation modal"
+msgid ""
+"Are you sure you want to clear all of your chats? This cannot be undone."
+msgstr ""
+
+#. Body text of the modal that asks the user if they want to clear the conversation.
+msgctxt "Modal body for clearing conversation"
+msgid "Are you sure you want to clear this conversation and start a new one?"
+msgstr ""
+
+#. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
+msgctxt "Body text for delete chat confirmation modal"
+msgid "Are you sure you want to delete this chat? This cannot be undone."
+msgstr ""
+
+#. Text asking the user to confirm if they want to disable chat history, with a warning that it will also delete currently saved chats including pinned chats.
+msgctxt "Body text for disable chat history confirmation modal"
+msgid ""
+"Are you sure you want to disable history? This will delete all chats, "
+"including pinned chats."
+msgstr ""
+
+#. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
+msgctxt "Body text for disable recent chats confirmation modal"
+msgid ""
+"Are you sure you want to disable recent chats? This will also delete any "
+"recent chats that are currently saved."
+msgstr ""
+
+#. Question asking user if they want to share the URL of the page they were on when giving feedback
+msgctxt "feedback form"
+msgid "Are you willing to share the page URL?"
+msgstr ""
+
+msgid "Argentina"
+msgstr "Argentinien"
+
+msgid "Armenia"
+msgstr ""
+
+#. The name of the Armenian language
+msgctxt "language_name"
+msgid "Armenian"
+msgstr ""
+
+msgid "Aruba"
+msgstr ""
+
+#. Indicates when the data was last updated e.g. 'As of 12:37 PM EST'
+msgctxt "Stocks module"
+msgid "As of"
+msgstr ""
+
+#. Summarizes our privacy policy and describes how the DuckDuckGo extension's privacy features don't send any information to DuckDuckGo.
+msgid ""
+"As per our privacy policy, we do not collect or share any personal "
+"information ourselves. All of this privacy protection happens on your device."
+msgstr ""
+"Gemäss unserer Datenschutzrichtlinie sammeln oder teilen wir keine "
+"personenbezogenen Daten. All dieser Datenschutz geschieht auf deinem Gerät."
+
+#. A button to ask Duck.ai a question
+msgid "Ask"
+msgstr ""
+
+#. Text on the send button when shown next to an inline terms-of-service disclaimer (instead of the arrow icon). Clicking it both accepts the terms and sends the message.
+msgctxt "Send user prompt button label (text variant)"
+msgid "Ask"
+msgstr ""
+
+#. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
+msgctxt "Placeholder text user’s chat input"
+msgid "Ask %s"
+msgstr ""
+
+#. Short version of the placeholder text used in chat input for user’s messages.
+msgctxt "Placeholder text user’s chat input"
+msgid "Ask AI"
+msgstr ""
+
+#. Label for a button that opens a DuckDuckGo AI chat session
+msgid "Ask AI Chat"
+msgstr ""
+
+#. A placeholder for the AI Chat prompt input
+msgid "Ask AI Chat anything"
+msgstr ""
+
+#. Will be used as tooltip for a navigation tab that takes the user to an AI Chat bot feature similar to ChatGPT.
+msgctxt "Tooltip text in duckbar tab"
+msgid "Ask AI privately"
+msgstr ""
+
+#. Label for autocomplete option to use Duck.ai
+msgctxt "Search form"
+msgid "Ask Duck.ai"
+msgstr ""
+
+#. A placeholder for the Duck.ai prompt input
+msgid "Ask Duck.ai anything"
+msgstr ""
+
+#. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
+msgid "Ask a follow-up question"
+msgstr ""
+
+#. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
+msgid "Ask a follow-up with Duck.ai"
+msgstr ""
+
+#. Page-suggestion chip label. Tapping it attaches the current web page so the user can ask the AI about it.
+msgctxt "Page suggestion chip label"
+msgid "Ask about this page"
+msgstr ""
+
+#. Title for the modal displayed to first-time sidebar users explaining the page context feature.
+msgctxt "Title for the page context onboarding modal"
+msgid "Ask about this page"
+msgstr ""
+
+#. Placeholder text used in chat input for user’s messages when the chat is empty.
+msgctxt "Placeholder text user’s chat input"
+msgid "Ask anything privately"
+msgstr ""
+
+#. Label indicating the option to ask clarifying questions. Once this is selected, the AI assistant will be prompted to ask more questions.
+msgctxt "Label for the switch to ask clarifying questions"
+msgid "Ask clarifying questions"
+msgstr ""
+
+#. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text used in chat input for user’s messages.
+msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask privately"
+msgstr ""
+
+#. The name of the Assamese language
+msgctxt "language_name"
+msgid "Assamese"
+msgstr ""
+
+#. Tab label for the duckassist instant answer (based on generative AI)
+msgid "Assist"
+msgstr ""
+
+msgctxt "settings"
+msgid "Assist"
+msgstr ""
+
+#. An accessibility label for the assist settings button (accessed via the title of the Assist module in the header).
+msgctxt "duckassist"
+msgid "Assist Settings"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Assist can anonymously generate AI-assisted answers to some searches based "
+"on summarizing relevant web content. You can choose how often you want "
+"Assist to appear: Never (completely removes Assist UI from search results), "
+"On-demand (only shows AI-assisted answers if you click the Assist button), "
+"Sometimes (only shows AI-assisted answers when highly relevant), or Often "
+"(shows more frequently on a wider range of searches). For now, AI-assisted "
+"answers are only available in the U.S. (English) region."
+msgstr ""
+
+#. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
+msgid ""
+"Assist is an optional feature in our search results that can anonymously "
+"generate AI-assisted answers to search queries. To do this, it scans the web "
+"for relevant content and then uses AI-powered natural language technology to "
+"generate a brief answer based on relevant information found. It’s important "
+"to remember that responses are auto-generated from cited sources and based "
+"on %scrawling the web%s."
+msgstr ""
+
+#. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
+msgctxt "Dropdown title for selecting assistant role"
+msgid "Assistant role"
+msgstr ""
+
+msgctxt "homepage ATB modal"
+msgid "At DuckDuckGo, we agree."
+msgstr "Bei DuckDuckGo stimmen wir zu."
+
+#. Disclaimer for when we do not have up to date Market Capitalization value
+msgctxt "Stocks module"
+msgid "At Prev Close"
+msgstr ""
+
+#. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. Explains that the VPN encrypts the internet connection and hides the IP address on public Wi-Fi networks.
+msgctxt "DuckDuckGo VPN instant answer"
+msgid ""
+"At the café, airport, or hotel, DuckDuckGo VPN encrypts your connection and "
+"hides your IP address on Wi-Fi."
+msgstr ""
+
+#. In the context of the National Hockey League (NHL), label for teams belonging to the Atlantic division
+msgctxt "Sports module"
+msgid "Atlantic"
+msgstr ""
+
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Attach"
+msgstr ""
+
+#. Accessible text of a button that adds an image to the current AI chat message being composed.
+msgctxt "Add an image to be uploaded to the AI chat conversation"
+msgid "Attach Image"
+msgstr ""
+
+#. Tooltip for the upload button when only PDF file upload is supported in the Duck.ai chat.
+msgctxt "Attach PDF files to the Duck.ai chat conversation"
+msgid "Attach PDF files"
+msgstr ""
+
+#. Accessible text of a button that toggles attaching page context to the current AI chat message being composed.
+msgctxt "Add page context from the current tab to the AI chat message"
+msgid "Attach Page Content"
+msgstr ""
+
+#. Accessible text of a button that adds an image to the current AI chat message being composed.
+msgctxt "Add an image to be uploaded to the AI chat conversation"
+msgid "Attach image"
+msgstr ""
+
+#. Accessible text of a button that toggles attaching page context to the current AI chat message being composed.
+msgctxt "Add page context from the current tab to the AI chat message"
+msgid "Attach page context"
+msgstr ""
+
+#. Alternative text that is used for export purposes when a file has been uploaded alongside an AI chat conversation. Placeholder is for the file name. E.g. 'Attached file notes.pdf'
+msgctxt "Alternative text for files added to chat conversations for users"
+msgid "Attached file %s"
+msgstr ""
+
+#. Alternative text that is used both for accessibility and export purposes when an image has been uploaded alongside an AI chat conversation. Placeholder is for the image number. E.g. 'Attached image 1'
+msgctxt "Alternative text for imges added to chat conversations for users"
+msgid "Attached image %s"
+msgstr ""
+
+msgid "Audio"
+msgstr "Audio"
+
+#. Description for the data retention highlight in the dictation consent modal.
+msgid "Audio is not stored by us or by OpenAI after the chat ends."
+msgstr ""
+
+#. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
+msgctxt "voice chat"
+msgid "Audio is not stored by us or by OpenAI after the chat ends."
+msgstr ""
+
+#. Description for the data retention highlight in the dictation consent modal.
+msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
+msgstr ""
+
+#. Error in the duck.ai chat input when MediaRecorder API is unavailable.
+msgid "Audio recording is not supported in this browser."
+msgstr ""
+
+msgid "Australia"
+msgstr "Australien"
+
+msgid "Austria"
+msgstr "Österreich"
+
+#. Label that's displayed next to an author below a web search result.
+msgctxt "Rich Facts label"
+msgid "Author"
+msgstr ""
+
+#. Option in the reasoning mode dropdown that lets the AI model decide when to use reasoning.
+msgctxt "Label for auto reasoning mode in Duck.ai"
+msgid "Auto"
+msgstr ""
+
+#. http://i.imgur.com/DIzKQRl.png
+msgctxt "settings"
+msgid "Auto-Suggest"
+msgstr "Suchvorschläge"
+
+msgctxt "settings"
+msgid "Auto-answer"
+msgstr ""
+
+#. Disclaimer for the duckassist instant answer (based on generative AI)
+msgid "Auto-generated based on listed sources. May contain inaccuracies."
+msgstr ""
+
+#. Disclaimer for the duckassist instant answer (based on generative AI)
+msgid ""
+"Auto-generated based on listed sources. Responses may contain inaccuracies."
+msgstr ""
+
+#. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
+msgid "Auto-generated from sources. May be inaccurate."
+msgstr ""
+
+msgctxt "settings"
+msgid "Autocomplete Suggestions"
+msgstr ""
+
+#. http://i.imgur.com/OZIO1I9.png
+msgctxt "settings"
+msgid "Automatically open relevant Instant Answers"
+msgstr "Automatische Öffnung relevanter Sofort-Antworten"
+
+msgctxt "settings"
+msgid ""
+"Automatically shows Assist for relevant searches. Assist can anonymously "
+"look up and summarize information in response to some searches. For now, "
+"Assist is only available in English regions."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Automatically shows DuckAssist for relevant searches. DuckAssist can "
+"anonymously look up and summarize information in response to some searches. "
+"For now, DuckAssist is only available in English regions."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Autoplay short, silent video previews when you hover over video results."
+msgstr ""
+
+#. Title for the menu listing free/degraded models available after the advanced-model usage limit has been reached.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Available Free Models"
+msgstr ""
+
+#. Screen-reader label for the radiogroup of tool options inside the Tools dropdown. Announced when assistive technology enters the group of menuitemradio items.
+msgctxt ""
+"Accessibility label for the group of selectable tool options (Create Image, "
+"Web Search) in the Tools dropdown menu in Duck.ai"
+msgid "Available chat tools"
+msgstr ""
+
+#. Used to show the numerical rating, when the user hovers over a visual star-rating. Sorry, this is hard to translate.
+msgctxt "homepage ATB social proof"
+msgid "Average rating: %s out of 5"
+msgstr "Durchschnittliche Bewertung: %s von 5"
+
+#. The average volume traded for a particular stock
+msgctxt "Stocks module"
+msgid "Avg Vol"
+msgstr ""
+
+#. Warning text shown below the chat input when the user has attached files, advising them not to upload files from untrusted sources.
+msgctxt "Disclaimer below chat input in Duck.ai when files are attached"
+msgid "Avoid uploading files from sources you don't trust."
+msgstr ""
+
+#. Indicates the Win-Loss record of a team when playing away
+msgctxt "Sports module"
+msgid "Away Record"
+msgstr ""
+
+msgid "Azerbaijan"
+msgstr ""
+
+#. The name of the Azerbaijani language
+msgctxt "language_name"
+msgid "Azerbaijani"
+msgstr ""
+
+#. Cricket scorecard: balls faced abbreviation
+msgctxt "Sports module"
+msgid "B"
+msgstr ""
+
+#. Abbreviate billions in a number. E.g. 1,000,000,000 becomes 1B
+msgctxt "Stocks module"
+msgid "B"
+msgstr ""
+
+#. Short name for the Belarus Olympic Comittee
+msgid "BOC"
+msgstr ""
+
+#. Rugby standings column: bonus points abbreviation
+msgctxt "Sports module"
+msgid "BP"
+msgstr ""
+
+#. A call to action to go back to a previous step typically used in forms
+msgid "Back"
+msgstr ""
+
+#. Button label to return to Duck.ai.
+msgctxt "duckai_migration"
+msgid "Back to Duck.ai"
+msgstr ""
+
+#. Mobile-only. Renders below the Paste button with a back-arrow icon. Switches consumeMode from paste back to scan in SyncAnotherDevicePane.
+msgctxt ""
+"Secondary CTA on the Enter Code body that returns the user to the camera "
+"scanner"
+msgid "Back to Scan"
+msgstr ""
+
+#. Button that takes the user to the DuckDuckGo search page.
+msgctxt "homepage onboarding"
+msgid "Back to search"
+msgstr "Zurück zur Suche"
+
+#. http://i.imgur.com/6Eip5h1.png
+msgctxt "settings"
+msgid "Background Color"
+msgstr "Hintergrundfarbe"
+
+#. https://duckduckgo.com/params under "Color Settings"
+msgid "Background:"
+msgstr "Hintergrund"
+
+msgid "Bahamas"
+msgstr ""
+
+msgid "Bahrain"
+msgstr ""
+
+#. Cricket scorecard: balls faced full name (tooltip)
+msgctxt "Sports module"
+msgid "Balls Faced"
+msgstr ""
+
+#. The name of the Bangla language
+msgctxt "language_name"
+msgid "Bangla"
+msgstr ""
+
+msgid "Bangladesh"
+msgstr ""
+
+#. This text always refers to the DuckDuckGo bangs function: https://duckduckgo.com/bang
+msgid "Bangs"
+msgstr "Bangs"
+
+msgid "Barbados"
+msgstr ""
+
+#. Instant Answer tab name
+msgid "Barcode"
+msgstr "Strichcode"
+
+#. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Based on this page, is this course worth taking?"
+msgstr ""
+
+msgctxt "settings"
+msgid "Basic"
+msgstr "einfach"
+
+msgctxt "theme"
+msgid "Basic"
+msgstr "Basic"
+
+#. Text displayed on the models list as a title for the basic AI (Artificial Intelligence) models section.
+msgctxt "Label for the basic AI models"
+msgid "Basic Models"
+msgstr ""
+
+#. The name of the Basque language
+msgctxt "language_name"
+msgid "Basque"
+msgstr ""
+
+#. Accessibility label for the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
+msgctxt "Aria label for the batch actions toolbar"
+msgid "Batch actions toolbar"
+msgstr ""
+
+#. Cricket scorecard batting column header
+msgctxt "Sports module"
+msgid "Batter"
+msgstr ""
+
+#. Placeholder text displayed while the assistant waits for the user to choose an action.
+msgctxt "Assistant response placeholder"
+msgid "Before continuing..."
+msgstr ""
+
+#. Explains that before storing the report, DuckDuckGo will anonymize the conversation by removing PII like names, email addresses, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"Before storing this report, DuckDuckGo will anonymize your conversation by "
+"removing PII like names, email addresses, and identifying metadata."
+msgstr ""
+
+#. Label that's displayed next to a past start date below a web search result.
+msgctxt "Rich Facts label"
+msgid "Began"
+msgstr ""
+
+#. Label that's displayed next to a start date below a web search result.
+msgctxt "Rich Facts label"
+msgid "Begins"
+msgstr ""
+
+msgid "Belgium"
+msgstr ""
+
+msgid "Belgium (fr)"
+msgstr "Belgien (F)"
+
+msgid "Belgium (nl)"
+msgstr "Belgien (nl)"
+
+msgid "Belize "
+msgstr ""
+
+#. This is an option for a user setting. It refers to showing the URL for a result BELOW the SNIPPET (description) of the result -- Example image: https://i.imgur.com/lnP77q4.png
+msgctxt "settingsvalue"
+msgid "Below Snippet"
+msgstr ""
+
+#. This is an option for a user setting. It refers to showing the URL for a result BELOW the TITLE of the result -- Example image: https://i.imgur.com/3cb6xx0.png
+msgctxt "settingsvalue"
+msgid "Below Title"
+msgstr ""
+
+msgid "Benin"
+msgstr ""
+
+msgid "Bermuda"
+msgstr ""
+
+#. Label for the best answer badge in the rich caption upvote carousel.
+msgctxt "Rich caption upvote carousel, best answer badge"
+msgid "Best answer"
+msgstr ""
+
+msgctxt "settingsvalue"
+msgid "Best available"
+msgstr ""
+
+#. One-line description rendered beneath the default model in the Recommended group.
+msgctxt ""
+"Short descriptor under the everyday-use recommended model in the model "
+"picker dropdown"
+msgid "Best for everyday use"
+msgstr ""
+
+#. In the right menu panel of the homepage.
+msgid "Beta"
+msgstr "Beta"
+
+#. Filters the duration of videos in search results.
+msgctxt "video-duration"
+msgid "Between 4 and 20 minutes"
+msgstr "Zwischen 4 und 20 Minuten"
+
+msgid "Bhutan"
+msgstr ""
+
+#. The color black.
+msgid "Black"
+msgstr "Schwarz"
+
+#. Filters the color of images in search results.
+msgctxt "color"
+msgid "Black"
+msgstr "Schwarz"
+
+#. Filters the color of images in search results.
+msgctxt "image-color"
+msgid "Black and white"
+msgstr ""
+
+#. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
+msgctxt "Weather IA"
+msgid "Blizzard"
+msgstr ""
+
+msgid "Block Trackers"
+msgstr "Tracker blockieren"
+
+#. Item in a list of features of a desktop web browser
+msgctxt "Browser Promo Popover"
+msgid "Block annoying cookie pop-ups"
+msgstr ""
+
+#. DuckDuckGo Email Protection offers the ability to generate random email addresses to protect your personal email address
+msgctxt "SERP footer content"
+msgid "Block email trackers and hide your address."
+msgstr ""
+
+#. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
+msgctxt "DuckDuckGo VPN instant answer"
+msgid ""
+"Block harmful sites, hide your IP address, plus get more premium protections "
+"with our subscription."
+msgstr ""
+
+#. A disclaimer about AI-generated images in search results
+msgid "Block list is not exhaustive and may contain inaccuracies."
+msgstr ""
+
+msgctxt "homepage ATB modal"
+msgid "Block most trackers as you browse."
+msgstr ""
+
+#. Menu option to block a site from the displayed results
+msgctxt "Organic result context menu"
+msgid "Block this site from all results"
+msgstr ""
+
+msgctxt "homepage ATB modal"
+msgid "Block trackers and take control of your personal data"
+msgstr ""
+
+msgctxt "homepage ATB modal"
+msgid "Block trackers as you browse."
+msgstr ""
+
+#. Part of a list of what our app can do. The app can: …
+msgctxt "welcome message eu search preference android"
+msgid "Block unsafe trackers"
+msgstr "Blockiere unsichere tracker"
+
+msgctxt "settings"
+msgid "Blocked Sites"
+msgstr ""
+
+#. Used as a toggle label in a page customization menu
+msgctxt "customizer_menu"
+msgid "Blocked Tracking Attempts"
+msgstr ""
+
+#. Header above a list of trackers (or tracking companies) that have been blocked in the past 24 hours.
+msgctxt "tracker_stats"
+msgid "Blocked by DuckDuckGo in the last 24 hours"
+msgstr ""
+
+#. Header above a list of trackers (or tracking companies) that have been blocked in the past hour.
+msgctxt "tracker_stats"
+msgid "Blocked by DuckDuckGo in the last hour"
+msgstr ""
+
+#. Title for filter to hide or include blocked results in search results
+msgctxt "Vertical results"
+msgid "Blocked results"
+msgstr ""
+
+#. Title for filter to hide or include blocked results in search results
+msgctxt "Vertical results"
+msgid "Blocked results:"
+msgstr ""
+
+#. Given as an option to select when providing feedback
+msgid "Blocked tracking attempts information"
+msgstr ""
+
+#. Shortened title for filter to hide or include blocked results in search results
+msgctxt "Vertical results"
+msgid "Blocked:"
+msgstr ""
+
+#. shown after the DuckDuckGo extension is installed
+msgctxt "welcome message"
+msgid "Blocks trackers on websites you visit"
+msgstr "Blockiert Tracker auf Webseiten, die du besuchst"
+
+msgid "Blog"
+msgstr "Blog"
+
+#. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
+msgctxt "Weather IA"
+msgid "Blowing Dust"
+msgstr ""
+
+#. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
+msgctxt "Weather IA"
+msgid "Blowing Snow"
+msgstr ""
+
+#. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
+msgctxt "Weather IA"
+msgid "Blowing dust"
+msgstr ""
+
+#. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
+msgctxt "Weather IA"
+msgid "Blowing snow"
+msgstr ""
+
+#. The color blue
+msgid "Blue"
+msgstr "Blau"
+
+#. Filters the color of images in search results.
+msgctxt "color"
+msgid "Blue"
+msgstr "Blau"
+
+msgid "Bolivia"
+msgstr ""
+
+#. Rugby standings column: bonus points full name
+msgctxt "Sports module"
+msgid "Bonus Points"
+msgstr ""
+
+#. Label for the URL that saves user's settings.
+#. Click "Show Bookmarklet and Settings Data" - http://i.imgur.com/WyGptiV.png
+#. In the box that opens - http://i.imgur.com/tZAkHF6.png
+msgctxt "settings"
+msgid "Bookmarklet URL:"
+msgstr "Lesezeichen URL:"
+
+#. Label that's displayed next to a date of birth below a web search result.
+msgctxt "Rich Facts label"
+msgid "Born"
+msgstr ""
+
+msgid "Bosnia and Herzegovina"
+msgstr ""
+
+#. The name of the Bosnian language
+msgctxt "language_name"
+msgid "Bosnian"
+msgstr ""
+
+msgid "Botswana"
+msgstr ""
+
+#. Cricket scorecard bowling column header
+msgctxt "Sports module"
+msgid "Bowler"
+msgstr ""
+
+#. In American College Football (NCAA), button label for selecting to show all the Bowls games of the posteason (e.g. Peach Bowl, Bahamas Bowl, etc).
+msgctxt "Sports module"
+msgid "Bowls"
+msgstr ""
+
+#. Title of a tab that displays the bracket for a sports league
+msgctxt "Sports module"
+msgid "Bracket"
+msgstr ""
+
+#. Label for the option prompting the AI assistant to adopt a role of a brainstorm partner in its responses.
+msgctxt "Assistant role option label for Brainstorm partner"
+msgid "Brainstorm partner"
+msgstr ""
+
+msgid "Brazil"
+msgstr "Brasilien"
+
+#. Tennis match stats
+msgctxt "Sports module"
+msgid "Break Points Won"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Walk me through the steps" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Break this down into clear, numbered steps."
+msgstr ""
+
+#. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
+msgctxt "Weather IA"
+msgid "Breezy"
+msgstr ""
+
+msgid "British Virgin Islands"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Broken formatting"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Broken link"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Broken link to Yelp"
+msgstr ""
+
+#. Header on a column that displays the bronze medal count for the country in the Olympics
+msgid "Bronze Medals"
+msgstr ""
+
+msgctxt ""
+"Header on a column that displays the bronze medal count for the country in "
+"the Olympics"
+msgid "Bronze Medals"
+msgstr ""
+
+#. Filters the color of images in search results.
+msgctxt "color"
+msgid "Brown"
+msgstr "Braun"
+
+#. Button label to browse files for upload.
+msgctxt "duckai_migration"
+msgid "Browse Files"
+msgstr ""
+
+msgid ""
+"Browse as usual while we add privacy protection. We bundled our search "
+"engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
+msgstr ""
+"Browse ganz normal weiter, während wir Privatsphäre hinzufügen. Wir haben "
+"unsere Suchmaschine,Trackerblocker und Verschlüsselungserzwinger in eine "
+"einzelne %s%s Erweiterung%s kombiniert."
+
+msgid ""
+"Browse as usual, and we'll take care of the rest. We bundled our search "
+"engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
+msgstr ""
+"Browse ganz normal weiter, wir kümmern uns um den Rest. Wir haben unsere "
+"Suchmaschine,Trackerblocker und Verschlüsselungserzwinger in eine einzelne "
+"%s%s Erweiterung%s kombiniert."
+
+msgid ""
+"Browse as usual, and we’ll take care of the rest. Get bundled private "
+"search, tracker blocking, and site encryption, all in one download, for "
+"%smajor browsers%s."
+msgstr ""
+"Browse ganz normal weiter, wir kümmern uns um den Rest. Bekomme kombinierte "
+"private Suche,Tracker blockierung und Webseitenverschlüsselung - alles in "
+"einem Download für alle%sgängigen Browser%s."
+
+#. Header for a call to action to browse with the DuckDuckGo browser
+msgctxt "Browser Promo Popover"
+msgid "Browse with DuckDuckGo!"
+msgstr ""
+
+#. Sidebar heading displayed above links to DuckDuckGo apps (our 'browser') on platforms such as iOS, Android, Windows, MacOS, and more.
+msgid "Browser Downloads"
+msgstr ""
+
+#. Refers to DuckDuckGo's web extension available on browsers like Chrome, Firefox, etc.
+msgid "Browser Extensions"
+msgstr ""
+
+#. Message indicating that the user's current location isn't available.
+msgctxt "precise_user_location"
+msgid "Browser Location Unavailable"
+msgstr ""
+
+#. Label for a menu that lets users select the language for their browser.
+msgctxt "settingsvalue"
+msgid "Browser Preferred Language"
+msgstr "Voreingestellte Sprache des Browsers"
+
+msgctxt "settings"
+msgid "Browser Promo Dismissed"
+msgstr ""
+
+#. Title shown when user's DDG app is too old to support migration.
+msgctxt "duckai_migration"
+msgid "Browser Update Required"
+msgstr ""
+
+#. Label for a menu that lets users select the language for their browser.
+msgctxt "settingsvalue"
+msgid "Browser preferred language"
+msgstr ""
+
+msgid "Brunei "
+msgstr ""
+
+#. Text that indicates which source an AI Model was built with, such as 'Built with Meta Llama 3'. Note that 'built' is used in the context of software, not of e.g. construction.
+msgctxt "Label copy indicating the source of an AI Model"
+msgid "Built with %s"
+msgstr ""
+
+msgid "Bulgaria"
+msgstr "Bulgarien"
+
+#. The name of the Bulgarian language
+msgctxt "language_name"
+msgid "Bulgarian"
+msgstr ""
+
+msgid "Burkina Faso"
+msgstr ""
+
+msgid "Burundi"
+msgstr ""
+
+#. The first %s is the action button label ('Continue'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab.
+msgctxt "Body copy of terms-of-service decision card on Duck.ai"
+msgid "By clicking '%s' you agree to our %s."
+msgstr ""
+
+#. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
+msgctxt ""
+"Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
+msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
+msgstr ""
+
+#. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
+msgctxt ""
+"Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
+msgid "By clicking “%s,” you accept Duck.ai’s %s."
+msgstr ""
+
+#. Describes how cookies are used to store user settings privately and securely.
+#. Click "Show Bookmarklet and Settings Data" - http://i.imgur.com/NKOWrRl.png
+#. Then - http://i.imgur.com/mo6wsE4.png
+msgctxt "settings"
+msgid ""
+"By default, settings are stored in non-personal browser cookies (in your "
+"browser). You can use anonymous Cloud Save to store your settings in a more "
+"permanent way (on a remote server in the cloud). No personally identifiable "
+"information will be stored in the cloud, and your passphrase will never "
+"leave your browser."
+msgstr ""
+
+#. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
+msgid ""
+"By enabling dictation, you consent to your voice data being sent to OpenAI "
+"for the use of this feature. See our %s before getting started."
+msgstr ""
+
+#. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
+msgctxt "voice chat"
+msgid ""
+"By enabling voice chat, you consent to your voice data being sent to OpenAI "
+"for the use of this feature. See our %s before getting started."
+msgstr ""
+
+#. Golf leaderboard: player missed the cut
+msgctxt "Sports module"
+msgid "CUT"
+msgstr ""
+
+msgid "Cabo Verde"
+msgstr ""
+
+#. Instant Answer tab name
+msgid "Calendar"
+msgstr "Kalender"
+
+#. Button that calls a listed phone number using the phone app.
+msgctxt "maps_places"
+msgid "Call"
+msgstr "Anrufen"
+
+msgid "Cambodia"
+msgstr ""
+
+msgid "Cameroon"
+msgstr ""
+
+#. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
+msgctxt "Full sentence for crafting a recipe"
+msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
+msgstr ""
+
+msgid "Canada"
+msgstr "Kanada"
+
+msgid "Canada (en)"
+msgstr ""
+
+msgid "Canada (fr)"
+msgstr "Kanada (F)"
+
+msgid "Cancel"
+msgstr "Abbrechen"
+
+#. Button label to decline delegating image generation.
+msgctxt "DuckChat image generation delegation prompt"
+msgid "Cancel"
+msgstr ""
+
+#. A cancel button that can appear in multiple product areas
+msgctxt "Generic cancel button"
+msgid "Cancel"
+msgstr ""
+
+#. Text of the secondary button in the modal that cancels the action of clearing the conversation.
+msgctxt "Modal secondary button for clearing conversation"
+msgid "Cancel"
+msgstr ""
+
+#. Text displayed on the secondary button in the modal that cancels the action when clicked.
+msgctxt "Modal secondary button text"
+msgid "Cancel"
+msgstr ""
+
+#. Closes the recover sheet and returns the user to the Sync & Backup intro screen.
+msgctxt "Secondary CTA on the recover-data intro sheet"
+msgid "Cancel"
+msgstr ""
+
+#. Returns the user to Manage Devices without making changes.
+msgctxt "Secondary action that dismisses the Delete Server Data modal"
+msgid "Cancel"
+msgstr ""
+
+#. Returns the user to Manage Devices without making changes.
+msgctxt "Secondary action that dismisses the Remove Device modal"
+msgid "Cancel"
+msgstr ""
+
+#. Returns the user to Manage Sync & Backup without changes.
+msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
+msgid "Cancel"
+msgstr ""
+
+#. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
+msgctxt "Site filter message"
+msgid "Cancel"
+msgstr ""
+
+#. A button to cancel the assist settings modal.
+msgctxt "duckassist"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "precise_user_location"
+msgid "Cancel"
+msgstr "Abbrechen"
+
+#. Tooltip and accessible label for the cancel button during dictation recording.
+msgid "Cancel dictation"
+msgstr ""
+
+#. Indicator that a game has been cancelled
+msgctxt "Sports module"
+msgid "Cancelled"
+msgstr ""
+
+#. Label on a link about all the candidates in the current election
+msgctxt "Elections IA"
+msgid "Candidates"
+msgstr ""
+
+#. Informational notice that the candidates shown in the elections module are in a random order
+msgctxt "Elections IA"
+msgid "Candidates listed in randomized order"
+msgstr ""
+
+#. Header that appears when a site is blocked unsuccessfully
+msgctxt "Organic result context menu"
+msgid "Cannot Block Site"
+msgstr ""
+
+#. The name of the Cantonese (Traditional) language
+msgctxt "language_name"
+msgid "Cantonese (Traditional)"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Can’t change settings"
+msgstr ""
+
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Can’t find what you’re looking for?"
+msgstr ""
+
+msgid "Cape Verde"
+msgstr ""
+
+#. NASCAR results table column: car number
+msgctxt "Sports module"
+msgid "Car"
+msgstr ""
+
+#. A category of ads
+msgctxt "Feedback prompt"
+msgid "Car Advertisements"
+msgstr ""
+
+#. Category of feedback for a car advertisement a user can select on a feedback form.
+msgctxt "feedback form for car ads"
+msgid "Car ad content is deceptive"
+msgstr ""
+
+#. A category of ads
+msgctxt "Feedback prompt"
+msgid "Car ads"
+msgstr ""
+
+#. Category of feedback for a car advertisement a user can select on a feedback form.
+msgctxt "feedback form for car ads"
+msgid "Car ads aren't relevant"
+msgstr ""
+
+#. Category of feedback for a car advertisement a user can select on a feedback form. Here we mean the location for the car ad, i.e. buy car in New York while the user is in London.
+msgctxt "feedback form for car ads"
+msgid "Car location is wrong"
+msgstr ""
+
+#. Category of feedback for a car advertisement a user can select on a feedback form.
+msgctxt "feedback form for car ads"
+msgid "Car pricing is misleading"
+msgstr ""
+
+#. Invite the user to leave more feedback
+msgctxt "feedback form"
+msgid "Care to tell us more?"
+msgstr ""
+
+#. Label for the option prompting the AI assistant to adopt a role of a career coach in its responses.
+msgctxt "Assistant role option label for Career coach"
+msgid "Career coach"
+msgstr ""
+
+#. Label for the option prompting the AI assistant to adopt a role of a career counselor in its responses.
+msgctxt "Assistant role option label for Career counselor"
+msgid "Career counselor"
+msgstr ""
+
+#. Label for the option prompting the AI assistant to adopt a role of a career strategist in its responses.
+msgctxt "Assistant role option label for Career strategist"
+msgid "Career strategist"
+msgstr ""
+
+msgid "Careers"
+msgstr "Stellenangebote"
+
+#. Text of a button that performs a search for the cast of a particular movie or tv show
+msgctxt "Movie/TV Show Title instant answer"
+msgid "Cast"
+msgstr ""
+
+#. Page-suggestion chip label "Cast & Crew", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Cast & Crew"
+msgstr ""
+
+#. Label for the option prompting the AI assistant to use casual tone in its responses.
+msgctxt "Tone option label for Casual"
+msgid "Casual"
+msgstr ""
+
+#. The name of the Catalan language
+msgctxt "language_name"
+msgid "Catalan"
+msgstr ""
+
+msgid "Catalonia"
+msgstr "Katalonien"
+
+#. In 0-click box -- link to category page.
+msgid "Category"
+msgstr "Kategorie"
+
+#. Label that's displayed next to a category below a web search result.
+msgctxt "Rich Facts label"
+msgid "Category"
+msgstr ""
+
+msgid "Cayman Islands"
+msgstr ""
+
+#. http://i.imgur.com/445XWLs.png
+msgctxt "settings"
+msgid "Center Alignment"
+msgstr "Zentriert"
+
+#. In the context of the National Hockey League (NHL), label for teams belonging to the Central division
+msgctxt "Sports module"
+msgid "Central"
+msgstr ""
+
+msgid "Central African Republic"
+msgstr ""
+
+msgid "Chad"
+msgstr ""
+
+#. Button that allows the user to change location.
+msgctxt "precise_user_location"
+msgid "Change Location"
+msgstr ""
+
+#. Tooltip text for the button that allows the user to change the default AI model.
+msgctxt "Tooltip for model selection"
+msgid "Change default model"
+msgstr ""
+
+#. Tooltip text shown when hovering over the reasoning mode dropdown button.
+msgctxt "Tooltip for the reasoning mode button in Duck.ai"
+msgid "Change reasoning level"
+msgstr ""
+
+#. Tooltip for a button that takes the user to the settings page.
+msgctxt "Tooltip for settings page button"
+msgid "Change search settings"
+msgstr ""
+
+#. This is the description of a user setting -- Example image: https://i.imgur.com/yihFekW.png
+msgctxt "settings"
+msgid "Changes how result URLs are displayed"
+msgstr ""
+
+#. This is the description of a user setting
+msgctxt "settings"
+msgid "Changes how the header is displayed and its behavior as you scroll"
+msgstr ""
+
+#. http://i.imgur.com/mcZdcaF.png
+msgctxt "settings"
+msgid "Changes search results based on region"
+msgstr ""
+
+#. http://i.imgur.com/OntTi6e.png
+msgctxt "settings"
+msgid "Changes the background color across the entire site"
+msgstr ""
+
+#. This is the description of a user setting
+msgctxt "settings"
+msgid ""
+"Changes the background color of results on hover, modules, and dropdown menus"
+msgstr ""
+
+#. http://i.imgur.com/NdpkbY0.png
+msgctxt "settings"
+msgid "Changes the background color when hovering over a result"
+msgstr "Ändert die Hintergrundfarbe du mit der Maus über ein Resultat fliegst"
+
+#. Description of a setting managing the color of search result snippet text.
+msgctxt "settings"
+msgid "Changes the color of descriptive content shown for results"
+msgstr ""
+
+#. This is the description of a user setting
+msgctxt "settings"
+msgid "Changes the color of result URLs"
+msgstr ""
+
+#. This is the description of a user setting
+msgctxt "settings"
+msgid "Changes the color of result snippets"
+msgstr ""
+
+#. This is the description of a user setting
+msgctxt "settings"
+msgid "Changes the color of result titles"
+msgstr ""
+
+#. This is the description of a user setting
+msgctxt "settings"
+msgid "Changes the color of titles for results you've visited"
+msgstr ""
+
+#. http://i.imgur.com/kE1ZsM9.png
+msgctxt "settings"
+msgid "Changes the font across the entire site"
+msgstr "Ändert die Schriftart der gesamten Seite"
+
+#. This is the description of a user setting
+msgctxt "settings"
+msgid "Changes the font of result titles"
+msgstr ""
+
+#. http://i.imgur.com/ftpln8q.png
+msgctxt "settings"
+msgid "Changes the font size across the entire site"
+msgstr "Ändert die Schriftgrösse der gesammten Seite"
+
+#. http://i.imgur.com/4AG1u9Q.png
+#. Setting to change the color of the top of DuckDuckGo: http://i.imgur.com/A1Nh20m.png
+msgctxt "settings"
+msgid "Changes the header color across the entire site"
+msgstr "Ändert die Farbe der Kopfzeile für die ganze Seite"
+
+#. http://i.imgur.com/w4XN6Fj.png
+msgctxt "settings"
+msgid "Changes the language across the entire site"
+msgstr "Die Sprache für die gesamte Seite ändern"
+
+#. Description of a setting.
+msgctxt "settings"
+msgid "Changes the language for buttons and other display text."
+msgstr ""
+
+#. Description of a setting managing the UI language.
+msgctxt "settings"
+msgid "Changes the language for elements like buttons, settings, and labels"
+msgstr ""
+
+#. Description of a setting managing the search result region (country).
+msgctxt "settings"
+msgid "Changes the preferred region for search results"
+msgstr ""
+
+#. Description of a setting that changes the prefer region for search results. Region here is meant to mean Country.
+msgctxt "settings"
+msgid "Changes the preferred region for search results."
+msgstr ""
+
+#. http://i.imgur.com/auITACf.png
+msgctxt "settings"
+msgid "Changes what happens when you click on a video thumbnail"
+msgstr "Ändert das Verhalten beim Drücken auf eine Video-Vorschau"
+
+#. This is the description of a user setting -- Example image: https://i.imgur.com/ALGzzZr.png
+msgctxt "settings"
+msgid "Changes where result URLs are displayed"
+msgstr ""
+
+msgid "Chat"
+msgstr "Chat"
+
+#. Will be used as a tab label to switch to the AI Chat bot feature similar to ChatGPT. Translation should not include the word AI (Artificial Intelligence). It's ok to leave it in English if that's the expectation in your language.
+msgctxt "Name in duckbar tab"
+msgid "Chat"
+msgstr ""
+
+msgctxt "settings"
+msgid "Chat"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Chat (via our Duck.ai service) lets you have anonymous conversations with "
+"3rd-party AI chat models, which supports models from OpenAI, Anthropic, and "
+"more. Turning this setting off will hide Chat buttons and links on "
+"DuckDuckGo Search. However, you can still access Chat when this setting is "
+"off by visiting %shttps://duck.ai%s directly."
+msgstr ""
+
+#. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
+msgctxt "Label for chat history setting"
+msgid "Chat History"
+msgstr ""
+
+#. Text displayed next to the Active Privacy Protection icon in the sidebar
+msgctxt ""
+"Text displayed next to the Active Privacy Protection icon in the sidebar"
+msgid "Chat Protection"
+msgstr ""
+
+#. Label for a pill-shaped tab below the empty-state Duck.ai chat input. Clicking it reveals a list of suggested text prompts the user can send.
+msgctxt "Pill label opening the chat-prompt suggestions panel"
+msgid "Chat Suggestions"
+msgstr ""
+
+#. Option for feedback when the user wants to complain that the chat does not save the user's conversations.
+msgctxt "Feedback option for chat not saving conversations"
+msgid "Chat does not save my conversations"
+msgstr ""
+
+#. Status label shown as a warning when the voice chat session is about to end.
+msgctxt "voice chat"
+msgid "Chat ends soon"
+msgstr ""
+
+#. Option for feedback when the user finds the chat is lacking features.
+msgctxt "Feedback option for chat lacking features"
+msgid "Chat is lacking features"
+msgstr ""
+
+#. Option for feedback when the user finds the chat is slow.
+msgctxt "Feedback option for slow chat"
+msgid "Chat is slow"
+msgstr ""
+
+#. Short version of the placeholder text used in chat input for user’s messages.
+msgctxt "Placeholder text user’s chat input"
+msgid "Chat privately"
+msgstr ""
+
+#. Mobile variant of DUCKCHAT_BROWSER_UPSELL_PROMO_TEXT. Shorter version for the promotional card encouraging third-party browser users to download the DuckDuckGo browser.
+msgctxt "Promotional text (mobile)"
+msgid "Chat privately on any website with Duck.ai built into our free browser."
+msgstr ""
+
+#. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
+msgctxt "Promotional text"
+msgid ""
+"Chat privately on any website with the Duck.ai sidebar in our free browser."
+msgstr ""
+
+#. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
+msgctxt "Placeholder text user’s chat input"
+msgid "Chat privately with %s"
+msgstr ""
+
+#. Will be used as tooltip for a navigation tab that takes the user to an AI Chat bot feature similar to ChatGPT.
+msgctxt "Tooltip text in duckbar tab"
+msgid "Chat privately with AI"
+msgstr ""
+
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
+#. Option for feedback when the chat response is below expectations.
+msgctxt "Feedback option for chat response below expectations"
+msgid "Chat response is below expectations"
+msgstr ""
+
+#. Option for feedback when the chat response is inaccurate.
+msgctxt "Feedback option for inaccurate chat response"
+msgid "Chat response is inaccurate"
+msgstr ""
+
+#. Option for feedback when the chat response is offensive.
+msgctxt "Feedback option for offensive chat response"
+msgid "Chat response is offensive"
+msgstr ""
+
+#. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
+msgctxt "Placeholder text user’s chat input"
+msgid "Chat with %s"
+msgstr ""
+
+#. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
+msgctxt "Button text for showing chat history"
+msgid "Chats"
+msgstr ""
+
+#. Sidebar navigation label for the Chats section of the Duck.ai settings page, where users can configure chat-related settings like recent chats.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Chats"
+msgstr ""
+
+#. Title for the chats section on the sidebar.
+msgctxt "Title for the chats section on the sidebar"
+msgid "Chats"
+msgstr ""
+
+#. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
+msgctxt "Description for Chat History feature"
+msgid ""
+"Chats are stored locally on your device instead of on DuckDuckGo servers or "
+"remote servers. Disabling chat history will delete pinned chats."
+msgstr ""
+
+#. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
+msgctxt "Description for Chat History feature"
+msgid ""
+"Chats are stored locally on your device. New prompts and responses are "
+"encrypted and temporarily stored on a DuckDuckGo server after being sent, to "
+"help recover a chat if you lose your internet connection. Disabling chat "
+"history will delete pinned chats, and disable the temporary storage of new "
+"prompts and responses."
+msgstr ""
+
+#. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
+msgctxt ""
+"Heading for recent chats warning when device storage (IndexedDB) is "
+"unavailable"
+msgid "Chats aren’t being saved"
+msgstr ""
+
+#. Title after successful download.
+msgctxt "duckai_migration"
+msgid "Chats downloaded securely"
+msgstr ""
+
+#. Description explaining that uploaded files are anonymously reviewed for CSAM by a content moderation provider, even on zero-provider-visibility models. First placeholder is the full model name (e.g. 'Gemma 4 31B'). Second placeholder is the acronym 'CSAM' (Child Sexual Abuse Material), injected as-is and NOT translated — it renders with a tooltip carrying the translated expansion. An example full sentence would be: Chats with Gemma 4 31B have zero provider visibility, but all files uploaded in Duck.ai are anonymously reviewed by a content moderation provider for CSAM.
+msgctxt "DuckChat upload consent prompt for encrypted models"
+msgid ""
+"Chats with %s have zero provider visibility, but all files uploaded in Duck."
+"ai are anonymously reviewed by a content moderation provider for %s."
+msgstr ""
+
+#. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
+msgctxt "Sync file storage inline disclaimer body"
+msgid ""
+"Chats with attachments have stopped syncing. Free up storage to resume Sync."
+msgstr ""
+
+#. Message shown when we have no data from upstream to display
+msgctxt "Single Place Hotel Offers Module"
+msgid "Check %s for rates and availability."
+msgstr ""
+
+#. Tells users where in the settings menu they can change their default search engine.
+msgid "Check %sMake this the current search engine%s"
+msgstr "Kreuze %sMache diese zur aktuellen Suchmaschine%s an"
+
+#. Displayed during an outage as a link to Reddit so folks can check on the status of the outage and get updates.
+msgctxt "noresults"
+msgid "Check Outage Status"
+msgstr ""
+
+#. Form label for selecting a check in date for a hotel stay.
+msgctxt "Single Place Hotel Offers Module"
+msgid "Check in"
+msgstr ""
+
+#. Form label for selecting a check out date for a hotel stay.
+msgctxt "Single Place Hotel Offers Module"
+msgid "Check out"
+msgstr ""
+
+#. A label above a list of other applications DuckDuckGo has made.
+msgctxt "showcase_aria_label"
+msgid "Check out the list of things that we've also made."
+msgstr "Schau dir die Liste der Dinge an, die wir auch gemacht haben."
+
+#. Message prompting users to check the spelling of their search term.
+msgctxt "directions"
+msgid "Check spelling"
+msgstr ""
+
+#. A prompt asking users to check the spelling of their query to get more results.
+msgctxt "noresults"
+msgid "Check spelling"
+msgstr ""
+
+#. Displayed during an outage indicating where users can find information about the outage and watch for updates
+msgctxt "noresults"
+msgid "Check the DuckDuckGo subreddit for updates on this outage."
+msgstr ""
+
+#. Displayed during an outage indicating where users can find information about the outage and watch for updates
+msgctxt "noresults"
+msgid "Check the status page for updates on this outage."
+msgstr ""
+
+#. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
+msgctxt "Title for the host-device success screen"
+msgid "Check your other device to finish."
+msgstr ""
+
+#. Body copy on the host device's success screen, prompting the user to check the other device to finish pairing.
+msgctxt "Description for the host-device success screen"
+msgid "Check your other device."
+msgstr ""
+
+#. Label for the option prompting the AI assistant to adopt a role of a chef in its responses.
+msgctxt "Assistant role option label for Chef"
+msgid "Chef"
+msgstr ""
+
+#. Tooltip shown on hover/focus of the acronym 'CSAM' in the upload consent prompt. This is the translated expansion of the 'CSAM' acronym.
+msgctxt "DuckChat upload consent prompt for encrypted models"
+msgid "Child Sexual Abuse Material"
+msgstr ""
+
+#. Option in a feedback form for image search results.
+msgctxt "Report image modal"
+msgid "Child sexual abuse"
+msgstr "Sexueller Kindesmissbrauch"
+
+msgid "Chile"
+msgstr "Chile"
+
+msgid "China"
+msgstr "China"
+
+#. The name of the Chinese Simplified language
+msgctxt "language_name"
+msgid "Chinese Simplified"
+msgstr ""
+
+msgid "Chinese Taipei"
+msgstr ""
+
+#. The name of the Chinese Traditional language
+msgctxt "language_name"
+msgid "Chinese Traditional"
+msgstr ""
+
+#. Text when onboarding users, describing that Duck.ai supports multiple AI models, and mentions 2 of the models available. Example: 'Choice of AI models, including GPT and Claude'
+msgctxt "Onboarding welcome screen feature"
+msgid "Choice of AI models, including %s and %s"
+msgstr ""
+
+#. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
+msgid "Choose %skeep it%s to continue protecting your privacy."
+msgstr ""
+
+#. A headline letting the user choose between two video player options
+msgid "Choose How You Watch"
+msgstr ""
+
+#. Opens a picker to re-run the second opinion against a manually chosen AI model.
+msgctxt "Button label in the second-opinion card"
+msgid "Choose Model"
+msgstr ""
+
+#. Screen-reader label for the dropdown menu opened by the model picker button in the chat input toolbar. Announced when the user navigates into the menu.
+msgctxt "Accessibility label for the model picker dropdown menu in Duck.ai"
+msgid "Choose a model"
+msgstr ""
+
+#. Label for the field where a user sets their passphrase.
+msgctxt "cloudsave"
+msgid "Choose a unique passphrase for your settings."
+msgstr ""
+
+#. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. '40+ server locations worldwide' are the VPN server locations the user can connect through; the VPN also helps block harmful sites and scams.
+msgctxt "DuckDuckGo VPN instant answer"
+msgid ""
+"Choose from 40+ server locations worldwide to help block harmful sites and "
+"scams."
+msgstr ""
+
+#. The title of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
+msgctxt "Third party map app picker"
+msgid "Choose how to get there"
+msgstr ""
+
+msgctxt "maps_places"
+msgid "Choose service"
+msgstr "Service auswählen"
+
+msgctxt "settings"
+msgid ""
+"Choose which app to use when you need directions for a location search result"
+msgstr ""
+
+#. Accessible label for the citations popover dialog in Duck.ai chat responses.
+msgctxt "Aria label for the citations dialog"
+msgid "Citations"
+msgstr ""
+
+#. Label indicating the option to ask clarifying questions is selected, the AI assistant will be prompted to ask more questions.
+msgctxt ""
+"Label for the sublabel on custom response menu item when asking clarifying "
+"questions"
+msgid "Clarifies"
+msgstr ""
+
+#. A theme name in the theme menu:
+#. https://duck.co/media/files/theme.png
+msgid "Classic"
+msgstr "Klassisch"
+
+#. This appears on a button that clears a user's input.
+msgid "Clear"
+msgstr "Löschen"
+
+#. Text for a button that clears and deletes a chat.
+msgctxt "Button text for clearing a chat"
+msgid "Clear"
+msgstr ""
+
+#. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
+msgctxt "Weather IA"
+msgid "Clear"
+msgstr ""
+
+#. User clicks this button to clear a saved device location
+msgctxt "precise_user_location"
+msgid "Clear"
+msgstr "Löschen"
+
+#. User clicks this button to clear a saved device location and disable precise user location
+msgctxt "precise_user_location"
+msgid "Clear & Disable"
+msgstr ""
+
+#. This appears on a button that clears all of a user's settings.
+msgid "Clear All"
+msgstr "Alles zurücksetzen"
+
+#. Text for a button that confirms the clearing of all chats.
+msgctxt "Primary button text in clear all chats modal"
+msgid "Clear All"
+msgstr ""
+
+#. Text for a button that clears and deletes a chat.
+msgctxt "Button text for clearing a chat"
+msgid "Clear Chat"
+msgstr ""
+
+#. Text of the primary button in the modal that clears the conversation.
+msgctxt "Modal primary button for clearing conversation"
+msgid "Clear Conversation"
+msgstr ""
+
+#. A button to clear the currently applied site filter.
+msgctxt "Site filter message"
+msgid "Clear Filter"
+msgstr ""
+
+#. A button that clears any filters that have been applied to search results.
+msgctxt "noresults"
+msgid "Clear Filters and Try Again"
+msgstr ""
+
+#. User clicks this button to clear a saved device location
+msgctxt "precise_user_location"
+msgid "Clear Location"
+msgstr "Standort zurücksetzen"
+
+#. Tooltip text for a button that clears all recent chat sessions.
+msgctxt "Tooltip text for the button that clears all recent chats"
+msgid "Clear all chats"
+msgstr ""
+
+#. Title of a modal that asks the user if they want to clear all chats.
+msgctxt "Modal header for clearing all chats confirmation"
+msgid "Clear all chats?"
+msgstr ""
+
+#. A button that clears are filters that have been applied to search results.
+msgid "Clear all filters"
+msgstr ""
+
+#. Text for a tooltip that appears when hovering over the clear chat button.
+msgctxt "Tooltip text for the clear chat button"
+msgid "Clear chat"
+msgstr ""
+
+#. Text in a button to clear a chat conversation, also used as a tooltip text.
+msgctxt "Clear Conversation button text and tooltip label text"
+msgid "Clear conversation"
+msgstr ""
+
+#. Title of the modal that asks the user if they want to clear the conversation.
+msgctxt "Modal title for clearing conversation"
+msgid "Clear conversation?"
+msgstr ""
+
+#. Part of a list of what our app can do. The app can: …
+msgctxt "welcome message eu search preference android"
+msgid "Clear data in one tap"
+msgstr "Lösche deine Daten mit einem klick"
+
+#. Positive feedback category a user can select on the Search Assist feedback form, meaning the answer was clear.
+msgctxt "feedback form"
+msgid "Clear explanation"
+msgstr ""
+
+#. Menu option to show search results from all sites
+msgctxt "Organic result context menu"
+msgid "Clear filter to show all search results"
+msgstr ""
+
+#. A message telling the user that they can clear the filter that is currently applied
+msgctxt "Site filter message"
+msgid "Clear filter to show all search results"
+msgstr ""
+
+#. Label for the button to clear the query filter
+msgctxt "Clear query filter button"
+msgid "Clear query filter"
+msgstr ""
+
+#. Descriptive text for a button that allows users to clear source text
+msgctxt "translations_module"
+msgid "Clear source text"
+msgstr ""
+
+#. Shown when the peer is on a different protocol version, which on the web usually means a stale Duck.ai bundle. The title is the full instruction; there is no body line. Native browsers use 'Update the DuckDuckGo browser and try again.' instead.
+msgctxt "Title for the version-mismatch error screen on Duck.ai (3p browser)"
+msgid "Clear your cache, refresh Duck.ai, and try again."
+msgstr ""
+
+#. Asks users if they clear the cookies from their web browser often.
+msgid "Clear your cookies often?"
+msgstr "Cookies häufig löschen?"
+
+#. Text explaining what happens to recent chats when browser data is cleared.
+msgctxt "Information about the effect of clearing browser data on recent chats"
+msgid ""
+"Clearing browser data deletes chats. Some browsers may keep recent chats "
+"indefinitely or auto-delete them after 7+ days of no AI Chat use."
+msgstr ""
+
+#. Text explaining what happens to recent chats when browser data is cleared.
+msgctxt "Information about the effect of clearing browser data on recent chats"
+msgid ""
+"Clearing browser data deletes recent chats. Recent chats may be saved "
+"indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
+"on your browser."
+msgstr ""
+
+#. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
+msgctxt "settings"
+msgid ""
+"Clearing browser data will reset your blocked sites. Save your block list "
+"permanently in"
+msgstr ""
+
+#. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
+msgid ""
+"Click \"More\" to go deeper on a topic, and ask follow-up questions via "
+"%sDuck.ai%s, our private AI chat service that supports chat models from "
+"OpenAI, Anthropic, and more."
+msgstr ""
+
+#. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
+msgid "Click %s+%s!"
+msgstr "Klicke %s+%s!"
+
+#. Instructions on what button the user has to click in order to add the DuckDuckGo extension to their browser.
+msgctxt "install-duckduckgo"
+msgid "Click %sAdd Extension%s."
+msgstr "Klicke %sErweiterung hinzufügen%s."
+
+#. Tells the user where to click in their browser. Part of a list of instructions on how to change the browser's home page.
+msgid "Click %sAdd or change home page...%s"
+msgstr "Klicken %sHinzufügen oder ändere die Startseite...%s"
+
+#. Tells users where to click to change their default search engine.
+msgid "Click %sAdd%s"
+msgstr "Klicke %shinzufügen%s"
+
+#. Instructions on which buttons the user has to click in order to add the DuckDuckGo extension to their browser.
+msgctxt "install-duckduckgo"
+msgid "Click %sAllow%s, then %sAdd%s."
+msgstr "Klicke %sErlauben%s, dann %shinzufügen%s."
+
+#. Tells users where in the settings menu they can change their default search engine.
+msgid "Click %sChange Search Settings%s in the drop down"
+msgstr "Klicke auf %sSucheinstellungen ändern%s in der Dropdownliste"
+
+#. Tells users where to click in their browser to find the Preferences menu.
+msgid ""
+"Click %sEdit > Preferences%s (on Windows) %sSeaMonkey > Preferences%s (on "
+"Mac)"
+msgstr ""
+"Klicke auf %sBearbeiten > Einstellungen%s (Auf Windows) oder klicke auf "
+"%sSeaMonkey > Einstellungen%s (Auf Mac)"
+
+#. Link that makes DuckDuckGo the default search engine in the user's browser.
+msgid "Click %sHere%s to add us as a search engine"
+msgstr "Klicke %shier%s um uns zu deiner Suchmaschine zu machen"
+
+#. Link to add the DuckDuckGo browser extension to Safari.
+msgid "Click %sHere%s to download the DuckDuckGo extension"
+msgstr "Klicke %shier%s um die DuckDuckGo Erweiterung herunterzuladen"
+
+#. Link to download the DuckDuckGo browser extension.
+msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
+msgstr ""
+"Klicke auf %sÖffnen%s zum Herunterladen und öffne die DuckDuckGo-Safari-"
+"Erweiterung"
+
+#. Tells users how to add DuckDuckGo to the list of search engines in their browser.
+msgid "Click %sPrivacy and Services%s in the left sidebar."
+msgstr "Klicke auf %sPrivatsphäre und Services%s in der Linken Sidebar."
+
+#. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
+msgid ""
+"Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
+"the top right)"
+msgstr ""
+"Klicken auf %sSafari%s im Startmenü (Falls du Windows benutzt, klicke auf "
+"das %sZahnrad-Symbol%s oben rechts)"
+
+#. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
+msgid "Click %sSettings%s"
+msgstr "Klicke auf %sEinstellungen%s"
+
+#. Tells users how to add DuckDuckGo to the list of search engines in their browser.
+msgid "Click %sSettings%s in the dropdown."
+msgstr "Klicke im Dropdown Menu auf %sEinstellungen%s."
+
+#. Tells the user how to make DuckDuckGo their home page.
+msgid "Click %sUse current pages%s then %sClick OK%s."
+msgstr "Klicke %sAktuelle Seiten benützen%s und %sdrücke OK%s."
+
+#. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
+msgid "Click %sYes%s"
+msgstr "Klicke %sJa%s"
+
+#. Tells the user where to click to open their browser's settings menu.
+msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
+msgstr ""
+"Klicke auf das %sEinstellungen- bzw. Hamburger-Symbol%s in der Chrome "
+"Werkzeugleiste."
+
+#. Tells users where to click to change their default search engine.
+msgid "Click OK."
+msgstr "Klicke auf OK."
+
+#. Tells users where to click to change their default search engine.
+msgid "Click add."
+msgstr "Klicke auf \"Hinzufügen\"."
+
+#. Tells users where to click in their browser to change their default search engine.
+msgid "Click on %sBrowser%s in the sidebar"
+msgstr "Klicke auf %sBrowser%s in der Seitenleiste"
+
+#. Tells users how to add DuckDuckGo to the list of search engines in their browser.
+msgid "Click on %sChange Search Settings%s in the dropdown menu"
+msgstr "Klicke auf %sändere Sucheinstellung%s im Auswahlmenü"
+
+#. Tells users how to add DuckDuckGo to the list of search engines in their browser.
+msgid "Click on %sSet as Default%s towards the bottom"
+msgstr "Klicke auf %sAls Standard setzen%s"
+
+#. Tells users how to add DuckDuckGo to the list of search engines in their browser.
+msgid "Click on the %sSearch Providers%s under Add-on Types"
+msgstr "Klicke auf %sSuchmaschine%s bei Add-on Typen"
+
+#. Tells users how to add DuckDuckGo to the list of search engines in their browser.
+msgid "Click on the %sTools icon%s in the top-right of the browser"
+msgstr "Klicke auf dass %sWerkzeugsymbol%s oben Rechts im Browser"
+
+#. Tells users how to add DuckDuckGo to the list of search engines in their browser.
+msgid "Click on the %smagnifying glass%s in the search bar"
+msgstr "Klicke auf das %sVergrösserungsglas%s in der Suchleiste"
+
+#. Tells users what icon to click in their browser to change their default search engine.
+msgid "Click on the magnifying glass in the search box at the top right"
+msgstr "Klicke auf das Vergrösserungsglas im Suchfeld oben rechts"
+
+#. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
+msgctxt "cloudsave"
+msgid ""
+"Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
+"it remains in your browser until you click/tap %sReset All Search Settings%s."
+msgstr ""
+
+#. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
+#. Click "What is this?" - http://i.imgur.com/KhmRHth.png
+#. In the cloud save box - http://i.imgur.com/FbCoYVE.png
+msgctxt "cloudsave"
+msgid ""
+"Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
+"it remains in your browser until you click/tap %sReset All Settings%s."
+msgstr ""
+
+#. Tells users what icon to click in order to make DuckDuckGo the default search engine in their browser. The placeholder is the icon they need to click.
+msgid "Click the %s icon in the top toolbar"
+msgstr "Klicke das %s Symbol in der oberen Symbolleiste"
+
+#. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
+msgid "Click the %s...%s icon at the top right:"
+msgstr "Klicke auf das %s...%s Icon ganz oben rechts:"
+
+#. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
+msgid "Click the %sGeneral%s tab."
+msgstr "Wähle den Reiter %sAllgemein%s."
+
+#. Tells users how to add DuckDuckGo to the list of search engines in their browser.
+msgid "Click the %sellipsis icon%s in the toolbar."
+msgstr "Klicke auf das %sEllipsenicon%s in der Werkzeugleiste."
+
+#. Tells users where to click in their browser to enable location service. Part of a list of instructions on how to enable location service.
+msgctxt "precise_user_location"
+msgid "Click the %slock icon%s on the address bar."
+msgstr ""
+
+#. Tells users where to click in their browser to enable location service. Part of a list of instructions on how to enable location service.
+msgctxt "precise_user_location"
+msgid "Click the %spermissions icon%s in the address bar"
+msgstr ""
+
+#. Tells users where to click in their browser to search using DuckDuckGo.
+msgid "Click the Duck icon at the top of your browser to search!"
+msgstr ""
+"Klicke auf das Enten-Symbol am oberen Rand deines Browsers um eine Websuche "
+"zu starten!"
+
+msgid "Click the Expand Icon."
+msgstr "Klicke auf das Erweitern-Icon"
+
+msgid "Click the Search Engine Icon in the Address Bar."
+msgstr "Klicke auf das Suchmaschinensymbol in der Adressleiste"
+
+#. Tells the user where to click in their browser. Part of a list of instructions on how to change the browser's home page.
+msgid "Click the arrow to the right of the %shome icon%s"
+msgstr "Klicke auf den Pfeil link des %shome icon%s"
+
+#. Tells users where to click in their browser to change the default search engine.
+msgid "Click the drop down in the search box"
+msgstr "Klicke das Dropdown-Menü in der Suchbox an"
+
+#. Tells users how to add DuckDuckGo to the list of search engines in their browser.
+msgid ""
+"Click the dropdown menu beside %sSearch engine used in the address bar%s and "
+"select %sDuckDuckGo%s."
+msgstr ""
+"Klicke auf das Dropdownmenü neben %sSuchmaschine in der Adressleiste%s und "
+"wähle%sDuckDuckGo%s."
+
+#. First step in a list of steps to take to disable the user's ad blocker
+msgid ""
+"Click the icon of the ad blocker extension. It's usually in the upper right "
+"hand corner of your browser."
+msgstr ""
+
+#. Tells users where to click to change their default search engine.
+msgid "Click the magnifying glass in the search bar"
+msgstr "Klicke auf die Lupe in der Suchleiste"
+
+#. Tells users what icon to click in order to make DuckDuckGo the default engine in their browser.
+msgid ""
+"Click the magnifying glass in the search box (at the top of the browser)"
+msgstr "Klicke auf die Lupe im Suchfeld (oben im Browser)"
+
+#. Tells users how to add DuckDuckGo to the list of search engines in their browser.
+msgid "Click this button to get started:"
+msgstr "Klicke diesen Knopf um zu beginnen:"
+
+#. A button that closes a window.
+msgid "Click to collapse"
+msgstr "Zum Ausblenden klicken"
+
+#. A button that makes a window larger.
+msgid "Click to expand"
+msgstr "Klicke zum expandieren"
+
+#. Filters the type of images in search results.
+msgctxt "image-type"
+msgid "Clipart"
+msgstr "Clipart"
+
+#. An accessible label for a button that closes a modal dialog
+msgid "Close"
+msgstr ""
+
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
+#. Aria label for the close button in the image lightbox.
+msgctxt "Aria label for image lightbox close button"
+msgid "Close"
+msgstr ""
+
+#. Hover tooltip for the button to close the batch actions. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
+msgctxt "Button to close the batch actions"
+msgid "Close"
+msgstr ""
+
+#. Accessibility label for the close ('X') button on the Search Assist overflow menu popover.
+msgctxt "duckassist"
+msgid "Close"
+msgstr ""
+
+msgctxt "Label for X button that closes side menu"
+msgid "Close menu"
+msgstr ""
+
+#. Screen-reader label for the X button that dismisses a suggested-prompts or How Duck.ai Works panel on mobile.
+msgctxt "Aria label for the close button on a suggested-prompts panel"
+msgid "Close panel"
+msgstr ""
+
+#. Aria label for the button that closes the pinned chats on boarding in the pinned chats section
+msgctxt ""
+"Aria label for the button that closes the pinned chats on boarding in the "
+"pinned chats section"
+msgid "Close pinned chats onboarding"
+msgstr ""
+
+#. Accessibility label for the close button in the chat search bar, which exits search mode and clears the query.
+msgctxt ""
+"Accessibility label for the button that exits chat search mode in Duck.ai"
+msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
+msgstr ""
+
+#. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
+msgctxt "Aria label for the selection toolbar"
+msgid "Close selection toolbar"
+msgstr ""
+
+#. Description for the notice displayed in the Duck.ai chat history sidebar when chat search cannot be loaded, telling users how to retry.
+msgctxt "Description shown when chat history search in Duck.ai is unavailable"
+msgid "Close the search bar and try again."
+msgstr ""
+
+#. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
+msgid "Close window."
+msgstr "Fenster schliessen."
+
+msgid "Closed"
+msgstr "Geschlossen"
+
+#. Indicates a business is currently closed.
+msgctxt "maps_places"
+msgid "Closed"
+msgstr "Geschlossen"
+
+#. Label for the time a business closes. For example: 'Closes at 10pm'
+msgctxt "maps_places"
+msgid "Closes"
+msgstr "Schliesst um"
+
+#. A place's closing time, for example: 'Closes at 11 PM'
+msgctxt "maps_places"
+msgid "Closes at %s"
+msgstr ""
+
+#. Indicates a business is closing soon.
+msgctxt "maps_places"
+msgid "Closes soon"
+msgstr "Schliesst bald"
+
+#. A place closing in X minutes, for example: 'Closing in 56 mins'
+msgctxt "maps_places"
+msgid "Closing in %s mins"
+msgstr ""
+
+#. Label for a feature that saves user settings to the cloud.
+#. Title for the bottom part of  the <a href="https://duckduckgo.com/settings.html">main settings page</a> about saving anonymously in the cloud.
+msgid "Cloud Save"
+msgstr "Sicherung in der Cloud"
+
+#. Label for a feature that saves user settings to the cloud.
+#. Title for the <em>Save Settings</em> form that is displayed when you click on the <em>Save Settings</em> from the <a href="https://duckduckgo.com/settings.html">settings page</a>.
+msgctxt "cloudsave"
+msgid "Cloud Save"
+msgstr "Sicherung in der Cloud"
+
+msgctxt "settings"
+msgid "Cloud Save"
+msgstr ""
+
+#. Enable cloud save, then click "Show Bookmarklet and Settings Data" - http://i.imgur.com/leUkNoB.png
+#. Then in the box that opens - http://i.imgur.com/8D4DdF8.png
+#. Label for the URL that saves user's settings.
+msgctxt "settings"
+msgid "Cloud Save Bookmarklet URL:"
+msgstr "Cloud-Bookmarklet-Adresse:"
+
+#. Message indicating that cloud save has been turned on
+msgctxt "cloudsave"
+msgid "Cloud Save Enabled"
+msgstr "Speichern in der Cloud aktiviert"
+
+#. Title above a list of questions and answers about the cloud save feature. FAQ stands for 'Frequently Asked Questions'
+msgctxt "cloudsave"
+msgid "Cloud Save FAQ"
+msgstr "F&A zum Speichern in der Cloud"
+
+#. Link to more information about the cloud save feature.
+msgctxt "cloudsave"
+msgid "Cloud Save discussion on duck.co"
+msgstr "Diskussion über Cloud-Sicherung auf duck.co"
+
+#. Text explaining the benefits of the cloud save feature.
+msgctxt "cloudsave"
+msgid ""
+"Cloud Save lets you save your settings more permanently by entering a "
+"passphrase. It is entirely optional."
+msgstr ""
+"Cloud Save ermöglicht es, Deine Einstellungen durch die Eingabe einer "
+"Passphrase längerfristig zu speichern. Es ist vollkommen freiwillig."
+
+#. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
+msgctxt "Weather IA"
+msgid "Cloudy"
+msgstr ""
+
+#. Explains what the copied code is for. Appears when hovering the copy button on the Scan QR tab.
+msgctxt "Tooltip shown on hover over the Copy Text Code button"
+msgid "Code for syncing with another device"
+msgstr ""
+
+#. Label for the option prompting the AI assistant to adopt a role of a coding coach in its responses.
+msgctxt "Assistant role option label for Coding coach"
+msgid "Coding coach"
+msgstr ""
+
+#. A link to the DuckDuckGo collaborations page (/collaborations)
+msgid "Collaborations"
+msgstr ""
+
+#. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
+msgctxt "Button label for showing more search result links in Duck.ai"
+msgid "Collapse"
+msgstr ""
+
+msgid "Colombia"
+msgstr "Kolumbien"
+
+#. Instant Answer tab name
+msgid "Color"
+msgstr "Farbe"
+
+#. List item indicating that a color filter is currently active for the search
+msgctxt "noresults"
+msgid "Color"
+msgstr ""
+
+#. Title for the <em>Color Settings</em> inside <a href="https://duckduckgo.com/params.html">querry parameters page</em>.
+msgid "Color Settings"
+msgstr "Farbeinstellungen"
+
+#. Filters the color of images in search results.
+msgctxt "image-color"
+msgid "Color only"
+msgstr ""
+
+#. In the top menu under Settings
+msgid "Colors"
+msgstr "Farben"
+
+#. Description shown to users who have reached their image generation limit, telling them to try again later.
+msgctxt "Default description for limit reached message"
+msgid "Come back later to create more images."
+msgstr ""
+
+#. Description shown to users who have reached their image generation limit, telling them to try again tomorrow.
+msgctxt "Default description for limit reached message"
+msgid "Come back tomorrow to create more images"
+msgstr ""
+
+msgid "Comics"
+msgstr "Comics"
+
+#. When suggesting a !newbang in the <a href="https://duckduckgo.com/newbang.html">!newbang page</a>, last field is a free text one for adding <em>comments</em>. This is the label for this field.
+msgid "Comments"
+msgstr "Kommentare "
+
+#. Link to duck.co from front page menu
+msgid "Community"
+msgstr "Gemeinschaft"
+
+msgid "Comoros"
+msgstr ""
+
+msgctxt "settings"
+msgid "Compact Results"
+msgstr ""
+
+#. Refers to the DuckDuckGo page for comparing privacy features across browsers and extensions. (https://duckduckgo.com/compare-privacy/)
+msgid "Compare Privacy"
+msgstr ""
+
+#. A link to a page that compares privacy features across different browsers and extensions (https://duckduckgo.com/compare-privacy/)
+msgctxt "SERP footer content"
+msgid "Compare Privacy"
+msgstr ""
+
+#. Title for the competition selector dropdown in the team module
+msgctxt "Sports module"
+msgid "Competition"
+msgstr ""
+
+#. Positive feedback category a user can select on the Search Assist feedback form, meaning the answer was complete.
+msgctxt "feedback form"
+msgid "Complete"
+msgstr ""
+
+#. An option that completely disables the Assist feature.
+msgctxt "duckassist"
+msgid "Completely disables Assist"
+msgstr ""
+
+#. An option that completely disables the Search Assist feature.
+msgctxt "duckassist"
+msgid "Completely disables Search Assist"
+msgstr ""
+
+#. Short string representing a prompt suggestion for composing a card.
+msgctxt "Brief for composing a card"
+msgid "Compose a card"
+msgstr ""
+
+#. Instant Answer Tab Name
+msgid "Concerts"
+msgstr "Konzerte"
+
+#. Indicates the Win-Loss record of a team within its conference in e.g. NBA
+msgctxt "Sports module"
+msgid "Conf"
+msgstr ""
+
+#. Indicates the Win-Loss record of a team within its conference in e.g. NBA
+msgctxt "Sports module"
+msgid "Conference Record"
+msgstr ""
+
+#. Title for modal letting you choose which Conference you wish to view
+msgctxt "Sports module"
+msgid "Conferences"
+msgstr ""
+
+#. Text for a button in the modal that confirms the deletion of recent chats and disables the feature.
+msgctxt "Primary button text in disable recent chats modal"
+msgid "Confirm Deletion and Disable"
+msgstr ""
+
+#. Heading for the table column indicating how many confirmed cases there have been in that location
+msgctxt "Covid 19 module"
+msgid "Confirmed"
+msgstr ""
+
+#. The number of confirmed Covid 19 cases
+msgctxt "Covid 19 module"
+msgid "Confirmed Cases"
+msgstr ""
+
+#. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was unclear.
+msgctxt "feedback form"
+msgid "Confusing"
+msgstr ""
+
+msgid "Congo "
+msgstr ""
+
+msgid "Congo DR"
+msgstr ""
+
+msgid "Congratulations!"
+msgstr "Gratuliere!"
+
+#. Replaces the button label alongside a spinner while the account is being created.
+msgctxt "Loading label on the Sync This Device Only button while setup runs"
+msgid "Connecting"
+msgstr ""
+
+#. Status label shown while connecting to the voice chat session.
+msgctxt "voice chat"
+msgid "Connecting"
+msgstr ""
+
+#. Short progress status displayed in the modal body while two devices complete pairing, before the success (device added) screen.
+msgctxt "Status line shown while the pairing handshake is in progress"
+msgid "Connecting…"
+msgstr ""
+
+#. Message to display during outages for users who do not have AI enabled to encourage them to enable AI features. Example: 'Consider trying Duck.ai, our private AI chat service:'
+msgctxt "noresults"
+msgid "Consider trying %s, our private AI chat service:"
+msgstr ""
+
+#. F1 standings tab label for constructor championship
+msgctxt "Sports module"
+msgid "Constructors"
+msgstr ""
+
+#. A call to action to move to the next step typically used in forms
+msgid "Continue"
+msgstr ""
+
+#. Button label on the minimal onboarding modal variant to accept terms and continue chatting.
+msgctxt "Modal onboarding experiment button text"
+msgid "Continue"
+msgstr ""
+
+#. Primary CTA on the intro screen; starts setup on this device. Shown on all viewport widths (mobile adds a leading icon).
+msgctxt "Primary button on the Sync & Backup intro screen"
+msgid "Continue"
+msgstr ""
+
+#. Primary CTA on the intro screen on desktop; no leading icon per Figma.
+msgctxt "Primary button on the Sync & Backup intro screen (desktop)"
+msgid "Continue"
+msgstr ""
+
+#. Button that validates the pasted pairing payload and advances to the synced state or the wrong code state.
+msgctxt "Submit button for the manual paste fallback"
+msgid "Continue"
+msgstr ""
+
+#. Button label to continue with the update.
+msgctxt "duckai_migration"
+msgid "Continue"
+msgstr ""
+
+#. Label of a button that dismisses the request for the user to turn off their ad blocker
+msgid "Continue Blocking Ads"
+msgstr ""
+
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
+#. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
+msgctxt "AI Chat - Tooltip for selecting a response in chat action"
+msgid "Continue with this model"
+msgstr ""
+
+#. A labelled link in About IA showing the source of the abstract, e.g. "Continued in Wikipedia"
+msgctxt "Link in About IA to continued content directly in source"
+msgid "Continued in %s"
+msgstr ""
+
+#. http://i.imgur.com/epDTyUE.png
+msgctxt "theme"
+msgid "Contrast"
+msgstr "Kontrast"
+
+#. http://i.imgur.com/G36h64l.png
+#. This setting controls the width of the search results:
+#. http://i.imgur.com/CoVquLr.png
+#. http://i.imgur.com/DiQq2Ll.png
+msgctxt "settings"
+msgid "Controls the width of the search box and results"
+msgstr "Bestimmt die Breite des Suchfeldes und der Resultate"
+
+#. Displayed when nearing the conversation limit. %s is the used percentage, e.g., 'Conversation limit: 78%'.
+msgctxt "Warning text shown with the current conversation usage percentage."
+msgid "Conversation limit: %s%"
+msgstr ""
+
+#. Instant Answer tab name
+msgid "Conversion"
+msgstr "Umwandlung"
+
+#. Rugby match stats
+msgctxt "Sports module"
+msgid "Conversions"
+msgstr ""
+
+#. Description for the dictation toggle in the duck.ai settings modal.
+msgid "Convert speech to text using your microphone."
+msgstr ""
+
+#. Description for the dictation toggle in the duck.ai settings modal.
+msgid "Convert your speech to text in Duck.ai chats."
+msgstr ""
+
+msgid "Cook Islands"
+msgstr ""
+
+#. Label for information about the cookie that saves the user's settings.
+#. http://i.imgur.com/fd7EjAN.png
+msgctxt "settings"
+msgid "Cookie data:"
+msgstr ""
+
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
+#. Short confirmation announcement shown to the user after copying the recovery code.
+msgctxt "Confirmation label after the recovery code has been copied"
+msgid "Copied"
+msgstr ""
+
+#. Renders a check icon + this label as a small pill replacing the Copy button for 2 seconds. Distinct from DUCKCHAT_SYNC_RECOVERY_COPIED_LABEL because that key is an aria-label.
+msgctxt "Confirmation pill shown after the user taps Copy on the View Code tab"
+msgid "Copied"
+msgstr ""
+
+#. Text of a tooltip displayed when the user has copied the text content after pressing a button
+msgctxt "Text for a button after copying content to the clipboard"
+msgid "Copied"
+msgstr ""
+
+#. Button text to copy the generation prompt (shown as the modal description) to the clipboard.
+msgctxt "Button label for image info modal"
+msgid "Copy"
+msgstr ""
+
+#. Sits below the recovery code text on the View Code tab. Briefly replaced by a 'Copied' confirmation pill on click.
+msgctxt "Button label that copies the recovery code text to clipboard"
+msgid "Copy"
+msgstr ""
+
+#. Label for the 'Copy' item in the Search Assist overflow menu (kebab menu next to the assist module title). Copies the generated answer to the user's clipboard.
+msgctxt "duckassist"
+msgid "Copy"
+msgstr ""
+
+#. Instructions on how to change the default search engine
+msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
+msgstr ""
+"Kopiere %sabout:preferences#search%s und füge es in der Adressleiste ein."
+
+#. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
+msgctxt "Text for a button for copying preformatted code block content"
+msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
+msgstr ""
+
+#. Label for the copy button on the Scan QR tab.
+msgctxt "Button label that copies the sync code text to clipboard"
+msgid "Copy Text Code"
+msgstr ""
+
+#. Centered line above the recovery token in the holding panel, aligned with Figma 435:111290 (manual code / recovery layout).
+msgctxt "Heading inside the recovery code panel"
+msgid "Copy or save this code"
+msgstr ""
+
+#. Aria label for the icon button that copies the recovery code to the clipboard.
+msgctxt "Accessible label for the copy button on the recovery code screen"
+msgid "Copy recovery code"
+msgstr ""
+
+#. Tooltip text for the button that copies the chat response content to the clipboard.
+msgctxt "Tooltip for copy action"
+msgid "Copy to Clipboard"
+msgstr ""
+
+#. Tooltip text for the button that copies the chat response content to the clipboard.
+msgctxt "Tooltip for copy action"
+msgid "Copy to clipboard"
+msgstr ""
+
+#. Descriptive text for a button that allows users to copy text that has been translated.
+msgctxt "translations_module"
+msgid "Copy translation"
+msgstr ""
+
+#. Option in a feedback form for image search results.
+msgctxt "Report image modal"
+msgid "Copyright violation"
+msgstr "Copyrightverletzung"
+
+#. Soccer match stats
+msgctxt "Sports module"
+msgid "Corners"
+msgstr ""
+
+#. Title of the Covid 19 module
+msgctxt "Covid 19 module"
+msgid "Coronavirus Disease (COVID-19)"
+msgstr ""
+
+#. Title of modal shown when user gets bot challenge correct
+msgctxt "Anomaly modal"
+msgid "Correct!"
+msgstr ""
+
+msgid "Costa Rica"
+msgstr ""
+
+#. Inline error shown on the recovery code screen when exportSyncSettings rejects.
+msgctxt "Error message when the recovery code fails to generate"
+msgid "Couldn't load your recovery code. Please close this and try again."
+msgstr ""
+
+#. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
+msgctxt ""
+"Inline error shown above the synced-devices list when the refresh request "
+"fails"
+msgid "Couldn't refresh devices."
+msgstr ""
+
+#. Instant Answer Tab Name
+msgid "Coupons"
+msgstr "Gutscheine"
+
+#. Short string representing a prompt suggestion for crafting a recipe.
+msgctxt "Brief for crafting a recipe"
+msgid "Craft a recipe"
+msgstr ""
+
+#. Text on the image-generation send button when shown next to an inline terms-of-service disclaimer (instead of the arrow icon). Clicking it both accepts the terms and starts image generation.
+msgctxt "Send user prompt button label for image generation (text variant)"
+msgid "Create"
+msgstr ""
+
+#. Label for a pill-shaped tab below the empty-state Duck.ai chat input. Clicking it reveals a grid of suggested image-generation prompts.
+msgctxt "Pill label opening the image-prompt suggestions panel"
+msgid "Create & Edit Images"
+msgstr ""
+
+#. Label for the AI image generation option in the Tools dropdown menu in the Duck.ai chat input toolbar.
+msgctxt "Label for the Image tool entry in the Tools dropdown menu"
+msgid "Create Image"
+msgstr ""
+
+#. CTA for a promotional card that encourages users to try the recently added image generation mode.
+msgctxt "Promotional CTA for new image generation mode"
+msgid "Create Image"
+msgstr ""
+
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Create a shopping list with quantities from this recipe."
+msgstr ""
+
+#. Placeholder text displayed in the input field when starting a new image generation session.
+msgctxt "Placeholder text for the image generation input field"
+msgid "Create an image of a cute duck..."
+msgstr ""
+
+#. Hints at what's inside the Tools dropdown — image creation, web search, and other tools. Shown on hover over the Tools button. The trailing ellipsis indicates there are additional tools beyond the two named.
+msgctxt ""
+"Hover tooltip for the Tools dropdown button in the Duck.ai chat input toolbar"
+msgid "Create image, web search..."
+msgstr ""
+
+#. Heading shown on the empty image generation screen. %s is replaced with an interactive privacy button containing a shield icon and the word 'privately'.
+msgctxt "Empty state heading in Duck.ai image generation mode"
+msgid "Create images %s"
+msgstr ""
+
+#. Heading shown on the empty image generation screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'privately' between both %s markers.
+msgctxt "Empty state heading in Duck.ai image generation mode"
+msgid "Create images %sprivately%s"
+msgstr ""
+
+#. Label that's displayed next to a video creator below a web search result.
+msgctxt "Rich Facts label"
+msgid "Created by"
+msgstr ""
+
+#. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
+msgctxt "Label copy indicating the creator of an AI Model"
+msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
+msgstr ""
+
+#. Label below a video that's available under the Creative Commons license.
+msgctxt "video-license"
+msgid "Creative Commons"
+msgstr "Creative Commons"
+
+#. A category of ads
+msgctxt "Feedback prompt"
+msgid "Credit Card Advertisements"
+msgstr ""
+
+#. A category of ads
+msgctxt "Feedback prompt"
+msgid "Credit card ads"
+msgstr ""
+
+#. Short string representing a prompt suggestion for critiquing writing.
+msgctxt "Brief for critiquing writing"
+msgid "Critique your writing"
+msgstr ""
+
+msgid "Croatia"
+msgstr "Kroatien"
+
+#. The name of the Croatian language
+msgctxt "language_name"
+msgid "Croatian"
+msgstr ""
+
+msgid "Cuba"
+msgstr ""
+
+#. Label that's displayed next to a cuisine type below a web search result.
+msgctxt "Rich Facts label"
+msgid "Cuisine"
+msgstr ""
+
+msgid "Curacao"
+msgstr ""
+
+#. A tooltip that is shown after the user has clicked the swap currencies button. Example: https://duckduckgo.com/?q=5+gbp+to+usd&ia=currency
+msgctxt "Currency module"
+msgid "Currencies swapped"
+msgstr ""
+
+#. Instant Answer tab name
+msgid "Currency"
+msgstr "Währung"
+
+#. The title shown when the Currency dropdown is opened on mobile. Example: https://duckduckgo.com/?q=5+gbp+to+usd&ia=currency
+msgctxt "Currency module"
+msgid "Currency"
+msgstr ""
+
+#. A label for the input field of the currency conversion tool. It explains that the value in that input field is in the specified currency. The placeholder string is the currency code. For example, 'Currency value in USD'.'
+msgctxt "Currency module"
+msgid "Currency value in %s"
+msgstr ""
+
+#. Indicates the current win or loss streak of a team
+msgctxt "Sports module"
+msgid "Current Streak"
+msgstr ""
+
+#. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
+msgctxt "Menu item to attach current tab page context to AI chat"
+msgid "Current Tab Content"
+msgstr ""
+
+#. Title for the Usage section in Duck.ai settings, where subscribers can view their usage limits.
+msgctxt "Duck.ai settings usage section"
+msgid "Current Usage"
+msgstr ""
+
+#. http://i.imgur.com/n6W3M3I.png
+msgctxt "settings"
+msgid "Custom"
+msgstr "Benutzerdefiniert"
+
+#. Button to enable entering a custom option
+#. Custom --> 'customized'
+#. A setting that *you* choose and is not a default.
+msgctxt "settingsvalue"
+msgid "Custom"
+msgstr "Benutzerdefiniert"
+
+msgctxt "settings"
+msgid "Custom %s"
+msgstr "Benutzerdefinierte %s"
+
+#. Placeholder for a custom option. Can be something like 'Custom Font'.
+msgctxt "settingsvalue"
+msgid "Custom %s"
+msgstr "Benutzerdefiniert %s"
+
+#. Label for a calendar that lets users select a range of dates.
+msgid "Custom date range"
+msgstr ""
+
+#. Used as a button label. When clicked, it opens a menu.
+msgid "Customize"
+msgstr ""
+
+#. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
+msgctxt "Label for customizing Duck.ai"
+msgid "Customize Duck.ai"
+msgstr ""
+
+#. The heading of a modal that's shown to a user when they ask to customize the page's components. The 'New Tab Page' is the page shown when a user opens a new empty tab in their browser.
+msgid "Customize New Tab Page"
+msgstr ""
+
+#. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
+msgctxt "Label for customizing Duck.ai"
+msgid "Customize Responses"
+msgstr ""
+
+#. Title for the modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
+msgctxt "Modal title for customizing Duck.ai"
+msgid "Customize Responses"
+msgstr ""
+
+#. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
+msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
+msgid "Customize responses"
+msgstr ""
+
+#. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
+msgid "Customize this page"
+msgstr ""
+
+#. Label for the button that opens a modal that allows users to customize the AI assistant conversation context. The label is shown whenever a customization is applied.
+msgctxt "Label for chat customization button"
+msgid "Customized"
+msgstr ""
+
+#. Label for cycling (bicycle) directions on a map.
+msgctxt "directions"
+msgid "Cycling"
+msgstr ""
+
+msgid "Cyprus"
+msgstr ""
+
+#. The name of the Czech language
+msgctxt "language_name"
+msgid "Czech"
+msgstr ""
+
+msgid "Czech Republic"
+msgstr "Tschechische Republik"
+
+msgid "Czechia"
+msgstr ""
+
+#. Indicates this is the number of draws for this team in e.g. soccer
+msgctxt "Sports module"
+msgid "D"
+msgstr ""
+
+msgctxt "settings"
+msgid "DC: Saved Chats"
+msgstr ""
+
+msgctxt "settings"
+msgid "DC: preferred"
+msgstr ""
+
+msgid "DR Congo"
+msgstr ""
+
+#. Label for the daily usage limit row in the Usage section of Duck.ai settings.
+msgctxt "Duck.ai settings usage section"
+msgid "Daily limit"
+msgstr ""
+
+#. Displayed in the Duck.ai usage limit banner for subscribers when the daily usage limit has been reached.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Daily limit reached"
+msgstr ""
+
+#. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
+msgctxt "Error message for fixed-window Duck.ai usage limit"
+msgid "Daily usage limit reached. You can continue this chat after %s."
+msgstr ""
+
+#. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
+msgctxt "Error message for fixed-window Duck.ai usage limit"
+msgid ""
+"Daily usage limit reached. You can keep chatting by using your weekly limit."
+msgstr ""
+
+#. The name of the Danish language
+msgctxt "language_name"
+msgid "Danish"
+msgstr ""
+
+#. The name of the Dari language
+msgctxt "language_name"
+msgid "Dari"
+msgstr ""
+
+#. A theme name in the theme menu:
+#. https://duck.co/media/files/theme.png
+msgid "Dark"
+msgstr "Dunkel"
+
+#. Text for a button that enables the dark theme .
+msgctxt "Dark theme button for theme selector"
+msgid "Dark"
+msgstr ""
+
+#. http://i.imgur.com/07cZIPc.png
+msgctxt "theme"
+msgid "Dark"
+msgstr "Dunkel"
+
+#. Indicate that we currently do not have chart data for prices of the current stock
+msgctxt "Stocks module"
+msgid "Data currently not available for this period"
+msgstr ""
+
+#. Attribution text for the sports module. Indicates where our sports data comes from. Note: "Sportradar" is a brand name and should not be translated
+msgctxt "Sports module"
+msgid "Data from Sportradar"
+msgstr ""
+
+#. Link text shown under the currency converter explaining that the data is coming from XE
+msgctxt "Currency module"
+msgid "Data from XE"
+msgstr ""
+
+#. Attribution text for the stocks module
+msgctxt "Stocks module"
+msgid "Data provided by IEX Cloud"
+msgstr ""
+
+#. Attribution text for the stocks module
+msgctxt "Stocks module"
+msgid "Data provided by Refinitiv"
+msgstr ""
+
+#. Instant Answer tab name
+msgid "Date"
+msgstr "Datum"
+
+#. Category a user can select on a feedback form.
+msgctxt "feedback form"
+msgid "Date Filters"
+msgstr "Datumsfilter"
+
+#. Category a user can select on a feedback form.
+msgctxt "feedback form"
+msgid "Date filters"
+msgstr ""
+
+#. List item indicating that a date filter is currently active for the search
+msgctxt "noresults"
+msgid "Date range"
+msgstr ""
+
+#. Heading for the table column indicating how many deaths there have been in that location
+msgctxt "Covid 19 module"
+msgid "Deaths"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Deceptive ad"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Deceptive content"
+msgstr ""
+
+#. A theme name in the theme menu:
+#. https://duck.co/media/files/theme.png
+msgid "Default"
+msgstr "Standard"
+
+#. A generic option label that is displayed in a dropdown by default and represents a default/neutral value
+msgctxt "Label for the default option"
+msgid "Default"
+msgstr ""
+
+#. http://i.imgur.com/BjrIFRp.png
+msgctxt "theme"
+msgid "Default"
+msgstr "Standard"
+
+msgctxt "settings"
+msgid "Default Navigation App"
+msgstr ""
+
+#. Short string representing a prompt suggestion for defining a term.
+msgctxt "Brief for defining a term"
+msgid "Define a term"
+msgstr ""
+
+#. Instant Answer Tab Name - define a word
+msgid "Definition"
+msgstr "Definition"
+
+#. Indicator that a game has been delayed
+msgctxt "Sports module"
+msgid "Delayed"
+msgstr ""
+
+#. Generic text for the tooltip on delete button when no chats are selected.
+msgctxt "Tooltip on delete button for batch actions toolbar."
+msgid "Delete"
+msgstr ""
+
+#. Primary action that deletes the oldest chats containing files. %s is replaced with the batch-size cap (currently 10), matching the count in the modal description.
+msgctxt "Sync file storage limit modal primary button"
+msgid "Delete %s Oldest Chats"
+msgstr ""
+
+#. Text for the tooltip on button to delete selected chats in the batch actions toolbar. %s is replaced with the number of selected chats. This will always be plural.
+msgctxt ""
+"Tooltip on delete button for batch actions toolbar when chats are selected."
+msgid "Delete %s chats"
+msgstr ""
+
+#. Button text to delete all chats and free up sync storage.
+msgctxt "Sync limit modal button"
+msgid "Delete All Chats"
+msgstr ""
+
+#. Text for a button that confirms the deletion of the current chat.
+msgctxt "Primary button text in delete chat modal"
+msgid "Delete Chat"
+msgstr ""
+
+#. Text for a button that clears all recent chats.
+msgctxt "Primary button text in mobile chat history modal"
+msgid "Delete Chats"
+msgstr ""
+
+#. Button text to delete unpinned chats older than 30 days to free up sync storage.
+msgctxt "Sync limit modal button"
+msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Button text to confirm deletion of an image.
+msgctxt "Button label in delete image modal"
+msgid "Delete Image"
+msgstr ""
+
+#. Button that deletes settings has backed up to the cloud.
+#. This token is displayed as a button, so keep it short!
+msgid "Delete My Data"
+msgstr ""
+
+#. Calls /delete-account and then clears local sync credentials.
+msgctxt "Destructive action that deletes the entire sync account"
+msgid "Delete Server Data"
+msgstr ""
+
+#. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
+msgctxt "Title for the destructive Delete Server Data confirmation modal"
+msgid "Delete Server Data?"
+msgstr ""
+
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
+#. Button text to delete a voice chat transcript.
+msgctxt "voice chat transcript"
+msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
+msgstr ""
+
+#. Tooltip text that appears when hovering over the delete chat button in the chat history list.
+msgctxt "Tooltip label for the delete chat button"
+msgid "Delete chat"
+msgstr ""
+
+#. Text for the tooltip on button to delete a single selected chat in the batch actions toolbar. This will always be singular.
+msgctxt ""
+"Tooltip on delete button for batch actions toolbar when only one chat is "
+"selected."
+msgid "Delete chat"
+msgstr ""
+
+#. Tooltip text for a button that deleted all recent chat sessions.
+msgctxt "Tooltip text for the button that deletes all recent chats"
+msgid "Delete chats"
+msgstr ""
+
+#. Call to action to invite users to delete a single generated image from the conversation.
+msgctxt "Tooltip for an action button"
+msgid "Delete image"
+msgstr ""
+
+#. Modal title asking users to confirm deletion of a generated image.
+msgctxt "Title for delete image confirmation modal"
+msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
+msgstr ""
+
+#. Title shown when user has reached the file storage sync quota (5GB).
+msgctxt "Sync file storage limit modal title"
+msgid "Delete oldest chats to free up storage?"
+msgstr ""
+
+#. Title shown when user has reached the file storage sync quota (5GB).
+msgctxt "Sync file storage limit modal title"
+msgid "Delete oldest chats with attachments to free up storage?"
+msgstr ""
+
+#. Title of a modal that asks the user if they want to delete all recent chats.
+msgctxt "Modal header for deleting all recent chats confirmation"
+msgid "Delete recent chats?"
+msgstr ""
+
+#. Title of the modal that asks the user if they want to delete their current chat.
+msgctxt "Modal header for deleting a chat"
+msgid "Delete this chat?"
+msgstr ""
+
+#. A negative feedback suggestion about the user's chats with an AI (Artificial Inteligence) chat bot being deleted
+msgctxt "Feedback prompt"
+msgid "Deleted chats"
+msgstr ""
+
+#. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
+msgctxt "settings"
+msgid "Deleting cookies will reset these settings."
+msgstr ""
+
+msgid "Democratic People's Republic of Korea"
+msgstr ""
+
+msgid "Denmark"
+msgstr "Dänemark"
+
+#. Placeholder text displayed in the input field when the user uploads an image and can make edits to it.
+msgctxt ""
+"Placeholder text for the image generation input field for editing uploaded "
+"images"
+msgid "Describe changes based on the image"
+msgstr ""
+
+#. Placeholder text displayed in the input field when the user can make follow-up edits to a generated image.
+msgctxt "Placeholder text for the image generation input field for follow-ups"
+msgid "Describe changes to continue editing this image"
+msgstr ""
+
+#. Title shown when the user first enters Image Generation mode, prompting them to describe the image they want to create.
+msgctxt "Empty state title for Image Generation mode"
+msgid "Describe the image you want to create"
+msgstr ""
+
+#. Positive feedback category a user can select on the Search Assist feedback form, meaning the answer was specific enough.
+msgctxt "feedback form"
+msgid "Detailed answer"
+msgstr ""
+
+#. Section heading in redesigned About IA for section showing facts and figures
+msgid "Details"
+msgstr ""
+
+#. Default value for a dropdown, indicating that the language of inputted text will be automatically-detected.
+msgctxt "translations_module"
+msgid "Detect language"
+msgstr ""
+
+msgctxt "attribution"
+msgid "Developer"
+msgstr "Entwickler"
+
+#. Rendered for entries whose name/type bytes are encrypted under a key this client doesn't hold.
+msgctxt ""
+"Placeholder name used when the device name cannot be decrypted; the %s is "
+"the 1-based position in the list"
+msgid "Device %s"
+msgstr ""
+
+#. Shown after a recovery code is applied and the device joins the sync account. Figma frame 3704-32225.
+msgctxt "Modal header for the recover-data success sheet"
+msgid "Device Synced!"
+msgstr ""
+
+#. Title shown after the two devices have successfully paired.
+msgctxt "Title for the success screen"
+msgid "Devices Synced"
+msgstr ""
+
+#. Accessible label for the microphone button in the duck.ai chat input toolbar.
+msgid "Dictate"
+msgstr ""
+
+#. Title for the dictation toggle in the duck.ai settings modal.
+msgid "Dictation"
+msgstr ""
+
+#. Title of the dictation privacy modal, shown both on first use (consent) and from the settings 'How it works' link (info-only).
+msgid "Dictation in Duck.ai"
+msgstr ""
+
+#. Description for the privacy highlight in the dictation consent modal.
+msgid "Dictation is anonymized by us, and never used to train AI models."
+msgstr ""
+
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
+msgid "Dictation limit reached"
+msgstr ""
+
+#. Tooltip for the disabled microphone button in the duck.ai chat input when the dictation service is temporarily disabled by a server-side kill switch.
+msgid "Dictation temporarily unavailable"
+msgstr ""
+
+#. Subtitle text in the dictation privacy consent modal explaining the feature.
+msgid ""
+"Dictation uses an OpenAI model to convert your speech to text, so you can "
+"chat in Duck.ai without having to type."
+msgstr ""
+
+#. In 0-click box -- link to definition.
+msgid "Dictionary"
+msgstr "Wörterbuch"
+
+#. Message displayed to the user when they use page context for the first time. It asks them if the response correctly used the page content.
+msgctxt "First time page context response feedback"
+msgid "Did this correctly use the page content?"
+msgstr ""
+
+#. A link to search results for a different search term. The placeholder value is a term the user may have intended to search for. For example: 'Did you mean pizza?'
+msgid "Did you mean %s?"
+msgstr "Meintest Du %s?"
+
+#. Label that's displayed next to a date of death below a web search result.
+msgctxt "Rich Facts label"
+msgid "Died"
+msgstr ""
+
+#. Label that's displayed next to a director below a web search result.
+msgctxt "Rich Facts label"
+msgid "Directed by"
+msgstr ""
+
+#. Label for directions on a map.
+msgctxt "directions"
+msgid "Directions"
+msgstr "Richtungen"
+
+#. Label for directions on a map.
+msgctxt "maps_places"
+msgid "Directions"
+msgstr "Richtungen"
+
+msgctxt "settings"
+msgid "Directions Source"
+msgstr "Routen Quelle"
+
+#. A button that turns off a feature in the settings menu.
+msgid "Disable"
+msgstr "Deaktivieren"
+
+#. A button to clear the AI images filter in the Images IA
+msgctxt "Images IA"
+msgid "Disable AI Images Filter"
+msgstr ""
+
+#. Text for a button in the modal that confirms the deletion of chat history and disables the feature.
+msgctxt "Primary button text in disable chat history modal"
+msgid "Disable Chat History"
+msgstr ""
+
+#. Text for a button where the user can click to disable the Duck.ai product.
+msgctxt "Onboarding welcome screen button text"
+msgid "Disable Duck.ai"
+msgstr ""
+
+#. Text for a button that confirms disabling chat history and disconnecting from Sync & Backup.
+msgctxt "Primary button text in disable chat history and disconnect sync modal"
+msgid "Disable and Disconnect"
+msgstr ""
+
+#. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
+msgctxt "Modal header for disabling chat history and disconnecting sync"
+msgid "Disable chat history and disconnect from Sync & Backup?"
+msgstr ""
+
+#. Title of a modal that asks the user if they want to turn off the chat history feature.
+msgctxt "Modal header for disabling chat history confirmation"
+msgid "Disable chat history?"
+msgstr ""
+
+#. Title of a modal that asks the user if they want to turn off recent chats.
+msgctxt "Modal header for disabling recent chats confirmation"
+msgid "Disable recent chats?"
+msgstr ""
+
+#. Text for the label that indicates the feature is disabled.
+msgctxt "Status label for a setting"
+msgid "Disabled"
+msgstr ""
+
+#. Title for the section that showcases the discussion results for a certain query, ex. Discussions on <b>Reddit</b>
+msgid "Discussions on %s%s%s"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Dislike AI"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Dislike Ask Duck.ai button"
+msgstr ""
+
+#. A negative feedback suggestion specifically about the visual design of the Search Assist module on the SERP. Distinct from 'Dislike AI' (which signals dislike of the AI feature itself); used to gauge user reaction to design changes during the visual-refresh experiment.
+msgctxt "Feedback prompt"
+msgid "Dislike design"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Dislike source"
+msgstr ""
+
+#. This appears on a button that a user clicks to close a notification.
+msgid "Dismiss"
+msgstr "Ablehnen"
+
+#. Accessible label for the close/dismiss button on the RetentionBrowserPromo card.
+msgctxt "Accessibility label for close button"
+msgid "Dismiss"
+msgstr ""
+
+#. A button to dismiss the assist settings modal.
+msgctxt "duckassist"
+msgid "Dismiss"
+msgstr ""
+
+#. A button to dismiss seeing the banner altogether
+msgctxt "Update browser banner"
+msgid "Dismiss and Hide Banner"
+msgstr ""
+
+#. This appears on a button that a user clicks to close a notification, and choose to never see that notification again.
+msgid "Dismiss forever"
+msgstr "für immer Verbergen"
+
+#. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
+msgctxt "Sidemenu subscription promo"
+msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
+#. Accessible label for the close button in the Duck.ai usage limit banner.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Dismiss usage limit warning"
+msgstr ""
+
+#. Label for the select dropdown to changing display language
+msgctxt "Display language selector"
+msgid "Display Language"
+msgstr ""
+
+#. Name of a setting that controls the language of the user interface.
+msgctxt "settings"
+msgid "Display Language"
+msgstr ""
+
+#. This is the description of a user setting
+msgctxt "settings"
+msgid "Displays a checkmark to the left of results you've visited"
+msgstr ""
+
+#. This is the description of a user setting
+msgctxt "settings"
+msgid "Displays favicons for each result"
+msgstr ""
+
+#. This is the description of a user setting
+msgctxt "settings"
+msgid "Displays results in the center of the page"
+msgstr ""
+
+msgctxt "settings"
+msgid "Displays site names for each result"
+msgstr ""
+
+#. Indicates the Win-Loss record of a team within its division in e.g. NBA
+msgctxt "Sports module"
+msgid "Div"
+msgstr ""
+
+#. Indicates the Win-Loss record of a team within its division in e.g. NBA
+msgctxt "Sports module"
+msgid "Division Record"
+msgstr ""
+
+msgid "Djibouti"
+msgstr ""
+
+#. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
+msgctxt "settingsvalue"
+msgid "Domains Only"
+msgstr ""
+
+msgid "Dominica"
+msgstr ""
+
+msgid "Dominican Republic"
+msgstr ""
+
+#. A button to dismiss seeing the banner altogether
+msgctxt "Update browser banner"
+msgid "Don't Remind Me"
+msgstr ""
+
+#. User clicks this button to not share their device's location
+msgctxt "precise_user_location"
+msgid "Don't Use"
+msgstr ""
+
+#. A setting for the safe search filter that doesn't remove content inappropriate for children.
+msgctxt "safe search"
+msgid "Don't filter adult content"
+msgstr "Nicht-Jugendfreie Inhalte nicht filtern"
+
+#. Headline on the Mountain Climber Onboarding slide
+msgctxt "onboarding_slide"
+msgid "Don't let friends get tracked!"
+msgstr ""
+
+#. Link to instructions explaining how to add DuckDuckGo to the list of search engines in your browser.
+msgid "Don't see DuckDuckGo in the list?"
+msgstr "DuckDuckGo ist in der Liste nicht aufgeführt?"
+
+#. Link to download a file again if the user can't find it on their computer.
+msgctxt "install-extension"
+msgid "Don't see it? %s%s%sClick here to re-download%s"
+msgstr "Siehst du es nicht? %s%s%sKlicke hier um es erneut herunterzuladen%s"
+
+#. Tells users how to add DuckDuckGo to the list of search engines in their browser.
+msgid "Don't see the checkbox? %sFollow these steps%s."
+msgstr "Du siehst die Checkbox nicht? %sDenn folge diesen Schritten%s."
+
+#. Setting that hides a user's most visited sites when they open a new browser tab.
+msgctxt "new tab page"
+msgid "Don't show"
+msgstr ""
+
+#. Button that finishes the pairing flow on the joiner device's success screen (this is the final step for the joiner, so 'Done' rather than 'Next').
+msgctxt "CTA on the joiner-device success screen"
+msgid "Done"
+msgstr ""
+
+#. Button that closes the modal after a successful pairing.
+msgctxt "Close button on the success screen"
+msgid "Done"
+msgstr ""
+
+msgctxt "precise_user_location"
+msgid "Done"
+msgstr "Fertig"
+
+#. Message shown in a modal after DuckDuckGo browser users disable AI features in Settings. The first two placeholders bold noai.duckduckgo.com. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
+"filtered out. %sLearn More%s"
+msgstr ""
+
+#. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
+"and AI images filtered out. %sLearn more%s"
+msgstr ""
+
+#. Tennis match stats
+msgctxt "Sports module"
+msgid "Double Faults"
+msgstr ""
+
+#. Text for a button that downloads a chat, as in it will it will create a file with the chat to be downloaded.
+msgctxt "Button for downloading a chat"
+msgid "Download"
+msgstr ""
+
+#. CTA button text in the RetentionBrowserPromo card that opens the DuckDuckGo browser download page.
+msgctxt "Promotional CTA"
+msgid "Download"
+msgstr ""
+
+#. Text of a button that will download a file (e.g. Browser installer)
+msgctxt "SERP footer content"
+msgid "Download"
+msgstr ""
+
+#. Text of a button that will install the DuckDuckGo browser when clicked
+msgctxt "Browser Promo Popover"
+msgid "Download Browser"
+msgstr ""
+
+#. CTA button text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser.
+msgctxt "Promotional CTA"
+msgid "Download Browser"
+msgstr ""
+
+#. Primary CTA to download chat history.
+msgctxt "duckai_migration"
+msgid "Download Chat History"
+msgstr ""
+
+#. Title after successful download.
+msgctxt "duckai_migration"
+msgid "Download Complete"
+msgstr ""
+
+#. Text of a button that will install the DuckDuckGo browser when clicked
+msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Text of a button that will install the DuckDuckGo browser when clicked
+msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo Browser"
+msgstr ""
+
+#. Text of a button that will install the DuckDuckGo browser when clicked
+msgctxt "Browser Promo Popover"
+msgid "Download Our Free Browser"
+msgstr ""
+
+#. Aria label for the download icon button in the recovery code box on the joiner-device ('New device added') success screen; triggers a download of the recovery code as a PDF (falling back to a .txt file).
+msgctxt ""
+"Accessible label for the download icon button on the joiner success screen"
+msgid "Download Recovery Code"
+msgstr ""
+
+#. Button that downloads a file.
+msgid "Download file"
+msgstr "Datei herunterladen"
+
+#. Call to action to invite users to download the image generated by an AI model.
+msgctxt "Tooltip for an action button"
+msgid "Download image"
+msgstr ""
+
+#. Step 1 label.
+msgctxt "duckai_migration"
+msgid "Download your chat history"
+msgstr ""
+
+#. Step 1 label.
+msgctxt "duckai_migration"
+msgid "Download your chats"
+msgstr ""
+
+#. Sidebar heading displayed above links to DuckDuckGo apps (our 'browser') on platforms such as iOS, Android, Windows, MacOS, and more.
+msgid "Downloads"
+msgstr ""
+
+#. Text for a prompt suggestion for drafting an email to a vendor requesting a quote for ceiling fan repair services.
+msgctxt "Full sentence for writing an email"
+msgid ""
+"Draft a concise and detailed email to a vendor requesting a quote for "
+"ceiling fan repair services."
+msgstr ""
+
+#. Text for a prompt suggestion asking for an email draft to a vendor requesting a quote for home refrigerator repair services.
+msgctxt "Full sentence for writing an email"
+msgid ""
+"Draft a concise and detailed email to a vendor requesting a quote for home "
+"refrigerator repair services."
+msgstr ""
+
+#. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Draft a cover letter"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Draft a cover letter" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Draft a cover letter for this job."
+msgstr ""
+
+#. Text for a prompt suggestion for drafting a social media post inviting people to an upcoming party.
+msgctxt "Full sentence for drafting a social media post"
+msgid ""
+"Draft a few options for a social media post inviting people to my upcoming "
+"party."
+msgstr ""
+
+#. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
+msgctxt "Full sentence for suggesting a blog post title"
+msgid ""
+"Draft a few options for a title of a post I’m writing about strategies to "
+"increase team collaboration."
+msgstr ""
+
+#. Short string representing a prompt suggestion for drafting a social media post.
+msgctxt "Brief for drafting a social media post"
+msgid "Draft a social media post"
+msgstr ""
+
+#. Tells the user how to make DuckDuckGo their home page.
+msgid "Drag %sThis Button%s on top of the home icon:"
+msgstr "Ziehe %sDiesen Button%s über das home Icon:"
+
+#. Indicates this is the number of draws for this team in e.g. soccer
+msgctxt "Sports module"
+msgid "Draws"
+msgstr ""
+
+#. Instant Answer Tab Name
+msgid "Drinks"
+msgstr "Getränke"
+
+#. F1 standings tab label for driver championship
+msgctxt "Sports module"
+msgid "Drivers"
+msgstr ""
+
+#. Label for driving directions on a map.
+msgctxt "directions"
+msgid "Driving"
+msgstr "Fahren"
+
+#. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
+msgctxt "Weather IA"
+msgid "Drizzle"
+msgstr ""
+
+#. Rugby match stats
+msgctxt "Sports module"
+msgid "Drop Goals"
+msgstr ""
+
+#. Text shown when user is dragging PDF files over the Duck.ai chat input to add them to the current chat message being composed.
+msgctxt "Drop PDF files to be uploaded to the Duck.ai chat conversation"
+msgid "Drop your PDF files"
+msgstr ""
+
+#. Text shown when user is dragging files over the AI chat interface to add images to the current AI chat message being composed.
+msgctxt "Drop an image to be uploaded to the AI chat conversation"
+msgid "Drop your image here"
+msgstr ""
+
+#. Text shown when user is dragging both image and PDF files over the Duck.ai chat input to add them to the current chat message being composed.
+msgctxt "Drop files to be uploaded to the Duck.ai chat conversation"
+msgid "Drop your photos or PDF files"
+msgstr ""
+
+#. A title explaining what Duck Player (DDG's feature to watch youtube videos more privately) does
+msgid "Duck Player lets you watch YouTube without targeted ads"
+msgstr ""
+
+#. This is the DDG version of "Google it", meaning "search it".
+msgid "Duck it"
+msgstr "Mit der Ente suchen"
+
+#. Page title for a ChatGPT-like chat bot feature. Translation should include the equivalent term for AI (Artificial Intelligence). It's ok to leave it in English if that's the expectation in your language.
+msgctxt "Page title in browser tab"
+msgid "Duck.ai"
+msgstr ""
+
+msgctxt "settings"
+msgid "Duck.ai"
+msgstr ""
+
+#. Text on link to the Duck.ai Privacy Policy & Terms of Service page.
+msgctxt "Text on link to the Duck.ai Privacy Policy & Terms of Service page."
+msgid "Duck.ai Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Title of the modal that contains settings for Duck.ai.
+msgctxt "Modal header for Duck.ai settings"
+msgid "Duck.ai Settings"
+msgstr ""
+
+#. Text for the duck.ai settings button that appears in the mobile app sidebar.
+msgctxt "Text for the duck.ai settings button"
+msgid "Duck.ai Settings"
+msgstr ""
+
+#. Text for the link to the Duck.ai Terms of Service page.
+msgctxt "Link text for Terms of Service"
+msgid "Duck.ai Terms of Service"
+msgstr ""
+
+#. The HTML <title> for Duck.ai.
+msgctxt "duckai_seo"
+msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
+msgstr ""
+
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
+#. Description explaining how the page context feature works in Duck.ai sidebar.
+msgctxt "Description text for the page context onboarding modal"
+msgid ""
+"Duck.ai can now help answer questions about the page you're viewing. Page "
+"content is only included when you attach it, unless you choose to attach "
+"pages automatically in Settings."
+msgstr ""
+
+#. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
+msgctxt ""
+"Recent chats list warning when device storage (IndexedDB) is unavailable"
+msgid ""
+"Duck.ai can’t access local storage to save your chats. Please check your "
+"browser settings or disable any extensions and try again."
+msgstr ""
+
+#. Displayed when the chat service has reached the maximum number of messages for one day.
+msgctxt "Error message for service limit"
+msgid ""
+"Duck.ai has reached the maximum number of messages for one day. Please "
+"continue this chat tomorrow."
+msgstr ""
+
+#. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
+msgctxt "Promotional banner body text"
+msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
+msgstr ""
+
+#. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
+msgctxt "About section description on the Duck.ai settings page"
+msgid ""
+"Duck.ai is created by DuckDuckGo. We're an independent online protection "
+"company for anyone who wants to take back control of their personal "
+"information."
+msgstr ""
+
+#. Title shown when an update is required before proceeding.
+msgctxt "duckai_migration"
+msgid "Duck.ai is moving domains"
+msgstr ""
+
+#. Body text prompting user to update Duck.ai.
+msgctxt "duckai_migration"
+msgid ""
+"Duck.ai is still a DuckDuckGo product, but will now have an easier to "
+"remember home on the web: https://duck.ai"
+msgstr ""
+
+#. Headline for domain change notice.
+msgctxt "duckai_migration"
+msgid "Duck.ai is switching domains"
+msgstr ""
+
+#. Displayed when there is an error in the chat making it unavailable, and asking the user to send an email with a specific code if the error persists. E.g. 'Duck.ai is temporarily unavailable. If this persists, please email this anonymous code abcdefg12345 to aichat-error@duckduckgo.com'
+msgctxt "Error message for BOTNET limit."
+msgid ""
+"Duck.ai is temporarily unavailable. If this persists, please email this "
+"anonymous code %s to %s"
+msgstr ""
+
+#. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
+msgctxt "Error message for VQD error"
+msgid ""
+"Duck.ai is temporarily unavailable. Please refresh the page and try again."
+msgstr ""
+
+#. Displayed when the AI chat service is temporarily unavailable.
+msgctxt "Error message for service unavailability"
+msgid "Duck.ai is temporarily unavailable. Please try again later."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you chat privately with popular AI models. Disabling it hides "
+"Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Duck.ai lets you have anonymous conversations with 3rd-party AI chat models, "
+"including models from OpenAI, Anthropic, and others. Turning this setting "
+"off will hide Duck.ai buttons and links on DuckDuckGo Search. However, you "
+"can still access Duck.ai when this setting is off by visiting %shttps://duck."
+"ai%s directly."
+msgstr ""
+
+#. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
+msgctxt "Disclaimer text at the bottom of the feedback form."
+msgid "Duck.ai may display inaccurate or offensive information."
+msgstr ""
+
+#. Error modal body line 2.
+msgctxt "duckai_migration"
+msgid ""
+"Duck.ai might have lost your recent chats. You can still use Duck.ai as "
+"usual."
+msgstr ""
+
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai now can read and analyze PDFs. Give it a try!"
+msgstr ""
+
+#. Disclaimer text shown above the chat input only when coming from a DuckAssist grounded response into ungrounded models.
+msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
+msgid ""
+"Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
+msgstr ""
+
+#. Title shown when native app needs to reload for service update.
+msgctxt "duckai_migration"
+msgid "Duck.ai update"
+msgstr ""
+
+#. Title for the modal shown to users who have just upgraded their Duck.ai subscription from Plus to Pro.
+msgctxt "Title of the post-upgrade success modal"
+msgid "Duck.ai upgraded!"
+msgstr ""
+
+#. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
+msgctxt "Promotional banner body text"
+msgid "Duck.ai works best in our private and free DuckDuckGo app!"
+msgstr ""
+
+#. Meta keywords content for Duck.ai.
+msgctxt "duckai_seo"
+msgid ""
+"Duck.ai, DuckDuckGo AI, private AI chatbot, free AI chat, anonymous AI chat, "
+"AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
+"models, privacy focused AI, no account AI chat"
+msgstr ""
+
+#. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
+msgctxt "Title under the Duck.ai logo on the empty chat page"
+msgid "Duck.ai, by DuckDuckGo"
+msgstr ""
+
+msgctxt "settings"
+msgid "DuckAssist"
+msgstr ""
+
+msgctxt "settings"
+msgid "DuckAssist <sup>BETA</sup>"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"DuckAssist can anonymously look up and summarize information in response to "
+"some searches. You can choose how often you want DuckAssist to appear: Never "
+"(completely removes DuckAssist UI from search results), On-demand (only "
+"shows if you click the Assist button), Sometimes (only show when highly "
+"relevant), or Often (shows more frequently on a wider range of searches). "
+"For now, DuckAssist is only available in the U.S. (English) region."
+msgstr ""
+
+#. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
+msgid ""
+"DuckAssist cannot answer follow-up questions, however, we also offer "
+"%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
+"supports chat models from OpenAI, and Anthropic, and more."
+msgstr ""
+
+#. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
+msgid ""
+"DuckAssist cannot answer follow-up questions, however, we also offer "
+"DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
+"supports chat models from OpenAI and Anthropic."
+msgstr ""
+
+#. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
+msgid ""
+"DuckAssist is a new feature in our search results that can anonymously "
+"generate answers to search queries. To do this, it scans Wikipedia and "
+"related sites for relevant content and then uses AI-powered natural language "
+"technology to generate a summary of that information. Please note that its "
+"responses are currently based on Wikipedia and related content and are not "
+"checked for accuracy."
+msgstr ""
+
+#. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
+msgid ""
+"DuckAssist is an optional feature in our search results that can anonymously "
+"generate answers to search queries. To do this, it scans the web for "
+"relevant content and then uses AI-powered natural language technology to "
+"generate a brief answer based on relevant information found. DuckAssist "
+"responses always link directly to one or two sources, citing where the "
+"answer came from, so you can easily go and get more detailed information. "
+"It’s important to remember that responses are auto-generated from cited "
+"sources and based on %scrawling the web%s."
+msgstr ""
+
+#. Disclaimer for the duckassist instant answer (based on generative AI)
+msgid ""
+"DuckAssist responses are auto-generated based on listed sources and not "
+"checked for accuracy."
+msgstr ""
+
+#. Displayed when the chat service has reached the maximum number of messages for one day.
+msgctxt "Error message for service limit"
+msgid ""
+"DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
+"Please continue this chat tomorrow."
+msgstr ""
+
+#. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
+msgctxt "Modal body for information"
+msgid ""
+"DuckDuckGo AI Chat is a private AI-powered chat service that currently "
+"supports %s’s %s and %s’s %s chat models."
+msgstr ""
+
+#. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
+msgctxt "Onboarding welcome screen subtitle"
+msgid ""
+"DuckDuckGo AI Chat is a private AI-powered chat service that currently "
+"supports %s’s %s and %s’s %s chat models."
+msgstr ""
+
+#. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
+msgctxt "Disclaimer text at the bottom of the feedback form."
+msgid ""
+"DuckDuckGo AI Chat is in Beta, it may display inaccurate or offensive "
+"information."
+msgstr ""
+
+#. Displayed when there is an error in the chat making it unavailable, and asking the user to send an email with a specific code if the error persists. E.g. 'DuckDuckGo AI Chat is temporarily unavailable. If this persists, please email this anonymous code abcdefg12345 to aichat-error@duckduckgo.com'
+msgctxt "Error message for BOTNET limit."
+msgid ""
+"DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
+"email this anonymous code %s to %s"
+msgstr ""
+
+#. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
+msgctxt "Error message for VQD error"
+msgid ""
+"DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
+"try again."
+msgstr ""
+
+#. Displayed when the AI chat service is temporarily unavailable.
+msgctxt "Error message for service unavailability"
+msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
+msgstr ""
+
+#. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
+msgctxt ""
+"Title of the DuckDuckGo account setting located on the settings modal "
+"(electron desktop app variant)"
+msgid "DuckDuckGo Account"
+msgstr ""
+
+#. this is either the title that gets created by opening https://duckduckgo.com/duckduckbot or the top header in https://duckduckgo.com/duckduckbot
+msgid "DuckDuckGo Bot"
+msgstr "DuckDuckGo-Suchroboter"
+
+#. Link label for DuckDuckGo 'App' page (https://duckduckgo.com/app)
+msgid "DuckDuckGo Browser"
+msgstr ""
+
+#. Shown for devices whose access credential is 'ddg' (a DuckDuckGo native client); their name/type bytes are encrypted under a key this client doesn't hold.
+msgctxt ""
+"Placeholder name for a DuckDuckGo native browser/app in the synced devices "
+"list; the %s is the 1-based position in the list"
+msgid "DuckDuckGo Browser %s"
+msgstr ""
+
+#. by opening https://duckduckgo.com/api it shows in the window title
+msgid "DuckDuckGo Instant Answer API"
+msgstr "DuckDuckGo-Sofortantwort-API"
+
+#. by opening https://duckduckgo.com/newbang it shows in the window title
+msgid "DuckDuckGo New !Bang"
+msgstr "DuckDuckGo Neuer !Bang"
+
+#. Inside your browser title bar or tab title when visiting the <a href="https://duckduckgo.com/privacy.html">privacy page</a>.
+msgid "DuckDuckGo Privacy"
+msgstr "DuckDuckGo Privatsphäre"
+
+#. Promotional message for the Privacy Pro subscription service.
+msgctxt "SERP footer content"
+msgid "DuckDuckGo Privacy Pro"
+msgstr ""
+
+#. Links to a page that provides a list of DuckDuckGo product updates
+msgctxt "SERP footer content"
+msgid "DuckDuckGo Releases"
+msgstr ""
+
+#. Sidebar subheading with links to DuckDuckGo homepage, Settings, and more.
+msgid "DuckDuckGo Search"
+msgstr ""
+
+#. Inside your browser title bar or tab title when visiting the <a href="https://duckduckgo.com/search_box.html">search box page</a>.
+msgid "DuckDuckGo Search Box"
+msgstr "DuckDuckGo Suchfeld"
+
+#. Inside your browser title bar or tab title when visiting the <a href="https://duckduckgo.com/settings.html">settings page</a>.
+msgid "DuckDuckGo Settings"
+msgstr "DuckDuckGo Einstellungen"
+
+#. Refers to the DuckDuckGo subscription product.
+msgid "DuckDuckGo Subscription"
+msgstr ""
+
+#. Sidebar navigation label for the DuckDuckGo Subscription section of the Duck.ai settings page, where users can manage their subscription.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "DuckDuckGo Subscription"
+msgstr ""
+
+#. Promotional message for the DuckDuckGo subscription service.
+msgctxt "SERP footer content"
+msgid "DuckDuckGo Subscription"
+msgstr ""
+
+#. Title for the subscription setting when users are subscribed to DuckDuckGo.
+msgctxt ""
+"Title of the DuckDuckGo subscription setting located on the settings modal"
+msgid "DuckDuckGo Subscription"
+msgstr ""
+
+#. A button that takes the user to the subscription FAQs.
+msgctxt "Button on the subscription welcome modal"
+msgid "DuckDuckGo Subscription FAQs"
+msgstr ""
+
+#. Link to the settings help in support center from the cloud save section.
+#. You have to click the "What is this?" link to display the link (that is contained on the bottom of a huge paragraph).
+msgid "DuckDuckGo Support Center"
+msgstr "DuckDuckGo Support-Center"
+
+#. Displayed into your browser's title bar, tab's title, when you visit the <a href="https://duckduckgo.com/params.html">params page</a>.
+#. Bonus : also available through the <head><title>HERE</title></head> tag.
+msgid "DuckDuckGo URL Parameters"
+msgstr "DuckDuckGo URL-Parameter"
+
+#. Headline of the VPN instant answer shown on the search results page. One of several messages rotated over time that promote the DuckDuckGo VPN (part of the paid subscription).
+msgctxt "DuckDuckGo VPN instant answer"
+msgid "DuckDuckGo VPN"
+msgstr ""
+
+#. Headline of the VPN instant answer shown on the search results page. One of several messages rotated over time that promote the DuckDuckGo VPN (part of the paid subscription). Emphasizes multi-device protection.
+msgctxt "DuckDuckGo VPN instant answer"
+msgid "DuckDuckGo VPN for all your devices"
+msgstr ""
+
+#. Headline of the VPN instant answer shown on the search results page. One of several messages rotated over time that promote the DuckDuckGo VPN (part of the paid subscription). Emphasizes that the VPN is easy to set up.
+msgctxt "DuckDuckGo VPN instant answer"
+msgid "DuckDuckGo VPN is easy to set up"
+msgstr ""
+
+#. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time. 'Try free' refers to the free trial of the paid subscription; VPN is the DuckDuckGo VPN product.
+msgctxt "Mobile SERP subscription badge"
+msgid "DuckDuckGo VPN. Try free!"
+msgstr ""
+
+#. Explains that DuckDuckGo anonymizes these reports by automatically removing PII like names, email addresses, phone numbers, and identifying metadata.
+msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
+msgid ""
+"DuckDuckGo anonymizes these reports by automatically removing PII like "
+"names, email addresses, phone numbers, and identifying metadata."
+msgstr ""
+
+#. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
+msgctxt "Body copy of terms-of-service decision card on Duck.ai"
+msgid ""
+"DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
+msgstr ""
+
+#. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
+msgctxt ""
+"Inline terms-of-service disclaimer below chat or image-gen input for new "
+"users"
+msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
+msgstr ""
+
+#. An information popup explaining that we block trackers
+msgid ""
+"DuckDuckGo blocks trackers on websites you visit, including trackers from "
+"companies like Google and Facebook, who often try to track you on other "
+"websites."
+msgstr ""
+
+#. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
+msgctxt "precise_user_location"
+msgid ""
+"DuckDuckGo is private by design. When you enable location, it is stored on "
+"your local device only. When you search, your device then sends it to us, we "
+"use it to improve results for that search, and then we promptly throw it "
+"away, such that you remain anonymous. %sLearn more about how we designed "
+"this technology to protect your privacy%s."
+msgstr ""
+
+msgctxt "new tab page"
+msgid "DuckDuckGo never has access to this data."
+msgstr ""
+
+msgctxt ""
+"Appears in the tooltip of the privacy reminder that may appear in the search "
+"filter bar"
+msgid "DuckDuckGo never tracks your searches."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"DuckDuckGo only uses your approximate location. That's all we need to "
+"deliver better results, closer to you. %sLearn more%s."
+msgstr ""
+
+msgid "DuckDuckGo search"
+msgstr "DuckDuckGo Suche"
+
+#. Used as a link to your personal settings  into the sentence <em>You can change *DuckDuckGo settings* via URL parameters by adding them after the search query</em>. See the <a href="https://duckduckgo.com/params.html">params page</a>.
+msgid "DuckDuckGo settings"
+msgstr "DuckDuckGo Einstellungen"
+
+#. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; shown in every market.
+msgctxt "DuckDuckGo Subscription instant answer"
+msgid "DuckDuckGo subscription"
+msgstr ""
+
+#. Will be used in the sentence, 'Activate your DuckDuckGo subscription in this browser again to continue the chat, or switch to a free model.'
+msgctxt ""
+"Link part of the error message that informs the user they need to activate "
+"their subscription to keep using the same AI model. It opens the "
+"subscription modal"
+msgid "DuckDuckGo subscription"
+msgstr ""
+
+#. Will be used in the sentence 'Unlock advanced AI models with a DuckDuckGo subscription' and open sthe subscription modal when clicked
+msgctxt "Link text used within sentences to open the subscription modal"
+msgid "DuckDuckGo subscription"
+msgstr ""
+
+#. Description for the subscription setting when subscriptions to DuckDuckGo are not available in the user region.
+msgctxt ""
+"Description of the DuckDuckGo subscription setting when it is not available "
+"in the user region"
+msgid "DuckDuckGo subscriptions are not available to purchase in this region."
+msgstr ""
+
+#. Label for the option prompting the AI assistant to use 'ducky' tone in its responses. When this option is selected, the AI assistant speaks like a duck.
+msgctxt "Tone option label for Ducky"
+msgid "Ducky"
+msgstr ""
+
+#. Label that's displayed next to a duration below a web search result.
+msgctxt "Rich Facts label"
+msgid "Duration"
+msgstr ""
+
+#. List item indicating that a layout filter (e.g. tall) is currently active for the search
+msgctxt "noresults"
+msgid "Duration"
+msgstr ""
+
+#. The name of the Dutch language
+msgctxt "language_name"
+msgid "Dutch"
+msgstr ""
+
+#. Abbreviation for 'East'
+msgctxt "forecast"
+msgid "E"
+msgstr "O"
+
+#. Abbreviation indicating that a match is in extra time, e.g. in soccer
+msgctxt "Sports module"
+msgid "ET"
+msgstr ""
+
+msgctxt "settings"
+msgid "EU Android Welcome Message"
+msgstr "EU Android Wilkommmensnachricht"
+
+#. Text explaining how random passphrases are generated.
+#. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
+#. You have to click the "What is this?" link to display it.
+msgctxt "cloudsave"
+msgid ""
+"Each time you ask for a passphrase suggestion, we receive a long list of "
+"random words from the DuckDuckGo servers. In the browser, we then select 4-5 "
+"random words from that list, ensuring that the passphrase is at least 18-20 "
+"characters long."
+msgstr ""
+
+msgctxt "Sports module"
+msgid "East"
+msgstr ""
+
+#. For US leagues that divide teams in two conferences, short version used e.g. in the Team module subtitle in NBA
+msgctxt "Sports module"
+msgid "Eastern"
+msgstr ""
+
+#. For US leagues that divide teams in two conferences, used e.g. in the Standings table in NBA
+msgctxt "Sports module"
+msgid "Eastern Conference"
+msgstr ""
+
+#. A positive feedback suggestion saying the feature provides the user with easy access to different AI (Artificial Intelligence) models
+msgctxt "Feedback prompt"
+msgid "Easy access to different AI models"
+msgstr ""
+
+#. Cricket scorecard: economy rate abbreviation
+msgctxt "Sports module"
+msgid "Econ"
+msgstr ""
+
+#. Cricket scorecard: economy rate full name (tooltip)
+msgctxt "Sports module"
+msgid "Economy Rate"
+msgstr ""
+
+msgid "Ecuador"
+msgstr ""
+
+#. Tooltip text for the button that allows the user to edit their previous message.
+msgctxt "Tooltip for edit message action"
+msgid "Edit"
+msgstr ""
+
+#. Text in button that opens the prompt editor so the user edit their last prompt (message) sent to the AI assistant.
+msgctxt "DuckChat upload consent prompt for encrypted models"
+msgid "Edit Prompt"
+msgstr ""
+
+#. Title text shown for an assistant response that contains an edited image. Shown to internal users only
+msgctxt "Assistant response title"
+msgid "Edited image. Cost %s (internal only)"
+msgstr ""
+
+#. Placeholder text displayed while the AI assistant is editing an image.
+msgctxt "Assistant response placeholder"
+msgid "Editing image..."
+msgstr ""
+
+#. Text explaining that editing a message will remove the original response and generate a new one.
+msgctxt "Info text for the editing message feature"
+msgid ""
+"Editing your message will remove the response below and generate a new one."
+msgstr ""
+
+#. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
+msgctxt "Assistant role option label for Editor"
+msgid "Editor"
+msgstr ""
+
+msgid "Egypt"
+msgstr ""
+
+msgid "El Salvador"
+msgstr ""
+
+#. Form field for your email ;)
+#. From <a href="https://duckduckgo.com/newbang.html ">new !bang page</a> and <a href="https://duckduckgo.com/feedback.html">feedback page</a>.
+msgid "Email"
+msgstr "Email"
+
+#. Refers to the DuckDuckGo Email Protection product.
+msgid "Email Protection"
+msgstr ""
+
+#. A link that takes the user to the Email Protection product page (https://duckduckgo.com/email/)
+msgctxt "SERP footer content"
+msgid "Email Protection"
+msgstr ""
+
+#. Label for the option prompting the AI assistant to use empathetic tone in its responses.
+msgctxt "Tone option label for Empathetic"
+msgid "Empathetic"
+msgstr ""
+
+#. Description text below the highlight toggle, explaining that the feature visually emphasizes key facts in Search Assist answers.
+msgctxt "duckassist"
+msgid "Emphasize important information in answers"
+msgstr ""
+
+#. Tells users which setting to change to enable location service.
+msgctxt "precise_user_location"
+msgid "Enable 'Sites can ask for my location.'"
+msgstr "Aktivere 'Seiten können meinen Standort anfragen.'"
+
+#. Button shown during outages to enable AI features
+msgctxt "noresults"
+msgid "Enable AI Features"
+msgstr ""
+
+#. Text explaining how to enable the cloud save feature.
+msgctxt "cloudsave"
+msgid "Enable Cloud Save by entering your existing passphrase."
+msgstr ""
+
+#. Primary button text in the dictation privacy consent modal to enable dictation.
+msgid "Enable Dictation"
+msgstr ""
+
+#. Title of the dictation privacy consent modal shown on first use.
+msgid "Enable Dictation in Duck.ai"
+msgstr ""
+
+msgctxt "settings"
+msgid "Enable Duck.ai Instant Answers"
+msgstr ""
+
+#. Button that allows a map to access the user's current location.
+msgctxt "precise_user_location"
+msgid "Enable Location"
+msgstr "Standort aktivieren"
+
+#. Setting that shows a user's most visited sites when they open a new browser tab.
+msgctxt "new tab page"
+msgid "Enable Most Visited Sites"
+msgstr "Zeige die meistbesuchten Seiten"
+
+#. Setting that shows a user's most visited sites when they open a new browser tab.
+msgctxt "new tab page"
+msgid "Enable Most-Visited Sites"
+msgstr ""
+
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
+#. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
+msgctxt "Label for enabling recent chats feature"
+msgid "Enable Recent Chats"
+msgstr ""
+
+#. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
+msgctxt "Title for the Sync & Backup intro screen"
+msgid "Enable Sync & Backup"
+msgstr ""
+
+#. Title for the enable voice chat section in the voice chat consent modal.
+msgctxt "voice chat"
+msgid "Enable Voice Chat"
+msgstr ""
+
+#. Text for button where the user consents to and enables the voice chat feature.
+msgctxt "voice chat button"
+msgid "Enable Voice Chat"
+msgstr ""
+
+#. Button to approve web search for the current conversation, shown inside an in-chat permission card in Duck.ai
+msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "Enable Web Search"
+msgstr ""
+
+#. Tells users how to enable location service on their device.
+msgid ""
+"Enable anonymous location for more accurate results. You can always change "
+"your mind later."
+msgstr ""
+
+#. Title of the dictation privacy consent modal shown on first use.
+msgid "Enable dictation in Duck.ai"
+msgstr ""
+
+#. Prompt to enable location service so that search results can be displayed near the user's current location.
+msgctxt "precise_user_location"
+msgid "Enable location settings on your device to use anonymous location"
+msgstr ""
+
+#. Prompts users to turn on the location service on their phone.
+msgctxt "precise_user_location"
+msgid "Enable the Location setting on your phone."
+msgstr "Aktiviere die Standorteinstellungen auf deinem Handy."
+
+#. Title of the web search permission prompt shown for zero-provider-visibility models, shown inside an in-chat permission card in Duck.ai
+msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "Enable web search for this chat?"
+msgstr ""
+
+#. Text for the label that indicates the feature is enabled.
+msgctxt "Status label for a setting"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "settings"
+msgid "Enables keyboard shortcuts on the site"
+msgstr "Ermöglicht Tastaturkürzel auf der Seite"
+
+#. Explains the benefit of enabling Precise User Location.
+msgctxt "precise_user_location"
+msgid ""
+"Enabling anonymous location gives more accurate results but still keeps your "
+"searches and exact location private to DuckDuckGo."
+msgstr ""
+
+msgid "Encrypt Connections"
+msgstr "Verbindungen verschlüsseln"
+
+#. Text for the label that enables or disables the Encrypted Storage feature, a.k.a Sync
+msgctxt "Label for encrypted storage setting"
+msgid "Encrypted Storage"
+msgstr ""
+
+#. Short label that appears briefly next to the AI model name after a response finishes generating, indicating the model uses encrypted inference
+msgctxt ""
+"Ephemeral badge next to the model name in a Duck.ai assistant message for "
+"encrypted inference models"
+msgid "Encrypted model"
+msgstr ""
+
+#. shown after the DuckDuckGo extension is installed
+msgctxt "welcome message"
+msgid "Encrypts connections when possible"
+msgstr "Verschlüsselt Verbindungen wenn möglich"
+
+#. Tooltip/label for the button to end the voice chat session.
+msgctxt "voice chat"
+msgid "End chat"
+msgstr ""
+
+#. In the context of the clock of a sports game, indicates that a game period is over and we are on a break. E.g. 'End of 1st', 'End of OT' where 1st would be 1st period, and OT would be an overtime period
+msgctxt "Sports module"
+msgid "End of %s"
+msgstr ""
+
+#. Label that's displayed next to a past end date below a web search result.
+msgctxt "Rich Facts label"
+msgid "Ended"
+msgstr ""
+
+#. Label that's displayed next to an end date below a web search result.
+msgctxt "Rich Facts label"
+msgid "Ends"
+msgstr ""
+
+msgid "England"
+msgstr ""
+
+#. The name of the English language
+msgctxt "language_name"
+msgid "English"
+msgstr ""
+
+#. The name of the English (United Kingdom) language
+msgctxt "language_name"
+msgid "English (United Kingdom)"
+msgstr ""
+
+#. The text inviting users to provide feedback about the Duck.ai product
+msgctxt "Feedback prompt"
+msgid "Enjoying Duck.ai?"
+msgstr ""
+
+#. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
+msgctxt "precise_user_location"
+msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
+msgstr ""
+
+#. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
+msgctxt "precise_user_location"
+msgid "Ensure 'Location Services' is %senabled%s."
+msgstr ""
+
+#. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
+msgctxt "precise_user_location"
+msgid "Ensure 'Location' is set to %sallow%s"
+msgstr ""
+
+#. Tells users how to enable location service.
+msgctxt "precise_user_location"
+msgid "Ensure 'Location' is set to %sallow%s."
+msgstr ""
+
+#. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
+msgctxt "precise_user_location"
+msgid "Ensure Location is set to %sAllow%s"
+msgstr ""
+
+#. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
+msgctxt "precise_user_location"
+msgid "Ensure location access is %sallowed%s"
+msgstr ""
+
+#. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
+msgctxt "precise_user_location"
+msgid "Ensure location access is %sallowed%s."
+msgstr ""
+
+#. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
+msgctxt "precise_user_location"
+msgid "Ensure your browser is allowed %slocation access%s"
+msgstr ""
+
+#. Tells users how to enable location service.
+msgctxt "precise_user_location"
+msgid "Ensure your browser is allowed %slocation access%s."
+msgstr ""
+
+#. Tells how to enable location service. Part of a list of instructions on how to enable location service.
+msgctxt "precise_user_location"
+msgid "Ensure your browser is allowed location access"
+msgstr ""
+
+#. Tells how to enable location service.
+msgctxt "precise_user_location"
+msgid "Ensure your browser is allowed location access."
+msgstr ""
+
+#. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
+msgid "Enter %shttps://duckduckgo.com%s"
+msgstr "Geben Si %shttps://duckduckgo.com%s ein"
+
+#. Always visible on desktop. On mobile, replaces Scan QR Code as the first tab label after the user taps Manually Enter Code.
+msgctxt "Tab label for the manual-entry side of the Sync Another Device pane"
+msgid "Enter Code"
+msgstr ""
+
+#. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse
+msgid "Enter a follow-up question"
+msgstr ""
+
+#. Tells users how to change their passphrase for the cloud save feature.
+msgctxt "cloudsave"
+msgid ""
+"Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
+"data under your new passphrase."
+msgstr ""
+
+#. Label for the field where a user enters their passphrase.
+msgctxt "settings"
+msgid "Enter a passphrase"
+msgstr ""
+
+#. Prompt to enter a starting location for driving directions.
+msgctxt "maps_directions"
+msgid "Enter start location"
+msgstr "Gebe den Startpunkt ein"
+
+#. Placeholder for a field where inputted text will be translated
+msgctxt "translations_module"
+msgid "Enter text"
+msgstr ""
+
+#. Instructions for how to change the default search engine.
+msgid ""
+"Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
+msgstr ""
+"Gebe folgende Informationen an: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
+
+#. Prompt to enter a destination for driving directions.
+msgctxt "maps_directions"
+msgid "Enter your destination"
+msgstr "Gebe dein Ziel ein"
+
+#. Label for an email address field.
+msgctxt "email newsletter"
+msgid "Enter your email address."
+msgstr "Gib deine E-Mail-Adresse an."
+
+#. A prompt asking users to enter their passphrase.
+msgctxt "cloudsave"
+msgid "Enter your passphrase to load your settings."
+msgstr ""
+
+#. Label for the option prompting the AI assistant to adopt a role of an entertainment guide in its responses.
+msgctxt "Assistant role option label for Entertainment guide"
+msgid "Entertainment guide"
+msgstr ""
+
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
+msgid "Equatorial Guinea"
+msgstr ""
+
+#. Body text in a popover encouraging the user to try the DuckDuckGo browser
+msgctxt "Browser Promo Popover"
+msgid "Erase your browsing data in a flash with our %sFire Button%s"
+msgstr ""
+
+msgid "Eritrea"
+msgstr ""
+
+#. Page-suggestion chip label "Estimate the nutrition", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Estimate the nutrition"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Estimate the nutrition" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Estimate the nutritional information for this recipe."
+msgstr ""
+
+msgid "Estonia"
+msgstr "Estland"
+
+#. The name of the Estonian language
+msgctxt "language_name"
+msgid "Estonian"
+msgstr ""
+
+msgid "Eswatini "
+msgstr ""
+
+msgid "Ethiopia"
+msgstr ""
+
+#. Golf standings column: number of events played
+msgctxt "Sports module"
+msgid "Events"
+msgstr ""
+
+#. Shown greyed in the empty textarea, above an example sync code. The example code itself is a non-translatable constant appended in the component.
+msgctxt ""
+"Label above the illustrative code in the enlarged Enter Code textarea "
+"placeholder"
+msgid "Example code:"
+msgstr ""
+
+#. Button that makes a map larger
+msgctxt "mobile expanded map"
+msgid "Expand Map"
+msgstr "Karte vergrössern"
+
+#. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
+msgctxt "SERP footer content"
+msgid "Expertly crafted products for people who give a duck about privacy."
+msgstr ""
+
+#. Label indicating that the user has an expired DuckDuckGo subscription.
+msgctxt "Text for the expired subscription label on the settings modal"
+msgid "Expired"
+msgstr ""
+
+#. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in X days. The placeholder is the number of days until the promotion expires. Example: 'Expires in 5 days'
+msgctxt "merchant promotion product ad extension"
+msgid "Expires in %s days"
+msgstr ""
+
+#. Promotional text that appears in a merchant ad extension dropdown, meaning that a product promotion expires in 1 day.
+msgctxt "merchant promotion product ad extension"
+msgid "Expires in 1 day"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain the top answer" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain the accepted answer in simple terms."
+msgstr ""
+
+#. Text for a prompt suggestion for explaining the fundamental concepts of black holes at a high-school level.
+msgctxt "Full sentence for understanding a topic"
+msgid ""
+"Explain the fundamental concepts of black holes to me at a high-school level."
+msgstr ""
+
+#. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain the top answer"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this simply" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this in simple, plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this paper", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this paper"
+msgstr ""
+
+#. Page-suggestion chip label "Explain this repo", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this repo"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this paper" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain this research paper in plain language."
+msgstr ""
+
+#. Page-suggestion chip label "Explain this simply", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Explain this simply"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Explain what this repository does and how to use it."
+msgstr ""
+
+#. Label to show if song lyrics contain explicit content
+msgctxt "lyrics_module"
+msgid "Explicit"
+msgstr ""
+
+#. Option in a feedback form for image search results.
+msgctxt "Report image modal"
+msgid "Explicit content"
+msgstr "Expliziter Inhalt"
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Explicit lyrics"
+msgstr ""
+
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Links to a page that provides a list of DuckDuckGo product updates
+msgctxt "SERP footer content"
+msgid "Explore DuckDuckGo's latest product and feature updates."
+msgstr ""
+
+#. Links to a page that provides a list of DuckDuckGo product updates
+msgctxt "SERP footer content"
+msgid "Explore DuckDuckGo's latest product updates."
+msgstr ""
+
+#. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
+msgctxt "SERP footer content"
+msgid "Explore DuckDuckGo’s latest product updates."
+msgstr ""
+
+#. Section heading for the explore more questions that appear at the end of a DuckAssist answer
+msgid "Explore More"
+msgstr ""
+
+#. Gives user a link to see all of the bangs DuckDuckGo has available. !bangs is not translated.
+msgctxt "noresults"
+msgid "Explore all 13,000+ !bangs"
+msgstr ""
+
+#. Text for a button that exports a chat, as in it will it will create a file with the chat to be downloaded.
+msgctxt "Button text for exporting a chat"
+msgid "Export"
+msgstr ""
+
+#. In the context of an AI Chat, tooltip text for the button that exports the whole chat conversation to a text file.
+msgctxt "AI Chat - Tooltip for export chat action"
+msgid "Export chat"
+msgstr ""
+
+#. In the context of an AI Chat, tooltip text for the button that exports the whole conversation to a text file.
+msgctxt "AI Chat - Tooltip for export chat action"
+msgid "Export conversation"
+msgstr ""
+
+#. In the context of an AI Chat, tooltip text for the button that exports the whole voice chat transcript to a text file.
+msgctxt "AI Chat - Tooltip for export chat action"
+msgid "Export transcript"
+msgstr ""
+
+#. Tooltip that appears when hovering over the extend reasoning button, which allows users to resubmit a prompt with AI reasoning/thinking enabled.
+msgctxt "Tooltip text for button to resubmit prompt with reasoning enabled"
+msgid "Extend reasoning"
+msgstr ""
+
+#. Option in the reasoning mode dropdown that enables deeper reasoning. Only available to Pro subscribers.
+msgctxt "Label for extended reasoning mode in Duck.ai"
+msgid "Extended Reasoning"
+msgstr ""
+
+#. Link to a page where users can download the DuckDuckGo browser extension and other products.
+msgid "Extensions & More"
+msgstr "Erweiterungen und mehr"
+
+#. Filters the size of images in search results.
+msgctxt "size"
+msgid "Extra Large"
+msgstr "Sehr gross"
+
+#. Title for the FIFA Women's World Cup. Please keep it short and generic (without year nor location), and keep FIFA in it.
+msgctxt "Sports module"
+msgid "FIFA Women's World Cup"
+msgstr ""
+
+#. Title for the FIFA World Cup. Please keep it short and generic (without year nor location), and keep FIFA in it.
+msgctxt "Sports module"
+msgid "FIFA World Cup"
+msgstr ""
+
+#. For some rankings of sports leagues where each team/player is evaluated by pollsters, the ranking results specify the number of pollsters that voted for a team/player to be first place in the rankings. It stands for First Place Votes. Feel free to leave in English unless there's an obvious alternative in your language.
+msgctxt "Sports module"
+msgid "FPV"
+msgstr ""
+
+#. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
+msgctxt "Text for the free badge"
+msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
+msgstr ""
+
+#. Full-time (match has ended) indicator in a soccer match
+msgctxt "Sports module"
+msgid "FT"
+msgstr ""
+
+#. Option in the reasoning mode dropdown that disables reasoning for faster responses.
+msgctxt "Label for fast reasoning mode in Duck.ai"
+msgid "Fast"
+msgstr ""
+
+#. Tagline in a promotion for a desktop web browser
+msgctxt "Browser Promo Popover"
+msgid "Fast. Secure. Free."
+msgstr ""
+
+#. Label for driving directions with the least amount of travel time.
+msgctxt "directions"
+msgid "Fastest route"
+msgstr ""
+
+#. <em>kf</em>'s label into <a href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
+msgid "Favicons:"
+msgstr "Favoriten-Symbol:"
+
+msgid "Feedback"
+msgstr "Feedback"
+
+#. Sidebar navigation label for the Feedback section of the Duck.ai settings page, where users can submit feedback about Duck.ai.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Feedback"
+msgstr ""
+
+#. Confirmation message after sending feedback.
+msgctxt "feedback form"
+msgid "Feedback Sent"
+msgstr "Feedback gesendet"
+
+#. Confirmation message after sending feedback.
+msgctxt "feedback form"
+msgid "Feedback Sent Successfully"
+msgstr "Feedback erfolgreich gesendet"
+
+#. Message that appears after submitting a feedback form.
+msgctxt "feedback form"
+msgid ""
+"Feedback like yours directly influences our product updates and improvements."
+msgstr ""
+
+#. Message that appears after submitting a feedback form.
+msgctxt "feedback form"
+msgid ""
+"Feedback like yours directly influences our product updates and "
+"improvements. Hopefully we can address the issue you shared too."
+msgstr ""
+
+#. https://duckduckgo.com/search_box
+msgid ""
+"Feel free to adjust the settings below. Then, just copy and paste the code "
+"into your website."
+msgstr ""
+"Passe die Felder unten wie gewünscht an. Kopiere danach den Code und füge "
+"diesen in deine Webseite ein."
+
+msgid "Fiji"
+msgstr ""
+
+#. The name of the Fijian language
+msgctxt "language_name"
+msgid "Fijian"
+msgstr ""
+
+#. Default filename displayed when an attached file in the Duck.ai chat has no name.
+msgctxt "Default filename for unnamed file attachment"
+msgid "File"
+msgstr ""
+
+#. Label that's displayed next to a file size below a web search result.
+msgctxt "Rich Facts label"
+msgid "File Size"
+msgstr ""
+
+#. The name of the Filipino language
+msgctxt "language_name"
+msgid "Filipino"
+msgstr ""
+
+#. Tells users how to add DuckDuckGo to the list of search engines in their browser.
+msgid "Fill in the last form field with %s"
+msgstr "Fülle das letzte Formularfeld mit %s"
+
+#. A button to filter search results by domain. The button is shown next to a message encouraging the user to filter results.
+msgctxt "Site filter message"
+msgid "Filter Results"
+msgstr ""
+
+msgid "Filter by Date"
+msgstr ""
+
+msgid "Filter by Region"
+msgstr ""
+
+#. Message that appears above the search results encouraging them to filter results by domain. The placeholder string would include the domain of the website. E.g. 'Filter to only see results from reddit.com'
+msgctxt "Site filter message"
+msgid "Filter to only see results from %s"
+msgstr ""
+
+#. Category of feedback a user can select on a feedback form.
+msgctxt "feedback form"
+msgid "Filters aren't working"
+msgstr ""
+
+#. Header for a list of filters that are currently applied
+msgctxt "noresults"
+msgid "Filters currently applied:"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Filters not effective"
+msgstr ""
+
+msgctxt "settings"
+msgid "Filters out AI-generated images from image search results"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Filters out AI-generated images from image search results. %sLearn more%s"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Filters out known AI spam sites from image search results. %sLearn More%s"
+msgstr ""
+
+#. Label for the final score of a sporting event.
+msgid "Final"
+msgstr "Final"
+
+#. Used to indicate the game is over and the score shown is the final score, e.g. 10-5 Final
+msgctxt "Sports module"
+msgid "Final"
+msgstr ""
+
+#. Tells users how to add DuckDuckGo to the list of search engines in their browser.
+msgid "Finally, click %sAdd%s"
+msgstr "Zum Schluss, klick uf %sHinzuefüege%s"
+
+#. Label for the option prompting the AI assistant to adopt a role of a financial advisor in its responses.
+msgctxt "Assistant role option label for Financial advisor"
+msgid "Financial advisor"
+msgstr ""
+
+#. Tells users where to click in their browser to change the default search engine.
+msgid "Find %sDuckDuckGo%s and click%sMake default%s"
+msgstr "Wähle %sDuckDuckGo%s und klicke auf%sals Standard verwenden%s"
+
+#. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
+msgctxt "duckai_migration"
+msgid "Find <b>%s</b> in your downloads folder"
+msgstr ""
+
+#. Tells users how to change their default search engine to DuckDuckGo.
+msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
+msgstr ""
+"Finde DuckDuckGo in der angezeigten Liste, und klicke auf %sMake Default%s"
+
+#. Short string representing a prompt suggestion for finding a better word.
+msgctxt "Brief for finding a better word"
+msgid "Find a better word"
+msgstr ""
+
+#. Short description shown below the 'Web Search' label in the Tools dropdown.
+msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
+msgid "Find current information"
+msgstr ""
+
+#. Page-suggestion chip label "Find me alternatives", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Find me alternatives"
+msgstr ""
+
+#. Button that searches for results closer to the user's current location.
+msgctxt "precise_user_location"
+msgid "Find results closer to you"
+msgstr ""
+
+#. Button that searches for results closer to the user's current location.
+msgctxt "precise_user_location"
+msgid "Find results closer to you."
+msgstr "Ergebnisse in deiner Nähe finden."
+
+#. Overlay message that explains why users should use precise user location on their device
+msgctxt "Precise user location overlay"
+msgid ""
+"Find results near you. %sYour location stays private, secure, and anonymous."
+msgstr ""
+
+#. Loading message shown while generating explore more follow-up questions
+msgid "Finding follow-ups you might like…"
+msgstr ""
+
+msgid "Finland"
+msgstr "Finnland"
+
+#. The name of the Finnish language
+msgctxt "language_name"
+msgid "Finnish"
+msgstr ""
+
+#. For some rankings of sports leagues where each team/player is evaluated by pollsters, the ranking results specify the number of pollsters that voted for a team/player to be first place in the rankings. Feel free to leave in English unless there's an obvious alternative in your language.
+msgctxt "Sports module"
+msgid "First Place Votes"
+msgstr ""
+
+#. Label for the option prompting the AI assistant to adopt a role of a fitness guru in its responses.
+msgctxt "Assistant role option label for Fitness guru"
+msgid "Fitness guru"
+msgstr ""
+
+#. Label for the option prompting the AI assistant to adopt a role of a fitness trainer in its responses.
+msgctxt "Assistant role option label for Fitness trainer"
+msgid "Fitness trainer"
+msgstr ""
+
+#. A feedback menu option to flag an AI-generated image.
+msgctxt "Feedback context menu"
+msgid "Flag AI-generated image"
+msgstr ""
+
+#. Instant Answer Tab Name
+msgid "Flights"
+msgstr "Flüge"
+
+#. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
+msgctxt "Weather IA"
+msgid "Flurries"
+msgstr ""
+
+#. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
+msgctxt "Weather IA"
+msgid "Foggy"
+msgstr ""
+
+#. Instruction on how to disable the user's ad blocker for DuckDuckGo.
+msgid ""
+"Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
+"may have to select a menu option or click a button."
+msgstr ""
+
+#. Privacy reassurance and instructions intro.
+msgctxt "duckai_migration"
+msgid "Follow these steps to move your chats to the new Duck.ai"
+msgstr ""
+
+#. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
+msgid "Follow-up question"
+msgstr ""
+
+#. Link to DuckDuckGo's Twitter profile.
+msgctxt "new user poll"
+msgid "Following us on Twitter"
+msgstr "Folge uns auf Twitter"
+
+#. http://i.imgur.com/JWnlmmo.png
+msgctxt "settings"
+msgid "Font"
+msgstr "Schriftart"
+
+#. http://i.imgur.com/rBFnfUF.png
+msgctxt "settings"
+msgid "Font Size"
+msgstr "Schriftgrösse"
+
+#. Description text shown below the Reasoning option in the reasoning mode dropdown.
+msgctxt "Description for reasoning mode in Duck.ai"
+msgid "For complex tasks"
+msgstr ""
+
+#. Part of a list of what our app can do. The app can: …
+msgctxt "welcome message eu search preference android"
+msgid "Force encryption on websites"
+msgstr "Erzwinge Verschlüsselung auf Webseiten"
+
+#. Label that's displayed next to a format below a web search result.
+msgctxt "Rich Facts label"
+msgid "Format"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Formatting issues"
+msgstr ""
+
+#. Soccer match stats
+msgctxt "Sports module"
+msgid "Fouls"
+msgstr ""
+
+#. Cricket scorecard: fours full name (tooltip)
+msgctxt "Sports module"
+msgid "Fours"
+msgstr ""
+
+msgid "France"
+msgstr "Frankreich"
+
+#. Indicates that there is no cost to download DuckDuckGo's browser.
+msgctxt "Browser Promo Popover"
+msgid "Free"
+msgstr ""
+
+#. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
+msgctxt "Text for the free upgrade badge"
+msgid "Free"
+msgstr ""
+
+#. Indicates that this streaming service is free (no cost) to watch
+msgctxt "Where to watch instant answer"
+msgid "Free"
+msgstr ""
+
+#. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
+msgctxt "Text for the free upgrade badge"
+msgid "Free Plan"
+msgstr ""
+
+#. Opens the file storage limit modal so the user can delete older chats.
+msgctxt "Sync file storage inline disclaimer primary button"
+msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
+msgstr ""
+
+#. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
+msgctxt "Onboarding welcome screen private claim"
+msgid "Free and private chats, anonymized by us"
+msgstr ""
+
+#. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
+msgctxt "Onboarding welcome screen private claim"
+msgid "Free and private chats, anonymized by us. No account required."
+msgstr ""
+
+#. a filter for images with the CC BY-NC usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use"
+msgstr ""
+
+#. a filter for images with the CC BY usage license
+msgctxt "image-licence"
+msgid "Free to Modify, Share, and Use Commercially"
+msgstr ""
+
+#. a filter for images with the CC BY-NC-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use"
+msgstr ""
+
+#. a filter for images with the CC BY-ND usage license
+msgctxt "image-licence"
+msgid "Free to Share and Use Commercially"
+msgstr ""
+
+#. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
+msgctxt "Sync limit modal description"
+msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
+msgstr ""
+
+#. Indicates that this streaming service is free to watch but shows ads
+msgctxt "Where to watch instant answer"
+msgid "Free with ads"
+msgstr ""
+
+#. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
+msgctxt "Weather IA"
+msgid "Freezing Drizzle"
+msgstr ""
+
+#. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
+msgctxt "Weather IA"
+msgid "Freezing Rain"
+msgstr ""
+
+#. The name of the French language
+msgctxt "language_name"
+msgid "French"
+msgstr ""
+
+#. The name of the French (Canada) language
+msgctxt "language_name"
+msgid "French (Canada)"
+msgstr ""
+
+#. Weekday abbreviation (short for 'Friday')
+msgctxt "maps_places"
+msgid "Fri"
+msgstr ""
+
+#. Weekday in plural form
+msgctxt "maps_places"
+msgid "Fridays"
+msgstr ""
+
+#. Response a user can select in a feedback form, indicating they heard about DuckDuckGo from a friend or family member.
+msgctxt "new user poll"
+msgid "Friend or family"
+msgstr "Freunde oder Familie"
+
+#. Label for the option prompting the AI assistant to use friendly tone in its responses.
+msgctxt "Tone option label for Friendly"
+msgid "Friendly"
+msgstr ""
+
+#. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
+msgctxt "Weather IA"
+msgid "Frigid"
+msgstr ""
+
+#. Indicates that prices for this product/service start from this value, e.g. From $4.99
+msgid "From %s"
+msgstr ""
+
+#. Indicates that prices for this movie on this streaming service start from this value, e.g. From $4.99
+msgctxt "Where to watch instant answer"
+msgid "From %s"
+msgstr ""
+
+#. Instructions to update the macOS browser. The parts within tags come from the OS itself and must be translated as in the OS itself if possible. Otherwise, make a best effort.
+msgctxt "Update browser banner"
+msgid ""
+"From the app menu bar on Mac, select <strong>DuckDuckGo</strong> > "
+"<strong>Check for Updates...</strong>, then select <strong>Install Update</"
+"strong>."
+msgstr ""
+
+#. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
+msgctxt "settingsvalue"
+msgid "Full URLs (Breadcrumbs)"
+msgstr ""
+
+#. This is an option for a user setting. It refers to showing the full URL for a website, including the url path (e.g. website.com/this/is/this/path) -- Example image: https://i.imgur.com/SxYWf9o.png
+msgctxt "settingsvalue"
+msgid "Full URLs (Slashes)"
+msgstr ""
+
+#. Indicates this is the total goals scored against this team
+msgctxt "Sports module"
+msgid "GA"
+msgstr ""
+
+#. Indicates this is the gap between a leading team and another team (https://en.wikipedia.org/wiki/Games_behind)
+msgctxt "Sports module"
+msgid "GB"
+msgstr ""
+
+#. Indicates this is the difference between goals 'for' and 'against' for this team
+msgctxt "Sports module"
+msgid "GD"
+msgstr ""
+
+#. http://i.imgur.com/tGau0Vx.png
+msgctxt "settings"
+msgid "GET Requests"
+msgstr ""
+
+#. Indicates this is the total 'goals for' (i.e. scored by) this team
+msgctxt "Sports module"
+msgid "GF"
+msgstr ""
+
+#. In the context of a standings table for NHL (hockey), column title that abbreviates 'Games Played' (the number of games lost during overtime of this team)
+msgctxt "Sports module"
+msgid "GP"
+msgstr ""
+
+msgid "Gabon"
+msgstr ""
+
+msgid "Gambia"
+msgstr ""
+
+#. Text indicating the game number
+msgctxt "Sports module"
+msgid "Game %s"
+msgstr ""
+
+#. Indicates that a sporting event has ended
+msgid "Game ended"
+msgstr "Spiel ist beendet"
+
+#. Label for the number of games that have been played between two sports teams.
+msgid "Games"
+msgstr "Spiele"
+
+#. Title of a tab that displays a list of games for a sports league
+msgctxt "Sports module"
+msgid "Games"
+msgstr ""
+
+#. Indicates this is the gap between a leading team and another team (https://en.wikipedia.org/wiki/Games_behind)
+msgctxt "Sports module"
+msgid "Games Behind"
+msgstr ""
+
+#. In the context of a standings table for NHL (hockey), indicates the total number of games a team has played in total
+msgctxt "Sports module"
+msgid "Games Played"
+msgstr ""
+
+#. F1 standings table column: points gap to leader
+msgctxt "Sports module"
+msgid "Gap"
+msgstr ""
+
+#. Label for the option prompting the AI assistant to adopt a role of a gardener in its responses.
+msgctxt "Assistant role option label for Gardener"
+msgid "Gardener"
+msgstr ""
+
+#. Label that's displayed next to a gender below a web search result.
+msgctxt "Rich Facts label"
+msgid "Gender"
+msgstr ""
+
+#. Header above a list of search settings.
+msgid "General"
+msgstr "Allgemein"
+
+#. http://i.imgur.com/wjw27ik.png
+msgctxt "settings"
+msgid "General"
+msgstr "Allgemein"
+
+#. Text with short description for an AI Model.
+msgctxt "Label copy with short description of AI Model"
+msgid "General Purpose"
+msgstr ""
+
+#. Text with short description for an AI (Artificial Intelligence) Model that has a high moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
+msgctxt "Label copy with short description of AI Model"
+msgid "General purpose AI with high built-in moderation"
+msgstr ""
+
+#. Text with short description for an AI (Artificial Intelligence) Model that has a low moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
+msgctxt "Label copy with short description of AI Model"
+msgid "General purpose AI with low built-in moderation"
+msgstr ""
+
+#. Text with short description for an AI (Artificial Intelligence) Model that has a medium moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
+msgctxt "Label copy with short description of AI Model"
+msgid "General purpose AI with medium built-in moderation"
+msgstr ""
+
+#. Text indicating that the AI (Artificial Intelligence) model is a model for general purpose use. General-purpose AI refers to AI systems that can perform a wide range of tasks, rather than being specialized for a specific task.
+msgctxt "duck.ai model card"
+msgid "General-purpose AI"
+msgstr ""
+
+#. Copy to invite the user to ask duckassist (an instant answer based on generative AI) for an answer
+msgid "Generate"
+msgstr ""
+
+#. Button label to approve delegating image generation to the image model.
+msgctxt "DuckChat image generation delegation prompt"
+msgid "Generate Image"
+msgstr ""
+
+#. Text for the button that generates more of an answer from duckassist when the answer has come from a collapsed state
+msgid "Generate More"
+msgstr ""
+
+#. Page-suggestion chip label "Generate a shopping list", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Generate a shopping list"
+msgstr ""
+
+#. Tab tooltip text for a navigation tab that takes the user to duckassist instant answer - a generative AI feature that generates a short answer based on relevant content on the web. Do not use the word AI or artificial inteligence in the translation.
+msgid "Generate a short answer from the web"
+msgstr ""
+
+#. A button for users to generate an AI generated answer from their query on the duckassist module
+msgctxt "duckassist"
+msgid "Generate an answer"
+msgstr ""
+
+#. Copy to invite the user to ask duckassist (an instant answer based on generative AI) for an answer
+msgid "Generate an answer from relevant content on the web."
+msgstr ""
+
+#. Text for the query that is displayed in the Search Assist introduction. For example: Get an answer for 'How to wash a car'.
+msgid "Generate answer for <strong>%s</strong>"
+msgstr ""
+
+#. Aria label for a successfully generated image thumbnail.
+msgctxt "Aria label for generated image thumbnail"
+msgid "Generated image"
+msgstr ""
+
+#. Title text shown for an assistant response that contains a generated image. Shown to internal users only
+msgctxt "Assistant response title"
+msgid "Generated image. Cost %s (internal only)"
+msgstr ""
+
+#. Aria label for the carousel (list of generated images) in the image generation mode.
+msgctxt "Aria label for generated images carousel"
+msgid "Generated images"
+msgstr ""
+
+#. Loading message shown while duckassist is generating an answer
+msgid "Generating answer..."
+msgstr ""
+
+#. Loading message shown while the image is being generated.
+msgctxt "Loading state message"
+msgid "Generating image"
+msgstr ""
+
+#. Placeholder text displayed while the AI assistant is generating an image.
+msgctxt "Assistant response placeholder"
+msgid "Generating image..."
+msgstr ""
+
+#. Placeholder text displayed while the AI assistant is generating a response.
+msgctxt "Assistant response placeholder"
+msgid "Generating response"
+msgstr ""
+
+#. Placeholder text displayed while the AI assistant is generating a response.
+msgctxt "Assistant response placeholder"
+msgid "Generating response..."
+msgstr ""
+
+#. Label that's displayed next to a genre below a web search result.
+msgctxt "Rich Facts label"
+msgid "Genre"
+msgstr ""
+
+#. The country, not the US state
+msgid "Georgia"
+msgstr ""
+
+#. The name of the German language
+msgctxt "language_name"
+msgid "German"
+msgstr ""
+
+msgid "Germany"
+msgstr "Deutschland"
+
+#. Button that takes users to the app store page for DuckDuckGo.
+msgid "Get App"
+msgstr "Lade die App herunter"
+
+#. Short CTA label for the Download button on mobile in the RetentionBrowserPromo banner.
+msgctxt "Promotional CTA (mobile)"
+msgid "Get Browser"
+msgstr ""
+
+#. Button that gets directions on a map.
+msgctxt "maps_maps_module"
+msgid "Get Directions"
+msgstr "Erhalte Richtungsangaben"
+
+#. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. Duck.ai is DuckDuckGo's AI chat product; 'Personal Info Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
+msgctxt "DuckDuckGo Subscription instant answer"
+msgid ""
+"Get DuckDuckGo VPN, advanced Duck.ai, Personal Info Removal, and Identity "
+"Theft Restoration."
+msgstr ""
+
+#. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
+msgctxt "DuckDuckGo Subscription instant answer"
+msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. 'Get' refers to downloading our free browser app from the Google Play Store
+msgctxt "SERP footer content"
+msgid "Get It on Google Play"
+msgstr ""
+
+#. 'Get' refers to downloading our free browser app from the Apple App Store
+msgctxt "SERP footer content"
+msgid "Get It on the App Store"
+msgstr ""
+
+#. Heading for Get More column containing list of links to DuckDuckGo Links
+msgctxt "SERP footer content"
+msgid "Get More"
+msgstr ""
+
+#. The title of a page where users can download the DuckDuckGo app or browser extension.
+msgctxt "showcase_app"
+msgid "Get Our App & Extension"
+msgstr "Hole dir unsere App & Erweiterung"
+
+#. 'Get' refers to downloading our free browser app
+msgctxt "SERP footer content"
+msgid "Get Our Browser"
+msgstr ""
+
+#. 'Get' refers to downloading our free browser app
+msgctxt "SERP footer content"
+msgid "Get Our Mac Browser"
+msgstr ""
+
+#. 'Get' refers to downloading our free browser app
+msgctxt "SERP footer content"
+msgid "Get Our Windows Browser"
+msgstr ""
+
+msgctxt "showcase_privacy"
+msgid "Get Privacy Tips"
+msgstr "Tipps zum Datenschutz erhalten"
+
+#. Text displayed on the button of the onboarding welcome screen.
+msgctxt "Onboarding welcome screen button text"
+msgid "Get Started"
+msgstr ""
+
+#. Promotional message explaining that a VPN and two additional privacy protections are included in the Privacy Pro subscription.
+msgctxt "SERP footer content"
+msgid "Get a VPN + two more protections in one easy subscription."
+msgstr ""
+
+#. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
+msgctxt "SERP footer content"
+msgid "Get a VPN + two more protections. Try it for free!"
+msgstr ""
+
+#. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; shown in every market.
+msgctxt "DuckDuckGo Subscription instant answer"
+msgid "Get a VPN and more"
+msgstr ""
+
+#. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; 'advanced AI chat' refers to Duck.ai; 'Personal Info Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
+msgctxt "DuckDuckGo Subscription instant answer"
+msgid ""
+"Get a fast, no-log VPN, optional advanced AI chat, Personal Info Removal, "
+"and Identity Theft Restoration."
+msgstr ""
+
+#. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; 'advanced AI chat' refers to Duck.ai; Identity Theft Restoration is a bundled feature.
+msgctxt "DuckDuckGo Subscription instant answer"
+msgid ""
+"Get a fast, no-log VPN, optional advanced AI chat, and Identity Theft "
+"Restoration."
+msgstr ""
+
+#. Description for the subscription modal where users can update their subscription to DuckDuckGo.
+msgctxt "Description of the modal to upgrade the DuckDuckGo subscription"
+msgid ""
+"Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
+"which also includes our VPN and other premium privacy protections."
+msgstr ""
+
+#. Description for the subscription setting where users can subscribe to DuckDuckGo.
+msgctxt ""
+"Description of the upgrade with subscription setting located on the settings "
+"modal"
+msgid ""
+"Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
+"which also includes our VPN and other premium privacy protections."
+msgstr ""
+
+#. A button for users to generate an AI generated answer from their query on the duckassist module
+msgctxt "duckassist"
+msgid "Get an answer"
+msgstr ""
+
+#. Text for the query that is displayed in the Search Assist introduction. For example: Get an answer for 'How to wash a car'.
+msgid "Get an answer for <strong>%s</strong>"
+msgstr ""
+
+#. Find answers to common problems in our help documentation
+msgctxt "SERP footer content"
+msgid "Get answers at DuckDuckGo Help."
+msgstr ""
+
+#. Short string representing a prompt suggestion for getting computer help.
+msgctxt "Brief for getting computer help"
+msgid "Get computer help"
+msgstr ""
+
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
+#. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
+msgctxt "Browser Promo Popover"
+msgid "Get our browser to never lose your settings."
+msgstr ""
+
+#. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; shown in every market. 'No-log' means the VPN keeps no activity logs; 'advanced AI models' with 'higher chat limits' refer to Duck.ai; the VPN and other premium protections are bundled subscription features.
+msgctxt "DuckDuckGo Subscription instant answer"
+msgid ""
+"Get our fast, no-log VPN, optional access to advanced AI models with higher "
+"chat limits, and more premium protections."
+msgstr ""
+
+#. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
+msgctxt "DuckDuckGo Subscription instant answer"
+msgid ""
+"Get our secure, no-log VPN, advanced Duck.ai, Personal Information Removal, "
+"and Identity Theft Restoration."
+msgstr ""
+
+#. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
+msgctxt "DuckDuckGo Subscription instant answer"
+msgid ""
+"Get our secure, no-log VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+msgid ""
+"Get seamless privacy protection on your browser for free with one download:"
+msgstr ""
+"Bekomme nahtlosen Privatsphärenschutz auf deinem Browser mit einem einzigen "
+"Download:"
+
+#. Text of a button that will install the DuckDuckGo app when clicked
+msgctxt "Browser Promo Popover"
+msgid "Get the App"
+msgstr ""
+
+#. Link text in the sidebar footer that takes users to the DuckDuckGo app download page.
+msgctxt "Sidebar footer"
+msgid "Get the App"
+msgstr ""
+
+#. Link text in the sidebar footer (Text specific to DuckDuckGo electron app only) that takes users to the DuckDuckGo browser download page.
+msgctxt "Sidebar footer"
+msgid "Get the Browser"
+msgstr ""
+
+#. This button will open a dialog that explains how to update the browser version manually
+msgctxt "Update browser banner"
+msgid "Get the Latest Version"
+msgstr ""
+
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
+#. Label for links to appropriate local health authorities
+msgctxt "Covid 19 module"
+msgid "Get the latest information:"
+msgstr ""
+
+#. Non-js means a version with JavaScript disabled. This is likely not in use anymore, so don't fuss too much about this.
+msgid "Get the non-JS version %s"
+msgstr "Zur JS freien Version %s"
+
+#. Label for a link to a music streaming platform. For example 'Get this song on: Spotify'
+msgctxt "access_song"
+msgid "Get this song on:"
+msgstr "Hole diesen Song:"
+
+msgctxt "spread_badge"
+msgid "Get your friends to switch and help us grow!"
+msgstr "Bringe Deine Freunde zum Wechseln und hilf uns zu wachsen!"
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
+
+msgid "Ghana"
+msgstr ""
+
+#. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
+msgctxt "Onboarding welcome screen button text"
+msgid "Give It a Try"
+msgstr ""
+
+#. Text for a button inviting users to give it a try for the Duck.ai product. On click, they're taken to the Duck.ai page.
+msgctxt "Onboarding welcome screen button text"
+msgid "Give it a Try"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Who is this person?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Give me a quick background on this person."
+msgstr ""
+
+#. Same as the Scan QR instruction plus the Copy Text Code step. Bold segments are UI path labels.
+msgctxt "Instruction under the Enter Code tab sub-heading"
+msgid ""
+"Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
+"go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
+msgstr ""
+
+#. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
+msgctxt "Instruction under the Scan QR tab sub-heading"
+msgid ""
+"Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
+"go to %sChats › Sync & Backup › Sync With Another Device%s"
+msgstr ""
+
+#. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
+msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
+msgid ""
+"Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
+"go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
+"code:"
+msgstr ""
+
+#. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
+msgctxt "Instruction on the recover-data scan/paste sheet"
+msgid ""
+"Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
+"go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
+"on your Recovery PDF."
+msgstr ""
+
+#. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
+msgctxt "precise_user_location"
+msgid "Go to %sPrivacy & Security > Location Services%s"
+msgstr ""
+
+#. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
+msgctxt "precise_user_location"
+msgid ""
+"Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
+"“Location Services” is turned on."
+msgstr ""
+
+#. Prompts users to turn on the location service on their phone.
+msgctxt "precise_user_location"
+msgid ""
+"Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
+"to %sDuckDuckGo%s."
+msgstr ""
+
+#. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
+msgctxt "precise_user_location"
+msgid "Go to 'Site Settings'."
+msgstr ""
+
+#. Tells users where in the settings menu they can change their default search engine.
+msgid "Go to Options."
+msgstr "Gehe zu Optionen."
+
+#. Tells users where in the settings menu they can change their default search engine.
+msgid "Go to Search Engine."
+msgstr "Gehe zur Suchmachine."
+
+#. Accessibility label for the ball icon shown between the two teams' goalscorers in a soccer match timeline.
+msgctxt "Sports module"
+msgid "Goal"
+msgstr ""
+
+#. Indicates this is the difference between goals 'for' and 'against' for this team
+msgctxt "Sports module"
+msgid "Goal Differential"
+msgstr ""
+
+#. Indicates this is the total goals scored against this team
+msgctxt "Sports module"
+msgid "Goals Against"
+msgstr ""
+
+#. Indicates this is the total 'goals for' (i.e. scored by) this team
+msgctxt "Sports module"
+msgid "Goals For"
+msgstr ""
+
+#. Header on a column that displays the gold medal count for the country in the Olympics
+msgid "Gold Medals"
+msgstr ""
+
+msgctxt ""
+"Header on a column that displays the gold medal count for the country in the "
+"Olympics"
+msgid "Gold Medals"
+msgstr ""
+
+#. A positive feedback suggestion specifically about the visual design of the Search Assist module on the SERP. Used to gauge user reaction to design changes during the visual-refresh experiment.
+msgctxt "Feedback prompt"
+msgid "Good design"
+msgstr ""
+
+#. A positive feedback suggestion saying the feature has a good privacy policy
+msgctxt "Feedback prompt"
+msgid "Good privacy policy"
+msgstr ""
+
+#. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
+msgctxt "shortbelieve"
+msgid "Goodies"
+msgstr "Leckerli"
+
+#. Button label that the user clicks to acknowledge and dismiss the pre-deprecation notice for a retiring AI model. Keep brief.
+msgctxt "AI Chat: Dismiss button on the pre-deprecation notice"
+msgid "Got It"
+msgstr ""
+
+#. A button that closes the welcome modal.
+msgctxt "Button on the subscription welcome modal"
+msgid "Got It"
+msgstr ""
+
+#. Closes the dialog shown by DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE and returns the user to the previous screen.
+msgctxt "Dismiss button for the DDG-browser-code dialog on Duck.ai"
+msgid "Got It"
+msgstr ""
+
+#. Closes the already-synced message and takes the user to the Sync & Backup device management screen.
+msgctxt "Dismiss button on the already-synced screen"
+msgid "Got It"
+msgstr ""
+
+#. Returns the user to the Sync Another Device scan screen after the clear-cache-and-refresh message.
+msgctxt "Dismiss button on the version-mismatch error screen"
+msgid "Got It"
+msgstr ""
+
+#. Text for the primary button that dismisses the post-upgrade success modal.
+msgctxt "Post-upgrade success modal dismiss button"
+msgid "Got It"
+msgstr ""
+
+#. Button that returns the user to the scan screen after a wrong code error.
+msgctxt "Retry button on the wrong code screen"
+msgid "Got It"
+msgstr ""
+
+#. Dismiss button for sync unavailable modal.
+msgctxt "Sync unavailable modal button"
+msgid "Got It"
+msgstr ""
+
+#. Option selected by user to acknowledge understanding of information
+msgctxt "precise_user_location"
+msgid "Got It"
+msgstr ""
+
+#. Text for a button that dismisses a tooltip because the user has acknowledged the information.
+msgctxt "Button text to dismiss the popover"
+msgid "Got It!"
+msgstr ""
+
+#. A button that closes the page context onboarding modal.
+msgctxt "Button on the page context onboarding modal"
+msgid "Got it"
+msgstr ""
+
+#. Acknowledge button label in error modal.
+msgctxt "duckai_migration"
+msgid "Got it"
+msgstr ""
+
+#. Option selected by user to acknowledge understanding of information
+msgctxt "precise_user_location"
+msgid "Got it"
+msgstr ""
+
+#. Text of the primary button in the modal that acknowledges the information.
+msgctxt "Modal primary button for closing information modal."
+msgid "Got it!"
+msgstr ""
+
+#. The title that confirms the settings have been saved and is included with the confirmation message.
+msgctxt "duckassist"
+msgid "Got it!"
+msgstr ""
+
+#. Positive feedback category a user can select on the Search Assist feedback form, meaning the answer was correct.
+msgctxt "feedback form"
+msgid "Got the facts right"
+msgstr ""
+
+#. Filters the color of images in search results.
+msgctxt "color"
+msgid "Gray"
+msgstr "Grau"
+
+msgctxt "theme"
+msgid "Gray"
+msgstr "Grau"
+
+msgid "Great Britain"
+msgstr ""
+
+msgid "Greece"
+msgstr "Griechenland"
+
+#. The name of the Greek language
+msgctxt "language_name"
+msgid "Greek"
+msgstr ""
+
+#. Color settings query parameters in the <a href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
+msgid "Green"
+msgstr "Grün"
+
+#. Filters the color of images in search results.
+msgctxt "color"
+msgid "Green"
+msgstr "Grün"
+
+msgid "Grenada"
+msgstr ""
+
+#. Used for various color settings  query parameters values captions into <a href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
+msgid "Grey"
+msgstr "Grau"
+
+#. F1 results table column header: starting grid position
+msgctxt "Sports module"
+msgid "Grid"
+msgstr ""
+
+#. Explains that the grid mode is disabled for this specific search result type.
+msgid "Grid mode disabled for this answer"
+msgstr "Der Rastermodus ist für diese Antwort deaktiviert "
+
+#. Indicates which Group a team belongs to in a competition such as the soccer World Cup, e.g. Group B
+msgctxt "Sports module"
+msgid "Group %s"
+msgstr ""
+
+#. Title for modal letting you choose which Group you wish to view, in e.g. the soccer World Cup
+msgctxt "Sports module"
+msgid "Groups"
+msgstr ""
+
+msgid "Guam"
+msgstr ""
+
+msgid "Guatemala"
+msgstr ""
+
+#. Text for a prompt suggestion for guiding through the basic steps of replacing a window wiper.
+msgctxt "Full sentence for learning a new skill"
+msgid "Guide me through the basic steps of replacing a window wiper."
+msgstr ""
+
+msgid "Guinea"
+msgstr ""
+
+msgid "Guinea-Bissau"
+msgstr ""
+
+#. The name of the Gujarati language
+msgctxt "language_name"
+msgid "Gujarati"
+msgstr ""
+
+msgid "Guyana "
+msgstr ""
+
+#. Indicates the Win-Loss record of a team when playing home
+msgctxt "Sports module"
+msgid "H"
+msgstr ""
+
+#. Halftime indicator in a soccer match
+msgctxt "Sports module"
+msgid "HT"
+msgstr ""
+
+#. http://i.imgur.com/LHG4IZQ.png
+msgctxt "settings"
+msgid "HTTPS"
+msgstr "HTTPS"
+
+#. <em>kh</em>'s label for one of the privacy settings query parameters into <a href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
+msgid "HTTPS:"
+msgstr "HTTPS:"
+
+#. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
+msgctxt "Weather IA"
+msgid "Hail"
+msgstr ""
+
+msgid "Haiti"
+msgstr ""
+
+#. The name of the Haitian Creole language
+msgctxt "language_name"
+msgid "Haitian Creole"
+msgstr ""
+
+#. Halftime in a game (like American football or basketball)
+msgctxt "Sports module"
+msgid "Halftime"
+msgstr ""
+
+#. A negative feedback suggestion where the user can provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid "Harmful or illegal"
+msgstr ""
+
+#. Querying the user if they need assistance
+msgctxt "SERP footer content"
+msgid "Have Questions?"
+msgstr ""
+
+#. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
+msgctxt "Weather IA"
+msgid "Haze"
+msgstr ""
+
+#. Label for the option prompting the AI assistant to adopt a role of a head chef in its responses.
+msgctxt "Assistant role option label for Head chef"
+msgid "Head chef"
+msgstr ""
+
+msgctxt "settings"
+msgid "Header Appearance"
+msgstr "Aussehen der Kopfzeilen"
+
+#. http://i.imgur.com/ug14CSY.png
+msgctxt "settings"
+msgid "Header Behavior"
+msgstr "Verhalten der Kopfzeile"
+
+#. http://i.imgur.com/MwUruEO.png
+msgctxt "settings"
+msgid "Header Color"
+msgstr "Farbe der Kopfzeile"
+
+#. <em>ko</em>'s and <em>kj</em>'s label for one of the color or interface settings query parameters into <a href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
+msgid "Header:"
+msgstr "Kopf:"
+
+#. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
+msgctxt "Weather IA"
+msgid "Heavy Rain"
+msgstr ""
+
+#. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
+msgctxt "Weather IA"
+msgid "Heavy Snow"
+msgstr ""
+
+#. The name of the Hebrew language
+msgctxt "language_name"
+msgid "Hebrew"
+msgstr ""
+
+#. homepage/ bottom right under More.
+msgid "Help"
+msgstr "Hilfe"
+
+msgctxt "precise_user_location"
+msgid "Help"
+msgstr "Hilfe"
+
+#. The main heading in the feedback form modal. Shown when a user has requested to share feedback with us. The placeholder is a line break. Please use good judgement to break the string appropriately.
+msgid "Help DuckDuckGo%s Improve This Page"
+msgstr ""
+
+#. Link to a feedback form.
+msgctxt "feedback form"
+msgid "Help DuckDuckGo%s improve searches like this"
+msgstr "Hilf DuckDuckGo%s Suchanfragen wie diese zu verbessern"
+
+msgctxt "settings"
+msgid "Help Improve DuckDuckGo"
+msgstr "Hilf mit, DuckDuckGo zu verbessern"
+
+#. Text for a button that links to the Help Pages website for additional information.
+msgctxt "Generic Help Pages button"
+msgid "Help Pages"
+msgstr ""
+
+#. Link to a page with information on how to share DuckDuckGo. 'Spread' in this case refers to sharing.
+msgctxt "SERP footer content"
+msgid "Help Spread DuckDuckGo"
+msgstr "Hilf bei der Verbreitung von DuckDuckGo"
+
+#. CTA for the Spread page, used in various locations
+msgctxt "Mobile footer, homepage tagline"
+msgid "Help Spread DuckDuckGo!"
+msgstr ""
+
+#. Link to a page with information about sharing DuckDuckGo with friends.
+msgid "Help Spread Privacy"
+msgstr "Hilf Privatsphäre zu verbreiten."
+
+#. Page-suggestion chip label "Help me prep for the interview", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Help me prep for the interview"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Help me tailor my resume for this job."
+msgstr ""
+
+#. Title of a SERP popup that invites users to take a survey (desktop only)
+msgctxt "User survey popup"
+msgid "Help us improve DuckDuckGo"
+msgstr ""
+
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Help us improve DuckDuckGo searches with your feedback"
+msgstr ""
+
+msgctxt "Feedback prompt"
+msgid "Help us improve searches like this"
+msgstr ""
+
+#. Title for a feedback form modal.
+msgctxt "Title of feedback form"
+msgid "Help us make %s better"
+msgstr ""
+
+#. Title for a feedback form modal.
+msgctxt "Title of feedback form"
+msgid "Help us make AI Chat better"
+msgstr ""
+
+#. Title for a feedback form modal.
+msgctxt "Title of feedback form"
+msgid "Help us make Assist better"
+msgstr ""
+
+#. Title for a feedback form modal.
+msgctxt "Title of feedback form"
+msgid "Help us make Duck.ai better"
+msgstr ""
+
+#. Title for a feedback form modal.
+msgctxt "Title of feedback form"
+msgid "Help us make DuckAssist better"
+msgstr ""
+
+msgctxt "SERP footer content"
+msgid "Help us raise the standard of trust online."
+msgstr "Hilf uns, den Vertrauensstandard im Internet zu erhöhen."
+
+#. Title of a modal inviting the user to leave negative feedback about DuckDuckGo
+msgctxt "feedback form"
+msgid "Help us understand how we missed the mark"
+msgstr ""
+
+#. A subtitle of a page that encourages users to share DuckDuckGo with their friends.
+msgctxt "showcase_spread"
+msgid "Help your friends and family join the Duck Side!"
+msgstr "Hilf deinen Freunden und Familie und komm zur Duck-Side"
+
+#. Text description for the Spread card in the SERP footer
+msgctxt "footer_card"
+msgid "Help your friends and family take back their privacy!"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Helpful"
+msgstr ""
+
+#. The title of a menu that shows other applications DuckDuckGo has made.
+msgctxt "showcase_aria_dropdown"
+msgid "Here are some things that we made that you might like."
+msgstr ""
+"Hier sind einige Dinge, die wir gemacht haben, die dir gefallen könnten."
+
+#. shown after the DuckDuckGo extension is installed
+msgctxt "welcome message"
+msgid "Here's what it does:"
+msgstr "Dies ist was es macht:"
+
+#. Text displayed before search results in Duck.ai to provide context for the list of search results shown
+msgctxt "Lead in text when showing search results in Duck.ai"
+msgid "Here’s what I found:"
+msgstr ""
+
+#. A filter option to hide AI-generated images in search results
+msgid "Hide"
+msgstr ""
+
+#. Title for button that hides collapsable content from the user.
+msgctxt "Collapses content in a message"
+msgid "Hide"
+msgstr ""
+
+#. A setting to hide AI-generated images in search results
+msgctxt "Settings"
+msgid "Hide AI images"
+msgstr ""
+
+#. List item indicating that the Hide AI images filter is currently active for the search
+msgctxt "noresults"
+msgid "Hide AI images"
+msgstr ""
+
+msgctxt "settings"
+msgid "Hide AI-Generated Images"
+msgstr ""
+
+#. Setting that hides a user's most visited sites when they open a new browser tab.
+msgctxt "new tab page"
+msgid "Hide Most-Visited Sites"
+msgstr ""
+
+#. A button that hides a passphrase the user has typed.
+msgctxt "settings"
+msgid "Hide Passphrase"
+msgstr ""
+
+#. Visible button text at the bottom of the expanded reasoning steps list that collapses it.
+msgctxt "Button label to collapse the reasoning steps list"
+msgid "Hide Reasoning"
+msgstr ""
+
+#. Hides details of a step-by-step navigation route
+msgctxt "directions"
+msgid "Hide Steps"
+msgstr ""
+
+#. Button text that allows the user to hide promotional tips displayed in the screen.
+msgctxt "Button to hide promotional tips"
+msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
+msgstr ""
+
+#. Label for the button to enable the site exclusion feature
+msgctxt "Exclusion message re-enable button"
+msgid "Hide blocked sites from results"
+msgstr ""
+
+#. Button in the Maps exclusion banner that re-hides place information from blocked sites after the user previously clicked 'Show all information'. Returns the view to the filtered state without blocked site data.
+msgctxt "Exclusion message re-enable button for maps vertical"
+msgid "Hide information"
+msgstr ""
+
+#. Tooltip text for the button that hides the model's reasoning steps when already expanded.
+msgctxt "Tooltip for reasoning duration button"
+msgid "Hide reasoning"
+msgstr ""
+
+#. Tooltip text that appears when hovering over the desktop sidebar collapse button, while sidebar is open.
+msgctxt ""
+"Tooltip label for the desktop sidebar collapse button, when the sidebar is "
+"open"
+msgid "Hide sidebar"
+msgstr ""
+
+#. Menu option to remove a site from the displayed results
+msgctxt "Organic result context menu"
+msgid "Hide site from these results"
+msgstr ""
+
+#. Tooltip/label for the button to hide the voice chat transcript.
+msgctxt "voice chat"
+msgid "Hide transcript"
+msgstr ""
+
+#. Item in a list of features of a desktop web browser
+msgctxt "Browser Promo Popover"
+msgid "Hide your email address"
+msgstr ""
+
+msgctxt "settings"
+msgid "Hides search term from being shown in browser tab/history"
+msgstr "Verbirgt den Suchbegriff im Browsertab/Verlauf"
+
+#. The highest stock price in a day
+msgctxt "Stocks module"
+msgid "High"
+msgstr ""
+
+#. Text with short description for an AI (Artificial Intelligence) Model that has a high built-in moderation level.
+msgctxt "duck.ai model card"
+msgid "High built-in moderation"
+msgstr ""
+
+#. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
+msgctxt "video-resolution"
+msgid "High definition"
+msgstr ""
+
+#. Label for the option prompting the AI assistant to adopt a role of a high-school teacher in its responses.
+msgctxt "Assistant role option label for High-school teacher"
+msgid "High-school teacher"
+msgstr ""
+
+#. Label for the toggle switch that enables or disables highlighting of key facts in Search Assist answers.
+msgctxt "duckassist"
+msgid "Highlight key facts"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Highlights key facts in Search Assist answers to help you find important "
+"information faster."
+msgstr ""
+
+#. The name of the Hindi language
+msgctxt "language_name"
+msgid "Hindi"
+msgstr ""
+
+#. Indicate that we have no chart data for prices of the current stock
+msgctxt "Stocks module"
+msgid "Historical prices not available"
+msgstr ""
+
+#. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
+msgctxt "Button text for showing chat history"
+msgid "History"
+msgstr ""
+
+#. Tells users how to add DuckDuckGo to the list of search engines in their browser.
+msgid ""
+"Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
+"click %sMake Default%s"
+msgstr ""
+"Drücke %sEnter%s auf deiner Tastatur, um %s DuckDuckGo in der Liste zu "
+"speichern. %sKlicke dann auf %sAls Standart%s."
+
+#. The name of the Hmong Daw language
+msgctxt "language_name"
+msgid "Hmong Daw"
+msgstr ""
+
+#. 'it' refers to the default search engine setting: this is displayed right next to a dialogue inviting users to change their default search engine back to what it was before adopting DuckDuckGo.
+msgid ""
+"Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
+"lose our privacy protection."
+msgstr ""
+
+#. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
+msgctxt "Warning message heading in Duck.ai chat"
+msgid "Hold on..."
+msgstr ""
+
+#. Indicates the Win-Loss record of a team when playing home
+msgctxt "Sports module"
+msgid "Home Record"
+msgstr ""
+
+#. Refers to the DuckDuckGo homepage.
+msgid "Homepage"
+msgstr ""
+
+msgctxt "settings"
+msgid "Homepage Privacy Tips"
+msgstr "Homepage Privatsphärentipps"
+
+#. Label for the option prompting the AI assistant to adopt a role of a homework helper in its responses.
+msgctxt "Assistant role option label for Homework helper"
+msgid "Homework helper"
+msgstr ""
+
+msgid "Honduras"
+msgstr ""
+
+msgid "Hong Kong"
+msgstr "Hongkong"
+
+#. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
+msgctxt "Weather IA"
+msgid "Hot"
+msgstr ""
+
+#. Information that hotel ad clicks are managed by Tripadvisor.
+msgid ""
+"Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
+"profile you."
+msgstr ""
+
+#. Refers to hours of operation for a business.
+msgctxt "maps_places"
+msgid "Hours"
+msgstr "Stunde"
+
+#. Category of feedback a user can select on a feedback form.
+msgctxt "feedback form"
+msgid "Hours are incorrect"
+msgstr ""
+
+#. Category of feedback a user can select on a feedback form.
+msgctxt "feedback form"
+msgid "Hours are missing"
+msgstr ""
+
+#. This is the name of a user setting
+msgctxt "settings"
+msgid "Hover, Module, and Dropdown Background Color"
+msgstr ""
+
+#. Label for a pill-shaped tab below the empty-state Duck.ai chat input. Clicking it opens a panel that explains how Duck.ai protects user privacy.
+msgctxt ""
+"Pill label opening the How Duck.ai Works panel under the empty-state chat "
+"input"
+msgid "How Duck.ai Works"
+msgstr ""
+
+#. Text for a button that opens a modal explaining how recent chats work.
+msgctxt "Button text to open the How It Works modal"
+msgid "How It Works"
+msgstr ""
+
+#. Label on a link to inform the user how to vote in the election
+msgctxt "Elections IA"
+msgid "How To Vote"
+msgstr ""
+
+#. Description of a page with more information about how anonymous location works in title case.
+msgctxt "precise_user_location"
+msgid "How We Keep Your Location Private"
+msgstr ""
+
+#. Text for a prompt suggestion for saving an email as a PDF.
+msgctxt "Full sentence for getting computer help"
+msgid "How can I save an email as a PDF?"
+msgstr ""
+
+#. Short subtitle text instructing the user to provide feedback for the Duck.ai product.
+msgctxt "Subtitle of feedback form"
+msgid "How could we improve Duck.ai?"
+msgstr ""
+
+#. Header above an explanation of how to change a passphrase.
+msgctxt "cloudsave"
+msgid "How do I change my passphrase?"
+msgstr "Wie ändere ich mein Passwort?"
+
+#. Header above an explanation of how the cloud save feature works.
+msgctxt "cloudsave"
+msgid "How does it work?"
+msgstr "Wie funktioniert das?"
+
+#. Header above an explanation of how passphrases are generated.
+msgctxt "cloudsave"
+msgid "How does passphrase generation work?"
+msgstr "Wie funktioniert der Passwortgenerator?"
+
+#. Header above an explanation of how the cloud save feature keeps user data anonymous.
+msgctxt "cloudsave"
+msgid "How is it anonymous?"
+msgstr "Wie ist es anonym?"
+
+#. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Text for the link that takes the user to the a model with more information about a feature.
+msgctxt "Link text for the settings modal"
+msgid "How it works"
+msgstr ""
+
+#. Link text to visit the voice chat help page.
+msgctxt "voice chat settings"
+msgid "How it works"
+msgstr ""
+
+#. Header for the assist settings modal where the user can choose how often they want AI-assisted answers to appear.
+msgctxt "duckassist"
+msgid "How much do you want AI-assisted answers to appear?"
+msgstr ""
+
+#. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
+msgctxt "Duck.ai settings usage section"
+msgid "How much of your daily and weekly limits you've used so far."
+msgstr ""
+
+#. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
+msgctxt "duckassist"
+msgid "How often do you want to see %s answers?"
+msgstr ""
+
+#. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
+msgctxt "duckassist"
+msgid "How often do you want to see AI-assisted answers?"
+msgstr ""
+
+#. Section title above the frequency radio options in the Search Assist settings modal.
+msgctxt "duckassist"
+msgid "How often do you want to see answers?"
+msgstr ""
+
+#. Text for a prompt suggestion for preparing to approach a colleague about their constant pencil tapping.
+msgctxt "Full sentence for preparing for a conversation"
+msgid ""
+"How should I tactfully approach a colleague about their constant pencil "
+"tapping and what should I say?"
+msgstr ""
+
+#. The title for a feedback prompt that includes thumbs up and thumbs down buttons
+msgid "How was this answer?"
+msgstr ""
+
+#. The title for a feedback prompt that includes thumbs up and thumbs down buttons
+msgid "How was this response?"
+msgstr ""
+
+#. Refers to humidity in the air, in a weather forecast module.
+msgctxt "forecast"
+msgid "Humidity"
+msgstr "Feuchtigkeit"
+
+#. The name of the Hungarian language
+msgctxt "language_name"
+msgid "Hungarian"
+msgstr ""
+
+msgid "Hungary"
+msgstr "Ungarn"
+
+#. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
+msgctxt "Weather IA"
+msgid "Hurricane"
+msgstr ""
+
+#. Text displayed on the button on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
+msgctxt "Onboarding terms screen button text"
+msgid "I Agree"
+msgstr ""
+
+#. Text for the button that takes the user to the external DuckDuckGo login subscription page.
+msgctxt ""
+"Text for the I already have a subscription button in the Duck.ai settings "
+"page"
+msgid "I Already Have a Subscription"
+msgstr ""
+
+#. Text for the button that takes the user to the login subscription page.
+msgctxt "Text for the I have a subscription button"
+msgid "I Have a Subscription"
+msgstr ""
+
+#. Text for the link that takes the user to the login subscription page.
+msgctxt "Text for the I already have a subscription link"
+msgid "I already have a subscription"
+msgstr ""
+
+#. Error message displayed when the upstream fails to process an uploaded image (e.g., bad image)
+msgctxt "Error message when text or an uploaded image cannot be processed"
+msgid "I can't help with this request."
+msgstr ""
+
+#. Feedback option for when customer dislikes AI
+msgid "I dislike AI"
+msgstr ""
+
+#. Category of feedback a user can select on a feedback form.
+msgctxt "feedback form"
+msgid "I don't want this type of result"
+msgstr "Ich möchte diesen Typ von Resultat nicht"
+
+#. Given as an option to select when providing feedback
+msgid "I don't want to see blocked tracking attempts"
+msgstr ""
+
+#. Given as an option to select when providing feedback
+msgid "I don’t understand this information"
+msgstr ""
+
+#. Given as an option to select when providing feedback
+msgid "I don’t want to see any information from DuckDuckGo on this page"
+msgstr ""
+
+#. Given as an option to select when providing feedback
+msgid "I don’t want to see my most-visited sites"
+msgstr ""
+
+#. Category of feedback a user can select on a feedback form.
+msgctxt "feedback form"
+msgid "I expected to see results from more sellers"
+msgstr ""
+
+#. Header above text explaining that passwords can't be recovered.
+msgctxt "cloudsave"
+msgid "I forgot my passphrase. Can you recover it?"
+msgstr "Ich habe mein Passwort vergessen. Könnt Ihr es wiederherstellen?"
+
+#. Option for feedback when the user hits a chat limit.
+msgctxt "Feedback option for hitting chat limit"
+msgid "I hit a chat limit"
+msgstr ""
+
+#. Text for a prompt suggestion for recommending books similar to 'Name of the Wind'.
+msgctxt "Full sentence for recommending a book"
+msgid ""
+"I like the book Name of the Wind. What are some other good books/series most "
+"like it and why?"
+msgstr ""
+
+#. Option for feedback when the user needs more help or information on how to use the chat.
+msgctxt "Feedback option for difficulty in using chat"
+msgid "I need more help/info on how to use Chat"
+msgstr ""
+
+msgid "IR Iran"
+msgstr ""
+
+msgid "Iceland"
+msgstr ""
+
+#. The name of the Icelandic language
+msgctxt "language_name"
+msgid "Icelandic"
+msgstr ""
+
+#. Short string representing a prompt suggestion for identifying product brands.
+msgctxt "Brief for identifying product brands"
+msgid "Identify product brands"
+msgstr ""
+
+#. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
+msgctxt "precise_user_location"
+msgid ""
+"If the browser location remains unavailable, then go to %sSettings > General "
+"> Reset > 'Reset Location & Privacy'%s."
+msgstr ""
+
+#. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
+msgctxt "precise_user_location"
+msgid ""
+"If the browser location remains unavailable, then in your browser go to %s⋮ "
+"> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
+"allowed location access."
+msgstr ""
+
+#. Inform the user we're still having errors and that we will investigate the issue
+msgctxt "noresults"
+msgid "If you continue to see this error, please reach out to %s."
+msgstr ""
+
+#. Tells users how to add DuckDuckGo to the list of search engines in their browser.
+msgid ""
+"If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
+"%sOther Search Engines%s"
+msgstr ""
+"Wenn du %sDuckDuckGo%s nicht siehst, musst du es zur Liste der %sanderen "
+"Suchmaschinen%s hinzufügen."
+
+#. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
+msgctxt "Disclaimer text at the bottom of the feedback form."
+msgid ""
+"If you have concerns about our chat providers or any particular chat "
+"response, you can also reach out directly to %s and %s support pages."
+msgstr ""
+
+#. Body copy explaining what the recovery code is for and how it can be saved.
+msgctxt "Body for the Sync & Backup recovery code screen"
+msgid ""
+"If you lose access to your devices, you will need this code to recover your "
+"saved chats. You can save this code to your device as a text file."
+msgstr ""
+
+#. http://i.imgur.com/ReKkJtU.png
+msgctxt "settings"
+msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
+msgstr ""
+"Wenn du uns anderweitig unterstützen möchtest, %shilf uns DuckDuckGo "
+"bekannter zu machen%s"
+
+#. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
+#. Message displayed at the bottom of the page, informing you that you can't use the settings page without Java Script activated into your browser. <em>%s</em> and <em>%s</em> are respectively for (raw) <em>HTML</em> and <em>lite</em> versions.
+#.
+msgid ""
+"If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
+"versions."
+msgstr ""
+"Wenn du DuckDuckGo ohne JavaScript verwenden willst, nutze bitte unsere %s "
+"oder %s Versionen."
+
+#. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
+msgid ""
+"If you want, select Home Page next to New windows and New tabs (open with)."
+msgstr ""
+"Wähle deine \"Startseite\" neben \"Neue Fenster\" und \"Neue "
+"Tabs\" (\"Öffnen mit...\")."
+
+#. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
+msgctxt "Menu item to attach an image to the AI chat message"
+msgid "Image"
+msgstr ""
+
+#. Heading shown above an assistant message that contains a generated image.
+msgctxt "Header for completed image generation message"
+msgid "Image generated"
+msgstr ""
+
+#. Aria label for a thumbnail that failed to generate.
+msgctxt "Aria label for error thumbnail"
+msgid "Image generation failed"
+msgstr ""
+
+#. Call to action to invite users to view information about a generated image.
+msgctxt "Tooltip for an action button"
+msgid "Image info"
+msgstr ""
+
+#. Disclaimer text shown at the bottom of the Image Generation mode, reminding users that prompts must comply with Terms of Service. Reads: 'Image prompts must comply with the Duck.aiTerms of Service'
+msgctxt "Disclaimer text for Image Generation mode"
+msgid "Image prompts must comply with the %s"
+msgstr ""
+
+#. Disclaimer text shown below chat input. %s is replaced with a clickable underlined 'terms' link that opens the Duck.ai terms of service page.
+msgctxt ""
+"Disclaimer below chat input in Duck.ai when image generation is enabled"
+msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+msgctxt "settingsvalue"
+msgid "Image tiles"
+msgstr ""
+
+#. Text for a label indicating that the AI (Artificial Intelligence) model has support for image upload, in the context that the user can upload an image for the AI to analyze.
+msgctxt "duck.ai model card"
+msgid "Image upload"
+msgstr ""
+
+#. Aria label for the image lightbox dialog.
+msgctxt "Aria label for image lightbox dialog"
+msgid "Image viewer"
+msgstr ""
+
+#. Label above image search results.
+msgid "Images"
+msgstr "Bilder"
+
+#. A message displayed when the AI images filter is applied in the Images IA and no images are displayed
+msgctxt "Images IA"
+msgid "Images are hidden by the AI images filter."
+msgstr ""
+
+#. A label that indicates a specific search result for images has been blocked by the safe search filter
+msgid "Images blocked by safe search."
+msgstr ""
+
+#. Tooltip title for the section that showcases the image results for a certain query, ex. Images for beach
+msgid "Images for %s"
+msgstr ""
+
+#. A label that indicates a specific search result for images has been blocked by the safe search filter. The placeholder value is the name of the search result that was blocked.
+msgid "Images for %s blocked by safe search"
+msgstr ""
+
+#. Title for the section that showcases the image results for a certain query, ex. Images for <b>beach</b>
+msgid "Images for %s%s%s"
+msgstr ""
+
+#. Instant Answer attribution to original image source e.g. 'Images: Wikimedia'
+msgctxt "Instant Answer attribution"
+msgid "Images: %s"
+msgstr ""
+
+#. Header for manual import step.
+msgctxt "duckai_migration"
+msgid "Import Your Chats"
+msgstr ""
+
+#. Step 3 label.
+msgctxt "duckai_migration"
+msgid "Import all your chats"
+msgstr ""
+
+#. Header for manual import step.
+msgctxt "duckai_migration"
+msgid "Import your chat history"
+msgstr ""
+
+#. Title shown while importing chats.
+msgctxt "duckai_migration"
+msgid "Importing Chats"
+msgstr ""
+
+#. Short string representing a prompt suggestion for improving arguments.
+msgctxt "Brief for improving arguments"
+msgid "Improve your arguments"
+msgstr ""
+
+#. This is the description of a user setting -- Example image: https://i.imgur.com/IqBhHpM.png
+msgctxt "settings"
+msgid ""
+"Improves result legibility with updated URL format, placement, and color"
+msgstr ""
+
+#. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
+msgid "In partnership with"
+msgstr "In Zusammenarbeit mit"
+
+msgctxt "settings"
+msgid ""
+"In some older browsers, it's necessary to redirect your clicks through our "
+"server to prevent search leakage. %sLearn more%s."
+msgstr ""
+
+#. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
+msgctxt ""
+"Body for the dialog shown when the user pastes/scans a DDG-browser-intended "
+"code on Duck.ai"
+msgid ""
+"In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
+"with another device”."
+msgstr ""
+
+#. Tells the user where in the settings menu they can change their default search engine.
+msgid "In the drop down select %sDuckDuckGo%s!"
+msgstr "Wähle %sDuckDuckGo%s im Dropdownmenu!"
+
+#. Text explaining how the cloud save feature works.
+msgctxt "cloudsave"
+msgid ""
+"In the interest of transparency, this data is not encrypted: You can see "
+"exactly what information we store."
+msgstr ""
+
+msgid "In the menu at the top select %sTools%s > %sSettings%s"
+msgstr "Wähle im Menü oben %sTools%s > %sSettings%s"
+
+#. Tells users how to add DuckDuckGo to the list of search engines in their browser.
+msgid "In the popup, check %sMake this my default search provider%s"
+msgstr "Im Pop-Up, überprüfe %sSetzte dies als Standardsuchmaschine%s"
+
+#. Tells users how to add DuckDuckGo to the list of search engines in their browser.
+msgid "In the popup, click %sAdd%s"
+msgstr "Im Pop-Up, klicke auf %sHinzufügen%s"
+
+#. Tells the user where in the settings menu they can change their default search engine.
+msgid "In the side menu select %sInternet Search%s"
+msgstr "Wähle %sInternet Search%s aus dem Seitenmenü"
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Inaccurate"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Inaccurate definition"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Inaccurate forecast"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Inaccurate lyrics"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Inaccurate response"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Inaccurate translation"
+msgstr ""
+
+#. Category of problem a user can select on a feedback form.
+msgctxt "feedback form"
+msgid "Inappropriate"
+msgstr ""
+
+#. e.g., 'Including results for Mozart' (when the user searched for 'Mozar')
+msgid "Including results for %s"
+msgstr ""
+
+#. A negative feedback suggestion saying that the response provided to the user was incorrect
+msgctxt "Feedback prompt"
+msgid "Incorrect response"
+msgstr ""
+
+msgid "India"
+msgstr "Indien"
+
+msgid "India (en)"
+msgstr ""
+
+#. Name given to the athletes competeing at the 2024 Olympics from Russia or Belarus
+msgid "Individual Neutral Athletes"
+msgstr ""
+
+msgid "Indonesia"
+msgstr "Indonesien"
+
+msgid "Indonesia (en)"
+msgstr "Indonesien (E)"
+
+#. The name of the Indonesian language
+msgctxt "language_name"
+msgid "Indonesian"
+msgstr ""
+
+#. http://i.imgur.com/7VuBXGO.png
+#. This setting used to be called 'Auto-Load'
+msgctxt "settings"
+msgid "Infinite Scroll"
+msgstr "Automatisch laden"
+
+#. This setting used to be called 'Auto-Load Images'
+#. Please update this translation if it no longer applies
+msgctxt "settings"
+msgid "Infinite Scroll for Images"
+msgstr "Bilder automatisch laden"
+
+msgctxt "settings"
+msgid "Infinite Scroll for Images and Videos"
+msgstr "Endlosscrollen für Bilder und Videos"
+
+msgctxt "settings"
+msgid "Infinite Scroll for Images, Videos, and Shopping"
+msgstr ""
+
+#. Feedback option when AI response is accurate
+msgid "Information is accurate"
+msgstr ""
+
+#. Feedback option when AI response is not accurate
+msgid "Information is inaccurate"
+msgstr ""
+
+#. Feedback option when AI response is not up to date
+msgid "Information is outdated"
+msgstr ""
+
+#. Feedback option when AI response is up-to-date
+msgid "Information is up-to-date"
+msgstr ""
+
+#. Cricket scorecard: innings tab label prefix
+msgctxt "Sports module"
+msgid "Innings"
+msgstr ""
+
+#. An error message to flag a missing input field in a form
+msgid "Input cannot be empty"
+msgstr ""
+
+#. An error message to flag an input field that is too short or too long in a form. The placeholders are numbers indicating the min and max character length.
+msgid "Input must be between %s and %s characters"
+msgstr ""
+
+#. This appears on a button that a user clicks to install a product on their computer.
+msgid "Install"
+msgstr "Installieren"
+
+#. Button that installs the DuckDuckGo app.
+msgctxt "homepage onboarding"
+msgid "Install DuckDuckGo"
+msgstr "DuckDuckGo installieren"
+
+msgctxt "settings"
+msgid "Install DuckDuckGo"
+msgstr "DuckDuckGo installieren"
+
+#. Label of the button that downloads/installs the DuckDuckGo desktop browser.
+msgctxt "new tab page"
+msgid "Install DuckDuckGo Browser"
+msgstr ""
+
+#. Text of a button to install the DuckDuckGo web browser for Mac
+msgctxt "Browser Promo Popover"
+msgid "Install DuckDuckGo Mac Browser"
+msgstr ""
+
+#. Link to add the DuckDuckGo browser extension to Safari.
+msgid "Install DuckDuckGo Safari Extension?"
+msgstr "DuckDuckGo Safari Erweiterung installieren?"
+
+#. Text of a button to install the DuckDuckGo web browser for Mac
+msgctxt "Browser Promo Popover"
+msgid "Install DuckDuckGo for Mac"
+msgstr ""
+
+#. Text of a button to install the DuckDuckGo web browser for Windows
+msgctxt "Browser Promo Popover"
+msgid "Install DuckDuckGo for Windows"
+msgstr ""
+
+#. Text of a button to install the DuckDuckGo web browser for Mac
+msgctxt "Sidemenu browser promo"
+msgid "Install Mac Browser"
+msgstr ""
+
+#. Button text in the modal that links users who already have the standard DuckDuckGo extension to the DuckDuckGo No AI search extension for their browser.
+msgctxt "settings"
+msgid "Install Now"
+msgstr ""
+
+#. Text of a button to install the DuckDuckGo app
+msgctxt "Serp footer content"
+msgid "Install Our App"
+msgstr ""
+
+#. Text of a button to install the DuckDuckGo web browser for Windows
+msgctxt "Sidemenu browser promo"
+msgid "Install Windows Browser"
+msgstr ""
+
+#. in https://duckduckgo.com/api/, topmost header
+msgid "Instant Answer API"
+msgstr "Sofortantwort-API"
+
+#. http://i.imgur.com/XW6brqX.png
+msgctxt "settings"
+msgid "Instant Answers"
+msgstr "Sofortantwort"
+
+#. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
+msgid "Intense green"
+msgstr "Dunkelgrün"
+
+#. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
+msgid "Intense red"
+msgstr "Intensives Rot"
+
+#. Title for one of the <a href="https://duckduckgo.com/params.html">URL params page section</a>.
+msgid "Interface Settings"
+msgstr "Benutzerobeflächeneinstellungen"
+
+#. Text for the badge displayed to indicate that the user is an internal user.
+msgctxt "Text for the internal badge"
+msgid "Internal"
+msgstr ""
+
+#. Indicator that a game has been interrupted
+msgctxt "Sports module"
+msgid "Interrupted"
+msgstr ""
+
+#. Title for a promotional card shown at the bottom of search results. DuckDuckGo Collaborations is a branded merchandise line (shirts, shoes, security keys) made in partnership with Cotton Bureau, Yubico, and Atoms.
+msgctxt "SERP footer content"
+msgid "Introducing DuckDuckGo Collaborations"
+msgstr ""
+
+#. A feedback suggestion about the search results presented (organics/ads)
+msgctxt "Feedback prompt"
+msgid "Intuitive look and feel"
+msgstr ""
+
+#. The name of the Inuktitut language
+msgctxt "language_name"
+msgid "Inuktitut"
+msgstr ""
+
+msgctxt "homepage onboarding"
+msgid "Invite friends to the Duck Side!"
+msgstr "Lade deine Freunde ein, der Duck Seite beizutreten."
+
+msgid "Iran"
+msgstr ""
+
+msgid "Iraq"
+msgstr ""
+
+msgid "Ireland"
+msgstr "Irland"
+
+#. The name of the Irish language
+msgctxt "language_name"
+msgid "Irish"
+msgstr ""
+
+#. Header above text explaining data deletion policy.
+msgctxt "cloudsave"
+msgid "Is deleted data really deleted?"
+msgstr "Sind gelöschte Daten wirklich gelöscht?"
+
+#. Page-suggestion chip label "Is it worth taking?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is it worth taking?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this place any good?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this place any good?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this place any good?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"Is this place any good? Summarize its reputation based on reviews and "
+"ratings."
+msgstr ""
+
+#. Question on a feedback form.
+msgctxt "feedback form"
+msgid "Is this video helpful?"
+msgstr ""
+
+#. Page-suggestion chip label "Is this worth watching?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Is this worth watching?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Is this worth watching? Give me a spoiler-free take."
+msgstr ""
+
+#. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
+msgctxt "Weather IA"
+msgid "Isolated Thunderstorms"
+msgstr ""
+
+msgid "Israel"
+msgstr "Israel"
+
+msgid "Israel (en)"
+msgstr ""
+
+#. Loading message shown when image generation is taking a very long time.
+msgctxt "Loading state message"
+msgid "It might take a few minutes"
+msgstr ""
+
+#. Body text of a card that promotes installing the DuckDuckGo desktop browser.
+msgctxt "new tab page"
+msgid "It's fast, free, and gives you even more online protection."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
+msgstr ""
+"Es ist in Ordnung, mich (sehr selten) nach meinen Erfahrungen mit DuckDuckGo "
+"zu fragen."
+
+#. The name of the Italian language
+msgctxt "language_name"
+msgid "Italian"
+msgstr ""
+
+msgid "Italy"
+msgstr "Italien"
+
+#. Tooltip above a list of products, clarifying the nature of the listing and that DuckDuckGo is not compensated for clicks on these products.
+msgid ""
+"Items are ranked based on relevance to your search terms and are delivered "
+"through Microsoft's Ad Network. Clicks lead directly to merchant landing "
+"pages and unlike ads, DuckDuckGo is not compensated for these results."
+msgstr ""
+
+#. Text explaining why passphrases use a series of words instead of random numbers and letters.
+msgctxt "cloudsave"
+msgid ""
+"It’s easier to remember 4-5 words than 10 random letters and numbers, and "
+"far more secure."
+msgstr ""
+
+msgid "Ivory Coast"
+msgstr ""
+
+msgid "Jamaica"
+msgstr ""
+
+msgid "Japan"
+msgstr "Japan"
+
+#. The name of the Japanese language
+msgctxt "language_name"
+msgid "Japanese"
+msgstr ""
+
+#. Instant Answer Tab Name (below the search box, above the results)
+msgid "Jobs"
+msgstr "Jobs"
+
+msgctxt "SERP footer content"
+msgid "Join Our Team!"
+msgstr "Tritt unserem Team bei!"
+
+msgctxt "showcase_donate"
+msgid "Join our $500,000 Privacy Challenge"
+msgstr "Nehme an unserer $500'000 Datenschutz Challenge teil."
+
+msgid "Jordan"
+msgstr ""
+
+#. Placeholder text displayed while the AI assistant is generating a response after losing connection and coming back online
+msgctxt "Assistant response placeholder"
+msgid "Just a moment..."
+msgstr ""
+
+#. The name of the Kannada language
+msgctxt "language_name"
+msgid "Kannada"
+msgstr ""
+
+#. The name of the Kazakh language
+msgctxt "language_name"
+msgid "Kazakh"
+msgstr ""
+
+msgid "Kazakhstan"
+msgstr ""
+
+#. Header title shown after a pairing code is scanned/shown, while the two devices complete their handshake. Reassures the user to keep both devices on the pairing screen until it finishes.
+msgctxt "Modal header shown on both devices while pairing connects"
+msgid "Keep Sync & Backup open on both devices."
+msgstr ""
+
+#. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. Explains that the VPN protects apps and online activity on up to 5 devices simultaneously.
+msgctxt "DuckDuckGo VPN instant answer"
+msgid ""
+"Keep all your apps and online activity private on up to 5 devices at once."
+msgstr ""
+
+#. An instruction to state that a list of companies/trackers will be updated with continued use
+msgctxt "tracker_stats"
+msgid "Keep browsing to see how many we block"
+msgstr ""
+
+#. Header above social media links.
+msgid "Keep in Touch"
+msgstr "Bleibe in Kontakt"
+
+msgctxt "homepage ATB modal"
+msgid "Keep your search history private"
+msgstr ""
+
+msgid "Kenya"
+msgstr ""
+
+#. Section heading (for right column).
+msgctxt "settings"
+msgid "Keyboard Shortcuts"
+msgstr "Tastaturkürzel"
+
+#. The name of the Khmer language
+msgctxt "language_name"
+msgid "Khmer"
+msgstr ""
+
+msgid "Kiribati "
+msgstr ""
+
+#. The name of the Klingon language
+msgctxt "language_name"
+msgid "Klingon"
+msgstr ""
+
+#. The name of the Klingon (Latin) language
+msgctxt "language_name"
+msgid "Klingon (Latin)"
+msgstr ""
+
+#. The name of the Klingon (pIqaD) language
+msgctxt "language_name"
+msgid "Klingon (pIqaD)"
+msgstr ""
+
+msgid "Korea"
+msgstr "Korea"
+
+msgid "Korea Republic"
+msgstr ""
+
+#. The name of the Korean language
+msgctxt "language_name"
+msgid "Korean"
+msgstr ""
+
+msgid "Kosovo"
+msgstr ""
+
+#. The name of the Kurdish (Central) language
+msgctxt "language_name"
+msgid "Kurdish (Central)"
+msgstr ""
+
+#. The name of the Kurdish (Northern) language
+msgctxt "language_name"
+msgid "Kurdish (Northern)"
+msgstr ""
+
+msgid "Kuwait"
+msgstr ""
+
+msgid "Kyrgyzstan"
+msgstr ""
+
+#. Indicates this is the number of losses for this team
+msgctxt "Sports module"
+msgid "L"
+msgstr ""
+
+#. Abbreviated version of the Win/loss record for a team's last 10 games, e.g. 10-5 means the team won 10 and lost 5. 'L' is an abbreviation for 'Last'.
+msgctxt "Sports module"
+msgid "L10"
+msgstr ""
+
+#. http://i.imgur.com/L74c87B.png
+#. Adjusts the displayed language of DuckDuckGo (translations)
+msgctxt "settings"
+msgid "Language"
+msgstr "Sprache"
+
+#. Label for the option prompting the AI assistant to adopt a role of a language tutor in its responses.
+msgctxt "Assistant role option label for Language tutor"
+msgid "Language tutor"
+msgstr ""
+
+#. Text of a tooltip displayed when the user has swapped origin and translated languages
+msgctxt "translations_module"
+msgid "Languages swapped"
+msgstr ""
+
+#. The name of the Lao language
+msgctxt "language_name"
+msgid "Lao"
+msgstr ""
+
+msgid "Laos"
+msgstr ""
+
+#. NASCAR results table column: number of laps completed
+msgctxt "Sports module"
+msgid "Laps"
+msgstr ""
+
+#. http://i.imgur.com/6jwHONe.png
+msgctxt "settingsvalue"
+msgid "Large"
+msgstr "Gross"
+
+#. Filters the size of images in search results.
+msgctxt "size"
+msgid "Large"
+msgstr "Gross"
+
+#. http://i.imgur.com/gwulPSF.png
+msgctxt "settingsvalue"
+msgid "Larger"
+msgstr "Grösser"
+
+#. http://i.imgur.com/n8wzFYd.png
+msgctxt "size"
+msgid "Larger"
+msgstr "Grösser"
+
+#. http://i.imgur.com/xdSUFar.png
+#. In the dropdown menu for, "Font Size"
+msgctxt "settingsvalue"
+msgid "Largest"
+msgstr "Grösste"
+
+#. http://i.imgur.com/AmVRhlP.png
+msgctxt "size"
+msgid "Largest"
+msgstr "Am grössten"
+
+#. Win/loss record for a team's last 10 games, e.g. 10-5 means the team won 10 and lost 5
+msgctxt "Sports module"
+msgid "Last 10"
+msgstr ""
+
+#. Text to indicate when Terms of Use were last updated, placeholder will contain a localized date. eg 'Last updated April 3, 2024'
+msgctxt "AI Chat Terms and Policy last update"
+msgid "Last updated %s"
+msgstr ""
+
+#. Date of last update of the Privacy Policy & Terms of Use page.
+msgctxt "Date of last update of the Privacy Policy & Terms of Use page."
+msgid "Last updated April 3, 2024"
+msgstr ""
+
+#. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Latest AI Models from: GPT, Claude, Mistral, Llama'
+msgctxt "Onboarding welcome screen feature"
+msgid "Latest AI Models from:"
+msgstr ""
+
+msgid "Latvia"
+msgstr "Lettland"
+
+#. The name of the Latvian language
+msgctxt "language_name"
+msgid "Latvian"
+msgstr ""
+
+#. List item indicating that a layout filter (e.g. tall) is currently active for the search
+msgctxt "noresults"
+msgid "Layout"
+msgstr ""
+
+#. A button that takes users to another page with additional information.
+msgid "Learn %sMore%s"
+msgstr "Erfahre %smehr%s"
+
+#. Option at the bottom of the homepage: http://i.imgur.com/HEtEDYE.png
+#. The second word of this sentence should be wrapped in placeholders, since it is used to insert the new-line, e.g.
+#. Mehr %serfahren%s
+#. If your language has a physically short string for this, feel free to drop the placeholders at the end, e.g.:
+#. 了解更多%s%s
+msgctxt "frontpage"
+msgid "Learn %sMore%s"
+msgstr "Mehr %serfahren%s"
+
+#. Text for a button that opens a modal or page with additional information about a feature.
+msgctxt "Button text to learn more about a feature"
+msgid "Learn More"
+msgstr ""
+
+#. Label for the button that opens the usage limits help page for Image Generation.
+msgctxt "Learn more button label"
+msgid "Learn More"
+msgstr ""
+
+#. Secondary CTA button text in the RetentionBrowserPromo banner.
+msgctxt "Promotional secondary CTA"
+msgid "Learn More"
+msgstr ""
+
+#. Link text to learn more about the migration process.
+msgctxt "duckai_migration"
+msgid "Learn More"
+msgstr ""
+
+#. Displayed during an outage as a link to see all of the bangs DuckDuckGo has available.
+msgctxt "noresults"
+msgid "Learn More"
+msgstr ""
+
+#. Link text on the full Settings page next to the cookie reset warning. Links to the help page explaining how settings are stored.
+msgctxt "settings"
+msgid "Learn More"
+msgstr ""
+
+#. A link to the DuckDuckGo browser extension on the Firefox Add-ons Store
+msgctxt "homepage ATB modal"
+msgid "Learn More at Firefox Add-Ons"
+msgstr ""
+
+#. Short string representing a prompt suggestion for learning a new skill.
+msgctxt "Brief for learning a new skill"
+msgid "Learn a new skill"
+msgstr ""
+
+#. Tooltip text that appears when hovering over the Active Privacy Protection button.
+msgctxt "Tooltip label for the Active Privacy Protection button in sidebar"
+msgid "Learn about Active Privacy Protection"
+msgstr ""
+
+msgctxt "showcase_newsletter"
+msgid "Learn about online privacy right in your inbox."
+msgstr "Erfahre mehr über Onlinedatenschutz direkt in deinem Posteingang."
+
+#. Link to a page with more information about how DuckDuckGo settings are managed.
+msgctxt "settings"
+msgid "Learn how DuckDuckGo settings are managed"
+msgstr ""
+
+#. Description of a page with more information about how anonymous location works.
+msgctxt "precise_user_location"
+msgid "Learn how we keep your location private"
+msgstr ""
+
+#. Link text in the Usage section of Duck.ai settings that opens a help page explaining Duck.ai usage limits.
+msgctxt "Duck.ai settings usage section"
+msgid "Learn more"
+msgstr ""
+
+#. A label in a sentence that takes users to another page with additional information.
+msgctxt "Learn more used in a sentence"
+msgid "Learn more"
+msgstr ""
+
+#. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Learn more' and opens the subscription modal when clicked. Shown only to authenticated users.
+msgctxt ""
+"Link text shown to authenticated users in the subscription promo card to "
+"open the subscription modal"
+msgid "Learn more"
+msgstr ""
+
+#. Text for a link to the help page that explain how DuckDuckGo uses the user location.
+msgctxt "Link to learn more about how DuckDuckGo uses the user location"
+msgid "Learn more"
+msgstr ""
+
+#. Link text on the full Settings page next to the cookie reset warning. Links to the help page explaining how settings are stored.
+msgctxt "settings"
+msgid "Learn more"
+msgstr ""
+
+#. Link to a documentation page to learn more about how duckassist (an instant answer based on generative AI) works
+msgid "Learn more about how it works"
+msgstr ""
+
+msgctxt "SERP footer content"
+msgid "Learn why reducing online tracking is important."
+msgstr "Erfahre, warum die Reduzierung von Online-Tracking wichtig ist."
+
+#. A link that takes users to a page where they can learn more about the dangers of online tracking.
+msgctxt "showcase_tracking"
+msgid "Learn why reducing tracking is important."
+msgstr "Erfahre, warum die Reduzierung von Online-Tracking wichtig ist."
+
+msgid "Lebanon"
+msgstr ""
+
+#. Discontinued, don't translate
+msgctxt "placement"
+msgid "Left"
+msgstr "Links"
+
+#. A link to legal information.
+msgid "Legal"
+msgstr "Rechtlich"
+
+#. Label indicating the length of AI assistant responses that can be selected. Example: User can pick from 'Short', 'Shortest', etc.
+msgctxt "Label for length of responses dropdown"
+msgid "Length of responses"
+msgstr ""
+
+msgid "Lesotho"
+msgstr ""
+
+#. Filters the duration of videos in search results.
+msgctxt "video-duration"
+msgid "Less than 4 minutes"
+msgstr "Weniger als 4 Minuten"
+
+#. Description text shown below the Auto option in the reasoning mode dropdown.
+msgctxt "Description for auto reasoning mode in Duck.ai"
+msgid "Let the model decide"
+msgstr ""
+
+#. Short sentence inviting user to return.
+msgctxt "duckai_migration"
+msgid "Let's get you back in."
+msgstr ""
+
+#. shown after the DuckDuckGo extension is installed
+msgctxt "welcome message"
+msgid "Lets you search anonymously with DuckDuckGo"
+msgstr "Lässt dich anonym mit DuckDuckGo suchen"
+
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
+msgid "Liberia"
+msgstr ""
+
+msgid "Libya"
+msgstr ""
+
+#. List item indicating that a license filter is currently active for the search
+msgctxt "noresults"
+msgid "License"
+msgstr ""
+
+msgid "Liechtenstein"
+msgstr ""
+
+#. Label for the option prompting the AI assistant to adopt a role of a life coach in its responses.
+msgctxt "Assistant role option label for Life coach"
+msgid "Life coach"
+msgstr ""
+
+#. Text for a button that enables the light theme .
+msgctxt "Light theme button for theme selector"
+msgid "Light"
+msgstr ""
+
+#. Discontinued, don't translate
+msgid "Light blue"
+msgstr "Hellblau"
+
+#. Discontinued, don't translate
+msgid "Light green"
+msgstr "Hellgrün"
+
+#. Title for the privacy claim that indicates the AI model provider retains chat data for a limited time.
+msgctxt "Privacy claim title in Duck.ai chat"
+msgid "Limited data retention"
+msgstr ""
+
+#. Title for the privacy claim that indicates the AI model provider retains chat data for a limited time.
+msgctxt "Privacy claim title in Duck.ai chat"
+msgid "Limited data retention for this chat"
+msgstr ""
+
+#. Description of a setting managing the length of search result snippet text.
+msgctxt "settings"
+msgid "Limits the amount of descriptive content shown for results"
+msgstr ""
+
+#. i.e. a type of image comprised of lines without gradiations in shade or hue
+msgctxt "image-type"
+msgid "Line Drawing"
+msgstr ""
+
+#. Rugby match stats
+msgctxt "Sports module"
+msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
+msgstr ""
+
+#. https://duckduckgo.com/params under "Look & Feel Settings"
+msgid "Link font:"
+msgstr "Link-Schriftart"
+
+#. https://duckduckgo.com/params under "Color Settings"
+msgid "Links:"
+msgstr "Links"
+
+#. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "List the tools, materials, or prerequisites I need for this."
+msgstr ""
+
+#. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
+msgid "Listen"
+msgstr "zuhören"
+
+#. Status text shown in the duck.ai chat input while recording audio for dictation.
+msgid "Listening"
+msgstr ""
+
+#. Status label shown when the AI is listening to the user.
+msgctxt "voice chat"
+msgid "Listening"
+msgstr ""
+
+msgid "Lithuania"
+msgstr "Litauen"
+
+#. The name of the Lithuanian language
+msgctxt "language_name"
+msgid "Lithuanian"
+msgstr ""
+
+#. Live match/tournament indicator
+msgctxt "Sports module"
+msgid "Live"
+msgstr ""
+
+#. Button that loads settings.
+msgctxt "settings"
+msgid "Load"
+msgstr "Laden"
+
+#. Button that loads settings that were backed up using a cloud-save feature.
+msgctxt "cloudsave"
+msgid "Load Cloud Settings"
+msgstr "Einstellungen der Cloud laden"
+
+#. A link that loads more content.
+msgid "Load More"
+msgstr "Lade mehr"
+
+#. Button that loads previously-saved user settings.
+msgid "Load Settings"
+msgstr "Einstellungen Laden"
+
+#. Aria label for the chat history search loading state.
+msgctxt "Aria label for loading chat search results"
+msgid "Loading chat search results"
+msgstr ""
+
+#. Accessible label displayed while a previously saved Duck.ai chat is being loaded from the server. Shown as a status indicator to screen readers and visually while the chat content is being fetched.
+msgctxt ""
+"Accessible label shown when a saved chat is being fetched from the server"
+msgid "Loading chat..."
+msgstr ""
+
+#. Aria label for a thumbnail that is loading.
+msgctxt "Aria label for loading thumbnail"
+msgid "Loading image"
+msgstr ""
+
+#. Status text displayed while the list of open browser tabs is loading in the tab picker.
+msgctxt "Loading state shown while browser tabs are being fetched"
+msgid "Loading tabs…"
+msgstr ""
+
+#. Instructions for user once they've passed the bot challenge
+msgctxt "Anomaly modal"
+msgid "Loading your search results now."
+msgstr ""
+
+#. Indicates that content is being loaded
+msgid "Loading..."
+msgstr "Laden..."
+
+#. Pending title while update is in progress.
+msgctxt "duckai_migration"
+msgid "Loading..."
+msgstr ""
+
+msgctxt "settings"
+msgid "Loads more image and video results when scrolling"
+msgstr "Lädt mehr Bild- und Videoergebnisse beim Scrollen."
+
+msgctxt "settings"
+msgid "Loads more image results when scrolling"
+msgstr "Lädt mehr Bildergebnisse beim Scrollen."
+
+msgctxt "settings"
+msgid "Loads more results in Images, Videos, and Shopping when scrolling"
+msgstr ""
+
+#. http://i.imgur.com/WTkvs9I.png
+msgctxt "settings"
+msgid "Loads more results when scrolling"
+msgstr "Lädt weitere Resultate beim Scrollen"
+
+#. Heading for the table column indicating the country or region for which the data applies
+msgctxt "Covid 19 module"
+msgid "Location"
+msgstr ""
+
+#. Label that's displayed next to a location below a web search result.
+msgctxt "Rich Facts label"
+msgid "Location"
+msgstr ""
+
+msgctxt "settings"
+msgid "Location"
+msgstr "Standort"
+
+#. Message informing users that location-based search is private.
+msgctxt "precise_user_location"
+msgid "Location information is stored only on your device."
+msgstr "Standortinformationen werden nur auf deinem Gerät gespeichert."
+
+#. Category of feedback a user can select on a feedback form.
+msgctxt "feedback form"
+msgid "Location on map is wrong"
+msgstr ""
+
+#. Text for the button that lets the user logout of the current session.
+msgctxt "Text for the logout of subscription button on the settings modal"
+msgid "Log Out"
+msgstr ""
+
+#. Used in the desktop electron app to take an existing DuckDuckGo account holder to the login flow. Replaces 'I already have a subscription' wording, since the app does not host purchases.
+msgctxt ""
+"Text for the link that lets a user log into their existing DuckDuckGo "
+"account (electron desktop app variant)"
+msgid "Login to your existing DuckDuckGo account"
+msgstr ""
+
+#. Filters the duration of videos in search results.
+msgctxt "video-duration"
+msgid "Long"
+msgstr "Lang"
+
+#. Label for the section of recent chats that were edited a long time ago.
+msgctxt "Title for the period of chats from a long time ago"
+msgid "Long Ago..."
+msgstr ""
+
+#. in https://duckduckgo.com/params
+#. bold header
+msgid "Look & Feel Settings"
+msgstr "Oberflächeneinstellungen"
+
+#. Short string representing a prompt suggestion for looking up basic facts.
+msgctxt "Brief for looking up basic facts"
+msgid "Look up basic facts"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Looking for different place"
+msgstr ""
+
+#. Short string representing a prompt suggestion for looking up basic facts.
+msgctxt "Brief for looking up basic facts"
+msgid "Lookup basic facts"
+msgstr ""
+
+#. Text indicating the loser of a World Cup game when that team is not yet known
+msgctxt "Sports module"
+msgid "Loser of Game %s"
+msgstr ""
+
+#. Indicates this is the number of losses for this team
+msgctxt "Sports module"
+msgid "Losses"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Lost my settings"
+msgstr ""
+
+msgctxt "spread_badge"
+msgid "Love DuckDuckGo?"
+msgstr "Magst du DuckDuckGo?"
+
+#. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time. Invites the user to try the paid subscription.
+msgctxt "Mobile SERP subscription badge"
+msgid "Love DuckDuckGo? Try our subscription!"
+msgstr ""
+
+#. The lowest stock price in a day
+msgctxt "Stocks module"
+msgid "Low"
+msgstr ""
+
+#. Text with short description for an AI (Artificial Intelligence) Model that has a low built-in moderation level.
+msgctxt "duck.ai model card"
+msgid "Low built-in moderation"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Low-quality response"
+msgstr ""
+
+msgid "Luxembourg"
+msgstr ""
+
+#. Link to our lyrics provider, e.g 'Lyrics provided by Musixmatch'. The word Musixmatch can be clicked to go visit the lyrics at their website.
+msgctxt "lyrics_module"
+msgid "Lyrics provided by"
+msgstr ""
+
+#. Cricket scorecard: maidens abbreviation
+msgctxt "Sports module"
+msgid "M"
+msgstr ""
+
+#. Abbreviate millions in a number. E.g. 1,000,000 becomes 1M
+msgctxt "Stocks module"
+msgid "M"
+msgstr ""
+
+#. Indicates this is the number of matches a team has played in e.g. the soccer World Cup
+msgctxt "Sports module"
+msgid "MP"
+msgstr ""
+
+#. Refers to the DuckDuckGo browser for Mac.
+msgid "Mac Browser"
+msgstr ""
+
+msgid "Madagascar"
+msgstr ""
+
+#. Cricket scorecard: maidens full name (tooltip)
+msgctxt "Sports module"
+msgid "Maidens"
+msgstr ""
+
+#. A prompt asking users to confirm that they spelled their search term correctly.
+msgctxt "noresults"
+msgid "Make sure all words are spelled correctly."
+msgstr "Achte darauf, dass alle Wörter korrekt geschrieben sind."
+
+#. Tells users where in the settings menu they can change their default search engine.
+msgid "Make sure to check %s\"Make this my default search provider\"%s"
+msgstr ""
+"Stelle sicher, dass du %s\"Mache diesen zu meinem normalen Suchanbieter\"%s "
+"angekreuzt hast"
+
+#. Message prompting users to check the spelling of their search term.
+msgctxt "directions"
+msgid "Make sure your search is spelled correctly."
+msgstr "Vergewissere dich, dass du deine Suche korrekt geschrieben hast."
+
+#. The name of the Malagasy language
+msgctxt "language_name"
+msgid "Malagasy"
+msgstr ""
+
+msgid "Malawi"
+msgstr ""
+
+#. The name of the Malay language
+msgctxt "language_name"
+msgid "Malay"
+msgstr ""
+
+#. The name of the Malayalam language
+msgctxt "language_name"
+msgid "Malayalam"
+msgstr ""
+
+msgid "Malaysia"
+msgstr "Malaysia"
+
+msgid "Malaysia (en)"
+msgstr "Malaysia (en)"
+
+msgid "Maldives"
+msgstr ""
+
+msgid "Mali"
+msgstr ""
+
+msgid "Malta"
+msgstr ""
+
+#. The name of the Maltese language
+msgctxt "language_name"
+msgid "Maltese"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Malware"
+msgstr ""
+
+#. Text for generic link to send the user to a page to manage their settings.
+msgid "Manage"
+msgstr ""
+
+#. Text for the button that takes the user to the sync settings page.
+msgctxt "Encrypted storage manage button"
+msgid "Manage"
+msgstr ""
+
+#. Text for the button that takes the user to the sync settings page.
+msgctxt "Manage button for chat syncing"
+msgid "Manage"
+msgstr ""
+
+#. Button label shown to DuckDuckGo native browser users to manage sync in the native app.
+msgctxt "Manage button for native sync flow"
+msgid "Manage"
+msgstr ""
+
+#. Text for the button that takes the user to the page where they can manage their DuckDuckGo subscription.
+msgctxt "Text for the manage subscription button on the settings modal"
+msgid "Manage"
+msgstr ""
+
+#. Label displayed on the manage subscription button in the sidebar footer.
+msgctxt "Label for the manage subscription button"
+msgid "Manage Subscription"
+msgstr ""
+
+#. Button label shown to DuckDuckGo native browser users to manage sync in the native app.
+msgctxt "Manage button for native sync flow"
+msgid "Manage Sync"
+msgstr ""
+
+#. Text for the button that takes the user to the Manage your subscription page when clicked.
+msgctxt ""
+"Text for the manage subscription button on the AI (Artificial Intelligence) "
+"models modal"
+msgid "Manage Your Subscription"
+msgstr ""
+
+#. Label for linke navigating to site exclusion feature on Settings page
+msgctxt "Exclusion message manage sites button"
+msgid "Manage blocked sites"
+msgstr ""
+
+#. Button on the AI Features settings page (DuckDuckGo app only) that deep-links into the browser's Duck.ai settings screen.
+msgctxt "setting"
+msgid "Manage in Browser Settings"
+msgstr ""
+
+#. Link to the site exclusion settings page
+msgctxt "Organic result context menu"
+msgid "Manage sites you've blocked"
+msgstr ""
+
+#. Button that switches the consume tab from camera scan to paste-textarea entry. Only shown when getUserMedia fails (permission denied, no device, etc.).
+msgctxt "Fallback CTA shown below a failed camera viewfinder"
+msgid "Manually Enter Code"
+msgstr ""
+
+#. Text link below the camera viewport that takes the user to the manual paste screen instead of scanning a QR code.
+msgctxt "Link on the Scan screen that switches to manual paste"
+msgid "Manually Enter Code"
+msgstr ""
+
+#. The name of the Maori language
+msgctxt "language_name"
+msgid "Maori"
+msgstr ""
+
+#. Used in 0-click box for local results, e.g. <a href="http://duckduckgo.com/?q=black+lab+bistro">http://duckduckgo.com/?q=black+lab+bistro</a>
+msgid "Map"
+msgstr "Karte"
+
+msgctxt "settings"
+msgid "Map Rendering"
+msgstr "Karten rendering"
+
+msgid "Maps"
+msgstr "Karten"
+
+msgctxt "feedback form"
+msgid "Maps"
+msgstr "Karte"
+
+#. Category a user can select on a feedback form.
+msgctxt "feedback form"
+msgid "Maps / location info"
+msgstr ""
+
+#. The name of the Marathi language
+msgctxt "language_name"
+msgid "Marathi"
+msgstr ""
+
+#. Label for the option prompting the AI assistant to adopt a role of a marketer in its responses.
+msgctxt "Assistant role option label for Marketer"
+msgid "Marketer"
+msgstr ""
+
+msgid "Marshall Islands"
+msgstr ""
+
+#. Label for the option prompting the AI assistant to adopt a role of a master chef in its responses.
+msgctxt "Assistant role option label for Master chef"
+msgid "Master chef"
+msgstr ""
+
+#. Used in cricket when a test match ends without a winner
+msgctxt "Sports module"
+msgid "Match Drawn"
+msgstr ""
+
+#. Label for the first part of the Groups stage of the soccer World Cup
+msgctxt "Sports module"
+msgid "Matchday 1 of 3"
+msgstr ""
+
+#. Label for the second part of the Groups stage of the soccer World Cup
+msgctxt "Sports module"
+msgid "Matchday 2 of 3"
+msgstr ""
+
+#. Label for the third part of the Groups stage of the soccer World Cup
+msgctxt "Sports module"
+msgid "Matchday 3 of 3"
+msgstr ""
+
+#. Title of a tab that displays a list of matches for a sports league. Nuance different than 'game', for sports that use 'match' like soccer.
+msgctxt "Sports module"
+msgid "Matches"
+msgstr ""
+
+#. Indicates this is the number of matches a team has played in e.g. the soccer World Cup
+msgctxt "Sports module"
+msgid "Matches Played"
+msgstr ""
+
+#. Indicates this is a list of matchups (games) between two teams
+msgctxt "Sports module"
+msgid "Matchups"
+msgstr ""
+
+msgid "Mauritania"
+msgstr ""
+
+msgid "Mauritius"
+msgstr ""
+
+#. Text for a button that indicates that the user has reached the maximum number of pinned chats.
+msgctxt ""
+"Button text for when the user has reached the maximum number of pinned chats"
+msgid "Max Pins Reached"
+msgstr ""
+
+#. Name of a setting managing the length of search result snippet text.
+msgctxt "settings"
+msgid "Max Snippet Length"
+msgstr ""
+
+#. Button that dismisses a message.
+msgctxt "precise_user_location"
+msgid "Maybe later"
+msgstr ""
+
+#. Label that's displayed next to a meal type below a web search result.
+msgctxt "Rich Facts label"
+msgid "Meal Type"
+msgstr ""
+
+#. In 0-click box -- for disambiguation.
+msgid "Meanings"
+msgstr "Bedeutungen"
+
+#. Button to show how many olympic medals a country has won
+msgid "Medals"
+msgstr ""
+
+msgctxt "Button to show how many olympic medals a country has won"
+msgid "Medals"
+msgstr ""
+
+msgctxt "settingsvalue"
+msgid "Medium"
+msgstr "Mittel"
+
+#. Filters the size of images in search results.
+msgctxt "size"
+msgid "Medium"
+msgstr "Mittel"
+
+#. Filters the duration of videos in search results.
+msgctxt "video-duration"
+msgid "Medium"
+msgstr "Mittel"
+
+#. Text with short description for an AI (Artificial Intelligence) Model that has a medium built-in moderation level.
+msgctxt "duck.ai model card"
+msgid "Medium built-in moderation"
+msgstr ""
+
+#. Header for front page menu
+msgid "Menu"
+msgstr "Menü"
+
+#. Refers to the menu of a restaurant.
+msgctxt "maps_places"
+msgid "Menu"
+msgstr "Menu"
+
+msgctxt "settingsvalue"
+msgid "Metric (Kilograms, Meters, Celsius)"
+msgstr "metrisch (Kilogramm, Meter, Celsius)"
+
+msgctxt "settingsvalue"
+msgid "Metric (kilograms, meters, Celsius)"
+msgstr ""
+
+#. In the context of the National Hockey League (NHL), label for teams belonging to the Metropolitan division
+msgctxt "Sports module"
+msgid "Metropolitan"
+msgstr ""
+
+msgid "Mexico"
+msgstr "Mexiko"
+
+msgid "Micronesia"
+msgstr ""
+
+#. Error in the duck.ai chat input when the user denies microphone access for dictation.
+msgid ""
+"Microphone access was denied. Please allow microphone access and try again."
+msgstr ""
+
+#. The Microsoft brand name.
+msgid "Microsoft"
+msgstr ""
+
+#. Discontinued, don't translate
+msgctxt "placement"
+msgid "Middle"
+msgstr "Mitte"
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Misleading"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Misleading ad"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Misleading pricing"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Misleading result "
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Misleading source"
+msgstr ""
+
+#. Accessibility label for a marker representing a penalty kick that was missed in a soccer shootout.
+msgctxt "Sports module"
+msgid "Missed"
+msgstr ""
+
+#. A negative feedback suggestion where the user can provide feedback on the feature missing having other AI (Artificial Intelligence) models available
+msgctxt "Feedback prompt"
+msgid "Missing AI models"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Missing bike routes"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Missing conversion unit"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Missing currency"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Missing dates"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Missing feature"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Missing filter"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Missing holiday"
+msgstr ""
+
+#. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was incomplete.
+msgctxt "feedback form"
+msgid "Missing info"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Missing information"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Missing language"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Missing location"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Missing news"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Missing persistent chat feature"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Missing public transit"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Missing routes"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Missing streaming option"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Missing traffic info"
+msgstr ""
+
+#. A negative feedback suggestion about the AI (Artificial Intelligence) chat feature missing the ability to do web search
+msgctxt "Feedback prompt"
+msgid "Missing web search"
+msgstr ""
+
+#. The market capitalization of the currently selected stock
+msgctxt "Stocks module"
+msgid "Mkt Cap"
+msgstr ""
+
+msgctxt "settings"
+msgid "Mobile Instructions (not displayed on settings page)"
+msgstr "Erklärungen für Mobile"
+
+#. A short label indicating that a user is a moderator of a discussion.
+msgctxt "Discussions IA"
+msgid "Mod"
+msgstr ""
+
+#. A setting for the safe search filter that removes some but not all results.
+msgctxt "safe search"
+msgid "Moderate"
+msgstr "Moderat"
+
+msgctxt "settingsvalue"
+msgid "Moderate"
+msgstr "Moderat"
+
+#. Weekday abbreviation (short for 'Monday')
+msgctxt "maps_places"
+msgid "Mon"
+msgstr ""
+
+msgid "Monaco"
+msgstr ""
+
+#. Weekday in plural form
+msgctxt "maps_places"
+msgid "Mondays"
+msgstr ""
+
+msgid "Mongolia"
+msgstr ""
+
+msgid "Montenegro"
+msgstr ""
+
+#. Label for the monthly usage limit row in the Usage section of Duck.ai settings.
+msgctxt "Duck.ai settings usage section"
+msgid "Monthly limit"
+msgstr ""
+
+#. Displayed in the Duck.ai usage limit banner for subscribers when the monthly usage limit has been reached.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Monthly limit reached"
+msgstr ""
+
+#. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
+msgctxt "Error message for fixed-window Duck.ai usage limit"
+msgid "Monthly usage limit reached. You can continue this chat after %s."
+msgstr ""
+
+#. Used to point to additional social networking profiles (in results).
+msgid "More"
+msgstr "Mehr"
+
+#. Accessible label (aria-label) for the three-dot overflow menu icon button on an assistant response action bar in Duck.ai. Announced by screen readers only. Menu items can include Search Web, Extend Reasoning, Export, and Report (Windows).
+msgctxt "Accessible label for the overflow menu on assistant response actions"
+msgid "More"
+msgstr ""
+
+#. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
+msgctxt "Button label for showing more search result links in Duck.ai"
+msgid "More"
+msgstr ""
+
+#. A link to more information.
+msgctxt "additional"
+msgid "More"
+msgstr "Mehr"
+
+#. As in Learn More
+msgctxt "frontpage"
+msgid "More"
+msgstr "Mehr"
+
+#. Sidebar subheading with links for links to other DuckDuckGo products and services.
+msgid "More From DuckDuckGo"
+msgstr ""
+
+#. A link that loads more image search results.
+msgid "More Images"
+msgstr "Weitere Bilder"
+
+#. A link to a page with more information.
+msgid "More Info"
+msgstr "Weitere Info"
+
+#. A button that loads additional links.
+msgid "More Links"
+msgstr "Weitere Links"
+
+#. A link that loads more news search results.
+msgid "More News"
+msgstr "Mehr News"
+
+#. Links to more search results.
+msgid "More Places"
+msgstr "Mehr Orte"
+
+#. A link that loads more product search results.
+msgid "More Products"
+msgstr "Mehr Produkte"
+
+#. A link that loads more recipe search results.
+msgid "More Recipes"
+msgstr "Mehr Empfehlungen"
+
+#. A header above links to topics related to the user's search.
+msgid "More Related Topics"
+msgstr "Weitere verwandte Themen"
+
+#. e.g., 'More Reviews on Tripadvisor'
+msgctxt "more_reviews_on_external_website"
+msgid "More Reviews on %s "
+msgstr ""
+
+#. Button text for navigating to full search results page for a related question in the Explore More section
+msgid "More Search Results"
+msgstr ""
+
+#. Link to additional theme settings.
+msgid "More Themes"
+msgstr "mehr Themen"
+
+#. A link that loads more video search results
+msgid "More Videos"
+msgstr "Mehr Videos"
+
+msgid "More about !bangs"
+msgstr "Mehr über !bangs"
+
+#. Title displayed on the onboarding modal when it is shown after the user's first prompt rather than immediately.
+msgctxt "Onboarding welcome screen title for deferred experiment"
+msgid "More about Duck.ai"
+msgstr ""
+
+#. A label that appears before a link where more information can be found. For example 'More at Wikipedia'.
+msgid "More at"
+msgstr "Mehr Informationen unter "
+
+#. In 0-click box -- %s will be a site name, like Wikipedia.
+msgid "More at %s"
+msgstr "Mehr bei %s"
+
+#. A link to additional information on a topic. The placeholder is the name of a website. For example 'More at Wikipedia'.
+msgid "More at %s "
+msgstr "Mehr auf %s"
+
+#. More from [domain], used in 'site:' search.
+msgid "More from"
+msgstr "Mehr von"
+
+#. Text that appears before a list of website links that contain additional information on an answer provided in search results. For example: 'More in: Wikipedia'
+msgid "More in"
+msgstr ""
+
+#. Text that appears before a list of website links that contain additional information on an answer provided in search results.
+msgid "More in %s"
+msgstr ""
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid "More info"
+msgstr ""
+
+#. Link to additional infromation.
+msgctxt "precise_user_location"
+msgid "More info"
+msgstr "Weitere Informationen"
+
+#. Source (article and site) of the answer generated by duckassist (an instant answer based on generative AI)
+msgid "More info in the %s %s article."
+msgstr ""
+
+#. Source (section, article and site) of the answer generated by duckassist (an instant answer based on generative AI)
+msgid "More info in the %s section of the %s %s article."
+msgstr ""
+
+msgctxt ""
+"Note on the Olympics module as to where they can find more information"
+msgid "More medal stats on %s"
+msgstr ""
+
+msgctxt ""
+"Note on the Olympics module as to where they can find more information"
+msgid "More medal stats on %solympics.com%s"
+msgstr ""
+
+#. A link to more information on a topic. The placeholder is the name of a website. For example 'More on Wikipedia'.
+msgid "More on %s "
+msgstr "Mehr auf %s"
+
+#. A link to get more results from a particular domain.
+msgid "More results"
+msgstr "Weitere Ergebnisse"
+
+#. A link that loads additional search results.
+msgctxt "additional_info_at"
+msgid "More results"
+msgstr "Mehr Resultate"
+
+#. Button text that links to full search results for a related question in the 'People also ask' module.
+msgid "More search results"
+msgstr ""
+
+#. Link to statistics tab
+msgctxt "Covid 19 module"
+msgid "More statistics"
+msgstr ""
+
+#. Note on the Olympics module as to where they can find more information. i.e. More stats on olympics.com
+msgid "More stats on %s"
+msgstr ""
+
+msgctxt ""
+"Note on the Olympics module as to where they can find more information"
+msgid "More stats on %s"
+msgstr ""
+
+#. Filters the duration of videos in search results.
+msgctxt "video-duration"
+msgid "More than 20 minutes"
+msgstr "Mehr als 20 Minuten"
+
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
+#. e.g. More ways to add DuckDuckGo to Firefox
+msgctxt "frontpage"
+msgid "More ways to add DuckDuckGo to %s"
+msgstr "Weitere Wege um DuckDuckGo zu %s hinzuzufügen"
+
+msgid "Morocco"
+msgstr ""
+
+#. Used as a toggle label in a page customization menu
+msgctxt "new tab page"
+msgid "Most-Visited Sites"
+msgstr ""
+
+#. Used when presented as an option in a feedback form
+msgctxt "new tab page"
+msgid "Most-visited sites"
+msgstr ""
+
+#. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
+msgctxt "Weather IA"
+msgid "Mostly Clear"
+msgstr ""
+
+#. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
+msgctxt "Weather IA"
+msgid "Mostly Cloudy"
+msgstr ""
+
+#. Prompt for users to move the map to their current location.
+msgctxt "precise_user_location"
+msgid "Move map to set current location"
+msgstr "Karte verschieben, um den aktuellen Standort festzulegen"
+
+#. Instant Answer Tab Name
+msgid "Movies"
+msgstr "Filme"
+
+msgid "Mozambique"
+msgstr ""
+
+msgctxt "settings"
+msgid "Multi-Step Add-to-Browser Onboarding Step"
+msgstr ""
+
+#. Text when onboarding users, describing that AI Chat supports multiple AI models, all in one place.
+msgctxt "Onboarding welcome screen feature"
+msgid "Multiple AI models, all in one place"
+msgstr ""
+
+msgid "Music"
+msgstr "Musik"
+
+#. Tooltip/label for the button to mute the microphone.
+msgctxt "voice chat"
+msgid "Mute microphone"
+msgstr ""
+
+#. Status label shown when the user's microphone is muted.
+msgctxt "voice chat"
+msgid "Muted"
+msgstr ""
+
+#. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
+msgid "Muted red"
+msgstr "mattes Rot"
+
+#. Label for the input field where users specify how they want to be referred to. Example: 'My name (is): John'
+msgctxt "Label for user name input"
+msgid "My name"
+msgstr ""
+
+#. Title for the dropdown menu where users select their role. The role is used by the AI assistant to modify its responses. Example: 'My role: Parent'
+msgctxt "Dropdown title for selecting user role"
+msgid "My role"
+msgstr ""
+
+#. Label indicating the user's role. The role is used by the AI assistant to modify its responses. Example: 'My role (is a): parent'
+msgctxt "Label for user role selection"
+msgid "My role"
+msgstr ""
+
+msgid "Myanmar"
+msgstr ""
+
+#. The name of the Myanmar (Burmese) language
+msgctxt "language_name"
+msgid "Myanmar (Burmese)"
+msgstr ""
+
+#. Abbreviation for 'North'
+msgctxt "forecast"
+msgid "N"
+msgstr "N"
+
+#. Abbreviation for 'Northeast'
+msgctxt "forecast"
+msgid "NE"
+msgstr "NO"
+
+#. Indicates a new product or feature release
+msgid "NEW"
+msgstr ""
+
+#. Abbreviation for 'National League Championship Series', the title of the divisional championship series for the National League division of Major League Baseball
+msgctxt "Sports module"
+msgid "NLCS"
+msgstr ""
+
+#. Abbreviation for 'National League Division Series', the title of the divisional semi-final series for the National League division of Major League Baseball
+msgctxt "Sports module"
+msgid "NLDS"
+msgstr ""
+
+#. Abbreviation for 'National League Wild Card Series', the title of the divisional runner-up series for the National League Division in Major League Baseball.
+msgctxt "Sports module"
+msgid "NLWC"
+msgstr ""
+
+#. NPM = node.js package manager.
+#. e.g. https://duckduckgo.com/?q=npm+packages
+msgid "NPM"
+msgstr "NPM"
+
+#. For teams that are newly ranked and have no previous rank and therefore no trend, this abbreviation stands for 'not previously ranked' or 'newly ranked'.  Feel free to leave in English unless there's an obvious alternative in your language.
+msgctxt "Sports module"
+msgid "NR"
+msgstr ""
+
+#. Label indicating that a discussion contains Not Safe For Work (i.e. Adult) content.
+msgctxt "Discussions IA"
+msgid "NSFW"
+msgstr ""
+
+#. Abbreviation for 'Northwest'
+msgctxt "forecast"
+msgid "NW"
+msgstr "NW"
+
+msgid "Namibia"
+msgstr ""
+
+#. Title of the divisional championship series for the National League division of Major League Baseball
+msgctxt "Sports module"
+msgid "National League Championship Series"
+msgstr ""
+
+#. Title of the divisional semi-final series for the National League division of Major League Baseball
+msgctxt "Sports module"
+msgid "National League Division Series"
+msgstr ""
+
+#. Title of the divisional runner-up series for the National League Division in Major League Baseball.
+msgctxt "Sports module"
+msgid "National League Wild Card Series"
+msgstr ""
+
+msgid "Nauru"
+msgstr ""
+
+#. Link to open driving directions in a different maps app. The name of the maps app appears after this string. For example: 'Navigate in Apple Maps'
+msgctxt "directions"
+msgid "Navigate in"
+msgstr "Navigiere in"
+
+#. Tells users where to find location settings on their phone. Part of a list of instructions on how to enable location service.
+msgctxt "precise_user_location"
+msgid "Navigate to %sSetting > Apps%s"
+msgstr ""
+
+#. Tells users where to find location settings on their phone. Part of a list of instructions on how to enable location service.
+msgctxt "precise_user_location"
+msgid "Navigate to Setting > Apps."
+msgstr ""
+
+#. A negative feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Negative feedback"
+msgstr ""
+
+msgid "Nepal"
+msgstr ""
+
+#. The name of the Nepali language
+msgctxt "language_name"
+msgid "Nepali"
+msgstr ""
+
+msgid "Netherlands"
+msgstr "Niederlande"
+
+#. Error in the duck.ai chat input when a network error occurs during dictation upload.
+msgid "Network error. Please check your connection and try again."
+msgstr ""
+
+#. The title of the 'Never' option in the assist settings modal.
+msgctxt "duckassist"
+msgid "Never"
+msgstr ""
+
+#. Short label for a button that starts a new chat session, used in compact or mobile views.
+msgctxt "Button label for starting a new chat in a compact form"
+msgid "New"
+msgstr ""
+
+#. Label for a button that starts a new chat session. Appears in the UI where users can initiate a new conversation.
+msgctxt "Button label for starting a new chat"
+msgid "New Chat"
+msgstr ""
+
+#. Title shown to the joiner device (the one that is not logged in) after the two devices have successfully paired.
+msgctxt "Title for the joiner-device success screen"
+msgid "New Device Added!"
+msgstr ""
+
+#. Title shown after the two devices have successfully paired.
+msgctxt "Title for the success screen"
+msgid "New Device Added!"
+msgstr ""
+
+#. Label for a button that starts a new AI image generation session. Appears in the UI where users can initiate a new image creation.
+msgctxt "Button label for starting a new image generation"
+msgid "New Image"
+msgstr ""
+
+msgctxt "settings"
+msgid "New Tab Page Most-Visited Sites"
+msgstr ""
+
+#. This is the name of a user setting -- Example image: https://i.imgur.com/LRuNuA8.png
+msgctxt "settings"
+msgid "New URL Style"
+msgstr ""
+
+#. Button text to start a new voice chat session.
+msgctxt "voice chat"
+msgid "New Voice Chat"
+msgstr ""
+
+msgid "New Zealand"
+msgstr "Neuseeland"
+
+#. Response a user can select in a feedback form, indicating that they have a new browser or computer.
+msgctxt "new user poll"
+msgid "New browser or computer"
+msgstr "Neue Browser oder Computer"
+
+#. Tooltip text that appears when hovering over the new chat button.
+msgctxt "Tooltip label for the new chat button"
+msgid "New chat"
+msgstr ""
+
+#. Title shown to the joiner device (the one that is not logged in) after the two devices have successfully paired. %s is a line break so the title wraps after "to"; rendered via <Translate>. This screen prompts the user to save the recovery code.
+msgctxt "Title for the joiner-device success screen"
+msgid "New device added to %sSync & Backup."
+msgstr ""
+
+#. Warning in the About Chat History and About Sync modals explaining that prompts and responses are temporarily stored encrypted on DuckDuckGo's server for connection recovery, and that disabling chat history deletes pinned chats.
+msgctxt "Chat history about modal list item"
+msgid ""
+"New prompts and responses are encrypted and temporarily stored on a "
+"DuckDuckGo server after being sent, to help recover a chat if you lose your "
+"internet connection. Disabling chat history will delete pinned chats, and "
+"disable the temporary storage of new prompts and responses."
+msgstr ""
+
+#. Question in a feedback form.
+msgctxt "new user poll"
+msgid "New to DuckDuckGo?"
+msgstr "Neu bei DuckDuckGo?"
+
+#. Label above news search results.
+msgid "News"
+msgstr "Neuigkeiten"
+
+#. A label that appears above a list of search results from news sites.
+msgid "News Articles"
+msgstr "Zeitungsartikel"
+
+#. Title for the section that showcases the news results for a certain query, ex. News for <b>elections</b>
+msgid "News for %s%s%s"
+msgstr ""
+
+#. Refers to the Privacy Newsletter (shortened version).
+msgid "Newsletter"
+msgstr ""
+
+#. A link to the Newsletter subscription page (https://duckduckgo.com/newsletter/)
+msgctxt "SERP footer content"
+msgid "Newsletter"
+msgstr ""
+
+#. Button label that advances the user to the recovery code screen.
+msgctxt "Continue button on the Sync & Backup enabled screen"
+msgid "Next"
+msgstr ""
+
+#. Button label that advances to the next step in the Sync & Backup pairing flow. Used both on the recovery code screen (to advance to the QR display) and on the devices-synced success screen (to advance to the QR display so another device can be paired).
+msgctxt "Next button in the Sync & Backup pairing flow"
+msgid "Next"
+msgstr ""
+
+#. Text displayed on a button to proceed to the next onboarding step.
+msgctxt "Onboarding pick a chat model screen button text"
+msgid "Next"
+msgstr ""
+
+#. Aria label for the next image navigation button on the image lightbox.
+msgctxt "Aria label for next image button"
+msgid "Next image"
+msgstr ""
+
+#. Accessibility label for the button that scrolls the rich caption tab row right to reveal later tabs.
+msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
+msgid "Next tabs"
+msgstr ""
+
+msgid "Nicaragua"
+msgstr ""
+
+#. The content of the placeholder of the input field for specifying the AI assistant's name
+msgctxt "Placeholder for input specifying assistant name"
+msgid "Nickname"
+msgstr ""
+
+#. The content of the placeholder of the input field for specifying user name
+msgctxt "Placeholder for input specifying user name"
+msgid "Nickname"
+msgstr ""
+
+msgid "Niger"
+msgstr ""
+
+msgid "Nigeria"
+msgstr ""
+
+msgid "No"
+msgstr "Nein"
+
+#. Indicates that there were no search results for a user's search. The first placeholder describes the type of result, and the second placeholder is the user's search term. For example: 'No results found for 'restaurants near me''
+msgctxt "noresults"
+msgid "No %s found for %s%s%s"
+msgstr ""
+
+#. Indicates that there were no search results for a user's search. The first placeholder describes the type of result, and the second placeholder is the user's search term. For example: 'No results found for 'restaurants near me''
+msgctxt "noresults"
+msgid "No %s found for %s%s%s."
+msgstr "Keine %s gefunden für %s%s%s."
+
+#. This message describes that no games are scheduled for a particular sports league. The placeholder value is the name of the league e.g. 'No America East games scheduled'
+msgctxt "Sports module"
+msgid "No %s games scheduled"
+msgstr ""
+
+#. Empty state message to indicate that there are no games for a particular conference/division in a particular period e.g. 'No FBS games scheduled in Week 14'
+msgctxt "Sports module"
+msgid "No %s games scheduled in %s"
+msgstr ""
+
+#. Heading for the highlight card explaining that chats are not used for AI training.
+msgctxt "Title for the no-AI-training card in the How Duck.ai Works panel"
+msgid "No AI Training"
+msgstr ""
+
+#. Title for the privacy claim that AI model providers do not use conversations for training. AI stands for Artificial Intelligence.
+msgctxt "Privacy claim title in Duck.ai chat"
+msgid "No AI training"
+msgstr ""
+
+#. Text describing feature highlighted on the welcome screen of the onboarding.
+msgctxt "Onboarding welcome screen feature"
+msgid "No AI training on your conversations"
+msgstr ""
+
+#. Text describing feature highlighted on the welcome screen of the onboarding.
+msgctxt "Onboarding welcome screen feature"
+msgid "No AI training on your conversations."
+msgstr ""
+
+#. Indicates that driving directions aren't available between two locations on a map.
+msgctxt "directions"
+msgid "No Available Routes"
+msgstr "Keine verfügbaren Routen"
+
+#. A label at the end of a photo carousel.
+msgid "No More Photos"
+msgstr "Keine Fotos mehr"
+
+#. Text of a button that will dismiss the DuckDuckGo app promo when clicked
+msgctxt "Browser Promo Popover"
+msgid "No Thanks"
+msgstr ""
+
+#. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
+msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
+msgid "No Thanks"
+msgstr ""
+
+#. Text describing how DuckDuckGo doesn't track its users.
+msgid "No Tracking. Ever."
+msgstr "Kein Tracking. Niemals."
+
+#. Description explaining that no account is needed to use the sync feature.
+msgctxt "Sync feature benefit description"
+msgid "No account required."
+msgstr ""
+
+#. A setting for the safe search filter that removes content inappropriate for children.
+msgctxt "safe search"
+msgid "No adult content"
+msgstr "Keine Inhalte für Erwachsene"
+
+#. Title for the section explaining that audio from the voice chat are not stored.
+msgctxt "voice chat"
+msgid "No audio gets stored"
+msgstr ""
+
+#. Title for the audio identification highlight in the dictation consent modal.
+msgid "No audio identification"
+msgstr ""
+
+#. Title for the section explaining that we do not use the user's voice to identify them.
+msgctxt "voice chat"
+msgid "No audio identification"
+msgstr ""
+
+#. Indicates that driving directions aren't available between two locations on a map.
+msgctxt "directions"
+msgid "No available routes between these locations"
+msgstr ""
+
+#. A setting for the safe search filter that removes images and videos inappropriate for children.
+msgctxt "safe search"
+msgid "No explicit images or videos"
+msgstr "Keine freizügige Bilder oder Videos"
+
+#. Indicates that there were no search results for a user's search. The placeholder is the user's search term. For example: 'No images found for 'ugly cats''
+msgctxt "noresults"
+msgid "No images found for %s"
+msgstr ""
+
+#. Status text displayed when the user's search query does not match any open browser tabs.
+msgctxt "Empty state when no tabs match the user filter text"
+msgid "No matching tabs"
+msgstr ""
+
+#. Indicates that there were no more search results for a user's search. The placeholder is the user's search term. For example: 'No more results found for 'restaurants near me''
+msgctxt "noresults"
+msgid "No more results found for %s%s%s"
+msgstr ""
+
+#. Indicates that there were no more search results for a user's search. The placeholder is the user's search term. For example: 'No more results found for 'restaurants near me''
+msgctxt "noresults"
+msgid "No more results found for %s%s%s."
+msgstr "Keine weitere Resultate für %s%s%s gefunden."
+
+#. A message displayed when no news articles are found for a search query
+msgid "No news articles found for %s"
+msgstr ""
+
+#. Indicates that there were no search results for a user's search. The placeholder is the user's search term. For example: 'No news articles found for 'big foot discovered''
+msgctxt "noresults"
+msgid "No news articles found for %s"
+msgstr ""
+
+#. Status text displayed when there are no open browser tabs available to attach.
+msgctxt "Empty state when there are no open browser tabs"
+msgid "No open tabs"
+msgstr ""
+
+msgctxt "settingsvalue"
+msgid "No preference (default)"
+msgstr ""
+
+#. Indicates that there were no search results for a user's search. The placeholder is the user's search term. For example: 'No products found for 'granting super powers''
+msgctxt "noresults"
+msgid "No products found for %s"
+msgstr ""
+
+#. This message describes that no games in a sports league have been played recently. The placeholder value is the name of the league e.g. 'No recent America East games'
+msgctxt "Sports module"
+msgid "No recent %s games"
+msgstr ""
+
+#. Title displayed when there are no recent chats available.
+msgctxt "Title text for empty state when there are no recent chats"
+msgid "No recent chats just yet..."
+msgstr ""
+
+#. Placeholder to indicate that nothing was blocked in the last hour
+msgid "No recent tracking activity"
+msgstr ""
+
+#. Indicates that there were no search results for a user's search.
+msgid "No results"
+msgstr "Keine Resultate"
+
+#. Title for the empty state displayed when searching recent chats in Duck.ai returns no results.
+msgctxt "Title shown when a chat search in Duck.ai returns no matching chats"
+msgid "No results found"
+msgstr ""
+
+#. Indicates that there were no search results for a user's search. The placeholder is the user's search term. For example: 'No results found for 'restaurants near me''
+msgctxt "noresults"
+msgid "No results found for %s"
+msgstr ""
+
+msgctxt "noresults"
+msgid "No results found for %s%s%s."
+msgstr "Keine Resultate für %s%s%s gefunden."
+
+#. Message indicating no search results were found.
+msgctxt "directions"
+msgid "No results found."
+msgstr "Keine Resultate gefunden."
+
+#. Error in the duck.ai chat input when the recording contains no audible speech.
+msgid "No speech detected. Please try again and speak into your microphone."
+msgstr ""
+
+#. Button that dismisses a feedback form.
+msgctxt "new user poll"
+msgid "No thanks."
+msgstr "Nein Danke."
+
+#. Heading for the tracker/companies list when we have observed trackers, but none in the last 24 hours
+msgctxt "tracker_stats"
+msgid "No trackers blocked in the last 24 hours"
+msgstr ""
+
+#. Heading for the tracker/companies list when we have observed trackers, but none in the last hour
+msgctxt "tracker_stats"
+msgid "No trackers blocked in the last hour"
+msgstr ""
+
+#. Refers to how web searches on DuckDuckGo aren't tracked.
+msgctxt "homepage onboarding"
+msgid "No tracking, no ad targeting, just searching!"
+msgstr "Keine Spurenverfolgung, keine gezielte Werbung, lediglich Suche!"
+
+#. Refers to how web searches on DuckDuckGo aren't tracked.
+msgctxt "homepage onboarding"
+msgid "No tracking, no ad targeting, just searching."
+msgstr "Keine Verfolgung, keine zugeschnittene Werbung, nur Suche."
+
+#. Indicates that there were no search results for a user's search. The placeholder is the user's search term. For example: 'No videos found for 'bad dogs''
+msgctxt "noresults"
+msgid "No videos found for %s"
+msgstr ""
+
+#. Response a user can select in a feedback form, indicating that they've used DuckDuckGo before.
+msgctxt "new user poll"
+msgid "No, old user!"
+msgstr "Nein, alter Benutzer!"
+
+#. http://i.imgur.com/WjSXsiZ.png
+msgctxt "settingsvalue"
+msgid "Normal"
+msgstr "Normal"
+
+#. http://i.imgur.com/i9mDrSN.png
+msgctxt "width"
+msgid "Normal"
+msgstr "Normal"
+
+msgctxt "Sports module"
+msgid "North"
+msgstr ""
+
+msgid "North Macedonia"
+msgstr ""
+
+msgid "Northern Ireland"
+msgstr ""
+
+msgid "Norway"
+msgstr "Norwegen"
+
+#. The name of the Norwegian language
+msgctxt "language_name"
+msgid "Norwegian"
+msgstr ""
+
+#. Text for a button where the user can dismiss the onboarding and not try the Duck.ai product right now.
+msgctxt "Onboarding welcome screen button text"
+msgid "Not Now"
+msgstr ""
+
+#. Dismiss the option to use their precise location
+msgctxt "Precise user location overlay"
+msgid "Not Now"
+msgstr ""
+
+#. Button on an inline disclaimer above the chat input that lets the user hide the file-storage-full warning for this browsing session.
+msgctxt "Sync file storage inline disclaimer dismiss button"
+msgid "Not Now"
+msgstr ""
+
+#. Replaces the regular subtitle of a tool entry (e.g. Create Image, Web Search) when the currently selected chat model does not support that tool. Indicates the option is disabled for that reason.
+msgctxt ""
+"Subtitle replacement shown on a disabled tool entry in the Tools dropdown "
+"menu"
+msgid "Not available for selected model"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Not enough information"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Not enough information on how to use"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Not enough results"
+msgstr ""
+
+#. Asks users if the search results shown on a map aren't close to their actual location.
+msgctxt "precise_user_location"
+msgid "Not getting nearby results?"
+msgstr "Du bekommst keine Resultate in der Nähe?"
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Not helpful"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Not looking for ads"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Not looking for apps"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Not looking for car ads"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Not looking for credit ads"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Not looking for definitions"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Not looking for directions"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Not looking for images"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Not looking for lyrics"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Not looking for map results"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Not looking for news"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Not looking for recipes"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Not looking for shopping results"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Not looking for sports"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Not looking for stock information"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Not looking for tour and activities ads"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Not looking for translation"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Not looking for videos"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Not looking for weather"
+msgstr ""
+
+#. Not many results contain '<query>' (<query> is the query that the user sent to the search engine)
+msgid "Not many results contain %s"
+msgstr ""
+
+#. Text for a button where the user can dismiss the onboarding and not try the Duck.ai product right now.
+msgctxt "Onboarding welcome screen button text"
+msgid "Not now"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Not relevant"
+msgstr ""
+
+#. Option in a feedback form for image search results.
+msgctxt "Report image modal"
+msgid "Not relevant"
+msgstr "Nicht relevant"
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Not relevant for my region"
+msgstr ""
+
+msgctxt "settingsvalue"
+msgid "Not set"
+msgstr ""
+
+#. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer lacked enough detail.
+msgctxt "feedback form"
+msgid "Not specific enough"
+msgstr ""
+
+#. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not relevant to their question.
+msgctxt "feedback form"
+msgid "Not what I asked for"
+msgstr ""
+
+#. A negative feedback suggestion saying that the feature is not working
+msgctxt "Feedback prompt"
+msgid "Not working"
+msgstr ""
+
+#. Positive feedback category a user can select on the Search Assist feedback form, meaning the answer was helpful.
+msgctxt "feedback form"
+msgid "Now I know what to do"
+msgstr ""
+
+#. Toast shown after a user switches an existing Duck.ai chat to a lower-cost model from the usage limit banner. %s is the selected AI model name, e.g., 'GPT-5 mini'.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Now chatting with %s."
+msgstr ""
+
+#. Title of dropdown that allows users to select the number of adults for their hotel booking
+msgctxt "Single Place Hotel Offers Module"
+msgid "Number of adults"
+msgstr ""
+
+#. Instant Answer tab name
+msgid "Nutrition"
+msgstr "Ernährung"
+
+#. Cricket scorecard: overs abbreviation
+msgctxt "Sports module"
+msgid "O"
+msgstr ""
+
+#. In a soccer match, abbreviation indicating that a player scored this goal on its own team. Example context: Andrés Iniesta 32' OG
+msgctxt "Sports module"
+msgid "OG"
+msgstr ""
+
+#. This appears on a button that a user clicks to confirm an action.
+msgid "OK"
+msgstr "OK"
+
+#. Button that confirms a user has read a message.
+msgctxt "mobile promotion on desktop"
+msgid "OK, got it!"
+msgstr "OK, verstanden!"
+
+#. Separator label between actions.
+msgctxt "duckai_migration"
+msgid "OR"
+msgstr ""
+
+#. Abbreviation indicating this is the score for a game that is in overtime
+msgctxt "Sports module"
+msgid "OT"
+msgstr ""
+
+#. Abbreviation indicating this is the score for a game that is in overtime, when there are multiple overtime periods. E.g. OT1, OT2, OT3
+msgctxt "Sports module"
+msgid "OT%s"
+msgstr ""
+
+#. In the context of a standings table for NHL (hockey), column title that abbreviates 'Overtime Losses' (the number of games lost during overtime of this team)
+msgctxt "Sports module"
+msgid "OTL"
+msgstr ""
+
+#. The name of the Odia language
+msgctxt "language_name"
+msgid "Odia"
+msgstr ""
+
+msgid "Off"
+msgstr "Aus"
+
+#. This is a label for a toggle that turns a setting on and off.
+msgctxt "setting"
+msgid "Off"
+msgstr "Aus"
+
+msgctxt "settingsvalue"
+msgid "Off"
+msgstr "Aus"
+
+#. A feedback suggestion where the user can provide feedback on the AI (Artificial Intelligence) chat bot providing information that is off topic
+msgctxt "Feedback prompt"
+msgid "Off topic"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Offensive"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Offensive ad"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Offensive response"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Offensive results"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Offensive site description"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Offensive translation"
+msgstr ""
+
+#. Used in 0-click box for product results, e.g. <a href="https://duckduckgo.com/?q=9780061353246">https://duckduckgo.com/?q=9780061353246</a>
+msgid "Offers"
+msgstr "Angebote"
+
+#. tooltip text for DuckDuckGo-sourced results
+msgctxt "organic_results"
+msgid "Official site identified by DuckDuckGo"
+msgstr ""
+
+#. Soccer match stats
+msgctxt "Sports module"
+msgid "Offsides"
+msgstr ""
+
+#. The title of the 'Often' option in the assist settings modal.
+msgctxt "duckassist"
+msgid "Often"
+msgstr ""
+
+#. The title of a module about the Olympic Games
+msgid "Olympic Games"
+msgstr ""
+
+msgctxt "The title of a module about the Olympic Games"
+msgid "Olympic Games"
+msgstr ""
+
+msgid "Oman"
+msgstr ""
+
+#. http://i.imgur.com/zQWKLIm.png
+msgctxt "settings"
+msgid "Omits objectionable (mostly adult) material"
+msgstr "Anstössige (meist nicht jugendfreie) Inhalte werden nicht angezeigt"
+
+msgid "On"
+msgstr "An"
+
+#. This is a label for a toggle that turns a setting on and off.
+msgctxt "setting"
+msgid "On"
+msgstr "An"
+
+#. in https://duckduckgo.com/params under Interface Settings
+#. previous note: Under Settings/ Layout( tab)/ Header
+msgctxt "setting"
+msgid "On & floating"
+msgstr "An & fixiert"
+
+#. http://i.imgur.com/TIY3iVP.png
+msgctxt "setting"
+msgid "On & scrolling"
+msgstr "An & scrollend"
+
+#. The title of the 'On Demand' option in the assist settings modal.
+msgctxt "duckassist"
+msgid "On Demand"
+msgstr ""
+
+#. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
+msgid ""
+"On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
+"Settings%s"
+msgstr ""
+"Auf Mac, %sklicke auf Maxthon > Einstellungen%s, auf Windows, %sklicke auf "
+"das %sIcon > Einstellungen%s"
+
+#. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
+msgctxt "setting"
+msgid "On but no numbers"
+msgstr "An, aber keine Zahlen"
+
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
+#. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
+msgctxt "voice chat"
+msgid "One moment please..."
+msgstr ""
+
+#. Error message displayed when one attached file has more pages than supported. Placeholder is the maximum supported page count. E.g. One of the files attached has more pages than we support. Please upload files with 15 pages or fewer.
+msgctxt ""
+"Error message when an attached file exceeds the supported page count limit"
+msgid ""
+"One of the files attached has more pages than we support. Please upload "
+"files with %s pages or fewer."
+msgstr ""
+
+#. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
+msgctxt "new user poll"
+msgid "Online article"
+msgstr "Online Artikel"
+
+#. Menu option to only show search results from the selected site
+msgctxt "Organic result context menu"
+msgid "Only include results for this site"
+msgstr ""
+
+#. A message saying that a site filter is applied to the search results. The placeholder string will contain a domain name. e.g. 'Only showing results from reddit.com'
+msgctxt "Site filter message"
+msgid "Only showing results from %s"
+msgstr ""
+
+#. Text explaining what information gets saved by the cloud save feature.
+msgctxt "cloudsave"
+msgid ""
+"Only the settings that you have changed. They are detailed on the %sURL "
+"Parameters%s page."
+msgstr ""
+"Nur die Einstellungen welche du veränderst. Eine detaillierte Auflistung "
+"findest du auf der %sURL-Parameter%s Seite. "
+
+#. An option that shows AI-assisted answers only when the user clicks the Assist button.
+msgctxt "duckassist"
+msgid "Only when Assist is clicked"
+msgstr ""
+
+#. Message displayed if there is an error during translation
+msgctxt "translations_module"
+msgid ""
+"Oops! An unexpected error occurred while translating this text. Please try "
+"again later."
+msgstr ""
+
+#. Title shown in a fatal error modal when Duck.ai fails to load.
+msgctxt "duckai_fatal_error"
+msgid "Oops! Something went wrong."
+msgstr ""
+
+#. Title for an error message that indicates something went wrong.
+msgctxt "Error message title"
+msgid "Oops..."
+msgstr ""
+
+#. Title shown when the scanned or pasted payload does not match the expected pairing format.
+msgctxt "Title for the wrong code error screen"
+msgid "Oops..."
+msgstr ""
+
+#. Title to inform the user we've encountered an error. This text is follow up with futher text. For example, 'The server encountered an error'
+msgctxt "noresults"
+msgid "Oops..."
+msgstr ""
+
+#. The price the markets opens at
+msgctxt "Stocks module"
+msgid "Open"
+msgstr ""
+
+#. Indicates a business is currently open.
+msgctxt "maps_places"
+msgid "Open"
+msgstr "Öffnen"
+
+#. Accessible label for the button that opens an attached file from the Duck.ai chat message. %s is the filename, e.g. 'Open document.pdf'.
+msgctxt "Accessible label for opening an attached file"
+msgid "Open %s"
+msgstr ""
+
+#. The placeholder is a business name, e.g. 'Open Ikea website'.
+msgid "Open %s website"
+msgstr ""
+
+#. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
+msgctxt "precise_user_location"
+msgid "Open %sLocation%s, and ensure location is %senabled%s"
+msgstr ""
+
+#. Instructions on how to change a browser's default search engine to DuckDuckGo.
+msgctxt "mobile homepage banner"
+msgid "Open %sMenu%s"
+msgstr "Öffne s'%sMenü%s"
+
+#. Instructions on how to change a browser's default search engine to DuckDuckGo.
+msgctxt "mobile homepage banner"
+msgid "Open %sSettings%s"
+msgstr "%sEinstellungen%s öffne"
+
+#. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
+msgctxt "precise_user_location"
+msgid "Open 'Location', and ensure location is %senabled%s."
+msgstr ""
+
+#. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
+msgctxt "precise_user_location"
+msgid "Open 'Privacy', then 'Location Services'."
+msgstr ""
+
+#. Indicates a business is open 24 hours a day.
+msgctxt "maps_places"
+msgid "Open 24 hours"
+msgstr "24 Stunden geöffnet"
+
+#. Opens the Duck.ai settings screen in the DuckDuckGo app
+msgctxt "setting"
+msgid "Open Duck.ai Settings"
+msgstr ""
+
+#. Button that makes a map larger.
+msgctxt "maps_places"
+msgid "Open Expanded Map"
+msgstr "Erweiterte Karte öffnen"
+
+#. http://i.imgur.com/jsSFfAr.png
+#. This setting used to be called 'New Window'
+#. Please update this translation if it no longer applies
+msgctxt "settings"
+msgid "Open Links in a New Tab"
+msgstr "Neues Fenster"
+
+#. Button that opens a map
+msgid "Open Map"
+msgstr "Karte öffnen"
+
+#. A button that opens the settings menu.
+msgid "Open Settings"
+msgstr "Einstellungen Öffnen"
+
+#. Text that indicates that an AI Model is open source. Please stick to a short translation as this is used in a small label.
+msgctxt "Label copy indicating that an AI Model is open source"
+msgid "Open Source"
+msgstr ""
+
+#. Header title shown after a pairing code is scanned/shown, while the two devices complete their handshake. Prompts the user to open Sync & Backup on their other device so the connection can finish.
+msgctxt "Modal header shown on both devices while pairing connects"
+msgid "Open Sync & Backup on your other device."
+msgstr ""
+
+#. Prompts users to open a new browser tab or window.
+msgid "Open a new tab or window"
+msgstr "Öffne einen neuen Tab oder ein Fenster"
+
+#. shown when DDG is selected after eu preference menu on android
+msgctxt "welcome message eu search preference android"
+msgid "Open app"
+msgstr "App öffnen"
+
+#. Accessible name for the pill tab that opens the panel listing suggested chat prompts.
+msgctxt "Aria label for the chat suggestions pill tab"
+msgid "Open chat suggestions"
+msgstr ""
+
+#. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
+msgctxt "Aria label for the create and edit images pill tab"
+msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
+msgstr ""
+
+#. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
+msgctxt "open_in_third_party_app"
+msgid "Open in %s"
+msgstr "Öffnen mit %s"
+
+msgctxt "Label for hamburger button that opens side menu"
+msgid "Open menu"
+msgstr ""
+
+#. http://i.imgur.com/MnvQ0IK.png
+msgctxt "settingsvalue"
+msgid "Open on third-party site"
+msgstr "Seite einer Drittpartei öffnen"
+
+#. Tooltip text that appears when hovering over the settings button.
+msgctxt "Tooltip label for the settings button"
+msgid "Open settings"
+msgstr ""
+
+#. Text that indicates that an AI Model is open source. Please stick to a short translation as this is used in a small label.
+msgctxt "Label copy indicating that an AI Model is open source"
+msgid "Open source"
+msgstr ""
+
+#. Tells users to open the setting application. Part of a list of instructions on how to enable location service.
+msgctxt "precise_user_location"
+msgid "Open the %sSettings app%s"
+msgstr ""
+
+#. Part of a list of instructions on how to enable location service.
+msgctxt "precise_user_location"
+msgid "Open the %sSettings app%s."
+msgstr ""
+
+#. Tells users to open the setting application. Part of a list of instructions on how to enable location service.
+msgctxt "precise_user_location"
+msgid "Open the %sSettings%s app"
+msgstr ""
+
+#. Part of a list of instructions on how to enable location service.
+msgctxt "precise_user_location"
+msgid "Open the %sSettings%s app."
+msgstr ""
+
+#. Accessible name for the pill tab that opens the explainer panel describing how Duck.ai works.
+msgctxt "Aria label for the How Duck.ai Works pill tab"
+msgid "Open the How Duck.ai Works panel"
+msgstr ""
+
+#. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
+msgctxt "precise_user_location"
+msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
+msgstr ""
+
+#. Label for the time a business opens. For example: 'Opens at 10am'
+msgctxt "maps_places"
+msgid "Opens"
+msgstr "Öffnet"
+
+#. A place's opening time, for example: 'Opens at 11 AM'
+msgctxt "maps_places"
+msgid "Opens at %s"
+msgstr ""
+
+#. http://i.imgur.com/iCNwHqR.png
+#. This setting controls how results open when you click on them.
+msgctxt "settings"
+msgid "Opens results in new windows/tabs"
+msgstr "Resultate in einem neuen Fenster/Tab öffnen"
+
+#. Indicates a business is openening soon.
+msgctxt "maps_places"
+msgid "Opens soon"
+msgstr "Öffnet bald"
+
+#. Keyboard shortcut for Duck.ai in MacOS
+msgctxt "Search form"
+msgid "Option+Enter"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback, and this field is optional.
+msgctxt "Feedback prompt"
+msgid "Optional"
+msgstr ""
+
+#. Label for an option field on a feedback form.
+msgctxt "feedback form"
+msgid "Optional"
+msgstr "Optional"
+
+#. A label that appears next to a suggested search term. For example 'Or did you mean pizza?'
+msgctxt "maps_maps_module"
+msgid "Or did you mean:"
+msgstr "Oder meintest du:"
+
+#. Displays when both AI chat and other otions are displayed for users to get what they need when we are having an outage. Sits between AI chat and other options
+msgctxt "noresults"
+msgid "Or:"
+msgstr ""
+
+#. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
+msgid "Orange"
+msgstr "Orange"
+
+#. Filters the color of images in search results.
+msgctxt "color"
+msgid "Orange"
+msgstr "Orange"
+
+#. Shown after the user has swapped origin and destination in a Maps `Direction` feature.
+msgctxt "directions"
+msgid "Origin and destination reversed"
+msgstr ""
+
+#. A feedback suggestion for page context feedback
+msgctxt "Feedback prompt"
+msgid "Other"
+msgstr ""
+
+msgctxt "feedback form"
+msgid "Other"
+msgstr "Andere"
+
+#. Sidemenu subheading displayed above links to resources such as Help, Press Kit, and more.
+msgid "Other Resources"
+msgstr ""
+
+#. Link to instructions on how to disable other ad blockers
+msgid "Other ad blockers"
+msgstr ""
+
+msgctxt "homepage onboarding"
+msgid ""
+"Other search engines track your searches even when you’re in private "
+"browsing mode. We don’t track you &mdash; period."
+msgstr ""
+"Andere Suchmaschinen verfolgen Deine Suchanfragen sogar im privaten "
+"Browsermodus. Wir verfolgen Dich nicht — Punkt."
+
+msgctxt "SERP footer content"
+msgid "Our Crash Course"
+msgstr "Unser Intensivkurs"
+
+#. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; shown in every market. 'No-log' means the VPN keeps no activity logs; 'smarter AI chats with higher limits' refers to Duck.ai.
+msgctxt "DuckDuckGo Subscription instant answer"
+msgid ""
+"Our fast, no-log VPN comes with smarter AI chats with higher limits, plus "
+"more premium protections. All in one subscription."
+msgstr ""
+
+msgctxt "homepage onboarding"
+msgid ""
+"Our privacy policy is simple: we don’t collect or share any of your personal "
+"information."
+msgstr ""
+"Unsere Datenschutzerklärung ist einfach: Wir sammeln oder teilen keine "
+"deiner persönlicher Daten."
+
+msgid ""
+"Our private browser for mobile comes equipped with our search engine, "
+"tracker blocker, encryption enforcer, and more. Available on %siOS & "
+"Android%s."
+msgstr ""
+"Unser Privater Browser für Mobilgeräte kommt ausgerüstet mit unserer "
+"Suchmaschine,einem Trackerblocker, Verschlüsselungserzwinger und mehr. "
+"Verfügbar für%siOS und Android%s."
+
+#. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
+msgctxt "feedback form"
+msgid "Outdated"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Outdated information"
+msgstr ""
+
+#. The number of searches performed on DuckDuckGo search engine. The placeholder value is a number.
+msgctxt "showcase_traffic"
+msgid "Over %s Billion anonymous searches."
+msgstr "Über %s Milliarden anonyme Suchen."
+
+#. Element title explaining this is the win loss record for team, e.g. 10-5
+msgctxt "Sports module"
+msgid "Overall Record"
+msgstr ""
+
+#. Cricket scorecard: overs full name (tooltip)
+msgctxt "Sports module"
+msgid "Overs"
+msgstr ""
+
+#. In the context of a standings table for NHL (hockey), indicates the number of games lost during overtime of this team
+msgctxt "Sports module"
+msgid "Overtime Losses"
+msgstr ""
+
+#. Label above a general description of a business.
+msgctxt "maps_places"
+msgid "Overview"
+msgstr "Überblick"
+
+#. Placeholder can be Apple Maps, TripAdvisor, or Foursquare
+msgctxt "feedback form"
+msgid "Own this business? Manage on %s"
+msgstr ""
+
+#. For some rankings of sports leagues, each team/player is scored with a certain number of points, and the team with the most points is ranked first. The rubric for how these points get calculated can be different for each ranking type and sport/league. The P stands for Points.  Feel free to leave in English unless there's an obvious alternative in your language.
+msgctxt "Sports module"
+msgid "P"
+msgstr ""
+
+#. The price / earnings multiple for the currently selected stock
+msgctxt "Stocks module"
+msgid "P/E"
+msgstr ""
+
+#. Indicates this is the total points scored against this team
+msgctxt "Sports module"
+msgid "PA"
+msgstr ""
+
+#. In a soccer match, abbreviation indicating that a goal was scored as a penalty. Example context: Andrés Iniesta 32' PEN
+msgctxt "Sports module"
+msgid "PEN"
+msgstr ""
+
+#. Indicates this is the total 'points for' (i.e. scored by) this team
+msgctxt "Sports module"
+msgid "PF"
+msgstr ""
+
+#. Label for the option prompting the AI assistant to adopt a role of a personally identifiable information redactor in its responses.
+msgctxt "Assistant role option label for PII redactor"
+msgid "PII redactor"
+msgstr ""
+
+#. Indicates these are the total points of this team, in e.g. the soccer World Cup
+msgctxt "Sports module"
+msgid "PTS"
+msgstr ""
+
+#. In the context of the National Hockey League (NHL), label for teams belonging to the Pacific division
+msgctxt "Sports module"
+msgid "Pacific"
+msgstr ""
+
+#. Instant Answer Tab Name
+msgid "Packages"
+msgstr "Pakete"
+
+msgctxt "settings"
+msgid "Page #'s"
+msgstr "Seitennummern"
+
+#. In https://duckduckgo.com/params under "Interface Settings" header. Leave "#s" as is.
+msgid "Page #s:"
+msgstr "Seite #s:"
+
+#. Indicates what page of a document the user is viewing. The placeholder is a number.
+msgid "Page %s"
+msgstr "Seite %s"
+
+msgctxt "settings"
+msgid "Page Break Lines"
+msgstr "Seitenumbruchlinien"
+
+msgctxt "settings"
+msgid "Page Break Numbers"
+msgstr ""
+
+#. A short title for a message that includes page context from the current tab.
+msgctxt "Title for the page context message"
+msgid "Page Content"
+msgstr ""
+
+#. A subtitle indicating that the page content is from a specific source URL. The placeholder will contain a link to the source page. Example: <a href='https://example.com'>example.com</a>
+msgctxt "Subtitle for the page context message"
+msgid "Page Content from %s"
+msgstr ""
+
+#. http://i.imgur.com/nyTQ3ki.png
+msgctxt "settings"
+msgid "Page Width"
+msgstr "Breite der Seite"
+
+#. A short title for a message that includes page context from the current tab.
+msgctxt "Title for the page context message"
+msgid "Page content"
+msgstr ""
+
+#. A subtitle indicating that the page content is from a specific source URL. The placeholder will contain a link to the source page. Example: <a href='https://example.com'>example.com</a>
+msgctxt "Subtitle for the page context message"
+msgid "Page content from %s"
+msgstr ""
+
+#. Title shown when user needs to refresh the page after migration.
+msgctxt "duckai_migration"
+msgid "Page refresh required"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Paid articles"
+msgstr ""
+
+#. Header on the wrong-code step when the failure is a session error rather than an invalid code. Placeholder copy pending review.
+msgctxt ""
+"Title shown when a pairing session fails (timeout, network, denied, etc.)"
+msgid "Pairing couldn't be completed"
+msgstr ""
+
+msgid "Pakistan"
+msgstr ""
+
+msgid "Pakistan (en)"
+msgstr ""
+
+msgid "Palau"
+msgstr ""
+
+msgid "Palestine"
+msgstr ""
+
+msgid "Panama"
+msgstr ""
+
+msgid "Papua New Guinea"
+msgstr ""
+
+msgid "Paraguay"
+msgstr ""
+
+#. Label for the option prompting the AI assistant to treat the user as if they are a parent.
+msgctxt "User role option for parent role"
+msgid "Parent"
+msgstr ""
+
+msgctxt "Subheader on a module about the 2024 olympic games"
+msgid "Paris 2024"
+msgstr ""
+
+#. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
+msgctxt "Weather IA"
+msgid "Partly Cloudy"
+msgstr ""
+
+#. The name of the Pashto language
+msgctxt "language_name"
+msgid "Pashto"
+msgstr ""
+
+#. An error message indicating that the passphrase the user has entered has already been used by them previously.
+msgctxt "cloudsave"
+msgid "Passphrase is already taken."
+msgstr ""
+
+#. An error message indicating that the passphrase the user has entered isn't long enough.
+msgctxt "cloudsave"
+msgid "Passphrase must be at least 9 characters long."
+msgstr ""
+
+#. Error message indicating that the user's passphrase wasn't recognized.
+msgctxt "cloudsave"
+msgid "Passphrase not found."
+msgstr ""
+
+#. Text explaining that passwords can't be recovered because DuckDuckGo does not have access to them.
+msgctxt "cloudsave"
+msgid ""
+"Passphrases cannot be recovered as we don't associate your IP address, "
+"browser fingerprint, or any other information with the file."
+msgstr ""
+
+#. Label for the section of recent chats that were edited in the past 7 days.
+msgctxt "Title for the period of chats from the past 7 days"
+msgid "Past 7 Days"
+msgstr ""
+
+#. Option for the filter-by-date search.
+msgid "Past Day"
+msgstr "Gestern"
+
+#. Indicates this is a list of past games for this team
+msgctxt "Sports module"
+msgid "Past Games"
+msgstr ""
+
+#. Indicates this is a list of past matches for this team. Nuance different than 'game', for sports that use 'match' like soccer.
+msgctxt "Sports module"
+msgid "Past Matches"
+msgstr ""
+
+#. Option for the filter-by-date search.
+msgid "Past Month"
+msgstr "Letzter Monat"
+
+#. Label for the section of recent chats that were edited in the past month.
+msgctxt "Title for the period of chats from the past month"
+msgid "Past Month"
+msgstr ""
+
+#. Option for the filter-by-date search.
+msgid "Past Week"
+msgstr "Letzte Woche"
+
+#. Option for the filter-by-date search.
+msgid "Past Year"
+msgstr "Letztes Jahr"
+
+#. A label for a filter that shows search results from only the last 24 hours.
+msgid "Past day"
+msgstr ""
+
+#. A label for a filter that shows search results from only the last month.
+msgid "Past month"
+msgstr ""
+
+#. A label for a filter that shows search results from only the last 7 days.
+msgid "Past week"
+msgstr ""
+
+#. A label for a filter that shows search results from only the last year.
+msgid "Past year"
+msgstr ""
+
+#. Reads the system clipboard when the textarea is empty (and submits) or submits whatever the user typed. Paired with a clipboard icon. Was 'Continue' historically; renamed to match the design's clipboard-first UX.
+msgctxt "Primary CTA on the Enter Code body"
+msgid "Paste"
+msgstr ""
+
+#. Label for the paste button on the Enter Code tab.
+msgctxt "Button label that pastes the sync code from clipboard"
+msgid "Paste Sync Code"
+msgstr ""
+
+#. Placeholder text inside the textarea where the user can paste the pairing payload as a fallback.
+msgctxt "Placeholder for the manual paste textarea"
+msgid "Paste pairing code"
+msgstr ""
+
+#. Placeholder text inside the textarea where the user can paste the pairing payload from another device.
+msgctxt "Placeholder for the manual paste textarea"
+msgid "Paste your code here"
+msgstr ""
+
+#. Text for the label that indicates the feature is paused.
+msgctxt "Status label for a setting"
+msgid "Paused"
+msgstr ""
+
+#. Indicates this is the percentage of wins for this team
+msgctxt "Sports module"
+msgid "Pct"
+msgstr ""
+
+#. Indicates that a match is in penalties stage, e.g. in soccer
+msgctxt "Sports module"
+msgid "Penalties"
+msgstr ""
+
+#. Rugby match stats
+msgctxt "Sports module"
+msgid "Penalties Conceded"
+msgstr ""
+
+#. Heading above a list of related questions and answers shown on the search results page.
+msgid "People also ask"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Permanently closed"
+msgstr ""
+
+#. The name of the Persian language
+msgctxt "language_name"
+msgid "Persian"
+msgstr ""
+
+#. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
+msgctxt "Assistant role option label for Personal trainer"
+msgid "Personal trainer"
+msgstr ""
+
+msgid "Peru"
+msgstr "Peru"
+
+msgid "Philippines"
+msgstr "Philippinen"
+
+msgid "Philippines (en)"
+msgstr ""
+
+msgid "Philippines (tl)"
+msgstr "Philippinen"
+
+#. Label that's displayed next to a phone number below a web search result.
+msgctxt "Rich Facts label"
+msgid "Phone"
+msgstr ""
+
+msgctxt "maps_places"
+msgid "Phone"
+msgstr "Telefon"
+
+msgctxt "maps_places"
+msgid "Phone Number"
+msgstr "Telefonnummer"
+
+#. Category of feedback a user can select on a feedback form.
+msgctxt "feedback form"
+msgid "Phone number is incorrect"
+msgstr ""
+
+#. Category of feedback a user can select on a feedback form.
+msgctxt "feedback form"
+msgid "Phone number is missing"
+msgstr ""
+
+#. Filters the type of images in search results.
+msgctxt "image-type"
+msgid "Photograph"
+msgstr "Foto"
+
+#. A link to additional photos of a business on a reviews site. The placeholder is the name of the reviews site. For example: 'Photos on Tripadvisor'
+msgid "Photos on %s"
+msgstr "Fotos auf %s"
+
+#. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
+msgid ""
+"Phrasing your search as a question and in a complete sentence makes AI-"
+"assisted answers more likely to appear automatically and often yields better "
+"answers. To turn them off and hide the Assist button visit %sSearch "
+"Settings%s."
+msgstr ""
+
+#. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
+msgid ""
+"Phrasing your search as a question and in a complete sentence makes "
+"DuckAssist more likely to appear and often yields better answers. To adjust "
+"how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
+msgstr ""
+
+#. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
+msgid ""
+"Phrasing your search as a question and in a complete sentence makes "
+"DuckAssist more likely to appear automatically and often yields better "
+"answers. To turn it off and hide the Assist button visit %sDuckAssist "
+"Settings%s."
+msgstr ""
+
+#. Button that allows users to manually select a location on a map.
+msgctxt "precise_user_location"
+msgid "Pick Custom Location"
+msgstr ""
+
+#. Label for a list of feedback categories on a feedback form.
+msgctxt "feedback form"
+msgid "Pick a category"
+msgstr "Wähle eine Kategorie aus"
+
+#. Text displayed in the header of the modal that allows the user to pick an AI chat model.
+msgctxt "Modal header text"
+msgid "Pick a chat model"
+msgstr ""
+
+#. Title displayed on the screen of the onboarding where the user picks an AI chat model.
+msgctxt "Onboarding pick a chat model screen title"
+msgid "Pick a chat model"
+msgstr ""
+
+#. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
+msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
+msgid ""
+"Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
+"etc."
+msgstr ""
+
+#. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
+msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
+msgid ""
+"Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, "
+"Mistral, etc."
+msgstr ""
+
+#. The description of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
+msgctxt "Third party map app picker"
+msgid ""
+"Pick a service to navigate to your destination. External apps won’t come "
+"with DuckDuckGo protections."
+msgstr ""
+
+#. Label for a list of problems on a feedback form.
+msgctxt "feedback form"
+msgid "Pick a specific problem"
+msgstr "Wähle ein spezifisches Problem"
+
+#. Header instructing the user to follow the instructions for their ad blocker
+msgid ""
+"Pick your ad blocker and follow the instructions to allow ads on DuckDuckGo."
+msgstr ""
+
+#. Text for a button that pins a chat, as in it will it will add the chat to the pinned chats list.
+msgctxt "Button for pinning a chat"
+msgid "Pin"
+msgstr ""
+
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
+#. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
+msgctxt "Pinned chats education row in Duck.ai"
+msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
+msgstr ""
+
+#. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
+msgid "Pink"
+msgstr "Pink"
+
+#. Filters the color of images in search results.
+msgctxt "color"
+msgid "Pink"
+msgstr "pink"
+
+#. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
+msgctxt "Title for the pinned chats section"
+msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
+msgstr ""
+
+#. https://duckduckgo.com/params under "Look & Feel Settings"
+msgid "Placement:"
+msgstr "Platzierung:"
+
+msgid "Places"
+msgstr "Orte"
+
+#. Short string representing a prompt suggestion for planning a trip.
+msgctxt "Brief for planning a trip"
+msgid "Plan a trip"
+msgstr ""
+
+#. Golf leaderboard column header
+msgctxt "Sports module"
+msgid "Player"
+msgstr ""
+
+#. Label for the option prompting the AI assistant to use playful tone in its responses.
+msgctxt "Tone option label for Playful"
+msgid "Playful"
+msgstr ""
+
+#. Description text when sync is temporarily unavailable.
+msgctxt "Sync unavailable modal description"
+msgid "Please check back later."
+msgstr ""
+
+#. Explanation of an anti-bot challenge for AI Chat users, where 'prompt' is a message sent to the AI
+msgctxt "Anomaly modal"
+msgid ""
+"Please complete the following challenge to confirm this prompt was made by a "
+"human."
+msgstr ""
+
+#. Bot challenge explanation
+msgctxt "Anomaly modal"
+msgid ""
+"Please complete the following challenge to confirm this search was made by a "
+"human."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is harmful or illegal. (optional)"
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
+msgctxt "Feedback prompt"
+msgid "Please describe why the chat response is illegal or harmful. (Optional)"
+msgstr ""
+
+#. A prompt asking users to enter their passphrase.
+msgctxt "cloudsave"
+msgid "Please enter a pass phrase"
+msgstr "Gib bitte ein Kennwort ein"
+
+#. Body copy shown when a scanned or pasted pairing payload fails schema validation.
+msgctxt "Description for the wrong code error screen"
+msgid "Please make sure the correct code was entered or scanned."
+msgstr ""
+
+#. Disclaimer text displayed in a modal that informs the user that starting a new chat with any AI model will delete their current chat session.
+msgctxt "Modal disclaimer text"
+msgid ""
+"Please note: starting a new chat with any model will delete your current "
+"chat session."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is harmful or illegal."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
+msgctxt "Feedback prompt"
+msgid ""
+"Please paste your prompt and the problematic output (with any personal "
+"information removed) and describe why the content is illegal or harmful."
+msgstr ""
+
+#. Title on a feedback form.
+msgctxt "feedback form"
+msgid "Please provide feedback"
+msgstr ""
+
+#. Title of the modal that prompts the user to refresh the page.
+msgctxt "Modal header for refresh page prompt"
+msgid "Please refresh this page"
+msgstr ""
+
+#. Shown on 3p browsers (Duck.ai) when the input is a legacy v1 recovery code or a v2 code with cid != '3party'. Directs the user to scan/paste the code on a DuckDuckGo browser instead.
+msgctxt ""
+"Title for the dialog shown when the user pastes/scans a DDG-browser-intended "
+"code on Duck.ai"
+msgid "Please scan this code with the DuckDuckGo browser."
+msgstr ""
+
+#. Short subtitle text instructing the user to pick up a category of feedback from a list.
+msgctxt "Subtitle of feedback form"
+msgid "Please select a category for your feedback"
+msgstr ""
+
+#. Short subtitle text instructing the user to pick up a category of feedback from a list.
+msgctxt "Subtitle of feedback form"
+msgid "Please select a category of your feedback"
+msgstr ""
+
+#. Asks users to select an option in a feedback form.
+msgctxt "new user poll"
+msgid "Please select one option."
+msgstr "Bitte wähle eine Option us."
+
+#. Invite the user to leave feedback about DuckDuckGo
+msgctxt "feedback form"
+msgid "Please share your thoughts"
+msgstr ""
+
+#. Invite the user to leave optional feedback about DuckDuckGo
+msgctxt "feedback form"
+msgid "Please share your thoughts (optional)"
+msgstr ""
+
+#. Category of feedback a user can select on a feedback form.
+msgctxt "feedback form"
+msgid "Please suggest the correct address"
+msgstr ""
+
+#. Prompt to provide hours of operation for a business on a feedback form.
+msgctxt "feedback form"
+msgid "Please suggest the correct hours of operation"
+msgstr ""
+
+#. Category of feedback a user can select on a feedback form.
+msgctxt "feedback form"
+msgid "Please suggest the correct phone number"
+msgstr ""
+
+#. Prompt to provide a web address on a feedback form.
+msgctxt "feedback form"
+msgid "Please suggest the correct website URL"
+msgstr ""
+
+#. Prompt to provide hours of operation for a business on a feedback form.
+msgctxt "feedback form"
+msgid "Please suggest the hours of operation"
+msgstr ""
+
+#. Category of feedback a user can select on a feedback form.
+msgctxt "feedback form"
+msgid "Please suggest the phone number"
+msgstr ""
+
+#. Prompt to provide a web address on a feedback form.
+msgctxt "feedback form"
+msgid "Please suggest the website URL"
+msgstr ""
+
+#. Error message displayed when the user's input exceeds the character limit.
+msgctxt "Error message when input exceeds character limit"
+msgid "Please try a shorter message."
+msgstr ""
+
+msgid "Please try again"
+msgstr "Bitte versuche es noch einmal"
+
+#. Title of modal shown when user gets bot challenge incorrect
+msgctxt "Anomaly modal"
+msgid "Please try again"
+msgstr ""
+
+#. Secondary line under DUCKCHAT_SYNC_PAIRING_FAILED_TITLE inviting the user to retry pairing.
+msgctxt "Body for the generic pairing-failure error screen"
+msgid "Please try again."
+msgstr ""
+
+#. A link that will allow users to reload the page.
+msgctxt "noresults"
+msgid "Please try again."
+msgstr ""
+
+#. Description shown when the image generation model cannot process the user's request.
+msgctxt "Error message from the image generation model"
+msgid "Please try describing your image in a different way."
+msgstr ""
+
+#. Body text prompting user to update Duck.ai.
+msgctxt "duckai_migration"
+msgid "Please update Duck.ai to get the latest version."
+msgstr ""
+
+#. Generic pending message.
+msgctxt "duckai_migration"
+msgid "Please wait..."
+msgstr ""
+
+#. Tagline for the subscription promo shown in the SERP sidemenu.
+msgctxt "Sidemenu subscription promo"
+msgid "Plus more premium features with a DuckDuckGo subscription."
+msgstr ""
+
+#. A description to provide more detail on what Duck Player does (Duck Player is DDG's feature to watch youtube videos more privately)
+msgid ""
+"Plus, what you watch in Duck Player won’t influence your recommendations on "
+"YouTube."
+msgstr ""
+
+#. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
+msgid "Podcast"
+msgstr ""
+
+#. A link to the Substack newsletter subscription page (https://insideduckduckgo.substack.com/?showWelcome=true)
+msgctxt "SERP footer content"
+msgid "Podcast"
+msgstr ""
+
+#. F1 driver standings column: number of podium finishes
+msgctxt "Sports module"
+msgid "Podiums"
+msgstr ""
+
+#. Renders as a small dark pill near the bottom of the viewfinder while the camera is live. Guides the user to aim at another device's QR.
+msgctxt "Overlay caption inside the camera viewfinder area"
+msgid "Point Camera at QR to Scan"
+msgstr ""
+
+#. Indicates these are the total points of this team, in e.g. the soccer World Cup
+msgctxt "Sports module"
+msgid "Points"
+msgstr ""
+
+msgid "Poland"
+msgstr "Polen"
+
+#. F1 driver standings column: number of pole positions
+msgctxt "Sports module"
+msgid "Poles"
+msgstr ""
+
+#. Menu point on the main DuckDuckGo menu, can be seen on all pages. (Links to <a href="https://duckduckgo.com/privacy">privacy</a> page)
+msgid "Policy"
+msgstr "Richtlinie"
+
+#. The name of the Polish language
+msgctxt "language_name"
+msgid "Polish"
+msgstr ""
+
+#. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
+msgctxt "Feedback prompt"
+msgid "Poor formatting"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
+#. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
+msgctxt "Onboarding welcome screen feature"
+msgid "Popular AI models from:"
+msgstr ""
+
+#. Popular hours of a place on a given weekday, for example: 'Popular hours on Mondays'
+msgctxt "maps_places"
+msgid "Popular hours on %s"
+msgstr ""
+
+msgid "Portugal"
+msgstr "Portugal"
+
+#. The name of the Portuguese (Brazil) language
+msgctxt "language_name"
+msgid "Portuguese (Brazil)"
+msgstr ""
+
+#. The name of the Portuguese (Portugal) language
+msgctxt "language_name"
+msgid "Portuguese (Portugal)"
+msgstr ""
+
+#. A positive feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Positive feedback"
+msgstr ""
+
+#. Rugby match stats
+msgctxt "Sports module"
+msgid "Possession"
+msgstr ""
+
+#. Describing when Reddit post was posted (If posted multiple days ago)
+msgctxt "Discussions IA"
+msgid "Posted %s days ago"
+msgstr ""
+
+#. Describing when Reddit post was posted (If posted multiple hours ago)
+msgctxt "Discussions IA"
+msgid "Posted %s hours ago"
+msgstr ""
+
+#. Describing when Reddit post was posted (If posted multiple minutes ago)
+msgctxt "Discussions IA"
+msgid "Posted %s minutes ago"
+msgstr ""
+
+#. Describing when Reddit post was posted (If posted multiple months ago)
+msgctxt "Discussions IA"
+msgid "Posted %s months ago"
+msgstr ""
+
+#. Describing when Reddit post was posted (If posted multiple seconds ago)
+msgctxt "Discussions IA"
+msgid "Posted %s seconds ago"
+msgstr ""
+
+#. Describing when Reddit post was posted (If posted multiple weeks ago)
+msgctxt "Discussions IA"
+msgid "Posted %s weeks ago"
+msgstr ""
+
+#. Describing when Reddit post was posted (If posted multiple years ago)
+msgctxt "Discussions IA"
+msgid "Posted %s years ago"
+msgstr ""
+
+#. Describing when Reddit post was posted (If posted 1 day ago)
+msgctxt "Discussions IA"
+msgid "Posted 1 day ago"
+msgstr ""
+
+#. Describing when Reddit post was posted (If posted 1 hour ago)
+msgctxt "Discussions IA"
+msgid "Posted 1 hour ago"
+msgstr ""
+
+#. Describing when Reddit post was posted (If posted 1 minute ago)
+msgctxt "Discussions IA"
+msgid "Posted 1 minute ago"
+msgstr ""
+
+#. Describing when Reddit post was posted (If posted 1 month ago)
+msgctxt "Discussions IA"
+msgid "Posted 1 month ago"
+msgstr ""
+
+#. Describing when Reddit post was posted (If posted 1 second ago)
+msgctxt "Discussions IA"
+msgid "Posted 1 second ago"
+msgstr ""
+
+#. Describing when Reddit post was posted (If posted 1 week ago)
+msgctxt "Discussions IA"
+msgid "Posted 1 week ago"
+msgstr ""
+
+#. Describing when Reddit post was posted (If posted 1 year ago)
+msgctxt "Discussions IA"
+msgid "Posted 1 year ago"
+msgstr ""
+
+#. Alt text for the poster image of the movie or TV show, displayed next to it in the instant answer
+msgctxt "Movie/TV Show Title instant answer"
+msgid "Poster image for movie or TV show"
+msgstr ""
+
+#. Indicator that a game has been postponed
+msgctxt "Sports module"
+msgid "Postponed"
+msgstr ""
+
+msgctxt "settings"
+msgid "Preferred units of measure"
+msgstr "Bevorzugte Masseinheiten"
+
+#. Label for the preliminary round of a soccer cup competition
+msgctxt "Sports module"
+msgid "Preliminary Round"
+msgstr ""
+
+#. Short string representing a prompt suggestion for preparing for a conversation.
+msgctxt "Brief for preparing for a conversation"
+msgid "Prepare for a conversation"
+msgstr ""
+
+#. Short string representing a prompt suggestion for preparing for a purchase.
+msgctxt "Brief for preparing for a purchase"
+msgid "Prepare for a purchase"
+msgstr ""
+
+#. Main page under "More"
+msgid "Press"
+msgstr "Presse"
+
+#. Tells the user where in the settings menu they can add a DuckDuckGo search shortcut to their phone's homescreen.
+msgid "Press %sMenu > Add to homescreen > Add%s!"
+msgstr "Drücke auf %sMenu > Zu Homebildschirm hinzufügen > Hinzufügen%s!"
+
+#. Link to a page with information for journalists.
+msgid "Press Kit"
+msgstr "Pressemitteilung"
+
+#. The price the stock previously closed at
+msgctxt "Stocks module"
+msgid "Prev Close"
+msgstr ""
+
+msgid "Preview"
+msgstr "Vorschau"
+
+#. Label for a video preview.
+msgctxt "video"
+msgid "Preview"
+msgstr "Vorschau"
+
+msgctxt "settings"
+msgid "Previous Region"
+msgstr "Vorherige Region"
+
+#. Aria label for the previous image navigation button on the image lightbox.
+msgctxt "Aria label for previous image button"
+msgid "Previous image"
+msgstr ""
+
+#. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
+msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
+msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
+msgstr ""
+
+#. Label that's displayed next to a price below a web search result.
+msgctxt "Rich Facts label"
+msgid "Price"
+msgstr ""
+
+#. Category of feedback a user can select on a feedback form.
+msgctxt "feedback form"
+msgid "Price shown doesn't reflect merchant site"
+msgstr ""
+
+#. A button that prints the contents of a page.
+msgid "Print"
+msgstr ""
+
+#. Button that prints out driving directions.
+msgctxt "directions"
+msgid "Print Directions"
+msgstr ""
+
+#. Header above a preview image of content that will be printed.
+msgid "Print Preview"
+msgstr ""
+
+#. Header above a list of privacy-related search settings.
+msgid "Privacy"
+msgstr "Privatsphäre"
+
+#. http://i.imgur.com/squ02on.png
+msgctxt "settings"
+msgid "Privacy"
+msgstr "Privatsphäre "
+
+#. Heading for the Privacy & Terms section of the About & Legal page in Duck.ai settings, shown above a summary of privacy protections and a link to the privacy policy and terms of service.
+msgctxt "Section heading on the Duck.ai settings page"
+msgid "Privacy & Terms"
+msgstr ""
+
+msgid "Privacy Blog"
+msgstr "Datenschutzblog"
+
+msgid "Privacy Browser App"
+msgstr "Privater Browser App"
+
+msgid "Privacy Browser Extension"
+msgstr "Privatsphären Browsererweiterung"
+
+msgid "Privacy Crash Course"
+msgstr "Datenschutz Crashkurs"
+
+msgid "Privacy Essentials"
+msgstr "Privacy Essentials"
+
+#. Placeholder is the name of a browser. For example: 'Privacy Essentials for Chrome'
+msgid "Privacy Essentials for %s"
+msgstr "Privacy Essentials für %s"
+
+#. A link to subscribe to DuckDuckGo's privacy newsletter.
+msgctxt "SERP footer content"
+msgid "Privacy Newsletter"
+msgstr "Datenschutz-Newsletter "
+
+msgctxt "settings"
+msgid "Privacy Newsletter"
+msgstr "Privatsphäre Newsletter"
+
+msgctxt "settings"
+msgid "Privacy Newsletters"
+msgstr ""
+
+#. Link to the company's privacy policy.
+msgid "Privacy Policy"
+msgstr "Datenschutzerklärung"
+
+#. Text used in other strings to link to the Privacy Policy content.
+msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy"
+msgstr ""
+
+#. Text on link to the Privacy Policy & Terms of Service page.
+msgctxt "Text on link to the Privacy Policy & Terms of Service page."
+msgid "Privacy Policy & Terms of Service"
+msgstr ""
+
+#. Text on link to the Privacy Policy & Terms of Use page.
+msgctxt "Text on link to the Privacy Policy & Terms of Use page."
+msgid "Privacy Policy & Terms of Use"
+msgstr ""
+
+#. Text used in other strings to link to the Privacy Policy and Terms of Service content.
+msgctxt "Copy used to compose link in sentences"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
+msgid "Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Title displayed on the screen of the onboarding where the user agrees to the Terms of Use and Privacy Policy.
+msgctxt "Onboarding terms screen title"
+msgid "Privacy Policy and Terms of Use"
+msgstr ""
+
+#. A link to the Privacy Pro product page (https://duckduckgo.com/pro/)
+msgctxt "SERP footer content"
+msgid "Privacy Pro"
+msgstr ""
+
+msgid "Privacy Protection For Any Device"
+msgstr "Privatsphärenschutz für jedes Gerät"
+
+#. https://duckduckgo.com/params. it is a bold header
+msgid "Privacy Settings"
+msgstr "Privatsphäre-Einstellungen"
+
+#. Placeholder is the name of a browser. For example: 'Privacy for Chrome'
+msgid "Privacy for %s"
+msgstr "Privatsphäre für %s"
+
+#. Link to a page where users can subscribe to a newsletter.
+msgctxt "SERP footer content"
+msgid "Privacy in Your Inbox"
+msgstr "Privatsphäre in deiner Mailbox"
+
+#. A title on the page where users can subscribe to DuckDuckGo's privacy newsletter.
+msgctxt "showcase_newsletter"
+msgid "Privacy in Your Inbox"
+msgstr "Privatsphäre in deiner Mailbox"
+
+#. shown when DDG is selected after eu preference menu on android
+msgctxt "welcome message eu search preference android"
+msgid "Privacy, simplified"
+msgstr "Privatsphäre, vereinfacht."
+
+msgid "Privacy, simplified."
+msgstr "Privatsphäre, vereinfacht."
+
+#. Refers to the DuckDuckGo search engine, on which your searches are always private. This is the shorter version, shown on smaller screens
+msgid "Private"
+msgstr ""
+
+#. Short label that appears briefly next to the AI model name after a response finishes generating, indicating the conversation is private.
+msgctxt "Ephemeral badge next to the model name in a Duck.ai assistant message"
+msgid "Private"
+msgstr ""
+
+msgid "Private Search"
+msgstr "Private Suche"
+
+#. Refers to the DuckDuckGo search engine, which allows users to search the internet privately. Please do translate this string.
+msgctxt "translatable"
+msgid "Private Search"
+msgstr ""
+
+msgid "Private Search Engine"
+msgstr "Private Suchmaschine"
+
+#. Title for the privacy highlight in the dictation consent modal.
+msgid "Private by design"
+msgstr ""
+
+#. Title for the privacy respecting description section of the voice chat consent modal.
+msgctxt "voice chat"
+msgid "Private by design"
+msgstr ""
+
+#. Text describing that chats are private and anonymized by us.
+msgctxt "Onboarding welcome screen private claim"
+msgid "Private chats, anonymized by us"
+msgstr ""
+
+#. Text describing feature highlighted on the welcome screen of the onboarding.
+msgctxt "Onboarding welcome screen feature"
+msgid "Private chats, never saved by us"
+msgstr ""
+
+#. The device location shared is is not logged by us
+msgctxt "precise_user_location"
+msgid "Private to us and secured on your device"
+msgstr ""
+
+#. Heading above the group of Pro-tier locked models in the model picker dropdown, when the user is on the Plus tier.
+msgctxt ""
+"Section heading inside the model picker dropdown for models gated behind the "
+"Pro tier, shown to Plus-tier users"
+msgid "Pro exclusive."
+msgstr ""
+
+#. Category of feedback a user can select on a feedback form.
+msgctxt "feedback form"
+msgid "Product ad content is deceptive"
+msgstr ""
+
+#. Category of feedback a user can select on a feedback form.
+msgctxt "feedback form"
+msgid "Product ad pricing is misleading"
+msgstr ""
+
+#. Category of feedback a user can select on a feedback form.
+msgctxt "feedback form"
+msgid "Product ads aren't relevant"
+msgstr ""
+
+#. Label for the option prompting the AI assistant to adopt a role of a product manager in its responses.
+msgctxt "Assistant role option label for Product manager"
+msgid "Product manager"
+msgstr ""
+
+#. Label above shopping search results.
+msgid "Products"
+msgstr "Produkte"
+
+#. Label for the option prompting the AI assistant to use professional tone in its responses.
+msgctxt "Tone option label for Professional"
+msgid "Professional"
+msgstr ""
+
+#. Label for the option prompting the AI assistant to treat the user as if they are a professional.
+msgctxt "User role option for professional role"
+msgid "Professional"
+msgstr ""
+
+#. Label for the option prompting the AI assistant to treat the user as if they are a programmer.
+msgctxt "User role option for programmer role"
+msgid "Programmer"
+msgstr ""
+
+#. Title shown at the top of the modal that displays the generation prompt for an AI-generated image.
+msgctxt "Title for image info modal"
+msgid "Prompt"
+msgstr ""
+
+#. http://i.imgur.com/KT5S1TR.png
+msgctxt "settingsvalue"
+msgid "Prompt me"
+msgstr "Nachfragen"
+
+msgctxt "settings"
+msgid "Prompt me to use my approximate location to get nearby results."
+msgstr ""
+
+#. DuckDuckGo Email Protection removes trackers from emails
+msgctxt "SERP footer content"
+msgid "Protect Your Inbox"
+msgstr ""
+
+#. DuckDuckGo's browser app has features to protect your data by keeping it private
+msgctxt "SERP footer content"
+msgid "Protect your data as you search and browse."
+msgstr ""
+
+#. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
+msgctxt "SERP footer content"
+msgid "Protect your data as you search, browse, and use AI."
+msgstr ""
+
+#. A title above links to download the DuckDuckGo apps.
+msgctxt "showcase_app"
+msgid "Protect your data on every device."
+msgstr "Schütze deine Daten auf allen Geräten"
+
+#. Refers to the DuckDuckGo search engine, on which your searches are always protected. This is the shorter version, shown on smaller screens
+msgid "Protected"
+msgstr ""
+
+#. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
+msgid "Protection. Privacy. Peace of mind."
+msgstr ""
+
+#. Text for a prompt suggestion for providing suggestions to make a text more concise.
+msgctxt "Full sentence for critiquing writing"
+msgid ""
+"Provide a few suggestions to make the following text more concise. [Insert "
+"your own text here.]"
+msgstr ""
+
+#. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
+msgctxt "Sports module"
+msgid "Pts"
+msgstr ""
+
+#. a filter for images with the CC0 usage license
+msgctxt "image-licence"
+msgid "Public Domain"
+msgstr ""
+
+#. Label for the option prompting the AI assistant to adopt a role of a public speaking coach in its responses.
+msgctxt "Assistant role option label for Public speaking coach"
+msgid "Public speaking coach"
+msgstr ""
+
+#. Label that's displayed next to a publication below a web search result.
+msgctxt "Rich Facts label"
+msgid "Publication"
+msgstr ""
+
+#. Label that's displayed next to a published date below a web search result.
+msgctxt "Rich Facts label"
+msgid "Published"
+msgstr ""
+
+msgid "Puerto Rico"
+msgstr ""
+
+#. The name of the Punjabi language
+msgctxt "language_name"
+msgid "Punjabi"
+msgstr ""
+
+#. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
+msgid "Purple"
+msgstr "Violett"
+
+#. Filters the color of images in search results.
+msgctxt "color"
+msgid "Purple"
+msgstr "violett"
+
+#. Golf tournament card: prize money label
+msgctxt "Sports module"
+msgid "Purse:"
+msgstr ""
+
+msgid "Qatar"
+msgstr ""
+
+#. Title of a modal inviting the user to leave positive feedback about DuckDuckGo. Translate 'Quack!' with the sound that a duck (DuckDuckGo's logo) makes (e.g., 'kwa kwa kwa' in Polish - see https://en.wikipedia.org/wiki/Cross-linguistic_onomatopoeias#Domestic_birds  for other examples). If there is no obvious onomotopoeias, use 'Thanks!' as a backup.
+msgctxt "feedback form"
+msgid "Quack! We're so glad."
+msgstr ""
+
+#. Label for the quarter-finals knockout stage in e.g. the soccer World Cup
+msgctxt "Sports module"
+msgid "Quarter-finals"
+msgstr ""
+
+#. The name of the Querétaro Otomi language
+msgctxt "language_name"
+msgid "Querétaro Otomi"
+msgstr ""
+
+#. A title for the quick links to social media section in About IA
+msgctxt "Quick links in About IA"
+msgid "Quick links"
+msgstr ""
+
+#. Instant Answer Tab Name
+msgid "Quotations"
+msgstr "Zitate"
+
+msgid "Quotes"
+msgstr "Zitate"
+
+#. Cricket scorecard: runs abbreviation
+msgctxt "Sports module"
+msgid "R"
+msgstr ""
+
+#. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo on the radio or in a podcast.
+msgctxt "new user poll"
+msgid "Radio or podcast"
+msgstr "Radio oder Podcast"
+
+#. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
+msgctxt "Weather IA"
+msgid "Rain"
+msgstr ""
+
+#. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
+msgctxt "Sports module"
+msgid "Rankings"
+msgstr ""
+
+#. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
+msgid "Rated %s/5"
+msgstr "Bewertet mit %s/5"
+
+#. A button that takes users to another page with additional information.
+msgid "Read More"
+msgstr "Lese mehr"
+
+#. A labelled link in About IA showing the source of the abstract, e.g. "Read more on Wikipedia"
+msgctxt "Link in redesigned About IA to continued content directly in source"
+msgid "Read more on %s"
+msgstr ""
+
+#. Text suggesting the user to read the Duck.ai Privacy Policy and Terms of Use, placeholder is a link to 'Privacy Policy and Terms of Use'. Example: 'Read our Privacy Privacy Policy & Terms of Use'
+msgctxt "Informational text with a link to Duck.ai Privacy Terms"
+msgid "Read our %s"
+msgstr ""
+
+#. Text suggesting the user to read the DuckDuckGo AI Chat Privacy Policy and Terms of Use, placeholder is a link to 'Privacy Policy and Terms of Use'. Example: 'Read our Privacy Privacy Policy & Terms of Use'
+msgctxt "Informational text with a link to DuckDuckGo AI Chat Privacy Terms"
+msgid "Read our %s"
+msgstr ""
+
+#. Text displayed while the AI assistant is reading a specific local document, such as an uploaded file or attached page context, while generating a response.
+msgctxt "Assistant response progress report"
+msgid "Reading document"
+msgstr ""
+
+#. Loading message shown while duckassist is reading search results
+msgid "Reading search results..."
+msgstr ""
+
+#. Text displayed while the AI assistant is loading a specific website while generating a response.
+msgctxt "Assistant response progress report"
+msgid "Reading website"
+msgstr ""
+
+#. Text displayed while the AI assistant is loading a specific website while generating a response.
+msgctxt "Assistant response progress report"
+msgid "Reading website…"
+msgstr ""
+
+#. Option in the reasoning mode dropdown that enables extended reasoning for AI models.
+msgctxt "Label for reasoning mode in Duck.ai"
+msgid "Reasoning"
+msgstr ""
+
+#. Text for a label indicating that the AI (Artificial Intelligence) model is a reasoning AI. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer.
+msgctxt "duck.ai model card"
+msgid "Reasoning AI"
+msgstr ""
+
+#. Text with short description for a reasoning AI (Artificial Intelligence) Model that has a high moderation level. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer. 'Built-in' in that sentence means that the moderation is part of the model.
+msgctxt "Label copy with short description of AI Model"
+msgid "Reasoning AI with high built-in moderation"
+msgstr ""
+
+#. Text with short description for a reasoning AI (Artificial Intelligence) Model that has a low moderation level. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer. 'Built-in' in that sentence means that the moderation is part of the model.
+msgctxt "Label copy with short description of AI Model"
+msgid "Reasoning AI with low built-in moderation"
+msgstr ""
+
+#. Text with short description for a reasoning AI (Artificial Intelligence) Model that has a medium moderation level. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer. 'Built-in' in that sentence means that the moderation is part of the model.
+msgctxt "Label copy with short description of AI Model"
+msgid "Reasoning AI with medium built-in moderation"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
+#. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
+msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
+msgid "Reasoning mode"
+msgstr ""
+
+#. Title for the recent chats section.
+msgctxt "Title for the recent chats section"
+msgid "Recent"
+msgstr ""
+
+#. Title displayed at the top of the Recent Chats list. This is a feature that stores the user's most recent AI chats.
+msgctxt "Title of the Recent Chats modal"
+msgid "Recent Chats"
+msgstr ""
+
+#. A label that appears above a list of search results from news sites.
+msgid "Recent News"
+msgstr "Letzte News"
+
+#. Header text for the section listing recently used browser tabs in the tab picker.
+msgctxt "Section header for the list of recent browser tabs"
+msgid "Recent Tabs"
+msgstr ""
+
+#. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
+msgctxt "Information about adjusting recent chat storage settings"
+msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
+msgstr ""
+
+#. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
+msgctxt "Description for recent chats feature"
+msgid ""
+"Recent chats are stored locally on your device instead of on DuckDuckGo "
+"servers or other remote servers."
+msgstr ""
+
+#. Text explaining that recent chats are stored locally on the user's device.
+msgctxt "Description of where recent chats are stored"
+msgid ""
+"Recent chats are stored locally on your device instead of on DuckDuckGo "
+"servers or other remote servers."
+msgstr ""
+
+#. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
+msgctxt "Description of where recent chats are stored"
+msgid ""
+"Recent chats are stored locally on your device. New prompts and responses "
+"are encrypted and temporarily stored on a DuckDuckGo server after being "
+"sent, to help recover a chat if you lose your internet connection."
+msgstr ""
+
+msgctxt "region filter"
+msgid "Recent:"
+msgstr "Kürzlich"
+
+#. Label above recipe search results.
+msgid "Recipes"
+msgstr "Rezepte"
+
+#. Title for the section that showcases the recipe results for a certain query, ex. Recipes for <b>cheescake</b>
+msgid "Recipes for %s%s%s"
+msgstr ""
+
+#. Short string representing a prompt suggestion for recommending a book.
+msgctxt "Brief for recommending a book"
+msgid "Recommend a book"
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar books", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar books"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar books" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar books."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Recommend similar titles" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Recommend similar movies or shows."
+msgstr ""
+
+#. Page-suggestion chip label "Recommend similar titles", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Recommend similar titles"
+msgstr ""
+
+#. Error in the duck.ai chat input when a WebKit encoder failure produces an empty audio blob.
+msgid "Recording failed. Please try again."
+msgstr ""
+
+#. Opens the Restore Your Chats sheet. Shown before Help Pages in the intro footer per desktop Figma.
+msgctxt "Footer link on the Sync & Backup intro (choose) screen"
+msgid "Recover Synced Data"
+msgstr ""
+
+#. Label preceding the recovery code description and Save Recovery Code button.
+msgctxt "Section header for the recovery code area inside Manage"
+msgid "Recovery"
+msgstr ""
+
+#. Left-aligned label naming the recovery code shown in the dashed box on the joiner-device ('New device added') success screen (Figma 4174-1377933).
+msgctxt "Label above the recovery code on the joiner success screen"
+msgid "Recovery Code"
+msgstr ""
+
+#. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
+msgid "Red"
+msgstr "Rot"
+
+#. Filters the color of images in search results.
+msgctxt "color"
+msgid "Red"
+msgstr "Rot"
+
+#. Rugby match stats
+msgctxt "Sports module"
+msgid "Red Cards"
+msgstr ""
+
+#. Accessibility label for the red card marker shown between the two teams' sent-off players in a soccer match timeline.
+msgctxt "Sports module"
+msgid "Red card"
+msgstr ""
+
+msgid "Reddit"
+msgstr "Reddit"
+
+msgctxt "settings"
+msgid "Redirect (When Necessary)"
+msgstr ""
+
+msgid "Redirect:"
+msgstr "Weiterleitung:"
+
+#. Tooltip text for the button that retries the assistant's response.
+msgctxt "Tooltip for redo action"
+msgid "Redo"
+msgstr ""
+
+#. Menu option to remove a site from the displayed results
+msgctxt "Organic result context menu"
+msgid "Redo search without this site"
+msgstr ""
+
+#. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Reduces extra space in and around results and reduces size of result title "
+"text"
+msgstr ""
+
+#. Label for the input field where users specify how they want to be referred to. Example: 'Refer to me as John'
+msgctxt "Label for user name input"
+msgid "Refer to me as"
+msgstr ""
+
+#. Label for the input field where user can specify how the AI assistant should refer to itself. Example: 'Refer to yourself as Fred'
+msgctxt "Label for assistant name input"
+msgid "Refer to yourself as"
+msgstr ""
+
+#. Button that refreshes the user's current location on a map.
+msgctxt "precise_user_location"
+msgid "Refresh Location"
+msgstr ""
+
+#. Text for a button that refreshes the page when pressed.
+msgctxt "Primary button text in refresh page modal"
+msgid "Refresh Page"
+msgstr ""
+
+#. Button label to refresh the page.
+msgctxt "duckai_migration"
+msgid "Refresh now"
+msgstr ""
+
+#. Button that reloads the Duck.ai desktop app to pick up the new version.
+msgctxt "Stale version banner in Duck.ai (Electron desktop app)"
+msgid "Refresh the App Now"
+msgstr ""
+
+msgid "Refugee Olympic Team"
+msgstr ""
+
+#. Label for a menu with different countries.
+msgid "Region"
+msgstr "Region"
+
+#. List item indicating that a region filter is currently active for the search
+msgctxt "noresults"
+msgid "Region"
+msgstr ""
+
+#. http://i.imgur.com/G0kt3wS.png
+#. Setting to boost results for your region.
+msgctxt "settings"
+msgid "Region"
+msgstr "Region"
+
+#. in https://duckduckgo.com/params under "Result Settings" .it is the second header
+msgid "Region:"
+msgstr "Region"
+
+#. Label for today's hours of operation for a business.
+msgctxt "maps_places"
+msgid "Regular Hours Today"
+msgstr "reguläre Öffnungszeiten heute"
+
+#. Label for the switch to temporarily disable site exclusion
+msgctxt "Organic result context menu"
+msgid "Rehide Results"
+msgstr ""
+
+#. Label above a list of search terms related to the user's current search.
+msgid "Related Searches"
+msgstr "Ähnliche Suchen"
+
+#. A label for a list of search results that are similar to what the user searched for.
+msgid "Related Topics"
+msgstr "Ähnliche Themen"
+
+#. Label that's displayed next to a movie/tv show release date below a web search result.
+msgctxt "Rich Facts label"
+msgid "Release Date"
+msgstr ""
+
+#. Label that's displayed next to a movie/tv show release date below a web search result.
+msgctxt "Rich Facts label"
+msgid "Released"
+msgstr ""
+
+#. Label for the year when the song album was released, e.g. 'Released: 1975'
+msgctxt "lyrics_module"
+msgid "Released"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Relevant"
+msgstr ""
+
+#. Header for list of sources returned by an AI model indicating they were used to generate an answer to a given prompt.
+msgctxt "Header in AI chat message for sources"
+msgid "Relevant Sources"
+msgstr ""
+
+#. A feedback suggestion where the user can provide feedback on the AI (Artificial Intelligence) chat bot providing relevant information
+msgctxt "Feedback prompt"
+msgid "Relevant info"
+msgstr ""
+
+#. Header for list of sources returned by an AI model indicating they were used to generate an answer to a given prompt.
+msgctxt "Header in AI chat message for sources"
+msgid "Relevant sources:"
+msgstr ""
+
+#. Primary button label to reload Duck.ai after a fatal error.
+msgctxt "duckai_fatal_error"
+msgid "Reload Duck.ai"
+msgstr ""
+
+#. Final step in disabling the user's ad blocker
+msgid ""
+"Reload DuckDuckGo by following the instructions, or clicking your browser's "
+"&quot;Refresh&quot; or &quot;Reload&quot; button."
+msgstr ""
+
+#. checkbox label that allows the user to save the setting
+msgid "Remember my choice"
+msgstr ""
+
+#. Button that saves the user's current settings
+msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
+msgstr "Meine Wahl merken (dies kann in %s%s%sSettings%s geändert werden)"
+
+#. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
+msgid "Remember my choice (this can be changed in %sSettings%s)"
+msgstr ""
+
+#. Button to be reminded later to update, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
+msgctxt "Old app version banner component in Duck.ai"
+msgid "Remind Me Later"
+msgstr ""
+
+#. Calls /logout-device with the target device id and removes the row optimistically. Note: `device sync session` is intentional (no apostrophe) because the token-loader uses single-quoted JS strings for the context field.
+msgctxt "Destructive action that revokes the selected device sync session"
+msgid "Remove"
+msgstr ""
+
+#. Screen-reader label for the close button on the chip that indicates an active per-turn tool selection (e.g. 'Remove Create Image' or 'Remove Web Search'). %s is replaced with the localized tool label.
+msgctxt ""
+"Accessibility label for the remove button on a tool chip above the chat input"
+msgid "Remove %s"
+msgstr ""
+
+#. Accessible label for the button that removes an attached file from the Duck.ai chat message. %s is the filename, e.g. 'Remove document.pdf'.
+msgctxt "Accessible label for remove button on attached file"
+msgid "Remove %s"
+msgstr ""
+
+#. Asks the user to confirm revoking another device's sync session.
+msgctxt "Title for the destructive Remove Device confirmation modal"
+msgid "Remove Device?"
+msgstr ""
+
+#. Text for a button that removes a pin from a chat, as in it will it will remove the chat from the pinned chats list.
+msgctxt "Button for removing a pin from a chat"
+msgid "Remove Pin"
+msgstr ""
+
+#. Used as aria-label on the small remove button next to a non-current device.
+msgctxt "Accessibility label for the per-row remove button in Manage Devices"
+msgid "Remove device"
+msgstr ""
+
+#. Accessible label for the button that removes an attached image from the Duck.ai chat message. %s is the image number, e.g. 'Remove image 1'.
+msgctxt "Accessible label for remove button on attached image"
+msgid "Remove image %s"
+msgstr ""
+
+#. Accessible label for button that removes the attached page context from the chat message.
+msgctxt "Remove the attached page context"
+msgid "Remove page context"
+msgstr ""
+
+#. Accessible label for button that removes an attached page text selection from the chat message.
+msgctxt "Remove the attached text selection"
+msgid "Remove text selection"
+msgstr ""
+
+#. A prompt asking users to try searching without any punctuation to get more results.
+msgctxt "noresults"
+msgid "Remove unnecessary punctuation"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Removes the \"Ask\" button so answers appear automatically in response to "
+"relevant searches. Cached answers always display automatically."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Removes the \"Generate\" button so answers appear automatically in response "
+"to relevant searches. Cached answers always display automatically."
+msgstr ""
+
+#. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
+msgctxt "Button text for renaming a chat"
+msgid "Rename"
+msgstr ""
+
+#. Indicates that this show (movie, series, etc.) is available to either rent or buy from the given streaming service.
+msgctxt "Where to watch instant answer"
+msgid "Rent or buy"
+msgstr ""
+
+#. Placeholder text used in chat input for user’s messages to reply to the assistant's response.
+msgctxt "Placeholder text user’s chat input"
+msgid "Reply..."
+msgstr ""
+
+#. Text for the button that reports a message.
+msgctxt "Report message button"
+msgid "Report"
+msgstr ""
+
+#. A button that appears next to an advertisement, allowing a user to send a report for an advertisment they think is spam.
+msgctxt "ads"
+msgid "Report Ad"
+msgstr "Werbung melden"
+
+#. A call to action to report a security issue.
+msgctxt "Feedback prompt"
+msgid "Report Security Issue "
+msgstr ""
+
+#. A feedback menu option to report an inappropriate image.
+msgctxt "Feedback context menu"
+msgid "Report inappropriate image"
+msgstr ""
+
+#. Link to a feedback form for image search results.
+msgctxt "Report image modal"
+msgid "Report this image"
+msgstr "Melde dieses Bild"
+
+#. Placeholder can be Apple Maps, TripAdvisor, and/or Foursquare
+msgctxt "feedback form"
+msgid ""
+"Reports are anonymous and sent to DuckDuckGo to help improve our search "
+"service. Your anonymous feedback is also shared with %s to help improve "
+"their services."
+msgstr ""
+
+msgctxt "Feedback prompt"
+msgid ""
+"Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
+"or identifying information in your feedback."
+msgstr ""
+
+msgctxt "Feedback prompt"
+msgid ""
+"Reports sent to DuckDuckGo include all of the text you've asked us to "
+"translate during this page load, and are anonymous. Please do not include "
+"any personal or identifying information in your feedback."
+msgstr ""
+
+msgid "Republic of Moldova"
+msgstr ""
+
+#. Note indicating that sharing the conversation is mandatory when reporting harmful or illegal content. Rendered alongside the standard share label (DUCKCHAT_RESPONSE_FEEDBACK_SHARE_PROMPT_RESPONSE_LABEL), not replacing it.
+msgctxt ""
+"Note shown under the share-content switch label on the Duck.ai response "
+"feedback form when the user has selected Harmful or Illegal as the feedback "
+"reason"
+msgid "Required for harmful or illegal reports"
+msgstr ""
+
+#. Description text shown below the Extended Reasoning option in the reasoning mode dropdown.
+msgctxt "Description for extended reasoning mode in Duck.ai"
+msgid "Researches before responding"
+msgstr ""
+
+#. A button that resets a user's settings.
+msgctxt "settings dropdown"
+msgid "Reset"
+msgstr "Zurücksetzen"
+
+#. A button that resets all search settings to their default values.
+msgctxt "cloudsave"
+msgid "Reset All Search Settings"
+msgstr ""
+
+#. A button that resets all settings to their default values.
+msgctxt "cloudsave"
+msgid "Reset All Settings"
+msgstr "Alle Einstellungen zurücksetzen"
+
+#. http://i.imgur.com/ktBWbzB.png
+#. Resets your configuration
+msgctxt "settings"
+msgid "Reset All Settings"
+msgstr "Alle Einstellungen zurücksetzten"
+
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
+#. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Resets in %s"
+msgstr ""
+
+#. List item indicating that a layout filter (e.g. tall) is currently active for the search
+msgctxt "noresults"
+msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
+msgstr ""
+
+#. Feedback option when AI response is helpful
+msgid "Response is helpful"
+msgstr ""
+
+#. Feedback option when AI response is midleading
+msgid "Response is misleading"
+msgstr ""
+
+#. Feedback option when AI response is not helpful
+msgid "Response is not helpful"
+msgstr ""
+
+#. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
+msgid ""
+"Responses are for educational purposes only and are not intended as medical, "
+"legal, financial, investment, or other professional advice. AI-assisted "
+"answers are subject to our %sTerms of Service%s."
+msgstr ""
+
+#. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
+msgid ""
+"Responses are for educational purposes only and are not intended as medical, "
+"legal, financial, investment, or other professional advice. DuckAssist is "
+"subject to our %sTerms of Service%s."
+msgstr ""
+
+#. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
+msgid ""
+"Responses are for educational purposes only and are not intended as medical, "
+"legal, financial, investment, or other professional advice. They're "
+"generated based on web content and may contain inaccuracies. Search Assist "
+"is subject to our %sTerms of Service%s."
+msgstr ""
+
+#. Label on the button for restoring all previous website data.
+msgctxt "new tab page"
+msgid "Restore all"
+msgstr ""
+
+#. Shown on the explainer sheet the user lands on from the Recover Synced Data link. Figma frame 3703-44420.
+msgctxt "Modal header for the recover-data intro sheet"
+msgid "Restore your chats"
+msgstr ""
+
+#. Text for the button that takes the user to the page where they can resubscribe to DuckDuckGo.
+msgctxt "Text for the resubscribe button on the settings modal"
+msgid "Resubscribe"
+msgstr ""
+
+#. http://i.imgur.com/kqN8dPT.png
+msgctxt "settings"
+msgid "Result Highlight Color"
+msgstr "Hervorhebungsfarbe"
+
+#. in https://duckduckgo.com/params in the top. it is the first header
+msgid "Result Settings"
+msgstr "Einstellungen für Suchergebnisse"
+
+msgctxt "settings"
+msgid "Result Visited Checkmark"
+msgstr ""
+
+#. In the top menu under Settings
+#. A label that appears above search results.
+msgid "Results"
+msgstr "Ergebnisse"
+
+#. Shown on the Olympics module as a link to more results
+msgctxt "Button to get the results of a sports competition like the Olympics"
+msgid "Results"
+msgstr ""
+
+#. Title of a tab that displays race results (used for motorsports like NASCAR)
+msgctxt "Sports module"
+msgid "Results"
+msgstr ""
+
+#. Button shown to get the results of a sports competition like the Olympics.
+msgctxt "olympics_module"
+msgid "Results"
+msgstr ""
+
+#. Message that appears when results exclude blocked sites
+msgctxt "Exclusion message at top of vertical"
+msgid "Results exclude blocked sites."
+msgstr ""
+
+#. Informational banner shown at the top of the Maps search results panel when the user has blocked Yelp or TripAdvisor in their settings. Explains why ratings, reviews, and other details may be missing from place listings.
+msgctxt "Exclusion message at top of maps vertical"
+msgid "Results exclude information from blocked sites."
+msgstr ""
+
+#. Message that appears when results exclude blocked sites
+msgctxt "Blocked sites filter disclaimer"
+msgid "Results exclude your blocked sites, which you can manage in your %s."
+msgstr ""
+
+#. A label showing the source of the results, e.g. "Results from Reddit"
+msgctxt "Discussions IA"
+msgid "Results from %s"
+msgstr ""
+
+#. Displays the selected location results, e.g.: Results near <Paris France 75004>
+msgctxt "precise_user_location"
+msgid "Results near"
+msgstr ""
+
+#. Text for the button that resumes a paused duckassist stream
+msgid "Resume"
+msgstr ""
+
+#. Tennis match status: player retired
+msgctxt "Sports module"
+msgid "Retired"
+msgstr ""
+
+#. http://i.imgur.com/OODM0bR.png
+#. Selecting "Retro" will change the look and layout of DuckDuckGo to resemble the old site: http://i.imgur.com/toYUxqn.png
+msgctxt "theme"
+msgid "Retro"
+msgstr "Retro"
+
+#. Sits next to the refresh-failed message; triggers another GET /devices call.
+msgctxt "Button label that retries fetching the synced-devices list"
+msgid "Retry"
+msgstr ""
+
+#. A new suggested search when the user has no results. The placeholder is the alternative search query
+msgctxt "noresults"
+msgid "Retry search without quotes: %s"
+msgstr ""
+
+#. Tells users how to enable location service.
+msgctxt "precise_user_location"
+msgid "Return to duckduckgo.com and allow permission."
+msgstr "Kehre zu duckduckgo.com zurück und erlaube die Berechtigung."
+
+#. Tooltip over the button that allows to swap origin and destination in a Maps `Direction` feature
+msgctxt "directions"
+msgid "Reverse origin and destination"
+msgstr ""
+
+#. Used in 0-click box for product results, e.g. <a href="https://duckduckgo.com/?q=9780061353246">https://duckduckgo.com/?q=9780061353246</a>
+msgid "Reviews"
+msgstr "Bewertungen"
+
+#. Label above a list of customer reviews of a business.
+msgctxt "maps_places"
+msgid "Reviews"
+msgstr "Reviews"
+
+#. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Rewrite this recipe scaled for a different number of servings."
+msgstr ""
+
+msgid "Romania"
+msgstr "Rumänien"
+
+#. The name of the Romanian language
+msgctxt "language_name"
+msgid "Romanian"
+msgstr ""
+
+#. Rugby match: round label prefix
+msgctxt "Sports module"
+msgid "Round"
+msgstr ""
+
+#. Label for a numbered early-stage round in a soccer cup competition (e.g. "Round 1", "Round 2" in the FA Cup)
+msgctxt "Sports module"
+msgid "Round %s"
+msgstr ""
+
+#. Label for the Round of 16 in the knockout stage of the soccer World Cup
+msgctxt "Sports module"
+msgid "Round of 16"
+msgstr ""
+
+#. Label for the Round of 32 in the knockout stage of the soccer World Cup
+msgctxt "Sports module"
+msgid "Round of 32"
+msgstr ""
+
+#. Cricket scorecard: runs full name (tooltip)
+msgctxt "Sports module"
+msgid "Runs"
+msgstr ""
+
+#. Cricket scorecard: runs conceded full name (tooltip)
+msgctxt "Sports module"
+msgid "Runs Conceded"
+msgstr ""
+
+msgid "Russia"
+msgstr "Russland"
+
+#. The name of the Russian language
+msgctxt "language_name"
+msgid "Russian"
+msgstr ""
+
+msgid "Rwanda"
+msgstr ""
+
+#. Abbreviation for 'South'
+msgctxt "forecast"
+msgid "S"
+msgstr "S"
+
+#. Abbreviation for 'Southeast'
+msgctxt "forecast"
+msgid "SE"
+msgstr "SO"
+
+msgctxt "settings"
+msgid "SERP promotion for desktop browsers has been dismissed"
+msgstr ""
+
+#. Abbreviation indicating that a game is in shootouts, e.g. in NHL (hockey)
+msgctxt "Sports module"
+msgid "SO"
+msgstr ""
+
+#. Cricket scorecard: strike rate abbreviation
+msgctxt "Sports module"
+msgid "SR"
+msgstr ""
+
+#. Text for the badge displayed to indicate that the user has a subscription to DuckDuckGo.
+msgctxt "Text for the subscriber badge"
+msgid "SUBSCRIBER"
+msgstr ""
+
+#. NASCAR standings column: abbreviated label for stage wins
+msgctxt "Sports module"
+msgid "SW"
+msgstr ""
+
+#. Abbreviation for 'Southwest'
+msgctxt "forecast"
+msgid "SW"
+msgstr "SW"
+
+#. A filter that removes search results that may be inappropriate.
+msgid "Safe Search"
+msgstr "Sichere Suche"
+
+#. http://i.imgur.com/hcN6sIA.png
+msgctxt "settings"
+msgid "Safe Search"
+msgstr "Sichere Suche"
+
+#. in https://duckduckgo.com/params near the top under "Result Settings" header
+msgid "Safe Search:"
+msgstr "Sichere Suche:"
+
+#. A filter that removes search results that may be inappropriate.
+msgid "Safe search"
+msgstr ""
+
+#. List item indicating that the safe search filter is currently active for the search
+msgctxt "noresults"
+msgid "Safe search"
+msgstr ""
+
+#. A label above search results that lets the user know the safe search filter blocked some of the results from showing. The placeholder value is the user's search term.
+msgid "Safe search blocked results for %s."
+msgstr "Sichere Suche blockierte Resultate für %s."
+
+#. A label above search results that lets the user know the safe search filter blocked some of the results from showing. The placeholder value is the user's search term.
+msgid "Safe search blocked some results for %s."
+msgstr "Die sichere Suche blockierte einige Ergebnisse für %s."
+
+#. Safe search lets you remove adult content from results on DuckDuckGo. This string is used to invite users to select the desired level of protection (e.g., strict, moderate, off)
+msgid "Safe search:"
+msgstr ""
+
+msgid "Saint Kitts and Nevis"
+msgstr ""
+
+msgid "Saint Lucia"
+msgstr ""
+
+msgid "Saint Vincent and the Grenadines"
+msgstr ""
+
+msgid "Samoa"
+msgstr ""
+
+#. The name of the Samoan language
+msgctxt "language_name"
+msgid "Samoan"
+msgstr ""
+
+msgid "San Marino"
+msgstr ""
+
+msgid "Sao Tome and Principe"
+msgstr ""
+
+#. Weekday abbreviation (short for 'Saturday')
+msgctxt "maps_places"
+msgid "Sat"
+msgstr ""
+
+#. Setting that displays a map using satellite imagery
+msgctxt "map-mode"
+msgid "Satellite"
+msgstr "Satellit"
+
+#. Weekday in plural form
+msgctxt "maps_places"
+msgid "Saturdays"
+msgstr ""
+
+msgid "Saudi Arabia"
+msgstr "Saudi-Arabien"
+
+#. A button that saves a user's settings.
+msgid "Save"
+msgstr "Speichern"
+
+#. Text for a button that saves the new title of a chat.
+msgctxt "Button text for saving chat title"
+msgid "Save"
+msgstr ""
+
+#. A button to save the assist settings.
+msgctxt "duckassist"
+msgid "Save"
+msgstr ""
+
+msgctxt "settings"
+msgid "Save"
+msgstr "Speichern"
+
+#. Title above the page where settings are saved to the cloud.
+msgctxt "settings"
+msgid "Save Cloud Settings"
+msgstr "Einstellungen der Datenwolke speichern"
+
+#. Secondary button on the 'Sync This Device Only' recovery code screen that triggers a download of the recovery code as a PDF (falling back to a .txt file).
+msgctxt "Button label that downloads the recovery code as a PDF file"
+msgid "Save Recovery Code"
+msgstr ""
+
+#. Secondary button on the recovery code screen that triggers a download of the recovery code as a .txt file.
+msgctxt "Button label that downloads the recovery code as a text file"
+msgid "Save Recovery Code"
+msgstr ""
+
+#. Button that saves user settings.
+msgid "Save Settings"
+msgstr "Einstellungen Speichern"
+
+#. Title for the screen where users save the recovery code needed to restore their saved chats.
+msgctxt "Title for the Sync & Backup recovery code screen"
+msgid "Save Your Recovery Code"
+msgstr ""
+
+#. A button that saves a user's settings and closes the settings window.
+msgid "Save and Exit"
+msgstr "Speichern und Verlassen"
+
+#. Description explaining that sync allows saving more chats than local browser storage.
+msgctxt "Sync feature benefit description"
+msgid "Save more chats than you can in your web browser."
+msgstr ""
+
+#. List item explaining that users can save more chats when Sync & Backup is enabled.
+msgctxt "Chat history with sync modal list item"
+msgid "Save more of your chats."
+msgstr ""
+
+#. Text for 3rd party browser users explaining Chat History with mention of Encrypted Storage option for saving more chats.
+msgctxt "Description for Chat History feature with Encrypted Storage option"
+msgid ""
+"Save up to 30 of your most recent chats locally on your device, with the "
+"option for more with Encrypted Storage."
+msgstr ""
+
+#. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
+msgctxt "Short description for Chat History feature on native DDG browsers"
+msgid "Save up to 30 of your most recent chats locally on your device."
+msgstr ""
+
+#. Desktop/mobile intro modal body under the title per Sync Chats Figma (choose step).
+msgctxt "Body copy for the Sync & Backup intro screen"
+msgid ""
+"Save your Duck.ai chats between your devices with end-to-end encryption."
+msgstr ""
+
+#. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
+msgctxt "Description for Chat History when sync is enabled"
+msgid "Save your chats across all your devices."
+msgstr ""
+
+#. List item in the About Chat History modal explaining that recent chats are saved.
+msgctxt "Chat history about modal list item"
+msgid "Save your most recent chats."
+msgstr ""
+
+#. Short description shown in Chat History settings when sync is not yet enabled, explaining chats are saved locally on the device.
+msgctxt "Description for Chat History when sync is not enabled"
+msgid "Save your recent chats on this device."
+msgstr ""
+
+#. Prompt to save user settings to the cloud.
+msgctxt "settings"
+msgid "Save your settings anonymously to the cloud"
+msgstr "Sichere deine Einstellungen anonym in der Cloud"
+
+#. Title displayed on the welcome screen of the onboarding.
+msgctxt "Onboarding welcome screen title"
+msgid "Say hello to Duck.ai"
+msgstr ""
+
+#. Title displayed on the welcome screen of the onboarding.
+msgctxt "Onboarding welcome screen title"
+msgid "Say hello to Duck.ai!"
+msgstr ""
+
+#. Title displayed on the welcome screen of the onboarding.
+msgctxt "Onboarding welcome screen title"
+msgid "Say hello to DuckDuckGo AI Chat!"
+msgstr ""
+
+#. Label for the Scan QR tab: on desktop it shows this device's QR for another device to scan; on mobile/tablet it opens the camera to scan the other device's QR. Used in both pairing and recovery.
+msgctxt "Tab label on the Sync Another Device pane for the QR/scan side"
+msgid "Scan QR"
+msgstr ""
+
+#. Text link below the paste textarea that takes the user back to the QR scan screen.
+msgctxt "Link on the manual paste screen that switches to camera scan"
+msgid "Scan QR Code"
+msgstr ""
+
+#. Shown when the user is scanning the QR from their Recovery PDF or typing the code manually. Figma frame 3705-32811.
+msgctxt "Modal header for the recover-data scan/paste sheet"
+msgid "Scan QR Code"
+msgstr ""
+
+#. Mobile-only label. When active, the user sees the camera viewfinder for scanning another device's QR code.
+msgctxt "Tab label for the camera-scan side of the Sync Another Device pane"
+msgid "Scan QR Code"
+msgstr ""
+
+#. Screen-reader label set as the aria-label on the QR code SVG so users know what the image represents. Not visible on screen.
+msgctxt "Accessible label for the QR pairing code image"
+msgid "Scan This Code"
+msgstr ""
+
+#. Header of the bottom sheet that shows this device's pairing QR and text code on mobile.
+msgctxt "Title of the mobile Scan-or-Copy-Code modal"
+msgid "Scan or Copy Code"
+msgstr ""
+
+#. Tells the user that either the QR or the text-form code below is what the other device should consume.
+msgctxt "Instruction text above the QR code in the View Code tab"
+msgid "Scan or copy this code to connect"
+msgstr ""
+
+#. Title of a tab that displays a list of the season schedule for a team
+msgctxt "Sports module"
+msgid "Schedule"
+msgstr ""
+
+#. Link to a site with the schedule and the results of competitions previously held.
+msgid "Schedule & Results"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Scientific notation not helpful"
+msgstr ""
+
+#. Label for the current score of a live sporting event.
+msgid "Score"
+msgstr "Ergebnis"
+
+#. Golf leaderboard column: score relative to par
+msgctxt "Sports module"
+msgid "Score"
+msgstr ""
+
+#. Accessibility label for a marker representing a penalty kick that was scored in a soccer shootout.
+msgctxt "Sports module"
+msgid "Scored"
+msgstr ""
+
+#. Title of a tab that displays a list of scores for a team
+msgctxt "Sports module"
+msgid "Scores"
+msgstr ""
+
+msgid "Scotland"
+msgstr ""
+
+#. Tells users where in the settings menu they can change their default search engine.
+msgid "Scroll down and click %sView advanced settings%s"
+msgstr "Scrolle hinunter und klicke %sZeige erweiterte Einstellungen%s"
+
+#. Tells users how to add DuckDuckGo to the list of search engines in their browser.
+msgid "Scroll down and click %sView advanced settings%s."
+msgstr "Scrolle runter und klicke auf %sErweiterte Einstellungen anzeigen%s."
+
+msgid ""
+"Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
+"%sAdd new%s)"
+msgstr ""
+"Scrolle runter und suche %sIn der Adressleiste suchen%s. Klicke auf "
+"%sWechseln%s (oder %sMach ei neues%s)"
+
+#. Tells users how to add DuckDuckGo to the list of search engines in their browser.
+msgid ""
+"Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
+"%sAdd new%s)."
+msgstr ""
+"Scrolle runter und finde %sSuche in der Adressleiste%s. Klicke auf "
+"%sÄndern%s (oder%sNeu hinzufügen%s)."
+
+#. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
+msgctxt "precise_user_location"
+msgid "Scroll down and locate %syour browser%s in the list"
+msgstr ""
+
+#. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
+msgctxt "precise_user_location"
+msgid "Scroll down and locate %syour browser%s in the list."
+msgstr ""
+
+#. Tells users which setting to change to enable location service.
+msgctxt "precise_user_location"
+msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
+msgstr ""
+
+#. Tells users how to add DuckDuckGo to the list of search engines in their browser.
+msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
+msgstr "Scrolle runter zu %sServices%s und klicke auf %sAdressleiste%s."
+
+#. Rugby match stats
+msgctxt "Sports module"
+msgid "Scrums Won"
+msgstr ""
+
+#. Refers to searching in a web browser.
+msgid "Search"
+msgstr "Suche"
+
+#. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
+msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
+msgid "Search %s to find results closer to you?"
+msgstr ""
+
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
+msgid "Search Anonymously"
+msgstr "Suche anonym"
+
+msgctxt "settings"
+msgid "Search Assist"
+msgstr ""
+
+msgctxt "settings"
+msgid "Search Assist Highlights"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Search Assist anonymously generates answers for search queries. To do this, "
+"it scans the web for relevant content and then uses AI to generate a brief "
+"answer. You can choose how often you want it to appear: Never, On-demand "
+"(only when Assist is clicked), Sometimes (when highly relevant), or Often "
+"(on a wide range of searches). For now, Search Assist is only available in a "
+"subset of English speaking regions."
+msgstr ""
+
+#. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
+msgid ""
+"Search Assist couldn't find enough reliable information to generate an "
+"answer for this question. Try another search."
+msgstr ""
+
+#. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
+msgid ""
+"Search Assist is an optional feature that anonymously generates answers for "
+"search queries. To do this, it %sscans the web%s for relevant content and "
+"then uses AI to generate a brief answer based on information found."
+msgstr ""
+
+#. in https://duckduckgo.com/search_box. top header
+msgid "Search Box"
+msgstr "Suchfeld"
+
+msgctxt "settings"
+msgid "Search Button Background"
+msgstr "Suchknopf Hintergrund"
+
+#. search for a place within the map area currently shown in expanded map
+msgctxt "vertical_map"
+msgid "Search Current Map Area"
+msgstr "Durchsuche den momentanen Kartenausschnitt"
+
+msgid "Search DuckDuckGo"
+msgstr "Durchsuche DuckDuckGo"
+
+#. Subheading label for site filters
+msgctxt "Organic result context menu"
+msgid "Search Filter:"
+msgstr ""
+
+#. search for a place near the user's location
+msgctxt "vertical_map"
+msgid "Search Near My Location"
+msgstr "In meiner Nähe suchen"
+
+#. Header above search settings.
+msgid "Search Options"
+msgstr "Suchoptionen"
+
+#. Link to search results.
+msgid "Search Results"
+msgstr "Suechresultat"
+
+#. Header for list of sources returned by an AI model indicating they were used to generate an answer to a given prompt.
+msgctxt "Header in AI chat message for sources"
+msgid "Search Results"
+msgstr ""
+
+#. Title for the search settings page
+msgctxt "settings pages title"
+msgid "Search Settings"
+msgstr ""
+
+#. A link to a page that explains Search Shortcuts (aka bangs) (https://duckduckgo.com/bangs/)
+msgctxt "SERP footer content"
+msgid "Search Shortcuts"
+msgstr ""
+
+#. A button that searches within an area shown on a map.
+msgctxt "map"
+msgid "Search This Area"
+msgstr ""
+
+msgctxt "settings"
+msgid "Search Visibility"
+msgstr ""
+
+#. Message prompting users to download the DuckDuckGo app.
+msgid "Search and browse privately with the DuckDuckGo app."
+msgstr "Suche und browse privat mit der DuckDuckGo App."
+
+#. Category a user can select on a feedback form.
+msgctxt "feedback form"
+msgid "Search box"
+msgstr ""
+
+#. Text for the chat search feature in Duck.ai. Used as the tooltip for the button that opens search mode, and as the placeholder text and accessibility label for the search input field.
+msgctxt ""
+"Label for searching chats in Duck.ai: tooltip on the button that opens "
+"search, and placeholder + accessibility label for the search input field"
+msgid "Search chats"
+msgstr ""
+
+#. A button that searches within a specific website. The placeholder value is the name of the website. For example: 'Search domain Wikipedia'
+msgid "Search domain %s"
+msgstr "Durchsuche Domain %s"
+
+#. Title for the notice displayed in the Duck.ai chat history sidebar when chat search cannot be loaded.
+msgctxt "Title shown when chat history search in Duck.ai is unavailable"
+msgid "Search is unavailable"
+msgstr ""
+
+#. Placeholder text for a text-based language filter
+msgctxt "translations_module"
+msgid "Search languages"
+msgstr ""
+
+#. A link to search results for a different search term. The placeholder value is the search term. For example: 'Search only for pizza?'
+msgid "Search only for %s?"
+msgstr "Suche nur nach %s?"
+
+#. Provide users with the ability to retry their search on a different search engine. Placeholder is a URL to the !bangs page: https://duckduckgo.com/bangs.
+msgctxt "noresults"
+msgid ""
+"Search other sites with %s shortcuts: a search for ”!w ducks” will search "
+"for “ducks” directly on Wikipedia."
+msgstr ""
+
+#. Placeholder text for the search form when no text has been entered
+msgctxt "Search form"
+msgid "Search privately"
+msgstr ""
+
+#. Item in a list of features of a desktop web browser
+msgctxt "Browser Promo Popover"
+msgid "Search privately and block trackers"
+msgstr ""
+
+msgid ""
+"Search privately with our app or extension, add private web search to your "
+"favorite browser, or search directly at %sduckduckgo.com%s."
+msgstr ""
+"Suche privat mit unserer App oder Browsererweiterung, füge private Suche zu "
+"deinemLieblingsbrowser hinzu, oder suche direkt auf %sduckduckgo.com%s."
+
+#. http://i.imgur.com/6LZAoqH.png
+msgctxt "settings"
+msgid ""
+"Search queries are included in URL (if off, searches will use POST requests)"
+msgstr ""
+"Suchanfragen sind in der URL beinhaltet. (Wenn ausgeschaltet werden POST-"
+"Anfragen verwendet)"
+
+#. Describes how cookies are used to store user settings privately and securely.
+msgctxt "settings"
+msgid ""
+"Search settings are stored in non-personal browser cookies and local storage "
+"in your browser, but you can also use Cloud Save to store your settings "
+"anonymously on a remote server in the cloud. No personally identifiable "
+"information will be stored in the cloud, and your passphrase will never "
+"leave your browser."
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Search terms ignored or changed"
+msgstr ""
+
+#. Call to action to invite users to request AI models to search the web while answering.
+msgctxt "Tooltip for an action button"
+msgid "Search the web"
+msgstr ""
+
+#. Tooltip text for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
+msgctxt ""
+"Tooltip text for the button that forces the LLM in Duck.ai to use web search "
+"to answer the question for the user."
+msgid "Search the web"
+msgstr ""
+
+#. Placeholder text for search box.
+msgctxt "search input box"
+msgid "Search the web without being tracked"
+msgstr "Durchsuche das Internet ohne getrackt zu werden"
+
+#. Search this area for hotels, restaurants, bars, parks, banks etc.
+msgctxt "map"
+msgid "Search this area for..."
+msgstr ""
+
+#. Text for a tooltip that let's users know that clicking the button will take them to the DuckDuckGo's web search page.
+msgctxt "AI Chat web button  tooltip"
+msgid "Search with DuckDuckGo"
+msgstr ""
+
+#. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
+msgctxt "Promotional text"
+msgid "Search, browse, and chat privately in our free browser"
+msgstr ""
+
+#. Message displayed sometimes at top of results (for bang syntax), e.g. <a href="https://duckduckgo.com/?q=twitter+test">https://duckduckgo.com/?q=twitter+test</a>
+msgid "Searches %s using our %s"
+msgstr "Durchsuche %s mit unserer %s"
+
+msgid "Searches related to \"%s\""
+msgstr "Zugehörige Suchen zu \"%s\""
+
+#. Label above a list of search terms related to the user's current search. The placeholder is the user's current search term.
+msgid "Searches related to <b>%s</b>"
+msgstr ""
+
+#. Text displayed while the AI assistant is searching the web while generating a response.
+msgctxt "Assistant response progress report"
+msgid "Searching the web"
+msgstr ""
+
+#. Status label shown when the AI is performing a web search during a voice conversation.
+msgctxt "voice chat"
+msgid "Searching the web"
+msgstr ""
+
+#. Text displayed while the AI assistant is searching the web while generating a response.
+msgctxt "Assistant response progress report"
+msgid "Searching the web…"
+msgstr ""
+
+#. Title for modal letting you choose which week of the season you wish to view
+msgctxt "Sports module"
+msgid "Season Weeks"
+msgstr ""
+
+#. Call to action that re-asks the same question to a different AI model so the user can compare answers.
+msgctxt "Tooltip for an action button"
+msgid "Second opinion"
+msgstr ""
+
+#. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
+msgctxt "Description for sync and backup feature"
+msgid "Securely save and sync your chats across all your devices."
+msgstr ""
+
+#. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
+msgctxt "Description explaining how native users can enable sync"
+msgid ""
+"Securely store nearly unlimited chats on our server using end-to-end "
+"encryption, and access them from all your devices."
+msgstr ""
+
+#. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
+msgctxt "Description for encrypted storage feature"
+msgid ""
+"Securely store nearly unlimited chats on our server using end-to-end "
+"encryption, and access them from all your devices."
+msgstr ""
+
+#. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
+msgctxt "Description explaining how native users can enable sync"
+msgid ""
+"Securely store nearly unlimited chats on our server using end-to-end "
+"encryption, and access them from all your synced devices."
+msgstr ""
+
+#. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
+msgctxt "Description explaining how native users can enable sync"
+msgid ""
+"Securely store your chats on our server using end-to-end encryption, and "
+"access them from all your devices."
+msgstr ""
+
+#. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
+msgctxt "Sync feature benefit description"
+msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
+msgstr ""
+
+#. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
+msgctxt "Chat history with sync modal list item"
+msgid ""
+"Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
+"but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
+msgstr ""
+
+msgctxt "Feedback prompt"
+msgid "Security issue"
+msgstr ""
+
+#. Category of problem a user can select on a feedback form.
+msgctxt "feedback form"
+msgid "Security issue (opens in new tab)"
+msgstr ""
+
+msgctxt "expand_text"
+msgid "See More"
+msgstr ""
+
+#. A link that loads user-uploaded photos of a location on a map.
+msgid "See Photos"
+msgstr "Schaue Fotos an"
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
+msgid "See Privacy Policy and Terms of Service"
+msgstr ""
+
+#. Text of the secondary button in the modal that allows the user to open the terms and privacy policy page.
+msgctxt "Modal secondary button for privacy"
+msgid "See Terms and Privacy Policy"
+msgstr ""
+
+#. Text for a button that links to the terms of use and privacy policy page.
+msgctxt "Secondary button text in active privacy modal"
+msgid "See Terms and Privacy Policy"
+msgstr ""
+
+#. Links to a page that provides a list of DuckDuckGo product updates
+msgctxt "SERP footer content"
+msgid "See What's New"
+msgstr ""
+
+#. A link to a page that provides the latest updates on DuckDuckGo products.
+msgctxt "SERP footer content"
+msgid "See What’s New"
+msgstr ""
+
+#. Click "What is this?" - http://i.imgur.com/KhmRHth.png
+#. Then at the bottom of the cloud save box - http://i.imgur.com/4Jo3jAf.png
+msgctxt "cloudsave"
+msgid "See also"
+msgstr ""
+
+#. Link text shown below a rich caption list in search results. The placeholder %s is the website domain name, e.g. 'wikipedia.org'.
+msgctxt "Rich caption simple list, see more link"
+msgid "See full list on %s"
+msgstr ""
+
+#. Text for tooltip shown on hover when displaying the number of reviews the merchant has on an ad
+msgid "See merchant reviews on bing.com"
+msgstr ""
+
+#. Link text shown below a rich caption dated list in search results. The placeholder %s is the website domain name, e.g. 'wikipedia.org'.
+msgctxt ""
+"Rich caption dated list, see more link that adds domain inclusion to query"
+msgid "See more from %s"
+msgstr ""
+
+#. Link text shown below a rich caption accordion in search results. The placeholder %s is the website domain name, e.g. 'wikipedia.org'.
+msgctxt "Rich caption accordion, see more link"
+msgid "See more on %s"
+msgstr ""
+
+#. Link text shown below a rich caption tabbed snippet in search results. The placeholder %s is the website domain name, e.g. 'wikipedia.org'.
+msgctxt "Rich caption tabbed snippet, see more link"
+msgid "See more on %s"
+msgstr ""
+
+#. Title of a notice that DuckDuckGo has noticed the user is blocking its non-tracking ads
+msgid "See more shopping results from popular retailers"
+msgstr ""
+
+#. Text for tooltip shown on hover when displaying the number of reviews the product has on an ad, indicating that users can see more ratings on bing.com
+msgctxt "ratings on product or text ad extension"
+msgid "See product ratings on bing.com"
+msgstr ""
+
+#. Link to the updates page.
+msgctxt "feedback form"
+msgid "See some of our latest updates"
+msgstr ""
+
+#. Link to a page with more information about how user settings are stored in a URL.
+msgctxt "settings"
+msgid "See the %sURL Parameter Reference page%s for more details."
+msgstr ""
+
+#. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
+msgctxt ""
+"Button text for selecting a chat in the context menu in chat history and "
+"begin batch selection mode."
+msgid "Select"
+msgstr ""
+
+#. Aria label for the checkbox in the chat history list item that allows the user to select a chat for batch actions. %s is replaced with the title of the chat.
+msgctxt "Aria label for the checkbox in the chat history list item"
+msgid "Select %s"
+msgstr ""
+
+#. Instructions on how to change a browser's default search engine to DuckDuckGo.
+msgctxt "mobile homepage banner"
+msgid "Select %s%s%s, then %sSearch Engine%s"
+msgstr "Wähle %s%s%s, dann %sSuchmaschine%s"
+
+#. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
+msgctxt "precise_user_location"
+msgid "Select %s'Setting for this Website...'%s from the Safari menu."
+msgstr ""
+
+#. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
+msgid ""
+"Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
+msgstr ""
+"Wähle %sBenutzerdefiniert%s aus und gib %shttps://duckduckgo.com%s in das "
+"Eingabefeld ein."
+
+#. Instructions to add a search engine in Microsoft Edge
+msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
+msgstr "Wähle %sDuckDuckGo%s und klicke %sals Voreinstellung hinzufügen%s!"
+
+msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
+msgstr "Wähle %sDuckDuckGo%s aus und klicke auf %sAls Standard festlegen%s"
+
+#. Tells users how to add DuckDuckGo to the list of search engines in their browser.
+msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
+msgstr "Wähle %sDuckDuckGo%s und klicke auf %sAls Standard festlegen%s."
+
+#. Tells users where in the settings menu they can change their default search engine.
+msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
+msgstr "Wähle %sDuckDuckGo%s im Standart-Suchmaschinen-Dropdown-Menü "
+
+#. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
+msgctxt "precise_user_location"
+msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
+msgstr ""
+
+#. Tells users how to add DuckDuckGo to the list of search engines in their browser.
+msgid "Select %sDuckDuckGo%s in the list of search providers"
+msgstr "Wähle %sDuckDuckGo%s in der Liste der Suchanbieter aus"
+
+#. Tells users how to add DuckDuckGo to the list of search engines in their browser.
+msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
+msgstr "Wähle bei %sStandard-Suchmaschine%s %sDuckDuckGo%s aus"
+
+#. Tells the user were in the settings menu they can change their default search engine.
+msgid "Select %sDuckDuckGo%s!"
+msgstr "Wähle %sDuckDuckGo%s!"
+
+#. Tells users where to click in their browser to change the default search engine.
+msgid "Select %sEdit Search Engines...%sin the dropdown"
+msgstr "Wähle %sändere Suchmaschine...%sim Auswahlmenü"
+
+#. Tells users how to add DuckDuckGo to the list of search engines in their browser.
+msgid "Select %sManage add-ons%s from the dropdown menu"
+msgstr "Wähle %sAddons verwalten%s aus dem Dropdownmenu aus"
+
+#. Tells users where in the settings menu they can change their default search engine.
+msgid ""
+"Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
+msgstr ""
+"Wähle %sOpera > Einstellungen%s (Mac) bzw. %sMenü > Einstellungen%s (Windows)"
+
+#. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
+msgid ""
+"Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
+msgstr ""
+"Wähle %sOpera > Einstellungen%s (unter Mac) oder %sOpera > Optionen%s (unter "
+"Windows)"
+
+#. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
+msgid "Select %sPreferences%s."
+msgstr "Wähle %sEinstellungen%s."
+
+#. Instructions on how to change a browser's default search engine to DuckDuckGo.
+msgctxt "mobile homepage banner"
+msgid "Select %sSearch Engine%s"
+msgstr "Wähle %sSuchmaschinen%s"
+
+#. Instructions on how to change a browser's default search engine to DuckDuckGo.
+msgctxt "mobile homepage banner"
+msgid "Select %sSearch engine%s, then %sOthers...%s"
+msgstr "Wähle %sSuchmaschinen%s, dann %sAndere...%s"
+
+#. Tells users to click on the settings menu
+msgid "Select %sSettings%s"
+msgstr "Wähle %sEinstellungen%s"
+
+#. Instructions on how to change a browser's default search engine to DuckDuckGo.
+msgctxt "mobile homepage banner"
+msgid "Select %sSettings%s"
+msgstr "Wähle %sEinstellungen%s"
+
+#. Tells the user where to click to open their browser's settings menu.
+msgid "Select %sSettings%s from the drop-down menu."
+msgstr "Wähle %sEinstellungen%s im Drop-Down-Menü."
+
+#. Instructions on how to change a browser's default search engine to DuckDuckGo.
+msgctxt "mobile homepage banner"
+msgid "Select %sSettings%s, then %sAdvanced settings%s"
+msgstr "Wähle %sEinstellungen%s, dann %serweiterte Einstellungen%s"
+
+#. Instructions on how to change a browser's default search engine to DuckDuckGo.
+msgctxt "mobile homepage banner"
+msgid "Select %sSettings%s, then %sDefault search engine%s"
+msgstr "Wähle %sEinstellungen%s, dann %sStandardsuchmaschine%s"
+
+#. Instructions on how to change a browser's default search engine to DuckDuckGo.
+msgctxt "mobile homepage banner"
+msgid "Select %sSettings%s, then %sSearch Engine%s"
+msgstr "Wähle %sEinstellungen%s, dann %sSuchmaschinen%s"
+
+#. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
+msgid ""
+"Select %sUse this webpage as your only home page%s (or one of the other "
+"options if you prefer)"
+msgstr ""
+"Wähle %sUse this webpage as your only home page%s (oder eine der anderen "
+"Optionen, falls dir das lieber ist)"
+
+#. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
+msgctxt "precise_user_location"
+msgid "Select %syour browser%s in the list and %sallow%s location access"
+msgstr ""
+
+#. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
+msgctxt ""
+"Button text for selecting chats in the modal for deleting all recent chats"
+msgid "Select Chats"
+msgstr ""
+
+#. Tells users to select DuckDuckGo from a dropdown menu.
+msgid "Select DuckDuckGo!"
+msgstr "Wähle DuckDuckGo!"
+
+#. Title text for a modal window allowing the user to choose a language
+msgctxt "translations_module"
+msgid "Select Language"
+msgstr ""
+
+#. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
+msgctxt "precise_user_location"
+msgid "Select Settings > Location."
+msgstr "Wähle Einstellungen > Standort."
+
+#. Bot challenge instructions
+msgctxt "Anomaly modal"
+msgid "Select all squares containing a duck:"
+msgstr ""
+
+#. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
+msgctxt "precise_user_location"
+msgid "Select an option to %sallow%s location access"
+msgstr ""
+
+#. Tells users where in the settings menu they can change their default search engine.
+msgid "Selected %sDuckDuckGo%s"
+msgstr "Wähle %sDuckDuckGo%s"
+
+#. A subheading for the summarize message. The placeholder will contain a link to the original source of the text.
+msgctxt "Subtitle for the summarize message"
+msgid "Selected Text from %s"
+msgstr ""
+
+#. Aria label for the main generated image that can be opened in a lightbox.
+msgctxt "Aria label for main generated image"
+msgid "Selected generated image"
+msgstr ""
+
+#. A subheading for the summarize message. The placeholder will contain a link to the original source of the text.
+msgctxt "Subtitle for the summarize message"
+msgid "Selected text from %s"
+msgstr ""
+
+#. A subtitle indicating that an attached text snippet was selected from a specific source page. The placeholder will contain a link to the source page. Example: <a href='https://example.com'>example.com</a>
+msgctxt "Subtitle for the text selection message"
+msgid "Selected text from %s"
+msgstr ""
+
+#. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
+msgctxt "Error message for selection input limit"
+msgid "Selected text is too long. Try again with a shorter selection."
+msgstr ""
+
+#. Label for the semi-finals knockout stage in e.g. the soccer World Cup
+msgctxt "Sports module"
+msgid "Semi-finals"
+msgstr ""
+
+#. "Send" button for feedback form.
+msgid "Send"
+msgstr "Senden"
+
+#. Text in a tooltip of a button that sends a user message to the chat.
+msgctxt "Send user prompt"
+msgid "Send"
+msgstr ""
+
+msgctxt "Feedback prompt"
+msgid "Send Feedback"
+msgstr ""
+
+#. Link to a feedback form.
+msgctxt "feedback form"
+msgid "Send feedback"
+msgstr "Sende Feedback"
+
+#. Label before a list of items a user can send feedback for.
+msgctxt "feedback form"
+msgid "Send feedback for:"
+msgstr "Sende eine Rückmeldung für:"
+
+#. A description of customization functionality show to users when they open a modal with all customization settings.
+msgctxt "A description of customizing Duck.ai"
+msgid ""
+"Sends a prompt to AI models with your messages with instructions on how to "
+"respond. These instructions will apply to all of your conversations going "
+"forward."
+msgstr ""
+
+msgid "Senegal"
+msgstr ""
+
+msgid "Serbia"
+msgstr ""
+
+#. The name of the Serbian (Cyrillic) language
+msgctxt "language_name"
+msgid "Serbian (Cyrillic)"
+msgstr ""
+
+#. The name of the Serbian (Latin) language
+msgctxt "language_name"
+msgid "Serbian (Latin)"
+msgstr ""
+
+#. Status label shown when the voice chat session has ended.
+msgctxt "voice chat"
+msgid "Session ended"
+msgstr ""
+
+#. Text prompting users to make DuckDuckGo the default search engine in their browser.
+msgid "Set DuckDuckGo as your %sdefault search engine"
+msgstr "Lege DuckDuckGo als deine %s standardmässige Suchmaschine fest"
+
+#. Button that allows users to manually select a location on a map.
+msgctxt "precise_user_location"
+msgid "Set Location on Map"
+msgstr ""
+
+#. Button that allows users to manually select their current location on a map.
+msgctxt "precise_user_location"
+msgid "Set Manually"
+msgstr "Manuell festlegen"
+
+#. Button that allows users to manually select a new location on a map.
+msgctxt "precise_user_location"
+msgid "Set New Location on Map"
+msgstr ""
+
+#. Text for the button that takes the user to the sync setup page.
+msgctxt "Encrypted storage setup button"
+msgid "Set Up Now"
+msgstr ""
+
+#. Primary button label on the Sync & Backup intro screen that starts the setup flow on this device.
+msgctxt "Primary button on the Sync & Backup intro screen"
+msgid "Set Up Now"
+msgstr ""
+
+#. Primary CTA on the intro screen on narrow/mobile viewports; starts setup on this device.
+msgctxt "Primary button on the Sync & Backup intro screen (mobile)"
+msgid "Set Up Now"
+msgstr ""
+
+#. Button label shown to DuckDuckGo native browser users to open the native sync flow.
+msgctxt "Setup button for native sync flow"
+msgid "Set Up Now"
+msgstr ""
+
+#. Native-browser variant of DUCKCHAT_SYNC_SETUP_BUTTON_TEXT; CTA at the Sync settings tile when Duck.ai runs inside a DuckDuckGo browser.
+msgctxt "Encrypted storage setup button shown in native browsers"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
+#. Title shown on the entry screen where the user chooses between setting up Sync & Backup or pairing with another device.
+msgctxt "Title for the Sync & Backup intro screen"
+msgid "Set Up Sync & Backup"
+msgstr ""
+
+#. Text prompting users to make DuckDuckGo the default search engine in their browser.
+msgid "Set as Default Search Engine"
+msgstr "Als standardmässige Suchmaschine festlegen"
+
+#. Button that sets the current webpage as the user's homepage in their browser.
+msgid "Set as Homepage"
+msgstr "Als Startseite festlegen"
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
+#. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
+msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
+msgid "Set tone, length and behavior"
+msgstr ""
+
+#. List item in the About Chat History modal explaining that users can set up Sync & Backup to sync chats across devices.
+msgctxt "Chat history about modal list item"
+msgid ""
+"Set up Sync & Backup after turning on Chat History to keep your chats synced "
+"across devices."
+msgstr ""
+
+#. Prompt for the user to indicate their location on a map, to enable more relevant search results.
+msgctxt "precise_user_location"
+msgid "Set your location manually, or ensure Location Services is enabled."
+msgstr ""
+"Lege deinen Standort manuell fest oder stelle sicher, dass die "
+"Standortdienste aktiviert sind."
+
+#. In the top dropdown menu  ("More" > "Settings")
+msgid "Settings"
+msgstr "Einstellungen"
+
+#. Link to the settings page
+msgctxt "Settings link"
+msgid "Settings"
+msgstr ""
+
+#. Text for the settings button that appears in the desktop sidebar.
+msgctxt "Text for the settings button"
+msgid "Settings"
+msgstr ""
+
+msgctxt "feedback form"
+msgid "Settings"
+msgstr "Einstellungen"
+
+#. Label displayed on the sidebar footer row indicating that the user can access the settings and more menu.
+msgctxt "Sidebar footer row"
+msgid "Settings & More"
+msgstr ""
+
+#. Label for the user's settings in JSON format.
+msgctxt "settings"
+msgid "Settings in JSON:"
+msgstr "Einstellungen als JSON:"
+
+#. Message indicating the user has changed their browser's settings
+msgid "Settings updated"
+msgstr ""
+
+msgid "Seychelles"
+msgstr ""
+
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
+#. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
+msgctxt "duckassist"
+msgid "Share"
+msgstr ""
+
+msgctxt "homepage onboarding"
+msgid "Share DuckDuckGo and help friends take their privacy back!"
+msgstr ""
+"Teile DuckDuckGo und helfe deinen Freunden um deren Priphatsphäre zu "
+"schützen!"
+
+#. Text displayed on a button that opens a feedback modal when clicked.
+msgctxt "Share Feedback button text"
+msgid "Share Feedback"
+msgstr ""
+
+#. Link to a feedback form.
+msgctxt "feedback form"
+msgid "Share Feedback"
+msgstr ""
+
+#. Primary button/link text to open the user survey (mobile only)
+msgctxt "User survey popup"
+msgid "Share Feedback in Survey"
+msgstr ""
+
+#. Text explaining that the Approximate Location feature helps improve AI Chatbot Assistant responses by using the user's approximate location, while keeping their exact location private.
+msgctxt "Description for Approximate Location feature"
+msgid ""
+"Share a city-level location with AI models to improve relevancy. Duck.ai "
+"never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
+msgstr ""
+
+#. Menu option to share feedback about a result
+msgctxt "Image result context menu"
+msgid "Share feedback about this image"
+msgstr ""
+
+#. Menu option to share feedback about a result
+msgctxt "Organic result context menu"
+msgid "Share feedback about this image"
+msgstr ""
+
+#. Menu option to share feedback about a result
+msgctxt "Organic result context menu"
+msgid "Share feedback about this site"
+msgstr ""
+
+#. Menu option to share feedback about a result
+msgctxt "Video result context menu"
+msgid "Share feedback about this video"
+msgstr ""
+
+#. Link to a feedback form.
+msgctxt "feedback form"
+msgid "Share feedback for these results."
+msgstr ""
+
+#. Link to a feedback form.
+msgctxt "feedback form"
+msgid "Share feedback for this result."
+msgstr "Gib uns ein Feedback zu diesem Resultat"
+
+#. Label for a text field where users can enter feedback.
+msgctxt "feedback form"
+msgid "Share feedback on your search results."
+msgstr "Gib uns ein Feedback zu deinen Suchresultaten"
+
+msgctxt "feedback form"
+msgid "Share negative feedback"
+msgstr ""
+
+#. Checkbox label for sharing the page URL with feedback
+msgctxt "feedback form"
+msgid "Share page URL"
+msgstr ""
+
+msgctxt "feedback form"
+msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share this conversation with DuckDuckGo"
+msgstr ""
+
+#. Label for a toggle; when enabled, the user agrees to include their message and the assistant reply with feedback sent to DuckDuckGo.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form"
+msgid "Share your prompt and chat response with DuckDuckGo"
+msgstr ""
+
+#. Variant of the share toggle label that makes sharing mandatory when reporting harmful or illegal content.
+msgctxt ""
+"Label beside the share-content switch on the Duck.ai response feedback form "
+"when the user has selected Harmful or Illegal as the feedback reason"
+msgid ""
+"Share your prompt and chat response with DuckDuckGo (required for illegal "
+"and harmful report)"
+msgstr ""
+
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Share your thoughts on the search box."
+msgstr ""
+
+#. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no logs of activity; emphasizes that the VPN is easy to set up and toggle.
+msgctxt "DuckDuckGo VPN instant answer"
+msgid ""
+"Shield your online activity with our no-log, fast VPN. Simple to set up and "
+"easy to turn on and off anytime."
+msgstr ""
+
+#. Keyboard shortcut for Duck.ai
+msgctxt "Search form"
+msgid "Shift+Enter"
+msgstr ""
+
+#. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
+msgctxt "merchant promotion product ad extension"
+msgid "Shop"
+msgstr ""
+
+#. Label above shopping search results.
+msgid "Shopping"
+msgstr "Einkaufen"
+
+#. Title for the section that showcases the product results for a certain query, ex. Shopping for <b>shoes</b>
+msgid "Shopping for %s%s%s"
+msgstr ""
+
+#. Label for the option prompting the AI assistant to use short responses.
+msgctxt "Length option label for Short"
+msgid "Short"
+msgstr ""
+
+#. Filters the duration of videos in search results.
+msgctxt "video-duration"
+msgid "Short"
+msgstr "Kurz"
+
+#. Description of an autocomplete function in the search bar.
+msgid "Shortcuts to other sites to search off DuckDuckGo"
+msgstr "Verknüpfungen um auf anderen Seiten wie DuckDuckGo zu suchen"
+
+#. Description of an autocomplete function in the search bar.
+msgid "Shortcuts to search results on other sites"
+msgstr ""
+
+#. Label for the option prompting the AI assistant to use shortest responses.
+msgctxt "Length option label for Shortest"
+msgid "Shortest"
+msgstr ""
+
+#. Soccer match stats
+msgctxt "Sports module"
+msgid "Shots"
+msgstr ""
+
+#. Soccer match stats
+msgctxt "Sports module"
+msgid "Shots on Target"
+msgstr ""
+
+#. A message that asks whether the user wants to enable Assist more frequently. Assist is a feature that generates answers to search queries based on relevant content found on the web. The full sentence would be: Show Never | Sometimes | Often, where the user picks one of the options.
+msgctxt "duckassist"
+msgid "Show"
+msgstr ""
+
+#. It's a verb on a button.
+msgctxt "visible"
+msgid "Show"
+msgstr ""
+
+#. button to show X>1 more options in a list
+msgctxt "shopping_vertical"
+msgid "Show %s more"
+msgstr ""
+
+#. button to show 1 more option in a list
+msgctxt "shopping_vertical"
+msgid "Show 1 more"
+msgstr ""
+
+#. Accessible label for the compact Search Assist button. %s is replaced with the user's search query. For example: 'Show AI answer for How to wash a car'.
+msgid "Show AI answer for %s"
+msgstr ""
+
+#. Button that displays more information about saved settings.
+msgctxt "setting"
+msgid "Show Bookmarklet and Settings Data"
+msgstr "Lesezeichen und Einstellungen anzeigen"
+
+#. Button that shows more details.
+msgctxt "mobile expanded map"
+msgid "Show Detail"
+msgstr "Details anzeigen"
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
+
+msgctxt "settings"
+msgid "Show DuckAssist <sup>BETA</sup>"
+msgstr ""
+
+#. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
+msgctxt "duckassist_optin"
+msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
+msgstr ""
+
+#. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
+msgctxt "Button label for showing more search result links in Duck.ai"
+msgid "Show Less"
+msgstr ""
+
+#. Button that shows less content.
+msgctxt "expand_text"
+msgid "Show Less"
+msgstr "Weniger anzeigen"
+
+#. Button that allows user to collapse list of rates and just show up to 4 rates and hide the rest
+msgctxt "Single Place Hotel Offers Module"
+msgid "Show Less Rates"
+msgstr ""
+
+#. Button that displays a list of search results
+msgctxt "mobile expanded map"
+msgid "Show List"
+msgstr "Liste anzeigen"
+
+#. Text for the button that shows more of an answer from duckassist
+msgid "Show More"
+msgstr ""
+
+#. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
+msgctxt "Button label for showing more search result links in Duck.ai"
+msgid "Show More"
+msgstr ""
+
+#. Title for button that shows collapsed content to the user.
+msgctxt "Expands content in a message"
+msgid "Show More"
+msgstr ""
+
+#. Button that shows more content.
+msgctxt "expand_text"
+msgid "Show More"
+msgstr "Mehr anzeigen"
+
+msgctxt "load_more"
+msgid "Show More"
+msgstr "Mehr anzeigen"
+
+#. Button that allows user to expand list of offers and show more than the displayed ones by default
+msgctxt "Single Place Hotel Offers Module"
+msgid "Show More Rates"
+msgstr ""
+
+msgctxt "new tab page"
+msgid "Show Most-Visited Sites"
+msgstr ""
+
+#. A button that shows a passphrase the user has typed.
+msgctxt "settings"
+msgid "Show Passphrase"
+msgstr ""
+
+#. Label for the switch to temporarily disable site exclusion
+msgctxt "Organic result context menu"
+msgid "Show Results"
+msgstr ""
+
+#. Shows details of a step-by-step navigation route
+msgctxt "directions"
+msgid "Show Steps"
+msgstr ""
+
+#. A button that loads search results.
+msgctxt "noresults"
+msgid "Show Web Results"
+msgstr ""
+
+#. Button in the Maps exclusion banner that temporarily shows all place information (including from blocked sites like Yelp/TripAdvisor) for the current session. Clicking this reveals the hidden ratings, reviews, and details.
+msgctxt "Exclusion message disable button for maps vertical"
+msgid "Show all information"
+msgstr ""
+
+#. Text for the toggle that shows all AI assistant instructions.
+msgctxt "Label for showing all instructions toggle"
+msgid "Show all instructions"
+msgstr ""
+
+#. Label for the button to disable the site exclusion feature
+msgctxt "Exclusion message disable button"
+msgid "Show all results"
+msgstr ""
+
+#. A button to clear the currently applied site filter.
+msgctxt "Site filter message"
+msgid "Show all results"
+msgstr ""
+
+#. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
+msgctxt "duckassist_optin"
+msgid "Show answers more often. (You can also %sturn them off%s.)"
+msgstr ""
+
+#. Accessible label for the button that reveals a popover listing multiple citation sources in Duck.ai chat responses.
+msgctxt ""
+"Aria label for the inline citation button that opens a list of citations"
+msgid "Show citations"
+msgstr ""
+
+#. Button that shows search results on a map.
+msgctxt "directions"
+msgid "Show map"
+msgstr "Karte anzeigen"
+
+#. Title for button that shows collapsed content to the user.
+msgctxt "Expands content in a message"
+msgid "Show more"
+msgstr ""
+
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
+#. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
+msgctxt ""
+"Accessible label for the next-page chevron button in the chat suggestions "
+"panel"
+msgid "Show next suggestions"
+msgstr ""
+
+#. Screen-reader label for the left chevron button that navigates to the previous page of suggested chat prompts.
+msgctxt ""
+"Accessible label for the previous-page chevron button in the chat "
+"suggestions panel"
+msgid "Show previous suggestions"
+msgstr ""
+
+#. Tooltip text for the button that shows the model's reasoning steps and how long they took.
+msgctxt "Tooltip for reasoning duration button"
+msgid "Show reasoning"
+msgstr ""
+
+#. The aria-label text for a toggle button that shows/hides the detailed feed
+msgid "Show recent activity"
+msgstr ""
+
+#. Tooltip text that appears when hovering over the desktop sidebar collapse button, while sidebar is collapsed.
+msgctxt ""
+"Tooltip label for the desktop sidebar collapse button, when the sidebar is "
+"collapsed"
+msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
+msgstr ""
+
+#. Tooltip/label for the button to show the voice chat transcript.
+msgctxt "voice chat"
+msgid "Show transcript"
+msgstr ""
+
+#. Filters the duration of videos in search results.
+msgctxt "video-duration"
+msgid "Show videos of any length"
+msgstr "Zeige alle Videos an, egal wie lang sie sind."
+
+#. Annotates a table that is currently showing N items out of a total set of size M. i.e. Showing 10 of 50
+msgid "Showing %s of %s"
+msgstr ""
+
+msgctxt ""
+"Annoataion on an expandable table that is currently showing N items out of a "
+"total set of size M"
+msgid "Showing %s of %s"
+msgstr ""
+
+#. Label for the switch to show all results
+msgctxt "Organic result context menu"
+msgid "Showing all results."
+msgstr ""
+
+msgid "Showing results excluding"
+msgstr "Zeige Ergebnisse ohne"
+
+msgid "Showing results from"
+msgstr "Resultat anzeigen von"
+
+msgid "Showing results without %s."
+msgstr "Zeigt Resultate ohne %s."
+
+#. Instant Answer Tab Name
+msgid "Shows"
+msgstr "Zeige"
+
+msgctxt "settings"
+msgid ""
+"Shows a reminder that searches on DuckDuckGo are always private. Turning "
+"this off hides the reminder and never affects search privacy."
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Shows a reminder that searches on DuckDuckGo are always protected. Turning "
+"this off hides the reminder and never affects search protection."
+msgstr ""
+
+msgctxt "settings"
+msgid "Shows horizontal lines at result page breaks"
+msgstr ""
+
+msgctxt "settings"
+msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
+msgstr ""
+
+#. An option that shows AI-assisted answers more frequently.
+msgctxt "duckassist"
+msgid "Shows more frequently"
+msgstr ""
+
+msgctxt "settings"
+msgid "Shows most-visited links on new tab page"
+msgstr ""
+
+msgctxt "settings"
+msgid "Shows occasional reminders to add DuckDuckGo to your browser"
+msgstr ""
+
+msgctxt "settings"
+msgid "Shows occasional reminders to add DuckDuckGo to your devices"
+msgstr ""
+
+msgctxt "settings"
+msgid ""
+"Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
+msgstr ""
+
+msgctxt "settings"
+msgid "Shows page numbers at result page breaks"
+msgstr ""
+
+msgctxt "settings"
+msgid "Shows sign-up form for the DuckDuckGo privacy newsletters"
+msgstr ""
+
+#. http://i.imgur.com/94erFcS.png
+msgctxt "settings"
+msgid "Shows suggestions under the search box as you type"
+msgstr ""
+
+msgctxt "settings"
+msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
+msgstr ""
+
+msgctxt "settings"
+msgid "Shows the search button background"
+msgstr "Zeige den Suchknopf-Hintergrund"
+
+msgctxt "settings"
+msgid "Shows welcome message on top of the search results page"
+msgstr ""
+
+msgctxt "settings"
+msgid "Shows welcome message to EU Android preference menu users"
+msgstr ""
+
+#. An option that shows AI-assisted answers sometimes.
+msgctxt "duckassist"
+msgid "Shows when highly relevant"
+msgstr ""
+
+msgid "Sierra Leone"
+msgstr ""
+
+#. Used in the desktop electron app to take a user to the DuckDuckGo sign-in flow. Replaces 'I already have a subscription' wording, since the app does not host purchases.
+msgctxt ""
+"Text for the link that lets a user sign in to DuckDuckGo (electron desktop "
+"app variant)"
+msgid "Sign in to DuckDuckGo"
+msgstr ""
+
+#. Header on a column that displays the silver medal count for the country in the Olympics
+msgid "Silver Medals"
+msgstr ""
+
+msgctxt ""
+"Header on a column that displays the silver medal count for the country in "
+"the Olympics"
+msgid "Silver Medals"
+msgstr ""
+
+#. Used in 0-click box for product results, e.g. <a href="https://duckduckgo.com/?q=9780061353246">https://duckduckgo.com/?q=9780061353246</a>
+msgid "Similar"
+msgstr "Ähnlich"
+
+msgid "Singapore"
+msgstr "Singapur"
+
+#. Header that appears when a site is blocked successfully
+msgctxt "Organic result context menu"
+msgid "Site Blocked Successfully"
+msgstr ""
+
+#. Refers to a feature of the DuckDuckGo web browser, which uses encrypted connections to websites to protect user privacy.
+msgid "Site Encryption"
+msgstr ""
+
+#. Subheading label for site feedback
+msgctxt "Organic result context menu"
+msgid "Site Feedback:"
+msgstr ""
+
+msgctxt "settings"
+msgid "Site Icons"
+msgstr "Seitenicons"
+
+msgctxt "settings"
+msgid "Site Names"
+msgstr ""
+
+#. A message saying that site filters are not currently working
+msgctxt "Site filter message"
+msgid "Site search is temporarily unavailable. We are working on a fix."
+msgstr ""
+
+msgctxt "settings"
+msgid "Sites you block will be hidden from all your search results"
+msgstr ""
+
+#. Cricket scorecard: sixes full name (tooltip)
+msgctxt "Sports module"
+msgid "Sixes"
+msgstr ""
+
+#. List item indicating that a size filter is currently active for the search
+msgctxt "noresults"
+msgid "Size"
+msgstr ""
+
+#. Label indicating the size of a downloadable file. For example: 'Size: 5MB'
+msgid "Size:"
+msgstr "Grösse:"
+
+#. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
+msgctxt "Weather IA"
+msgid "Sleet"
+msgstr ""
+
+#. The name of the Slovak language
+msgctxt "language_name"
+msgid "Slovak"
+msgstr ""
+
+msgid "Slovakia"
+msgstr "Slowakei"
+
+msgid "Slovenia"
+msgstr "Slovenien"
+
+#. The name of the Slovenian language
+msgctxt "language_name"
+msgid "Slovenian"
+msgstr ""
+
+#. http://i.imgur.com/JDDRzkk.png
+msgctxt "settingsvalue"
+msgid "Small"
+msgstr "Klein"
+
+#. Filters the size of images in search results.
+msgctxt "size"
+msgid "Small"
+msgstr "Klein"
+
+#. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
+msgctxt "Weather IA"
+msgid "Smoky"
+msgstr ""
+
+#. This is the name of a user setting
+msgctxt "settings"
+msgid "Snippet Color"
+msgstr ""
+
+#. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
+msgctxt "Weather IA"
+msgid "Snow"
+msgstr ""
+
+msgid "Social"
+msgstr "Sozial"
+
+#. Label for the option prompting the AI assistant to adopt a role of a social media copywriter in its responses.
+msgctxt "Assistant role option label for Social media copywriter"
+msgid "Social media copywriter"
+msgstr ""
+
+msgid "Software"
+msgstr "Software "
+
+#. One-line description rendered beneath the frontier / higher-cost model in the Recommended group, warning that it consumes usage limits more quickly.
+msgctxt ""
+"Short descriptor under the higher-cost recommended model in the model picker "
+"dropdown"
+msgid "Solid but hits limits sooner"
+msgstr ""
+
+#. One-line description rendered beneath the frontier / higher-cost model in the Recommended group, warning that it consumes usage limits more quickly.
+msgctxt ""
+"Short descriptor under the higher-cost recommended model in the model picker "
+"dropdown"
+msgid "Solid but uses limits faster"
+msgstr ""
+
+msgid "Solomon Islands"
+msgstr ""
+
+#. Text for a promotional card that encourages users to try the reasoning mode on complex problems which thinks longer to hopefully provide a more accurate answer.
+msgctxt "Promotional text for reasoning mode"
+msgid "Solve complex problems with reasoning mode!"
+msgstr ""
+
+#. Text for a promotional card that encourages users to try the reasoning mode on complex problems which thinks longer to hopefully provide a more accurate answer.
+msgctxt "Promotional text for reasoning mode"
+msgid "Solve complex problems with the new reasoning mode!"
+msgstr ""
+
+#. Text for a promotional card that encourages users to try the reasoning mode on complex problems which thinks longer to hopefully provide a more accurate answer.
+msgctxt "Promotional text for reasoning mode"
+msgid "Solve complex problems with the reasoning mode!"
+msgstr ""
+
+msgid "Somalia"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Something else"
+msgstr ""
+
+#. Error modal title.
+msgctxt "duckai_migration"
+msgid "Something went wrong"
+msgstr ""
+
+#. Error message indicating that the user's settings weren't able to be saved.
+msgctxt "cloudsave"
+msgid "Something went wrong saving to the server, please try again."
+msgstr ""
+"Beim Speichern auf dem Server ist etwas schief gelaufen, bitte versuche es "
+"erneut."
+
+#. Body copy displayed under the Set Up Now button when the sync setup call fails.
+msgctxt "Generic error shown when sync setup fails"
+msgid "Something went wrong while enabling Sync & Backup. Please try again."
+msgstr ""
+
+#. Displayed when the voice chat session ends with an unknown error.
+msgctxt "voice chat error"
+msgid "Something went wrong, please try again later."
+msgstr ""
+
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
+#. Error message shown when the user tries to activate their subscription but the process fails.
+msgctxt "Error message when subscription activation fails"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
+#. The title of the 'Sometimes' option in the assist settings modal.
+msgctxt "duckassist"
+msgid "Sometimes"
+msgstr ""
+
+#. Generic error message shown when the image generation model cannot process the user's request.
+msgctxt "Error message from the image generation model"
+msgid "Sorry I can't help, please describe your image in a different way."
+msgstr ""
+
+#. Error message for the duckassist instant answer (based on generative AI)
+msgid "Sorry, Assist is currently unavailable."
+msgstr ""
+
+#. Error message for the duckassist instant answer (based on generative AI)
+msgid "Sorry, DuckAssist is currently unavailable."
+msgstr ""
+
+#. Error message for the duckassist instant answer (based on generative AI)
+msgid "Sorry, Search Assist is currently unavailable."
+msgstr ""
+
+#. Error message for explore more questions when a non-retryable error occurs (server, invalid response, etc.)
+msgid "Sorry, an unexpected error occurred."
+msgstr ""
+
+#. Error message for the duckassist instant answer (based on generative AI)
+msgid "Sorry, no relevant information was found in our search."
+msgstr ""
+
+#. Indicates that there were no search results for a user's search.
+msgid "Sorry, no results here."
+msgstr "Entschuldigung, keine Resultate gefunden."
+
+#. Error message displayed when the browser fails to decode or process an uploaded image (e.g., corrupted file, empty data, unsupported encoding)
+msgctxt "Error message when an uploaded image cannot be decoded or processed"
+msgid ""
+"Sorry, the uploaded image couldn't be processed. Please try a different "
+"image or format."
+msgstr ""
+
+#. Body copy shown when a scanned or pasted pairing payload fails schema validation.
+msgctxt "Description for the wrong code error screen"
+msgid ""
+"Sorry, this code is invalid. Please make sure the correct code was entered "
+"or scanned."
+msgstr ""
+
+#. Error message for the duckassist instant answer (based on generative AI)
+msgid ""
+"Sorry, we couldn't generate a richer answer. You can try asking Duck.ai."
+msgstr ""
+
+#. Inform the users that "something" went wrong and that they could try to refresh the page to resolve the error. Placeholders are for markup, please ignore.
+msgctxt "noresults"
+msgid ""
+"Sorry, we ran into an error displaying these results. %sClick here%s to try "
+"again."
+msgstr ""
+
+#. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
+msgctxt "feedback form"
+msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
+msgstr ""
+
+#. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
+msgctxt ""
+"Error message header when text or an uploaded image will not be processed"
+msgid "Sorry..."
+msgstr ""
+
+#. Title for a dialog shown in the shopping experience (https://duckduckgo.com/nike?iax=shopping&ia=shopping). The dialog lets users sort results by price and refine their search by size, color, etc.
+msgctxt "shopping_vertical"
+msgid "Sort and Filter"
+msgstr ""
+
+#. Label for the sorting options on a shopping interface. The options will be translated separately and will be presented as a dropdown menu.
+msgctxt "shopping_vertical"
+msgid "Sort by"
+msgstr ""
+
+#. The source of a piece of information, e.g. Wikipedia
+msgctxt "Q&A module attribution"
+msgid "Source"
+msgstr ""
+
+#. Short description shown below the 'Web Search' label in the Tools dropdown.
+msgctxt "Subtitle for the Web Search tool entry in the Tools dropdown menu"
+msgid "Source answers from the web"
+msgstr ""
+
+#. Feedback option when AI response has a trustworthy source
+msgid "Source is not trustworthy"
+msgstr ""
+
+#. Feedback option when AI response has a trustworthy source
+msgid "Source is trustworthy"
+msgstr ""
+
+#. Text of a tooltip displayed when the user has cleared source text
+msgctxt "translations_module"
+msgid "Source text cleared"
+msgstr ""
+
+#. Displayed when the user attempts to summarize a text selection that exceeds the maximum message size.
+msgctxt "Error message for summary selection input limit"
+msgid ""
+"Source text is too long to summarize. Try again with a shorter selection."
+msgstr ""
+
+#. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
+msgid "Source:"
+msgstr "Quelle:"
+
+#. Instant Answer attribution to original data source e.g. 'Source: Wikipedia'
+msgctxt "Instant Answer attribution"
+msgid "Source: %s"
+msgstr ""
+
+#. Instant Answer attribution to original data source e.g. 'Source: Wikipedia'
+msgctxt "Instant Answer attribution"
+msgid "Source: %s%s%s"
+msgstr ""
+
+#. Attribution text for the stocks module
+msgctxt "Stocks module"
+msgid "Source: IEX Cloud"
+msgstr ""
+
+#. Attribution text for the stocks module
+msgctxt "Stocks module"
+msgid "Source: Refinitiv"
+msgstr ""
+
+msgctxt "Sports module"
+msgid "South"
+msgstr ""
+
+msgid "South Africa"
+msgstr "Südafrika"
+
+msgid "South Korea"
+msgstr ""
+
+msgid "South Sudan"
+msgstr ""
+
+msgid "Spain"
+msgstr "Spanien"
+
+msgid "Spain (ca)"
+msgstr "Spanien"
+
+msgid "Spain (es)"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Spam"
+msgstr ""
+
+#. The name of the Spanish language
+msgctxt "language_name"
+msgid "Spanish"
+msgstr ""
+
+#. Description for the voice chat setting in the settings modal.
+msgctxt "voice chat settings"
+msgid "Speak with Duck.ai using your voice."
+msgstr ""
+
+#. Label for the voice chat character when the AI is speaking/responding.
+msgctxt "voice chat"
+msgid "Speaking"
+msgstr ""
+
+#. A title of a page that encourages users to share DuckDuckGo with their friends. 'Spread' in this case means 'share'.
+msgctxt "showcase_spread"
+msgid "Spread DuckDuckGo"
+msgstr "Verbreite DuckDuckGo"
+
+#. Filters the shape of images in search results.
+msgctxt "image-layout"
+msgid "Square"
+msgstr "Quadrat"
+
+msgid "Sri Lanka"
+msgstr ""
+
+#. Title for modal letting you choose which stage of the competition you wish to view, e.g. Round of 16, Semi-finals, etc in the soccer World Cup
+msgctxt "Sports module"
+msgid "Stages"
+msgstr ""
+
+#. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
+msgctxt "video-resolution"
+msgid "Standard definition"
+msgstr ""
+
+#. Title of a tab that displays a list of standings for a sports league
+msgctxt "Sports module"
+msgid "Standings"
+msgstr ""
+
+#. Secondary button to start fresh.
+msgctxt "duckai_migration"
+msgid "Start Fresh"
+msgstr ""
+
+#. Text displayed on the primary button in the modal that starts a new chat when clicked.
+msgctxt "Modal primary button text"
+msgid "Start New Chat"
+msgstr ""
+
+#. Button label shown with a 6-hour Duck.ai usage limit error. Clicking it opts in to continue chatting against the daily limit.
+msgctxt "Action button for fixed-window Duck.ai usage limit"
+msgid "Start Using Daily Limit"
+msgstr ""
+
+#. Button label shown with a weekly Duck.ai usage limit error. Clicking it opts in to continue chatting against the monthly limit.
+msgctxt "Action button for fixed-window Duck.ai usage limit"
+msgid "Start Using Monthly Limit"
+msgstr ""
+
+#. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
+msgctxt "Action button for fixed-window Duck.ai usage limit"
+msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
+msgstr ""
+
+#. A prompt to start a new web search.
+msgid "Start searching!"
+msgstr "Beginne zu suchen!"
+
+#. Alternative text of a button that adds an image to the current AI chat message being composed.
+msgctxt "Add an image to be uploaded to the AI chat conversation"
+msgid "Start with an image"
+msgstr ""
+
+#. Warning that starting fresh deletes conversations.
+msgctxt "duckai_migration"
+msgid "Starting fresh will delete all your past conversations."
+msgstr ""
+
+#. Footnote warning that starting fresh deletes conversations.
+msgctxt "duckai_migration"
+msgid "Starting fresh will delete your chat history."
+msgstr ""
+
+#. Initial loading message shown while the image generation process starts.
+msgctxt "Loading state message"
+msgid "Starting up"
+msgstr ""
+
+#. Label for statistics tab
+msgctxt "Covid 19 module"
+msgid "Statistics"
+msgstr ""
+
+#. Section label preceding the Enabled/Paused indicator.
+msgctxt "Label for the sync status row inside the Manage modal"
+msgid "Status"
+msgstr ""
+
+#. The label shown below the dax logo on the 3rd party app picker when the user wishes to stay on DuckDuckGo and use our mapping service for directions
+msgctxt "Third party map app picker feedback dialog"
+msgid "Stay on DuckDuckGo"
+msgstr ""
+
+#. Prompt to subscribe to a newsletter.
+msgctxt "SERP footer content"
+msgid "Stay protected and informed with our privacy newsletter."
+msgstr ""
+
+#. Prompt to subscribe to a newsletter.
+msgctxt "SERP footer content"
+msgid "Stay protected and informed with our privacy newsletters."
+msgstr "Bleibe geschützt und informiert mit unseren Datenschutz-Newslettern."
+
+#. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
+msgctxt "showcase_newsletter"
+msgid "Stay protected and informed with our privacy newsletters."
+msgstr "Bleibe geschützt und informiert mit unseren Datenschutz-Newslettern."
+
+#. Loading message shown when image generation is taking longer than usual.
+msgctxt "Loading state message"
+msgid "Still working on it"
+msgstr ""
+
+#. Instant Answer tab name - eg. https://duckduckgo.com/?q=Energy+Transfer+Equity&ia=stock
+msgid "Stock"
+msgstr "Aktien"
+
+#. Text for the button that shows more of an answer from duckassist when the answer is being streamed
+msgid "Stop"
+msgstr ""
+
+#. Text in a tooltip of a button that stops an ongoing streaming response from the AI chat.
+msgctxt "Stop ongoing streaming response from AI chat"
+msgid "Stop"
+msgstr ""
+
+#. Accessible label for the microphone button while recording is active.
+msgid "Stop dictation"
+msgstr ""
+
+#. Text in a button that stops an ongoing streaming that is generating a response from the AI chat.
+msgctxt "Stop ongoing streaming response from AI chat"
+msgid "Stop generating"
+msgstr ""
+
+msgctxt "homepage ATB modal"
+msgid "Stop hidden trackers lurking on other websites."
+msgstr ""
+
+msgctxt "homepage ATB modal"
+msgid "Stop most hidden trackers lurking on other websites."
+msgstr ""
+
+msgctxt "settings"
+msgid "Stores the previous region that was set"
+msgstr "Speichert die vorher ausgewählte Region"
+
+#. Label for the option prompting the AI assistant to adopt a role of a storyteller in its responses.
+msgctxt "Assistant role option label for Storyteller"
+msgid "Storyteller"
+msgstr ""
+
+#. A setting for the safe search filter that removes the most results.
+msgctxt "safe search"
+msgid "Strict"
+msgstr "Streng"
+
+msgctxt "settingsvalue"
+msgid "Strict"
+msgstr "Streng"
+
+#. Cricket scorecard: strike rate full name (tooltip)
+msgctxt "Sports module"
+msgid "Strike Rate"
+msgstr ""
+
+#. Indicates the current win or loss streak of a team
+msgctxt "Sports module"
+msgid "Strk"
+msgstr ""
+
+#. Golf leaderboard column: total strokes
+msgctxt "Sports module"
+msgid "Strokes"
+msgstr ""
+
+#. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
+msgctxt "Weather IA"
+msgid "Strong Storms"
+msgstr ""
+
+#. Label for the option prompting the AI assistant to treat the user as if they are a student.
+msgctxt "User role option for student role"
+msgid "Student"
+msgstr ""
+
+#. Button that submits feedback.
+msgid "Submit"
+msgstr "Abschicken"
+
+#. Label showing what year a subreddit (discussion hosted on reddit.com) was created. To be displayed on a card about that subreddit. e.g. "Subreddit since 2019".
+msgctxt "Discussions IA"
+msgid "Subreddit since %s"
+msgstr ""
+
+#. Label for the button that opens the subscription modal.
+msgctxt "Subscribe button label"
+msgid "Subscribe"
+msgstr ""
+
+#. Button that subscribes the user to an email newsletter.
+msgctxt "email newsletter"
+msgid "Subscribe"
+msgstr "Abonnieren"
+
+#. Text for the button that takes the user to the sign up page to get a DuckDuckGo subscription.
+msgctxt "Text for the subscribe button"
+msgid "Subscribe to DuckDuckGo"
+msgstr ""
+
+#. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
+msgctxt "Description prompting subscription for higher limits"
+msgid ""
+"Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
+"later to create more images."
+msgstr ""
+
+#. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
+msgctxt "Description prompting subscription for higher limits"
+msgid "Subscribe to unlock higher Duck.ai limits"
+msgstr ""
+
+#. Heading above the group of tier-locked models in the model picker dropdown, when the user is on the Free tier and could become a subscriber.
+msgctxt ""
+"Section heading inside the model picker dropdown for models gated behind a "
+"paid Duck.ai subscription, shown to Free-tier users"
+msgid "Subscriber exclusive."
+msgstr ""
+
+#. A link to the DuckDuckGo Subscription product page (https://duckduckgo.com/pro/)
+msgctxt "SERP footer content"
+msgid "Subscription"
+msgstr ""
+
+#. Indicates that this streaming service requires a subscription
+msgctxt "Where to watch instant answer"
+msgid "Subscription"
+msgstr ""
+
+#. Text for the secondary button that links to subscription FAQ page in the post-upgrade success modal.
+msgctxt "Post-upgrade success modal FAQ link"
+msgid "Subscription FAQs"
+msgstr ""
+
+#. Generic success modal title.
+msgctxt "duckai_migration"
+msgid "Success!"
+msgstr ""
+
+msgid "Sudan"
+msgstr ""
+
+#. Button that suggests a random passphrase for the user.
+msgctxt "settings"
+msgid "Suggest Different Passphrase"
+msgstr ""
+
+#. Button that suggests a random passphrase for the user.
+msgctxt "settings"
+msgid "Suggest a Passphrase"
+msgstr ""
+
+#. A feedback option where the user can suggest a feature
+msgctxt "Feedback prompt"
+msgid "Suggest a feature"
+msgstr ""
+
+#. Text for a prompt suggestion for suggesting a phrase to write on a get-well card for someone recovering from a surgery.
+msgctxt "Full sentence for composing a card"
+msgid ""
+"Suggest a phrase to write on a get-well card for someone recovering from a "
+"surgery?"
+msgstr ""
+
+#. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
+msgctxt "Brief for suggesting a blog post title"
+msgid "Suggest a title for a blog post"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest related articles or topics worth exploring next."
+msgstr ""
+
+#. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Suggest related articles to explore"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Find me alternatives" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Suggest some alternatives to this product."
+msgstr ""
+
+#. Label for suggested alternative search terms, when the user is suspected of having made a typo or entered a search term incorrectly.
+msgctxt "directions"
+msgid "Suggestions:"
+msgstr "Vorschläge:"
+
+msgctxt "noresults"
+msgid "Suggestions:"
+msgstr "Vorschläge:"
+
+#. Page-suggestion chip label "Sum up the reviews", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Sum up the reviews"
+msgstr ""
+
+#. A short title for the a message asking the AI to summarize a text.
+msgctxt "Title for the summarize message"
+msgid "Summarize"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize the Q&As", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize the Q&As"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the background and notable work of this person."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the key details of this event."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize the Q&As" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize the questions and answers on this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize their background", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize their background"
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this book", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this book"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this book" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this book."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this discussion", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this discussion"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this discussion" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this discussion thread."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this page" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this page."
+msgstr ""
+
+#. Page-suggestion chip label "Summarize this video", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Summarize this video"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Summarize this video" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize this video."
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Sum up the reviews" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Summarize what the reviews say."
+msgstr ""
+
+#. Label for the option prompting the AI assistant to adopt a role of a summarizer in its responses.
+msgctxt "Assistant role option label for Summarizer"
+msgid "Summarizer"
+msgstr ""
+
+#. Label for summary tab
+msgctxt "Covid 19 module"
+msgid "Summary"
+msgstr ""
+
+#. Weekday abbreviation (short for 'Sunday')
+msgctxt "maps_places"
+msgid "Sun"
+msgstr ""
+
+#. Weekday in plural form
+msgctxt "maps_places"
+msgid "Sundays"
+msgstr ""
+
+#. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
+msgctxt "Weather IA"
+msgid "Sunflurries"
+msgstr ""
+
+#. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
+msgctxt "Weather IA"
+msgid "Sunshowers"
+msgstr ""
+
+#. http://i.imgur.com/FczLkAL.png
+msgctxt "settingsvalue"
+msgid "Super Wide"
+msgstr "Extra breit"
+
+#. http://i.imgur.com/hAG8srI.png
+msgctxt "width"
+msgid "Super wide"
+msgstr "Super breit"
+
+msgid "Support"
+msgstr "Unterstützung"
+
+msgid "Suriname"
+msgstr ""
+
+#. Indicator that a game has been suspended
+msgctxt "Sports module"
+msgid "Suspended"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Suspicious ad"
+msgstr ""
+
+#. The name of the Swahili language
+msgctxt "language_name"
+msgid "Swahili"
+msgstr ""
+
+#. A tooltip that describes the swap currencies button in the currency converter. Example: https://duckduckgo.com/?q=5+gbp+to+usd&ia=currency.
+msgctxt "Currency module"
+msgid "Swap currencies"
+msgstr ""
+
+#. Descriptive text for a button that allows users to swap origin and translated languages
+msgctxt "translations_module"
+msgid "Swap languages"
+msgstr ""
+
+#. A tooltip that describes the swap units button in the unit converter. Example: https://duckduckgo.com/?q=5+meters+to+cm&ia=answer
+msgctxt "Conversions module"
+msgid "Swap units"
+msgstr ""
+
+msgid "Sweden"
+msgstr "Schweden"
+
+#. The name of the Swedish language
+msgctxt "language_name"
+msgid "Swedish"
+msgstr ""
+
+#. Text for the button that allows the user to switch to a different model.
+msgctxt "Button to switch to a different model"
+msgid "Switch Model"
+msgstr ""
+
+#. Button text that opens a menu of free/degraded models from the fixed-window limit error.
+msgctxt "Error message action for fixed-window Duck.ai usage limit."
+msgid "Switch Model"
+msgstr ""
+
+#. In the context of an AI Chat, tooltip text for the button that allows the user to switch to a different AI model.
+msgctxt "AI Chat - Tooltip for switch model chat action"
+msgid "Switch model"
+msgstr ""
+
+#. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
+msgctxt "Error message for fixed-window Duck.ai usage limit."
+msgid "Switch this chat to a free model or wait until %s."
+msgstr ""
+
+#. Button that switches the conversation to the second-opinion model. %s is the model name.
+msgctxt "Switch-model button label in the second-opinion card"
+msgid "Switch to %s"
+msgstr ""
+
+#. Call to action in the Duck.ai usage limit banner. %s is the recommended lower-cost AI model name, e.g., 'Sonnet 4.5'.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Switch to %s"
+msgstr ""
+
+#. Prompt title asking the user if they want to delegate image generation to a specific model. %s is the image model display name.
+msgctxt "DuckChat image generation delegation prompt"
+msgid "Switch to %s to generate images?"
+msgstr ""
+
+msgctxt "homepage onboarding"
+msgid "Switch to DuckDuckGo and take back your privacy!"
+msgstr "Wechsle zu DuckDuckGo und hole dir Deine Privatsphäre zurück!"
+
+#. Prompt for users to switch to the DuckDuckGo browser by downloading it.
+msgctxt "SERP footer content"
+msgid "Switch to Our Browser"
+msgstr ""
+
+#. Heading of a card that promotes installing the DuckDuckGo desktop browser.
+msgctxt "new tab page"
+msgid "Switch to Our Browser"
+msgstr ""
+
+#. Button text that opens a menu of free/degraded models after the advanced-model usage limit has been reached.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Switch to a Free Model"
+msgstr ""
+
+#. Title for the Duck.ai usage limit banner menu listing lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Switch to a more efficient model"
+msgstr ""
+
+#. Text prompting  users to switch their current search engine to the DuckDuckGo private search engine.
+msgid "Switch to the search engine that doesn't track you. Ever."
+msgstr "Wechsle zur Suchmaschine, welche Dich nicht verfolgt. Niemals."
+
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
+#. Shown in the second-opinion card after the user switches to its model. %s is the model name.
+msgctxt "Confirmation label"
+msgid "Switched to %s"
+msgstr ""
+
+#. Warning text shown in the model switch dropdown when the user is currently using an encrypted model. Warns that the new model will not have zero provider visibility.
+msgctxt "AI Chat warning when switching from an encrypted model"
+msgid ""
+"Switching will send your chat to a model without zero provider visibility"
+msgstr ""
+
+msgid "Switzerland"
+msgstr ""
+
+msgid "Switzerland (de)"
+msgstr "Schweiz (D)"
+
+msgid "Switzerland (fr)"
+msgstr "Schweiz (F)"
+
+msgid "Switzerland (it)"
+msgstr "Schweiz (I)"
+
+#. Label for symptoms tab
+msgctxt "Covid 19 module"
+msgid "Symptoms"
+msgstr ""
+
+#. Title for the sync setting shown to users inside the DuckDuckGo native browser.
+msgctxt ""
+"Label for encrypted storage setting when running inside a DuckDuckGo native "
+"browser"
+msgid "Sync & Backup"
+msgstr ""
+
+#. Title for the Sync & Backup section in Duck.ai settings
+msgctxt "Label for sync and backup setting"
+msgid "Sync & Backup"
+msgstr ""
+
+#. Header of the Manage Devices modal opened from the settings sync tile.
+msgctxt "Title for the Manage Sync & Backup modal"
+msgid "Sync & Backup"
+msgstr ""
+
+#. Title shown after the user has successfully enabled Sync & Backup on this device.
+msgctxt "Title for the Sync & Backup setup success screen"
+msgid "Sync & Backup Enabled!"
+msgstr ""
+
+#. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
+msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
+msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
+msgstr ""
+
+#. Reuses the existing Sync Another Device pairing modal stack.
+msgctxt "Action that opens the pairing flow from inside Manage"
+msgid "Sync Another Device"
+msgstr ""
+
+#. Shared header for every screen in the Sync Another Device flow: QR display, camera scan, camera-unavailable fallback, and explicit manual entry. The header stays constant throughout pairing.
+msgctxt "Modal header for the device-pairing flow"
+msgid "Sync Another Device"
+msgstr ""
+
+#. Title for the sync setting shown to users inside the DuckDuckGo native browser.
+msgctxt ""
+"Label for encrypted storage setting when running inside a DuckDuckGo native "
+"browser"
+msgid "Sync History"
+msgstr ""
+
+#. Full contents of the .txt file downloaded when a user saves their Sync & Backup recovery code. %s is replaced with the recovery code. Keep the \n sequences exactly as-is - they mark line and paragraph breaks.
+msgctxt "Body of the downloaded recovery-code .txt file"
+msgid ""
+"Sync Recovery Code\n"
+"\n"
+"The recovery code allows you to sync your passwords, autofill data, and Duck."
+"ai chats across multiple devices, and recover your synced data if you lose "
+"access to a device.\n"
+"\n"
+"Keep this information safe and secure.\n"
+"Anyone with access to this code can access your synced data.\n"
+"\n"
+"%s\n"
+"\n"
+"How does this code work?\n"
+"1. Go to Duck.ai in your browser and open Duck.ai Settings.\n"
+"2. Select \"Turn on Sync & Backup\", then \"Recover Synced Data\"\n"
+"3. Copy the recovery code above and paste where it says \"Paste your code "
+"here\"\n"
+"\n"
+"If you go more than 18 months without using a DuckDuckGo browser with Sync & "
+"Backup enabled, your data will be deleted from the server and cannot be "
+"restored."
+msgstr ""
+
+#. Sets up sync on this device alone, then shows the recovery code.
+msgctxt "Secondary CTA on the sync setup choice modal"
+msgid "Sync This Device Only"
+msgstr ""
+
+#. Secondary button label on the Sync & Backup intro screen that takes the user to the camera scan screen to pair with another device.
+msgctxt "Secondary button on the Sync & Backup intro screen"
+msgid "Sync With Another Device"
+msgstr ""
+
+#. Title shown when sync service is temporarily unavailable.
+msgctxt "Sync unavailable modal title"
+msgid "Sync and Backup is temporarily unavailable"
+msgstr ""
+
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
+#. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
+msgctxt "Title for the generic pairing-failure error screen"
+msgid "Sync failed."
+msgstr ""
+
+#. Tooltip text shown when sync is temporarily paused due to an error.
+msgctxt "Tooltip for sync error indicator"
+msgid "Sync is paused"
+msgstr ""
+
+#. Header of the first sync setup screen offering to pair with another device or set up this device only.
+msgctxt "Title of the sync setup choice modal"
+msgid "Sync with a nearby device."
+msgstr ""
+
+#. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
+msgctxt "Chat history with sync modal list item"
+msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Label preceding the list of devices currently registered to the account.
+msgctxt "Section header for the device list inside Manage Sync & Backup"
+msgid "Synced Devices"
+msgstr ""
+
+msgid "Syria"
+msgstr ""
+
+#. Text for a button that enables the theme to follow the operating system's color scheme preference.
+msgctxt "System theme button for theme selector"
+msgid "System"
+msgstr ""
+
+#. Abbreviation indicating this is the total score for a game
+msgctxt "Sports module"
+msgid "T"
+msgstr ""
+
+#. Abbreviate trillions in a number. E.g. 1,000,000,000,000 becomes 1T
+msgctxt "Stocks module"
+msgid "T"
+msgstr ""
+
+#. Indicates that an upcoming game's scheduled time is still to be determined. Please keep it short.
+msgctxt "Sports module"
+msgid "TBD"
+msgstr ""
+
+msgid "TV"
+msgstr "Fernsehen"
+
+#. The name of the Tahitian language
+msgctxt "language_name"
+msgid "Tahitian"
+msgstr ""
+
+#. Page-suggestion chip label "Tailor my resume", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Tailor my resume"
+msgstr ""
+
+msgid "Taiwan"
+msgstr "Taiwan"
+
+msgid "Tajikistan"
+msgstr ""
+
+#. Header on a page prompting users to switch to the DuckDuckGo private search engine.
+msgid "Take Back Your Privacy!"
+msgstr "Hole dir Deine Privatsphäre zurück!"
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
+
+#. Primary button/link text to open the user survey (desktop only)
+msgctxt "User survey popup"
+msgid "Take Our Survey"
+msgstr ""
+
+msgctxt "homepage ATB modal"
+msgid "Take control of your personal data"
+msgstr ""
+
+msgctxt "homepage ATB modal"
+msgid "Take control of your personal data!"
+msgstr ""
+
+#. Description for the Feedback section of the Duck.ai settings page, asking the user to take an anonymous survey to let us know how we can make Duck.ai better.
+msgctxt "Feedback section description on the Duck.ai settings page"
+msgid ""
+"Take this anonymous survey to let us know how we can make Duck.ai better."
+msgstr ""
+
+#. Description text shown below the Reasoning option in the reasoning mode dropdown.
+msgctxt "Description for reasoning mode in Duck.ai"
+msgid "Takes a moment to respond"
+msgstr ""
+
+#. Description text shown below the Reasoning option in the reasoning mode dropdown.
+msgctxt "Description for reasoning mode in Duck.ai"
+msgid "Takes longer to respond"
+msgstr ""
+
+#. Text fot a button that encourages users to try the recently added voice chat mode, and talk to our AI at Duck.ai.
+msgctxt "Promotional CTA"
+msgid "Talk to Duck.ai"
+msgstr ""
+
+#. Status label shown when the AI is speaking and the user can interrupt it by talking.
+msgctxt "voice chat"
+msgid "Talk to interrupt"
+msgstr ""
+
+#. Filters the shape of images in search results.
+msgctxt "image-layout"
+msgid "Tall"
+msgstr "Gross"
+
+#. The name of the Tamil language
+msgctxt "language_name"
+msgid "Tamil"
+msgstr ""
+
+#. It's a color, if you are confused. See <a href="http://en.wikipedia.org/wiki/Tan_(color)">http://en.wikipedia.org/wiki/Tan_(color)</a>
+msgid "Tan"
+msgstr "Lohfarbe"
+
+msgid "Tanzania"
+msgstr ""
+
+#. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
+msgctxt "precise_user_location"
+msgid "Tap %sPermissions > Location%s"
+msgstr ""
+
+#. Tells users to select the app info. Part of a list of instructions on how to enable location service.
+msgctxt "precise_user_location"
+msgid "Tap the %sapp info icon%s"
+msgstr ""
+
+#. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
+msgctxt "precise_user_location"
+msgid "Tap the %slock icon%s on the address bar."
+msgstr ""
+
+#. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
+msgctxt "precise_user_location"
+msgid "Tap the %spermissions icon%s in the address bar"
+msgstr ""
+
+#. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
+msgctxt "precise_user_location"
+msgid "Tap the vertical dots in the DuckDuckGo app."
+msgstr "Klicke auf die vertikalen Punkte in der DuckDuckGo App."
+
+#. Label for the option prompting the AI assistant to adopt a role of a teacher in its responses.
+msgctxt "Assistant role option label for teacher"
+msgid "Teacher"
+msgstr ""
+
+#. Filters the color of images in search results.
+msgctxt "color"
+msgid "Teal"
+msgstr "blaugrün"
+
+#. Label displaying with a teams' name
+msgctxt "Sports module"
+msgid "Team"
+msgstr ""
+
+#. Label for the option prompting the AI assistant to adopt a role of a tech support specialist in its responses.
+msgctxt "Assistant role option label for Tech support specialist"
+msgid "Tech support specialist"
+msgstr ""
+
+#. A default prompt that can be prefilled in the Ask AI Chat (e.g. with DuckAssist) to handoff to AI chat
+msgid "Tell me more"
+msgstr ""
+
+#. Title for a generic feedback prompt shown when the user clicks on the 'How was this response?' thumbs up/down buttons, or a 'Share feedback' button.
+msgid "Tell us more"
+msgstr ""
+
+#. The name of the Telugu language
+msgctxt "language_name"
+msgid "Telugu"
+msgstr ""
+
+#. An option under "Theme" http://i.imgur.com/fFIMtgl.png
+#. changes the look of DuckDuckGo to a Terminal, like this: http://i.imgur.com/BDN8Tfm.png
+msgctxt "theme"
+msgid "Terminal"
+msgstr "Terminal"
+
+#. A link to a terms and conditions page that is one word and is as short as possible
+msgid "Terms"
+msgstr ""
+
+msgid "Terms of Service"
+msgstr ""
+
+#. Text used in other strings to link to the Terms of Service content.
+msgctxt "Copy used to compose link in sentences"
+msgid "Terms of Service"
+msgstr ""
+
+#. This words are inserted into the sentence 'Image prompts must comply with the Duck.ai [Terms of Service].' as a clickable link that opens the Duck.ai terms of service page.
+msgctxt "Privacy link label in Duck.ai disclaimer below chat input"
+msgid "Terms of Service"
+msgstr ""
+
+#. Error message displayed if the input text is too long
+msgctxt "translations_module"
+msgid "Text exceeds %s character limit"
+msgstr ""
+
+#. in https://duckduckgo.com/params under "Look & Feel Settings" header
+msgid "Text font:"
+msgstr "Schriftart:"
+
+msgid "Text:"
+msgstr "Text:"
+
+#. The name of the Thai language
+msgctxt "language_name"
+msgid "Thai"
+msgstr ""
+
+msgid "Thailand"
+msgstr "Thailand"
+
+msgid "Thailand (en)"
+msgstr ""
+
+#. Message displayed after the user has submitted feedback. It invites the user to share more feedback.
+msgctxt "Feedback toast"
+msgid "Thank you for your feedback. Have more to share?"
+msgstr ""
+
+msgid "Thank you!"
+msgstr "Vielen Dank!"
+
+msgctxt "homepage onboarding"
+msgid "Thank you."
+msgstr "Vielen Dank."
+
+#. Title of modal shown when user gets bot challenge correct
+msgctxt "Anomaly modal"
+msgid "Thanks for confirming you’re human!"
+msgstr ""
+
+#. Confirmation message after sending feedback.
+msgctxt "feedback form"
+msgid "Thanks for your feedback!"
+msgstr ""
+
+#. Inform the users that "something" went wrong and we are unable to show any results.
+msgctxt "noresults"
+msgid "Thanks for your patience while we get our ducks in a row!"
+msgstr ""
+
+#. Inform the users that "something" went wrong and we are unable to show any results.
+msgctxt "noresults"
+msgid "Thanks for your patience while we get our ducks in a row."
+msgstr ""
+
+#. Message indicating that the open lock icon in the address bar means that a website is not secure.
+msgctxt "Lock icon next to HTTP search result"
+msgid ""
+"That means information sent between your device and the webpage behind this "
+"link is at increased risk of being intercepted by a third party. In rare "
+"cases this includes passwords, or payment details."
+msgstr ""
+"Das bedeutet, dass Informationen, die zwischen deinem Gerät und der Webseite "
+"hinter diesem Link gesendet werden, einem erhöhten Risiko unterliegen, von "
+"Dritten abgefangen zu werden. In seltenen Fällen sind dies Passwörter oder "
+"Zahlungsdaten."
+
+#. Text explaining how the cloud save feature works.
+msgctxt "cloudsave"
+msgid ""
+"The Cloud Save bookmarklet allows any changes you make to your settings to "
+"automatically save in the cloud."
+msgstr ""
+
+msgid "The Gambia"
+msgstr ""
+
+#. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
+msgctxt "Error message when combined file size exceeds the limit"
+msgid "The attached files exceed the total size limit of %s MB"
+msgstr ""
+
+#. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
+msgctxt "Error message when combined file size exceeds the limit"
+msgid "The attached files exceed the total size limit of %s MB."
+msgstr ""
+
+#. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
+msgid "The audio could not be processed. Please try recording again."
+msgstr ""
+
+#. Second paragraph explaining where the encryption key is stored on the entry screen.
+msgctxt "Second paragraph for the Sync & Backup intro screen"
+msgid ""
+"The encryption key is only saved in your browser's local storage, and only "
+"you can access it."
+msgstr ""
+
+#. Description explaining that the AI model provider deletes all chat data within 30 days.
+msgctxt "Privacy claim description in Duck.ai chat"
+msgid ""
+"The model provider deletes any data associated with this chat within 30 days."
+msgstr ""
+
+#. Description explaining that the AI model provider does not store any chat data on their servers.
+msgctxt "Privacy claim description in Duck.ai chat"
+msgid "The model provider does not save this chat on their servers."
+msgstr ""
+
+#. Description explaining that the AI model provider does not store any chat data on their servers.
+msgctxt "Privacy claim description in Duck.ai chat"
+msgid ""
+"The model provider does not save this chat or any associated data on their "
+"servers."
+msgstr ""
+
+msgctxt "settings"
+msgid "The rendering method to use for interactive maps"
+msgstr "Die Methode zum rendern von interaktiven Karten"
+
+#. Error in the duck.ai chat input when the dictation upload request exceeds 30 seconds.
+msgid "The request timed out. Please try again."
+msgstr ""
+
+#. Inform the users that "something" went wrong and we are unable to show any results.
+msgctxt "noresults"
+msgid "The server encountered an error and could not complete your request."
+msgstr ""
+
+#. Title for the theme menu:
+#. https://duck.co/media/files/theme.png
+msgid "Theme"
+msgstr "Design"
+
+#. Text for the theme selector label that allows users to switch between Light and dark theme.
+msgctxt "Label for the theme selector feature"
+msgid "Theme"
+msgstr ""
+
+#. http://i.imgur.com/LpFhb1e.png
+msgctxt "settings"
+msgid "Theme"
+msgstr "Designs"
+
+#. Message indicating the user has changed their browser's theme.
+msgid "Theme Changed"
+msgstr "Design geändert"
+
+#. Header above settings that change the color scheme of the search engine.
+msgid "Themes"
+msgstr "Designs"
+
+#. Inform the users that "something" went wrong and we are unable to show any results.
+msgctxt "noresults"
+msgid "There was an error displaying the search results."
+msgstr ""
+
+#. Error message displayed when there was an issue in saving the chat locally to the browser's storage
+msgctxt "Error message when there was an issue saving a chat to the browser"
+msgid ""
+"There was an error saving this chat locally. Please check your browser "
+"settings to make sure local data storage is enabled."
+msgstr ""
+
+#. Error modal body line 1.
+msgctxt "duckai_migration"
+msgid "There was an unexpected error during this process."
+msgstr ""
+
+#. Inform the users that "something" went wrong and discourage the user from immediately reloading the page.
+msgctxt "noresults"
+msgid ""
+"There was still an error displaying the search results. Please wait a few "
+"minutes before you try again."
+msgstr ""
+
+#. Error message for explore more questions when a retryable error occurs (timeout, network)
+msgid "There's been an issue loading this answer. Please try again."
+msgstr ""
+
+#. Instant Answer Tab Name
+msgid "Thesaurus"
+msgstr "Wörterbuch"
+
+#. Describes why the DuckDuckGo extension needs permission to block trackers and enable other features.
+msgid ""
+"These browser permissions are used to add privacy protection on websites you "
+"visit by blocking hidden trackers, encrypting connections where possible, "
+"and by making DuckDuckGo your default search engine."
+msgstr ""
+"Diese Browser-Berechtigungen werden verwendet, um den Datenschutz auf "
+"Websites die du besuchst, zu verbessern, indem sie versteckte Tracker "
+"blockieren, wenn möglich Verbindungen verschlüsseln und indem sie DuckDuckGo "
+"zu deiner Standardsuchmaschine machen."
+
+#. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
+msgctxt "Body for the already-synced screen"
+msgid "These devices are already connected to Sync & Backup."
+msgstr ""
+
+#. Placeholder text displayed while a reasoning AI model is thinking before generating a response.
+msgctxt "Assistant response placeholder"
+msgid "Thinking"
+msgstr ""
+
+#. Text for the button that shows more of an answer from duckassist when the answer is being generated
+msgid "Thinking..."
+msgstr ""
+
+#. Placeholder text displayed while a reasoning AI model is thinking before generating a response.
+msgctxt "Assistant response placeholder"
+msgid "Thinking…"
+msgstr ""
+
+#. Label for the game to determine the 3rd place in e.g. the soccer World Cup
+msgctxt "Sports module"
+msgid "Third place"
+msgstr ""
+
+#. Displayed when an AI chat model is no longer supported altogether, with no no upgraded version available
+msgctxt "AI Chat: Error message for when a model is removed"
+msgid ""
+"This AI model is no longer available. Try starting a new chat with a "
+"different model."
+msgstr ""
+
+#. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
+msgctxt "AI Chat: Error message for when a model is deprecated"
+msgid ""
+"This AI model version is no longer supported. Try starting a new chat with "
+"the latest version of this model."
+msgstr ""
+
+#. Appears below a type of search results called 'Instant Answers'
+msgctxt "attribution"
+msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
+msgstr ""
+
+#. Label for the monthly usage row in the Usage section of Duck.ai settings.
+msgctxt "Duck.ai settings usage section"
+msgid "This Month"
+msgstr ""
+
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
+#. Label for the weekly usage row in the Usage section of Duck.ai settings.
+msgctxt "Duck.ai settings usage section"
+msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
+msgstr ""
+
+#. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
+msgctxt "Export chat feature in AI Chat"
+msgid ""
+"This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
+"chats may display inaccurate or offensive information (see %s for more info)."
+msgstr ""
+
+#. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
+msgctxt "Export chat feature in AI Chat"
+msgid ""
+"This conversation was generated with Duck.ai (%s) using multiple chat "
+"models. AI chats may display inaccurate or offensive information (see %s for "
+"more info)."
+msgstr ""
+
+#. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
+msgctxt "Export chat feature in AI Chat"
+msgid ""
+"This conversation was generated with Duck.ai voice chat (%s). AI may provide "
+"inaccurate or offensive information. (see %s for more info)."
+msgstr ""
+
+#. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
+msgctxt "Export chat feature in AI Chat"
+msgid ""
+"This conversation was generated with DuckDuckGo AI Chat (%s) using %s's %s "
+"Model. AI chats may display inaccurate or offensive information (see %s for "
+"more info)."
+msgstr ""
+
+#. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
+msgctxt "Error message when a single file exceeds the size limit"
+msgid "This file is too large. The maximum file size is %s MB"
+msgstr ""
+
+#. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
+msgctxt "Error message when a single file exceeds the size limit"
+msgid "This file is too large. The maximum file size is %s MB."
+msgstr ""
+
+#. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
+msgctxt "Error message when an uploaded file type is not supported"
+msgid "This file type is not supported"
+msgstr ""
+
+#. Error message displayed when the user tries to upload an unsupported file type and we know which types are accepted. Placeholder is a single accepted type. E.g. This file type is not supported, please attach a PDF
+msgctxt "Error message when an uploaded file type is not supported"
+msgid "This file type is not supported, please attach a %s"
+msgstr ""
+
+#. Error message for unsupported file type when multiple types are accepted. First placeholder is a comma-separated list of all accepted types except the last (e.g. PNG, JPG, WebP, GIF). Second placeholder is the last accepted type (e.g. PDF). Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF
+msgctxt ""
+"Error message when an uploaded file type is not supported, with list ending "
+"in or"
+msgid "This file type is not supported, please attach a %s or %s"
+msgstr ""
+
+#. Error message for unsupported file type when multiple types are accepted. First placeholder is a comma-separated list of all accepted types except the last (e.g. PNG, JPG, WebP, GIF). Second placeholder is the last accepted type (e.g. PDF). Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF
+msgctxt ""
+"Error message when an uploaded file type is not supported, with list ending "
+"in or"
+msgid "This file type is not supported, please attach a %s or %s."
+msgstr ""
+
+#. Error message displayed when the user tries to upload an unsupported file type and we know which types are accepted. Placeholder is a single accepted type. E.g. This file type is not supported, please attach a PDF
+msgctxt "Error message when an uploaded file type is not supported"
+msgid "This file type is not supported, please attach a %s."
+msgstr ""
+
+#. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
+msgctxt "Error message when an uploaded file type is not supported"
+msgid "This file type is not supported."
+msgstr ""
+
+#. Header above a list of benefits of the cloud save feature.
+msgctxt "cloudsave"
+msgid "This has a few benefits:"
+msgstr "Dies hat ein paar Vorteile:"
+
+#. Title shown when image generation fails due to content policy or API error.
+msgctxt "Title for image generation error"
+msgid "This image couldn't be created."
+msgstr ""
+
+#. Error message displayed when a file that the user tried to upload is not of a supported format
+msgctxt "Error message when an uploaded file is not the right format"
+msgid ""
+"This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
+msgstr ""
+
+#. Error message displayed when a file that the user tried to upload is not of a supported format
+msgctxt "Error message when an uploaded file is not the right format"
+msgid ""
+"This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
+msgstr ""
+
+#. Given as an option to select when providing feedback
+msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
+msgstr ""
+
+#. Title shown when the scanned or pasted payload does not match the expected pairing format.
+msgctxt "Title for the wrong code error screen"
+msgid "This is not a valid Sync code."
+msgstr ""
+
+#. Body shown while importing chats.
+msgctxt "duckai_migration"
+msgid "This might take a moment."
+msgstr ""
+
+#. Description explaining that the AI model provider deletes chat data within 30 days, and that other providers may not retain chat data at all.
+msgctxt "Privacy claim description in Duck.ai chat"
+msgid ""
+"This model provider deletes data associated with this chat within 30 days. "
+"Other model providers follow a zero data retention model."
+msgstr ""
+
+#. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
+msgctxt "Privacy claim description in Duck.ai chat"
+msgid ""
+"This model provider does not store any data associated with this chat. Other "
+"model providers follow a limited data retention model."
+msgstr ""
+
+#. Info that page may refresh during update.
+msgctxt "duckai_migration"
+msgid "This page might refresh."
+msgstr ""
+
+msgid "This page requires Javascript to function."
+msgstr "Diese Seite benötigt JavaScript."
+
+#. Information tooltip text explaining that the current page's content will be included with the chat message.
+msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
+msgid "This page's content will be sent with your message to Duck.ai"
+msgstr ""
+
+#. Category of feedback a user can select on a feedback form.
+msgctxt "feedback form"
+msgid "This place is permanently closed"
+msgstr ""
+
+#. Category of feedback a user can select on a feedback form.
+msgctxt "feedback form"
+msgid "This place is too far away"
+msgstr ""
+
+#. First paragraph explaining what Sync & Backup does on the entry screen.
+msgctxt "First paragraph for the Sync & Backup intro screen"
+msgid ""
+"This saves your chats with end-to-end encryption on DuckDuckGo's secure "
+"server, which later can be accessed from any browser."
+msgstr ""
+
+#. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
+msgctxt "duckassist"
+msgid ""
+"This setting is stored in your browser, which means if you clear duckduckgo."
+"com browser data, then you may see AI-assisted answers again."
+msgstr ""
+
+#. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
+msgctxt "duckassist"
+msgid ""
+"This setting is stored in your browser, which means if you clear duckduckgo."
+"com browser data, then you may see AI-assisted answers again. However, we "
+"also have a start page that never shows AI-assisted answers at %s."
+msgstr ""
+
+#. User feedback indicating that a translation is helpful
+msgctxt "translations_module"
+msgid "This translation is helpful"
+msgstr ""
+
+#. User feedback indicating that a translation is offensive
+msgctxt "translations_module"
+msgid "This translation is offensive"
+msgstr ""
+
+#. User feedback indicating that a translation is incorrect
+msgctxt "translations_module"
+msgid "This translation is wrong"
+msgstr ""
+
+#. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
+msgid "This video is not yet able to be watched here. You can watch it on %s."
+msgstr ""
+"Dieses Videos kann hier nicht abgespielt werden. Du kannst es auf %s schauen."
+
+#. Message indicating that a website is not using an encrypted connection and is not secure.
+msgctxt "Lock icon next to HTTP search result"
+msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
+msgstr ""
+"Diese Webseite verwendet keine sichere, verschlüsselte Verbindung (HTTPS)."
+
+#. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
+msgctxt "Body text for disable chat history and disconnect sync modal"
+msgid ""
+"This will delete all of your Duck.ai chats from this browser, and disconnect "
+"Sync & Backup. You'll still be able to access your chats in other browsers "
+"connected to Sync & Backup."
+msgstr ""
+
+#. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
+msgctxt "Body text for clear all recent chats confirmation modal"
+msgid ""
+"This will delete all your recent chats, unless they're pinned. This cannot "
+"be undone."
+msgstr ""
+
+#. Message explaining what will happen when the user deletes an image.
+msgctxt "Confirmation message in delete image modal"
+msgid "This will delete your selected image. This cannot be undone."
+msgstr ""
+
+#. Confirmation message asking if the user is sure they want to reset all of their settings.
+msgctxt "settings"
+msgid "This will erase all settings. Continue?"
+msgstr "Alle Einstellungen werden gelöscht. Weiterfahren?"
+
+#. Confirmation message asking if the user is sure they want to reset all of their settings.
+msgctxt "settings"
+msgid "This will reset your saved settings to default values. Continue?"
+msgstr ""
+"Dies setzt deine gespeicherten Einstellungen auf die Standardwerte zurück. "
+"Fortfahren?"
+
+#. Golf leaderboard column: holes completed in current round
+msgctxt "Sports module"
+msgid "Thru"
+msgstr ""
+
+#. Weekday abbreviation (short for 'Thursday')
+msgctxt "maps_places"
+msgid "Thu"
+msgstr ""
+
+#. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
+msgctxt "Weather IA"
+msgid "Thunderstorms"
+msgstr ""
+
+#. Weekday in plural form
+msgctxt "maps_places"
+msgid "Thursdays"
+msgstr ""
+
+#. Indicates this is the number of ties for this team
+msgctxt "Sports module"
+msgid "Ties"
+msgstr ""
+
+#. The name of the Tigrinya language
+msgctxt "language_name"
+msgid "Tigrinya"
+msgstr ""
+
+#. F1 results table column header: race time or gap to leader
+msgctxt "Sports module"
+msgid "Time"
+msgstr ""
+
+#. List item indicating that a time filter (images) is currently active for the search
+msgctxt "noresults"
+msgid "Time"
+msgstr ""
+
+#. Text that tells in which time zone the game times are displayed. The time zone will be displayed in a tooltip that appears when hovering over the words
+msgctxt "Sports module"
+msgid "Times are in your %slocal time zone%s"
+msgstr ""
+
+#. Text that tells in which time zone the game times are displayed
+msgctxt "Sports module"
+msgid "Times are in your local time zone"
+msgstr ""
+
+msgid "Timor Leste"
+msgstr ""
+
+#. Label for tips tab
+msgctxt "Covid 19 module"
+msgid "Tips"
+msgstr ""
+
+msgid "Tired of being tracked online? %sWe can help.%s"
+msgstr "Müde vom getrackt werden? %sWir können helfen.%s"
+
+#. This is the name of a user setting
+msgctxt "settings"
+msgid "Title Color"
+msgstr ""
+
+#. This is the name of a user setting
+msgctxt "settings"
+msgid "Title Font"
+msgstr ""
+
+#. This is the name of a user setting
+msgctxt "settings"
+msgid "Title Underline"
+msgstr ""
+
+#. Informative header on a list of steps for the user to take to disable their adblocker
+msgid "To allowlist DuckDuckGo in other ad blocker extensions:"
+msgstr ""
+
+#. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to Duck.ai’s Privacy Policy and Terms of Service'
+msgctxt ""
+"Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
+msgid "To continue, you must agree to Duck.ai’s %s and %s"
+msgstr ""
+
+#. Text stating agreement to AI Chat Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to DuckDuckGo AI Chat’s Privacy Policy and Terms of Service'
+msgctxt ""
+"Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
+msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
+msgstr ""
+
+#. Instructions for how to print driving directions.
+msgctxt "directions"
+msgid ""
+"To print directions:%sGo back to the map.%sSelect the route you want to "
+"print.%sClick the print icon.%s"
+msgstr ""
+
+#. Explains where the user can find their recovery code. Figma frame 3703-44420.
+msgctxt "Body copy on the recover-data intro sheet"
+msgid ""
+"To restore your synced data, you'll need the Recovery Code you saved when "
+"you first set up Sync. This code may have been saved as a PDF on the device "
+"you originally used to set up Sync."
+msgstr ""
+
+#. Body text explaining that the user needs to update their DDG browser before migration can proceed.
+msgctxt "duckai_migration"
+msgid ""
+"To transfer your chat history to Duck.ai, please update your DuckDuckGo "
+"browser to the latest version and try again."
+msgstr ""
+
+#. Error in the duck.ai chat input when the user denies microphone access for dictation.
+msgid ""
+"To use dictation, allow your browser to access the microphone in your system "
+"settings."
+msgstr ""
+
+msgid "Today"
+msgstr "Heute"
+
+#. Button label for selecting chart of today's prices
+msgctxt "Stocks module"
+msgid "Today"
+msgstr ""
+
+#. Label for the section of recent chats that were edited today.
+msgctxt "Title for the period of chats from today"
+msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
+msgstr ""
+
+msgid "Togo"
+msgstr ""
+
+msgid "Tomorrow"
+msgstr "Morgen"
+
+#. Label indicating the tone of AI assistant responses that can be selected. Example: User can pick from 'Friendly', 'Empathetic', 'Casual', etc.
+msgctxt "Label for tone of responses dropdown"
+msgid "Tone of responses"
+msgstr ""
+
+msgid "Tonga"
+msgstr ""
+
+#. The name of the Tongan language
+msgctxt "language_name"
+msgid "Tongan"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Too far away"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Too many YouTube results"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Too many ads"
+msgstr ""
+
+#. Displayed when the user has sent too many requests in a short period of time.
+msgctxt "Error message for rate limit"
+msgid "Too many requests. Please take a short break and try again."
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Too many results from this source"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Too slow"
+msgstr ""
+
+#. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
+msgctxt ""
+"Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
+"toolbar"
+msgid "Tools"
+msgstr ""
+
+#. Visible button label. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
+msgctxt "Label for the Tools dropdown button in the Duck.ai chat input toolbar"
+msgid "Tools"
+msgstr ""
+
+#. Screen-reader label for the dropdown menu opened by the Tools button. Announced when the user navigates into the menu.
+msgctxt "Accessibility label for the Tools dropdown menu in Duck.ai"
+msgid "Tools menu"
+msgstr ""
+
+#. Used in headings on Category pages, e.g. <a href="https://duckduckgo.com/?q=simpsons+characters">https://duckduckgo.com/?q=simpsons+characters</a>
+msgid "Top"
+msgstr "Oben"
+
+#. Indicates this is the total score for a game
+msgctxt "Sports module"
+msgid "Total"
+msgstr ""
+
+#. Header on a column that displays the total medal count for the country in the Olympics
+msgid "Total Medals"
+msgstr ""
+
+msgctxt ""
+"Header on a column that displays the total medal count for the country in "
+"the Olympics"
+msgid "Total Medals"
+msgstr ""
+
+#. In the context of a standings table for NHL (hockey), indicates these are the total points of this team
+msgctxt "Sports module"
+msgid "Total Points"
+msgstr ""
+
+#. Indicates this is the total points scored against this team
+msgctxt "Sports module"
+msgid "Total Points Against"
+msgstr ""
+
+#. Indicates this is the total 'points for' (i.e. scored by) this team
+msgctxt "Sports module"
+msgid "Total Points For"
+msgstr ""
+
+#. Tennis match stats
+msgctxt "Sports module"
+msgid "Total Points Won"
+msgstr ""
+
+msgid "Tour"
+msgstr "Rundgang"
+
+msgctxt "frontpage"
+msgid "Tour"
+msgstr "Rundgang"
+
+#. A category of ads
+msgctxt "Feedback prompt"
+msgid "Tour & activities ads"
+msgstr ""
+
+#. A category of ads
+msgctxt "Feedback prompt"
+msgid "Tours & Activities Advertisements"
+msgstr ""
+
+#. Refers to the feature of the DuckDuckGo web browser, which blocks websites from tracking users.
+msgid "Tracker Blocking"
+msgstr ""
+
+#. Header above a list of trackers (or tracking companies) that have been blocked in the past hour.
+msgctxt "tracker_stats"
+msgid "Trackers blocked in the last hour"
+msgstr ""
+
+#. Placeholder for when we cannot report any blocked trackers yet
+msgctxt "tracker_stats"
+msgid "Trackers that DuckDuckGo blocks will appear here"
+msgstr ""
+
+#. Placeholder for when we cannot report any blocked trackers yet
+msgctxt "tracker_stats"
+msgid ""
+"Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
+"how many we block."
+msgstr ""
+
+#. Placeholder for when we cannot report any blocked trackers yet
+msgctxt "tracker_stats"
+msgid "Tracking attempts blocked by DuckDuckGo will appear here"
+msgstr ""
+
+#. Tooltip and accessible label for the confirm (checkmark) button that stops recording and sends audio for transcription.
+msgid "Transcribe"
+msgstr ""
+
+#. Status text shown in the duck.ai chat input while audio is being sent to the server for transcription. The trailing ellipsis is part of the text and should be preserved.
+msgid "Transcribing..."
+msgstr ""
+
+#. Fallback error in the duck.ai chat input when dictation fails for an unknown reason.
+msgid "Transcription failed. Please try again."
+msgstr ""
+
+#. Primary button to update now.
+msgctxt "duckai_migration"
+msgid "Transfer Chat History"
+msgstr ""
+
+#. A short title for the a message asking the AI to translate a text.
+msgctxt "Title for the translate message"
+msgid "Translate"
+msgstr ""
+
+#. Short string representing a prompt suggestion for translating text.
+msgctxt "Brief for translating text"
+msgid "Translate text"
+msgstr ""
+
+#. Text for a prompt suggestion for translating an English sentence into French.
+msgctxt "Full sentence for translating text"
+msgid ""
+"Translate this English sentence into French: “How do I get to the nearest "
+"movie theatre?”"
+msgstr ""
+
+#. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
+msgctxt "Full sentence for translating text prompt"
+msgid ""
+"Translate this English sentence into French: “How do I get to the nearest "
+"movie theatre?”"
+msgstr ""
+
+#. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Translate this page"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "Translate this page" page-suggestion chip. %s is the target language name (e.g. "Spanish").
+msgctxt "Page suggestion prompt"
+msgid "Translate this page into %s."
+msgstr ""
+
+#. Placeholder text for a region that will display translated text.
+msgctxt "translations_module"
+msgid "Translation"
+msgstr ""
+
+#. Text of a tooltip displayed when the user has copied text that has been translated
+msgctxt "translations_module"
+msgid "Translation copied"
+msgstr ""
+
+#. Label for the option prompting the AI assistant to adopt a role of a translator in its responses.
+msgctxt "Assistant role option label for Translator"
+msgid "Translator"
+msgstr ""
+
+#. Filters the type of images in search results.
+msgctxt "image-type"
+msgid "Transparent"
+msgstr "Transparent"
+
+#. Label for the option prompting the AI assistant to adopt a role of a travel guide in its responses.
+msgctxt "Assistant role option label for Travel guide"
+msgid "Travel guide"
+msgstr ""
+
+#. Label indicating the user's role. The role is used by the AI assistant to modify its responses. Example: 'Treat me as a parent'
+msgctxt "Label for user role selection"
+msgid "Treat me as"
+msgstr ""
+
+#. For rankings of sports leagues that come out on a periodic basis such as weekly, this represents the change in the rank of the team/player over that time period. For example, if in week 1 team A was ranked #5 but in week 2 team A was ranked #11, the trend would be -6.
+msgctxt "Sports module"
+msgid "Trend"
+msgstr ""
+
+#. Rugby match stats
+msgctxt "Sports module"
+msgid "Tries"
+msgstr ""
+
+msgid "Trinidad and Tobago"
+msgstr ""
+
+#. The TripAdvisor brand name.
+msgid "TripAdvisor"
+msgstr ""
+
+#. Label for the option prompting the AI assistant to adopt a role of a trivia expert in its responses.
+msgctxt "Assistant role option label for Trivia expert"
+msgid "Trivia expert"
+msgstr ""
+
+#. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
+msgctxt "Weather IA"
+msgid "Tropical Storm"
+msgstr ""
+
+msgid "Trusted by tens of millions worldwide!"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Trustworthy source"
+msgstr ""
+
+#. Positive feedback category a user can select on the Search Assist feedback form, meaning the answer was grounded in trustworthy sources.
+msgctxt "feedback form"
+msgid "Trustworthy sources"
+msgstr ""
+
+#. Button label for a promotional card that encourages users to try the encrypted AI model. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
+msgctxt "Promotional CTA for encrypted AI model"
+msgid "Try %s"
+msgstr ""
+
+#. Prompt for the user to start using our homepage that doesn't show promotional messages. The placeholder is a homepage url (e.g., 'start.duckduckgo.com')
+msgid "Try %s to stop seeing messages like this."
+msgstr ""
+
+#. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
+msgctxt "Promotional text for encrypted AI model"
+msgid "Try %s, our first model with zero provider visibility."
+msgstr ""
+
+msgid "Try %sDuck.ai%s, our private AI chat service:"
+msgstr ""
+
+#. Button text to retry loading an explore more question that failed
+msgid "Try Again"
+msgstr ""
+
+#. Text of button allowing users to try the bot challenge again
+msgctxt "Anomaly modal"
+msgid "Try Again"
+msgstr ""
+
+#. Returns the user to the Sync Another Device scan screen to attempt pairing again.
+msgctxt "Retry button on the generic pairing-failure screen"
+msgid "Try Again"
+msgstr ""
+
+#. Button that returns the user to the scan screen after a wrong code error.
+msgctxt "Retry button on the wrong code screen"
+msgid "Try Again"
+msgstr ""
+
+#. A link that will allow users to reload the page, show when no search results loaded due to an error
+msgctxt "noresults"
+msgid "Try Again"
+msgstr ""
+
+#. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). One of several CTAs rotated over time.
+msgctxt "DuckDuckGo VPN instant answer"
+msgid "Try Free"
+msgstr ""
+
+#. Call-to-action button for the subscription promo in the SERP sidemenu.
+msgctxt "Sidemenu subscription promo"
+msgid "Try Free"
+msgstr ""
+
+#. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. One of several CTAs rotated over time.
+msgctxt "DuckDuckGo Subscription instant answer"
+msgid "Try Free!"
+msgstr ""
+
+#. Button text in the modal that sends DuckDuckGo browser users to noai.duckduckgo.com after they disable AI features in Settings.
+msgctxt "settings"
+msgid "Try It Now"
+msgstr ""
+
+#. CTA for a promotional card that encourages users to try new AI model that was added recently
+msgctxt "Promotional CTA for new AI models"
+msgid "Try Now"
+msgstr ""
+
+#. Button label for a promotional card that encourages users to try the reasoning mode which thinks longer to hopefully provide a more accurate answer.
+msgctxt "Promotional CTA for reasoning mode"
+msgid "Try Now"
+msgstr ""
+
+#. CTA for a promotional card that encourages DuckDuckGo Subscription users to try the advanced AI models that the subscription unlocks.
+msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
+msgid "Try Them Out"
+msgstr ""
+
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
+#. Alternate header text for front page
+msgid "Try a search!"
+msgstr "Beginne eine Suche!"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
+
+#. Message prompting users to add more information to their search term.
+msgctxt "directions"
+msgid "Try adding a city, state, or postal code"
+msgstr ""
+
+#. Message prompting users to add more information to their search term.
+msgctxt "directions"
+msgid "Try adding a city, state, or postal code."
+msgstr "Versuche eine Stadt, Land oder eine Postleitzahl hinzuzufügen."
+
+#. Message to display during errors for users who have AI enabled to encourage them to use that feature while the site is having issues. Example: 'Try asking Duck.ai, our private AI chat service:'
+msgctxt "noresults"
+msgid "Try asking %s, our private AI chat service:"
+msgstr ""
+
+#. A message suggesting that the user clears their filters and tries their search again when they get no results
+msgctxt "noresults"
+msgid "Try clearing your filters and searching again."
+msgstr ""
+
+#. A prompt asking users to try searching with different words.
+msgctxt "noresults"
+msgid "Try different keywords."
+msgstr "Versuche es mit anderen Suchbegriffen."
+
+#. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
+msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
+msgstr ""
+
+#. Prompt to enable location access in order to get search results closer to the user's actual location.
+msgctxt "precise_user_location"
+msgid "Try enabling anonymous location for more accurate results."
+msgstr "Aktiviere den anonymen Standort, um genauere Ergebnisse zu erhalten."
+
+#. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
+msgctxt "Onboarding pick a chat model screen subtitle"
+msgid ""
+"Try experimenting with each model — they will provide different responses."
+msgstr ""
+
+#. A prompt asking users to try searching with fewer words.
+msgctxt "noresults"
+msgid "Try fewer keywords."
+msgstr "Versuche es mit weniger Suchbegriffen."
+
+#. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
+msgctxt "DuckDuckGo Subscription instant answer"
+msgid "Try for Free"
+msgstr ""
+
+#. Call-to-action button label on the VPN instant answer shown on the search results page. Starts a free trial of the DuckDuckGo VPN (part of the paid subscription). Default CTA, used by most rotated VPN messages.
+msgctxt "DuckDuckGo VPN instant answer"
+msgid "Try for Free"
+msgstr ""
+
+#. Will be used in the sentence 'Unlock more capable AI models with a DuckDuckGo subscription. Try for free' and opens the subscription modal when clicked. Shown only to unauthenticated users.
+msgctxt ""
+"Link text shown to unauthenticated users in the subscription promo card to "
+"open the subscription modal"
+msgid "Try for free"
+msgstr ""
+
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
+#. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
+msgctxt ""
+"Trailing CTA on the Subscriber exclusive section header in the model picker "
+"dropdown"
+msgid "Try for free"
+msgstr ""
+
+#. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
+msgctxt "SERP footer content"
+msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
+msgstr ""
+
+#. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
+msgid "Try generating an AI-assisted answer"
+msgstr ""
+
+#. Copy to invite the user to ask duckassist (an instant answer based on generative AI) for an answer
+msgid "Try generating an answer from Wikipedia."
+msgstr ""
+
+#. A prompt asking users to try searching with words that are less specific.
+msgctxt "noresults"
+msgid "Try more general keywords."
+msgstr "Versuche es mit allgemeineren Begriffen."
+
+#. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time. 'Try for free' refers to the free trial of the paid subscription; VPN is the DuckDuckGo VPN product.
+msgctxt "Mobile SERP subscription badge"
+msgid "Try our VPN for free!"
+msgstr ""
+
+#. Link text encouraging users to download the DuckDuckGo browser. Links to the browser download page.
+msgctxt "settings"
+msgid "Try our browser"
+msgstr ""
+
+#. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
+msgid "Try our homepage that never shows these messages:"
+msgstr "Probiere unsere Homepage aus, welche diese Nachrichten nie anzeigt:"
+
+#. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time; shown in the US. Invites the user to start a free trial of the paid subscription.
+msgctxt "Mobile SERP subscription badge"
+msgid "Try our subscription for free!"
+msgstr ""
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
+
+#. A prompt asking users to try searching with different words to get more results.
+msgctxt "noresults"
+msgid "Try related keywords"
+msgstr ""
+
+#. e.g., 'Try search for Mozart' (when the user searched for 'Mozar')
+msgid "Try searching for %s"
+msgstr ""
+
+#. Prompt for the user to indicate their location on a map, to enable more relevant search results.
+msgctxt "precise_user_location"
+msgid "Try setting your location manually."
+msgstr "Versuche deinen Standort manuell festzulegen."
+
+#. Body text in a popover encouraging the user to try the DuckDuckGo browser
+msgctxt "Browser Promo Popover"
+msgid "Try the %sDuckDuckGo Browser.%s Fast. Free. Private."
+msgstr ""
+
+#. Link to a page where users can download the DuckDuckGo Browser for iOS or Android.
+msgid "Try the DuckDuckGo Browser"
+msgstr ""
+
+#. Link to a page where users can download the DuckDuckGo app for iOS or Android.
+msgid "Try the DuckDuckGo app"
+msgstr "Versuche die DuckDuckGo App"
+
+#. Text for a promotional card that encourages users to try the recently added AI models. The placeholders are the names of AI models like 'Try the new Claude 3.5 and Llama 4 models'
+msgctxt "Promotional text for new AI models"
+msgid "Try the new %s and %s models"
+msgstr ""
+
+#. Text for a promotional card that encourages users to try the recently added open-source AI model. The placeholder is the name of the AI model, Example: 'Try the new Llama 3.3 open-source model'
+msgctxt "Promotional text for new AI model"
+msgid "Try the new %s open-source model"
+msgstr ""
+
+#. Text for a promotional card that encourages users to try the recently added image generation mode.
+msgctxt "Promotional text for new image generation mode"
+msgid "Try the new image generation mode!"
+msgstr ""
+
+#. Alternative text for a promotional card that encourages users to try the recently added AI model.
+msgctxt "Alternative promotional text for a single new AI model"
+msgid "Try the new model from OpenAI"
+msgstr ""
+
+#. Text for a promotional card that encourages users to try the recently added voice chat mode.
+msgctxt "Promotional text"
+msgid "Try the new private, real-time voice chat!"
+msgstr ""
+
+#. Text for a promotional card that encourages users to try the recently added open-source AI models. The placeholders are the names of AI models like 'Try the recently added open-source Llama 3.1 and Mistral.'
+msgctxt "Promotional text for new AI models"
+msgid "Try the recently added open-source %s and %s"
+msgstr ""
+
+#. Text for a promotional card that encourages users to try the recently added open-source AI models Llama 3.1 and Mixtral.
+msgctxt "Promotional text for new AI models"
+msgid "Try the recently added open-source Llama 3.1 and Mixtral"
+msgstr ""
+
+#. Message displayed to suggest the user to try the provided prompts or enter their own.
+msgctxt "Prompt suggestion message"
+msgid "Try these prompts to get started or enter your own prompt below"
+msgstr ""
+
+#. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
+msgctxt ""
+"Description shown when a chat search in Duck.ai returns no matching chats, "
+"suggesting the user rephrase their query"
+msgid "Try using a different search term or phrase."
+msgstr ""
+
+#. In the context of an AI Chat, text prompting the user to try their prompt with a different AI model.
+msgctxt "AI Chat"
+msgid "Try with a different model"
+msgstr ""
+
+#. Message displayed sometimes at top of results (for bang syntax), e.g. <a href="https://duckduckgo.com/?q=twitter+test">https://duckduckgo.com/?q=twitter+test</a>
+msgid "Try: %s"
+msgstr "Versuche: %s"
+
+#. Response a user can select in a feedback form, indicating that they're trying DuckDuckGo again.
+msgctxt "new user poll"
+msgid "Trying DuckDuckGo again"
+msgstr "Ich probiere DuckDuckGo erneut aus"
+
+#. Message shown in a modal after supported third-party browser users disable AI features in Settings. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
+"extension to remember your settings. %sLearn More%s"
+msgstr ""
+
+#. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
+msgctxt "Assistant response placeholder"
+msgid "Trying with %s"
+msgstr ""
+
+#. Weekday abbreviation (short for 'Tuesday')
+msgctxt "maps_places"
+msgid "Tue"
+msgstr ""
+
+#. Weekday in plural form
+msgctxt "maps_places"
+msgid "Tuesdays"
+msgstr ""
+
+msgid "Tunisia"
+msgstr ""
+
+msgid "Turkey"
+msgstr "Türkei"
+
+#. The name of the Turkish language
+msgctxt "language_name"
+msgid "Turkish"
+msgstr ""
+
+msgid "Turkmenistan"
+msgstr ""
+
+#. Confirms turning off Sync & Backup; routes through disconnect3rdPartySync.
+msgctxt "Destructive action that disconnects this device from Sync & Backup"
+msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Disconnects the current device from sync without deleting server data.
+msgctxt "Secondary action that disables sync on this device only"
+msgid "Turn Off Sync & Backup"
+msgstr ""
+
+#. Asks the user to confirm disconnecting this device from Sync & Backup.
+msgctxt ""
+"Title for the confirmation dialog shown before turning off Sync & Backup on "
+"this device"
+msgid "Turn Off Sync & Backup?"
+msgstr ""
+
+#. Opens the Delete Server Data confirmation modal.
+msgctxt "Destructive link at the bottom of the Manage modal"
+msgid "Turn Off and Delete Server Data"
+msgstr ""
+
+#. Shorter CTA label at the Sync & Backup entry points. Shown on all platforms and viewport widths.
+msgctxt "Encrypted storage setup button"
+msgid "Turn On"
+msgstr ""
+
+#. Short CTA for mobile / narrow settings and bottom sheets; same entry points as DUCKCHAT_SYNC_SETUP_BUTTON_TEXT.
+msgctxt "Encrypted storage setup button (third-party browsers, narrow width)"
+msgid "Turn On"
+msgstr ""
+
+#. Shown over the intro animation; tapping it prompts for camera access so scanning can start. Also used to retry after the camera is denied/unavailable.
+msgctxt "Button on the mobile scan tab that requests camera permission"
+msgid "Turn On Camera"
+msgstr ""
+
+#. This is a button that lets the user play a video in our custom video player
+msgid "Turn On Duck Player"
+msgstr ""
+
+#. Button label shown to DuckDuckGo native browser users to open the native sync flow.
+msgctxt "Setup button for native sync flow"
+msgid "Turn On Sync"
+msgstr ""
+
+#. CTA at the Sync & Backup entry points (the Sync settings tile and the About Sync modal). Shown on all platforms and viewport widths.
+msgctxt "Encrypted storage setup button"
+msgid "Turn On Sync & Backup"
+msgstr ""
+
+#. CTA shown on third-party browsers (non-DDG) at the Sync & Backup entry points: the Sync settings tile and the About Sync modal. Native DDG browsers use DUCKCHAT_SYNC_NATIVE_SETUP_BUTTON_TEXT instead.
+msgctxt "Encrypted storage setup button (third-party browsers)"
+msgid "Turn On Sync & Backup"
+msgstr ""
+
+#. A button that turns off a setting.
+msgid "Turn off:"
+msgstr "Safe Search ausschalten"
+
+#. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
+msgctxt "precise_user_location"
+msgid "Turn on %sPrecise Location%s for more accurate results"
+msgstr ""
+
+#. A headline letting the user choose between two video player options
+msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
+msgstr ""
+
+#. Tells users which setting to change to enable location service.
+msgctxt "precise_user_location"
+msgid "Turn on “Precise Location” for more accurate results."
+msgstr ""
+
+#. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
+msgctxt "precise_user_location"
+msgid "Turn on “Use precise location” for more accurate results."
+msgstr ""
+
+#. Short description shown below the 'Create Image' label in the Tools dropdown.
+msgctxt "Subtitle for the Image tool entry in the Tools dropdown menu"
+msgid "Turn text into image"
+msgstr ""
+
+#. Short description shown below the 'Create Image' label in the Tools dropdown.
+msgctxt "Subtitle for the Image tool entry in the Tools dropdown menu"
+msgid "Turn text into images"
+msgstr ""
+
+#. Rugby match stats
+msgctxt "Sports module"
+msgid "Turnovers Won"
+msgstr ""
+
+msgid "Tuvalu "
+msgstr ""
+
+msgid "Twitter"
+msgstr "Twitter"
+
+#. List item indicating that an image type filter (e.g. clipart) is currently active for the search
+msgctxt "noresults"
+msgid "Type"
+msgstr ""
+
+#. Tells users how to add DuckDuckGo to the list of search engines in their browser.
+msgid "Type %sDuckDuckGo%s in the first %sform field"
+msgstr "Schreibe %sDuckDuckGo%s in das erste %sFormularfeld"
+
+#. Tells users how to add DuckDuckGo to the list of search engines in their browser.
+msgid "Type %sduckduckgo.com%s in the %ssecond form field"
+msgstr "Schreibe %sduckduckgo.com%s in das %szweite Formularfeld"
+
+msgctxt "settings"
+msgid ""
+"Types out DuckAssist answers as they're generated. Turning this off may "
+"result in a short delay between a search and the answer being displayed."
+msgstr ""
+
+msgctxt "settings"
+msgid "Typing Animation"
+msgstr ""
+
+msgid "Türkiye"
+msgstr ""
+
+#. Shortened form referring to the United Kingdom
+msgid "UK"
+msgstr ""
+
+#. This is the name of a user setting
+msgctxt "settings"
+msgid "URL Color"
+msgstr ""
+
+#. This is the name of a user setting -- Example image: https://i.imgur.com/icuYX4J.png
+msgctxt "settings"
+msgid "URL Format"
+msgstr ""
+
+#. 1. in https://duckduckgo.com/settings near the bottom by clicking "Bookmarklet and settings data" under "Your settings as a URL parameter bookmarklet:" in the sentence "see the URL Parameters page for detailed descriptions"
+#. 2. in https://duckduckgo.com/settings near the bottom under "Cloud Save" by clicking "What's this" under "What information gets saved?". It is a link
+#. 3. in https://duckduckgo.com/params in the top. It is a header
+msgid "URL Parameters"
+msgstr "URL Parameter"
+
+#. This is the name of a user setting -- Example image: https://i.imgur.com/0tyrveK.png
+msgctxt "settings"
+msgid "URL Placement"
+msgstr ""
+
+#. https://duckduckgo.com/params under "Color Settings"
+msgid "URLs:"
+msgstr "URLs:"
+
+msgid "US (English)"
+msgstr "Vereinigte Staaten"
+
+msgid "US (Spanish)"
+msgstr "Vereinigte Staaten (ES)"
+
+msgctxt "settingsvalue"
+msgid "US based (Pounds, Feet, Fahrenheit)"
+msgstr "amerikanisch (Pfund, Fuss, Fahrenheit)"
+
+msgctxt "settingsvalue"
+msgid "US-based (pounds, feet, Fahrenheit)"
+msgstr ""
+
+msgid "USA"
+msgstr ""
+
+msgid "Uganda"
+msgstr ""
+
+#. Inform the user that we retried but still did not succeed
+msgctxt "noresults"
+msgid "Ugh, it happened again!"
+msgstr ""
+
+msgid "Ukraine"
+msgstr ""
+
+#. The name of the Ukrainian language
+msgctxt "language_name"
+msgid "Ukrainian"
+msgstr ""
+
+#. The heading for the modal shown when the feedback form failed to send. For example, if the user lost connectivity.
+msgctxt "feedback form"
+msgid "Unable To Send Feedback"
+msgstr ""
+
+#. Message shown to the user when the voice chat failed to establish a connection, and they should try again later.
+msgctxt "voice chat"
+msgid "Unable to connect to voice chat, please try again later."
+msgstr ""
+
+#. Message shown to the user when there was an issue connecting to their microphone.
+msgctxt "voice chat"
+msgid "Unable to connect to your mic. Please try again."
+msgstr ""
+
+#. Error message for explore more questions when answer fails to load
+msgid "Unable to load answer. Please try again."
+msgstr ""
+
+#. Menu option to unblock a site from the displayed results
+msgctxt "Organic result context menu"
+msgid "Unblock this site"
+msgstr ""
+
+#. Short string representing a prompt suggestion for uncovering pros and cons.
+msgctxt "Brief for uncovering pros and cons"
+msgid "Uncover pros and cons"
+msgstr ""
+
+#. Tells the user where in the settings menu they can change their browser's home page.
+msgid ""
+"Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
+"Pages%s."
+msgstr ""
+"Unter %sBeim Start%s wähle %sBestimmte Seite oder Seiten öffnen%s und klicke "
+"dann auf %sSeiten festlegen%s."
+
+#. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
+msgid ""
+"Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
+msgstr ""
+"Unter %sBeim Start%s, wähle %sStartseite%s aus und gib ein: https://"
+"duckduckgo.com"
+
+#. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
+msgid "Under %sOpen with%s select %sA specific page or pages%s"
+msgstr "Unter %sÖffnen mit%s wähle %sEine spezifische Seite oder Seiten%s aus"
+
+#. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
+msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
+msgstr "Geben sie unter %sStartup > Homepage%s https://duckduckgo.com ein"
+
+#. Tells users where in the settings menu they can change their default search engine.
+msgid "Under %sSearch Settings%s select %sDuckDuckGo%s"
+msgstr "Unter %sSucheinstellungen%s wähle %sDuckDuckGo%s"
+
+#. Tells users where in the settings menu they can change their default search engine.
+msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
+msgstr ""
+"Unter %s«In Adressleiste suchen mit»%s bitte %sNeu hinzufügen%s auswählen"
+
+#. Tells users where in the settings menu they can change their default search engine.
+msgid "Under %sSearch%s section, click %sManage search engines...%s"
+msgstr "Drücke im Bereich %sSuchen%s auf %sSuchmachinen verwalten...%s"
+
+#. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
+msgid "Under On startup select %sOpen a specific page or set of pages%s"
+msgstr ""
+"Unter \"Beim Start\" wähle %sÖffne eine spezifische Seite oder mehrere "
+"Seiten%s aus"
+
+#. Tells users where in the settings menu they can change their default search engine
+msgid "Under Search click the drop down and select %sDuckDuckGo%s"
+msgstr ""
+"Unter Suche/Suchmaschine klicke auf das Dropdown-Menu und wähle "
+"%sDuckDuckGo%s aus"
+
+#. https://duckduckgo.com/params under "Look & Feel Settings" header
+msgid "Underline:"
+msgstr "Unterstreichen:"
+
+#. This is the description of a user setting
+msgctxt "settings"
+msgid "Underlines result titles"
+msgstr ""
+
+#. Short string representing a prompt suggestion for understanding a topic.
+msgctxt "Brief for understanding a topic"
+msgid "Understand a topic"
+msgstr ""
+
+#. Button text in the usage limit model switch toast that restores the previously selected AI model.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Undo"
+msgstr ""
+
+#. Label on the button that allows the previous action to be undone. For example, after removing a website this is shown.
+msgctxt "new tab page"
+msgid "Undo"
+msgstr ""
+
+#. Title of modal shown when we believe a user to be a bot
+msgctxt "Anomaly modal"
+msgid "Unfortunately, bots use DuckDuckGo too."
+msgstr ""
+
+#. Instant Answer tab name
+msgid "Unicode"
+msgstr " Unicode "
+
+#. A feedback suggestion about the search results presented (organics/ads)
+msgctxt "Feedback prompt"
+msgid "Unintuitive look and feel"
+msgstr ""
+
+msgid "United Arab Emirates"
+msgstr ""
+
+msgid "United Kingdom"
+msgstr "Vereinigtes Königreich"
+
+msgid "United States"
+msgstr ""
+
+msgctxt "settings"
+msgid "Units of Measure"
+msgstr "Masseinheiten"
+
+#. A tooltip that is shown after the user has clicked the swap units button. Example: https://duckduckgo.com/?q=5+meters+to+cm&ia=answer
+msgctxt "Conversions module"
+msgid "Units swapped"
+msgstr ""
+
+#. Description for the modal shown to Plus subscribers, explaining the benefits of upgrading to the Pro plan. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
+msgctxt "Description of the modal to upgrade to Pro"
+msgid ""
+"Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
+"plan by upgrading to Pro."
+msgstr ""
+
+#. Title for the subscription promo shown in the SERP sidemenu.
+msgctxt "Sidemenu subscription promo"
+msgid "Unlock VPN + Advanced AI"
+msgstr ""
+
+#. Text for the button that allows the user to unlock an AI model with a DuckDuckGo subscription when clicked.
+msgctxt ""
+"Text for the unlock with subscription button on the AI (Artificial "
+"Intelligence) models modal"
+msgid "Unlock With a DuckDuckGo Subscription"
+msgstr ""
+
+#. Upsell message shown in the voice chat limit modal for free users.
+msgctxt "voice chat limit modal"
+msgid ""
+"Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
+msgstr ""
+
+#. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
+msgctxt ""
+"Text that shows users they can unlock advanced AI models with a subscription."
+msgid "Unlock advanced AI models with a %s"
+msgstr ""
+
+#. Tooltip text shown when the user hovers over the free badge telling the user that they can unlock advanced AI (Artificial Intelligence) models with a DuckDuckGo subscription.
+msgctxt "Tooltip for the free badge"
+msgid "Unlock advanced AI models with a DuckDuckGo subscription"
+msgstr ""
+
+#. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
+msgctxt "Text promotion"
+msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
+msgstr ""
+
+#. Upsell message shown in the voice chat duration limit modal for free users.
+msgctxt "voice chat duration limit modal"
+msgid "Unlock longer voice chats with a DuckDuckGo Subscription"
+msgstr ""
+
+#. Text informing the user that more capable AI models can be unlocked with a subscription, with a trailing call-to-action link. %s is replaced with either the 'Try for free' link (for unauthenticated users) or the 'Learn more' link (for authenticated users). The link opens the subscription modal. Example: Unlock more capable AI models with a DuckDuckGo subscription. Try for free
+msgctxt ""
+"Text shown in the subscription promo card, with a trailing call-to-action "
+"link."
+msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
+msgstr ""
+
+#. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
+msgctxt "Mobile SERP subscription badge"
+msgid "Unlock premium protections"
+msgstr ""
+
+#. Tooltip/label for the button to unmute the microphone.
+msgctxt "voice chat"
+msgid "Unmute"
+msgstr ""
+
+#. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was not grounded in trustworthy sources.
+msgctxt "feedback form"
+msgid "Unverified information"
+msgstr ""
+
+#. Text explaining the limit on the number of recent chats that can be stored. Example: 'Up to 30 of your most recent chats can be saved at a time.'
+msgctxt "Information about the limit of recent chats that can be saved"
+msgid "Up to %s of your most recent chats can be saved at a time."
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Up-to-date"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Up-to-date information"
+msgstr ""
+
+msgctxt "precise_user_location"
+msgid "Update"
+msgstr "Aktualisieren"
+
+#. Button to update the DuckDuckGo browser, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
+msgctxt "Old app version banner component in Duck.ai"
+msgid "Update Browser"
+msgstr ""
+
+#. Button that updates the user's current location on a map.
+msgctxt "precise_user_location"
+msgid "Update Location"
+msgstr "Standort anpassen"
+
+#. Primary button to update now.
+msgctxt "duckai_migration"
+msgid "Update Now"
+msgstr ""
+
+#. Title shown when an update is required before proceeding.
+msgctxt "duckai_migration"
+msgid "Update Required"
+msgstr ""
+
+#. The title of a pop up where we explain how to update the browser manually.
+msgctxt "Update browser banner"
+msgid "Update Your Browser"
+msgstr ""
+
+#. Title when update finished.
+msgctxt "duckai_migration"
+msgid "Update complete!"
+msgstr ""
+
+#. Title for a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
+msgctxt "Old app version banner component in Duck.ai"
+msgid ""
+"Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
+"access advanced models"
+msgstr ""
+
+#. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
+msgid "Updated %s"
+msgstr ""
+
+#. Waiting for the device to send an updated location
+msgctxt "precise_user_location"
+msgid "Updating location..."
+msgstr ""
+
+#. Pending title while update is in progress.
+msgctxt "duckai_migration"
+msgid "Updating..."
+msgstr ""
+
+#. Link-style CTA shown on the right of the Pro exclusive section header; clicking starts the Pro upgrade flow.
+msgctxt ""
+"Trailing CTA on the Pro exclusive section header in the model picker dropdown"
+msgid "Upgrade"
+msgstr ""
+
+#. Label for the button that takes Plus subscribers to the Pro plans page when they hit the image generation limit. Context ('Upgrade to Pro') is already provided by the description above.
+msgctxt "Upgrade button label for image generation limit"
+msgid "Upgrade"
+msgstr ""
+
+#. Label for the button that takes Plus subscribers to the Pro plans page when they hit a voice chat limit. Context ('Upgrade to Pro') is already provided by the description above.
+msgctxt "Upgrade button label for voice chat limit"
+msgid "Upgrade"
+msgstr ""
+
+#. Text for the sidebar action button that takes the opens the upgrade subscription modal.
+msgctxt "Upgrade subscription sidebar action button"
+msgid "Upgrade"
+msgstr ""
+
+#. Title for the subscription setting where users can subscribe to DuckDuckGo.
+msgctxt ""
+"Title of the upgrade with subscription setting located on the settings modal"
+msgid "Upgrade Duck.ai With a DuckDuckGo Subscription"
+msgstr ""
+
+#. Title for the subscription setting where users can subscribe to DuckDuckGo.
+msgctxt ""
+"Title of the upgrade with subscription setting located on the settings modal"
+msgid "Upgrade Duck.ai with a DuckDuckGo Subscription"
+msgstr ""
+
+#. Title for the subscription modal where users can update their subscription to DuckDuckGo.
+msgctxt "Title of the modal to upgrade the DuckDuckGo subscription"
+msgid "Upgrade Duck.ai with a DuckDuckGo subscription"
+msgstr ""
+
+#. Text for the sidebar action button that takes the user to the upgrade models page.
+msgctxt "Upgrade models sidebar action button"
+msgid "Upgrade Models"
+msgstr ""
+
+#. Promotional message asking users to upgrade to the Privacy Pro subscription service.
+msgctxt "SERP footer content"
+msgid "Upgrade to Privacy Pro"
+msgstr ""
+
+#. Used as the text for the primary action button shown to Plus subscribers when they try to use a Pro-only model. Clicking this button takes the user to the Pro plans page.
+msgctxt ""
+"Button text for upgrading to Pro when a Plus subscriber encounters a Pro-"
+"only model"
+msgid "Upgrade to Pro"
+msgstr ""
+
+#. Used as the clickable link text in the sentence 'Upgrade to Pro to unlock 2x higher limits.' shown to Plus subscribers in usage limit error messages.
+msgctxt "Link text for upgrading to Pro plan within an error message"
+msgid "Upgrade to Pro"
+msgstr ""
+
+#. Title for the modal shown to Plus subscribers encouraging them to upgrade to the Pro plan.
+msgctxt "Title of the modal to upgrade to Pro"
+msgid "Upgrade to Pro"
+msgstr ""
+
+#. Label for the button that takes Plus subscribers to the Pro plans page when they hit the image generation limit.
+msgctxt "Upgrade button label for image generation limit"
+msgid "Upgrade to Pro"
+msgstr ""
+
+#. Text for the sidebar action button that opens the upgrade to Pro modal for Plus subscribers.
+msgctxt "Upgrade to Pro sidebar action button"
+msgid "Upgrade to Pro"
+msgstr ""
+
+#. Description shown to Plus subscribers who have reached their image generation limit, encouraging them to upgrade to Pro.
+msgctxt ""
+"Description prompting Plus subscribers to upgrade to Pro for higher image "
+"generation limits"
+msgid "Upgrade to Pro to unlock 2x higher limits"
+msgstr ""
+
+#. Description shown to Plus subscribers who have reached their image generation limit, encouraging them to upgrade to Pro.
+msgctxt ""
+"Description prompting Plus subscribers to upgrade to Pro for higher image "
+"generation limits"
+msgid ""
+"Upgrade to Pro to unlock 2x higher limits than Plus, or come back later to "
+"create more images."
+msgstr ""
+
+#. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
+msgctxt "voice chat limit modal"
+msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
+msgstr ""
+
+#. Heading in a promotion for a desktop web browser
+msgctxt "Sidemenu browser promo"
+msgid "Upgrade to our Private Browser"
+msgstr ""
+
+#. Heading in a promotion for a desktop web browser
+msgctxt "Browser Promo Popover"
+msgid "Upgrade to our Private Browser for Mac"
+msgstr ""
+
+#. Heading in a promotion for a desktop web browser
+msgctxt "Browser Promo Popover"
+msgid "Upgrade to our Private Browser for Windows"
+msgstr ""
+
+#. Header for a call to action to install the DuckDuckGo browser
+msgctxt "Browser Promo Popover"
+msgid "Upgrade to our browser."
+msgstr ""
+
+#. Response a user can select in a feedback form, indicating that they want to use DuckDuckGo as their primary search engine.
+msgctxt "new user poll"
+msgid "Upgrading to full-time user"
+msgstr "Upgrade auf Vollzeit-Nutzer"
+
+#. Button label for a promotional card that encourages users to upload a PDF file to Duck.ai.
+msgctxt "Promotional CTA for PDF upload feature"
+msgid "Upload PDF"
+msgstr ""
+
+#. The name of the Urdu language
+msgctxt "language_name"
+msgid "Urdu"
+msgstr ""
+
+msgid "Uruguay"
+msgstr ""
+
+#. Sidebar navigation label for the Usage section of the Duck.ai settings page, where users can view their usage limits.
+msgctxt "Navigation label on the Duck.ai settings page"
+msgid "Usage"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Usage limit"
+msgstr ""
+
+#. This is a verb and will be concatenated with a noun in dropdown boxes, e.g. "Use xyz". The text was previously "Using".
+msgid "Use"
+msgstr "Nutze"
+
+#. Text for a promotional card that encourages users to use https://duck.ai to access the service faster. Example: 'Use duck.ai to get here faster'
+msgctxt "Promotional text encouraging users to use duck.ai"
+msgid "Use %s to get here faster"
+msgstr ""
+
+#. Button that allows search results to be shown near the user's current location.
+msgctxt "precise_user_location"
+msgid "Use Anonymous Location"
+msgstr ""
+
+#. Text for the switch label that enables or disables the Approximate Location feature, a feature that helps improve Assistant responses by using the user's general location.
+msgctxt "Label for enabling Approximate Location feature"
+msgid "Use Approximate Location"
+msgstr ""
+
+#. Text for the switch label that enables or disables the Approximately Location feature, a feature that helps improve Assistant responses by using the user's general location.
+msgctxt "Label for enabling Approximately Locationfeature"
+msgid "Use Approximate Location"
+msgstr ""
+
+#. Meta description content for Duck.ai.
+msgctxt "duckai_seo"
+msgid ""
+"Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
+"scammers, and companies. Keep info confidential. Free. No account required."
+msgstr ""
+
+#. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
+msgctxt "mobile homepage"
+msgid "Use DuckDuckGo Private Search"
+msgstr "Verwende DuckDuckGo Private Search"
+
+#. Explains that DuckDuckGo is available for multiple devices.
+msgctxt "mobile promotion on desktop"
+msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
+msgstr "Nutze DuckDuckGo private search uf deinem iPad, iPhone oder Android"
+
+#. User clicks this button to share their device's location
+msgctxt "precise_user_location"
+msgid "Use Location"
+msgstr ""
+
+#. User clicks this button to share their device's location
+msgctxt "Precise user location overlay"
+msgid "Use Your Location"
+msgstr ""
+
+#. Link to download the DuckDuckGo extension for the Firefox browser.
+msgid "Use in Firefox"
+msgstr "In Firefox verwenden"
+
+#. Link to download the DuckDuckGo extension for the Safari browser.
+msgid "Use in Safari"
+msgstr "In Safari benutzen"
+
+#. Headline of the VPN instant answer shown on the search results page. One of several messages rotated over time that promote the DuckDuckGo VPN (part of the paid subscription). Emphasizes protection on public Wi-Fi networks.
+msgctxt "DuckDuckGo VPN instant answer"
+msgid "Use public Wi-Fi? Use our VPN."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
+
+#. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
+msgctxt "Description for the joiner-device success screen"
+msgid ""
+"Use this code to restore your data if you lose access to your devices. Keep "
+"it safe."
+msgstr ""
+
+#. First sentence of the recovery section. The 18-month inactivity notice is rendered by the component using DUCKCHAT_SYNC_RECOVERY_INACTIVITY_NOTICE so both surfaces stay consistent.
+msgctxt "Description for the recovery section inside Manage"
+msgid ""
+"Use this code to restore your saved chats if you lose access to your devices."
+msgstr ""
+
+#. Prompt to ask the user if they want to use their approximate location for more accurate results
+msgctxt "DuckChat location prompt"
+msgid "Use your approximate location for more accurate results?"
+msgstr ""
+
+#. When a user exports a chat they had with an AI model, this text goes before every user message in the downloaded file, indicating which message it is out of the total number of messages. Example: 'User prompt 3 of 5'
+msgctxt "Export chat feature in AI Chat"
+msgid "User prompt %s of %s"
+msgstr ""
+
+#. Label showing what year a user, such as a Reddit user was created. To be displayed on a card about that subreddit. e.g. "User since 2014".
+msgctxt "Discussions IA"
+msgid "User since %s"
+msgstr ""
+
+msgid "Uzbekistan"
+msgstr ""
+
+#. Label for vaccines tab
+msgctxt "Covid 19 module"
+msgid "Vaccines"
+msgstr ""
+
+msgid "Vanuatu"
+msgstr ""
+
+#. A title for a set of auto ads
+msgid "Vehicles for sale"
+msgstr ""
+
+msgid "Venezuela"
+msgstr ""
+
+#. Indicates the main road that will be traveled on in driving directions. For example: 'Via the highway'
+msgctxt "directions"
+msgid "Via"
+msgstr "Via"
+
+#. http://i.imgur.com/BF3gZsZ.png
+msgctxt "settings"
+msgid "Video Playback"
+msgstr "Video Wiedergabe"
+
+msgctxt "settings"
+msgid "Video Previews on Hover"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Video not playing"
+msgstr ""
+
+#. Label above video search results.
+msgid "Videos"
+msgstr "Videos"
+
+#. A label that indicates a specific search result for videos has been blocked by the safe search filter
+msgid "Videos blocked by safe search."
+msgstr ""
+
+#. A label that indicates a specific search result for videos has been blocked by the safe search filter. The placeholder value is the name of the search result that was blocked.
+msgid "Videos for %s blocked by safe search"
+msgstr ""
+
+#. Title for the section that showcases the video results for a certain query, ex. Videos for <b>japan</b>
+msgid "Videos for %s%s%s"
+msgstr ""
+
+msgid "Vietnam"
+msgstr "Vietnam"
+
+msgid "Vietnam (en)"
+msgstr ""
+
+#. The name of the Vietnamese language
+msgctxt "language_name"
+msgid "Vietnamese"
+msgstr ""
+
+#. Always-visible second tab. When active the user sees their own QR plus the recovery code text for another device to consume.
+msgctxt "Tab label for the share-my-code side of the Sync Another Device pane"
+msgid "View Code"
+msgstr ""
+
+#. Button that shows the contents of a file.
+msgid "View File"
+msgstr ""
+
+#. A button that opens the settings modal from the page context onboarding modal.
+msgctxt "Button on the page context onboarding modal"
+msgid "View Settings"
+msgstr ""
+
+#. Heading for a dropdown that toggles more items
+msgid "View more items"
+msgstr ""
+
+#. A link that appears next to videos in search results that takes users to the website that hosts the video. The placeholder is the name of the video website. For example: View on YouTube.'
+msgid "View on %s"
+msgstr "Auf %s anschauen"
+
+#. Button that shows a location on a map.
+msgctxt "maps_maps_module"
+msgid "View on Map"
+msgstr "Auf der Karte zeigen"
+
+#. Will be used for allowing users to explore pricing information for a hotel.
+msgctxt "Single Place Hotel Offers Module"
+msgid "View prices for your stay"
+msgstr ""
+
+#. A description for the ads tooltip that explains that viewing ads is privacy protected by DuckDuckGo.
+msgid "Viewing ads is privacy protected by DuckDuckGo."
+msgstr ""
+
+msgctxt "Ads GDPR, internal use only. Do not change"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Microsoft's ad network"
+msgstr ""
+
+#. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
+msgctxt "Single Place Hotel Offers Module"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"TripAdvisor's ad network."
+msgstr ""
+
+msgid "Virgin Islands"
+msgstr ""
+
+#. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
+msgctxt "duckassist"
+msgid ""
+"Visit %sAssist Settings%s to adjust how this feature works or turn it off."
+msgstr ""
+
+#. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
+msgctxt "duckassist"
+msgid ""
+"Visit %sDuckAssist Settings%s to adjust how this feature works or turn it "
+"off."
+msgstr ""
+
+#. Prompt to visit DuckDuckGo on another device.
+msgctxt "mobile promotion on desktop"
+msgid ""
+"Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
+"instructions."
+msgstr ""
+"Gehe auf %sDuckDuckGo.com%s auf deinem Tablet oder Handy und befolge die "
+"Anleitungen"
+
+#. Primary button to visit Duck.ai.
+msgctxt "duckai_migration"
+msgid "Visit Duck.ai"
+msgstr ""
+
+#. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
+msgctxt "Modal body for the device-pairing flow"
+msgid ""
+"Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
+"& Backup%s > %sManage%s then select %sSync With Another Device%s."
+msgstr ""
+
+#. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
+msgctxt "Body copy on the recover-data scan/paste sheet"
+msgid ""
+"Visit Duck.ai in your other browser and open Duck.ai Settings. Select “Turn "
+"On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
+"QR on your Recovery PDF."
+msgstr ""
+
+#. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
+msgctxt "Modal body for the device-pairing flow"
+msgid ""
+"Visit Duck.ai in your other browser or the DuckDuckGo app and go to %sDuck."
+"ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
+"Another Device%s."
+msgstr ""
+
+#. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
+msgctxt "Body copy on the recover-data scan/paste sheet"
+msgid ""
+"Visit Duck.ai in your other browser or the DuckDuckGo app and open Duck.ai "
+"Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
+"Device”. Or scan the QR on your Recovery PDF."
+msgstr ""
+
+#. Step 2 label for export screens.
+msgctxt "duckai_migration"
+msgid "Visit the new Duck.ai"
+msgstr ""
+
+msgctxt "settings"
+msgid "Visited Checkmark"
+msgstr ""
+
+#. This is the name of a user setting. Changes the color of visited site's title in the search results.
+msgctxt "settings"
+msgid "Visited Title Color"
+msgstr ""
+
+#. https://duckduckgo.com/params under "Color Settings" header
+msgid "Visited links:"
+msgstr "Besuchte Links:"
+
+#. Title for the Voice Chat feature.
+msgctxt "voice chat"
+msgid "Voice Chat"
+msgstr ""
+
+#. Aria label for the voice chat overlay dialog.
+msgctxt "voice chat"
+msgid "Voice chat"
+msgstr ""
+
+#. Title of the modal shown when the user has reached the maximum duration for a voice chat session.
+msgctxt "voice chat duration limit modal"
+msgid "Voice chat duration reached"
+msgstr ""
+
+#. Message shown to the user indicating the voice chat session has ended.
+msgctxt "voice chat"
+msgid "Voice chat ended"
+msgstr ""
+
+#. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
+msgctxt "voice chat"
+msgid "Voice chat is anonymized by us, and never used to train AI models."
+msgstr ""
+
+#. Title of the modal shown when the user has reached their daily voice chat limit.
+msgctxt "voice chat limit modal"
+msgid "Voice chat limit reached"
+msgstr ""
+
+#. Title of the voice chat privacy disclaimer and consent modal.
+msgctxt "voice chat"
+msgid "Voice chat with Duck.ai"
+msgstr ""
+
+#. Indicates this is the number of wins for this team
+msgctxt "Sports module"
+msgid "W"
+msgstr ""
+
+#. Abbreviation for 'West'
+msgctxt "forecast"
+msgid "W"
+msgstr "W"
+
+#. Element title explaining this is the win draw loss record for team, e.g. 5-1-2
+msgctxt "Sports module"
+msgid "W-D-L"
+msgstr ""
+
+#. Element title explaining this is the win loss record for team, e.g. 10-5
+msgctxt "Sports module"
+msgid "W-L"
+msgstr ""
+
+#. Indicates this is the gap between a leading team and another team in the Wild Card view (https://en.wikipedia.org/wiki/Games_behind#Wild_card_race). The acronym stands for Wild Card Games Behind.
+msgctxt "Sports module"
+msgid "WCGB"
+msgstr ""
+
+#. Abbreviation for 'World Series', the title of the annual championship series of Major League Baseball (MLB)
+msgctxt "Sports module"
+msgid "WS"
+msgstr ""
+
+#. Waiting for the device location sensor to return data
+msgctxt "precise_user_location"
+msgid "Waiting for Location..."
+msgstr ""
+
+msgid "Wales"
+msgstr ""
+
+#. Page-suggestion chip label "Walk me through the steps", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Walk me through the steps"
+msgstr ""
+
+#. Label for walking directions on a map.
+msgctxt "directions"
+msgid "Walking"
+msgstr "Laufen"
+
+#. Tennis match status: walkover
+msgctxt "Sports module"
+msgid "Walkover"
+msgstr ""
+
+#. Filters the size of images in search results.
+msgctxt "size"
+msgid "Wallpaper"
+msgstr "Hintergrund"
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Want more images"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Want more map results"
+msgstr ""
+
+#. Question on a feedback form.
+msgctxt "feedback form"
+msgid "Want to tell us a bit more?"
+msgstr "Möchtest du uns noch ein wenig mehr mitteilen?"
+
+#. The text inviting users to provide feedback on a result or instant answer
+msgctxt "Feedback prompt"
+msgid "Was this helpful?"
+msgstr ""
+
+#. Message displayed to the user when they use page context for the first time. It asks them if the response correctly used the page content.
+msgctxt "First time page context response feedback"
+msgid "Was this response accurate?"
+msgstr ""
+
+#. Prompt asking the user to rate the AI response using the thumbs up/down buttons.
+msgctxt ""
+"Title of the one-time popover shown above the thumbs up/down buttons on an "
+"AI response"
+msgid "Was this response helpful?"
+msgstr ""
+
+#. A button that plays a video on the current page.
+msgid "Watch Here"
+msgstr "Hier ansehen"
+
+#. Item in a list of features of a desktop web browser
+msgctxt "Browser Promo Popover"
+msgid "Watch YouTube without targeted ads"
+msgstr ""
+
+#. This is a button that lets the user play a video in our custom video player
+msgid "Watch in Duck Player"
+msgstr ""
+
+#. Explains the benefits of using our custom video player, the Duck Player
+msgid ""
+"Watch in Duck Player to block personalized ads on YouTube and prevent your "
+"viewing activity from influencing YouTube recommendations."
+msgstr ""
+
+#. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
+msgid "Watch on %s"
+msgstr "Auf %s ansehen"
+
+#. A button that takes a user to YouTube in order to watch a video.
+msgid "Watch on YouTube"
+msgstr "Auf YouTube ansehen"
+
+#. A privacy disclaimer that appears above YouTube videos.
+msgid ""
+"Watching a video here means the website where it is hosted can track you "
+"because we have to stream the content from there. DuckDuckGo is an "
+"independent company and has no relationship with YouTube, where most videos "
+"are hosted."
+msgstr ""
+
+#. Heading for the highlight card explaining anonymized prompt delivery.
+msgctxt "Title for the anonymized card in the How Duck.ai Works panel"
+msgid "We Anonymize"
+msgstr ""
+
+#. Explains how location service is used to show users search results near their current location.
+msgctxt "precise_user_location"
+msgid "We can anonymize%s your location%s to show you more accurate results."
+msgstr ""
+
+#. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share this conversation with DuckDuckGo so we can investigate and "
+"address the issue."
+msgstr ""
+
+#. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
+msgctxt ""
+"Inline warning shown below the share-content toggle when the user selects "
+"Harmful or Illegal but has not enabled sharing"
+msgid ""
+"We can only fix what we can see. To report a harmful or illegal response, "
+"please share your prompt and response so we can investigate and address the "
+"issue."
+msgstr ""
+
+#. Explains how location service is used to show users search results near their current location.
+msgctxt "precise_user_location"
+msgid "We can use your anonymous%s location%s to show you nearby results."
+msgstr ""
+
+#. Error message displayed when one or more attached files are encrypted and cannot be read.
+msgctxt "Error message when at least one attached file is encrypted"
+msgid ""
+"We can't read the files attached because at least one of them is encrypted."
+msgstr ""
+
+msgctxt "reasons-to-use-duckduckgo"
+msgid "We don't follow you around with ads."
+msgstr "Gründe DuckDuckGo zu benutzen"
+
+#. Text explaining how the cloud save feature works.
+msgctxt "cloudsave"
+msgid "We don't store usernames or any personally identifiable information."
+msgstr ""
+
+msgctxt "homepage onboarding"
+msgid "We don't store your personal info or track you. Ever."
+msgstr ""
+"Wir speichern deine persönlichen Informationen nicht und verfolgen dich auch "
+"nicht. Niemals."
+
+msgctxt "reasons-to-use-duckduckgo"
+msgid "We don't store your personal info."
+msgstr "Wir speichern keine deiner persönlichen Informationen."
+
+msgid ""
+"We don't store your personal info. We don't follow you around with ads. We "
+"don't track you. Ever."
+msgstr ""
+"Wir speichern keine deiner persönlichen Informationen. Wir verfolgen dich "
+"nichtmit Werbungen. Wir tracken dich nicht. Nie."
+
+msgctxt "reasons-to-use-duckduckgo"
+msgid "We don't store your personal information."
+msgstr "Wir speichern keine persönliche Daten."
+
+#. Message prompting users to fill out a feedback form.
+msgctxt "new user poll"
+msgid ""
+"We don't track you, so we could use your help telling us what brought you "
+"back today:"
+msgstr ""
+"Wir verfolgen dich nicht, deshalb benötigen wir deine Hilfe indem du uns "
+"verrätst was dich heute zurückgebracht hat:"
+
+#. Message prompting users to fill out a feedback form.
+msgctxt "new user poll"
+msgid ""
+"We don't track you, so we could use your help telling us what convinced you "
+"to try us out today:"
+msgstr ""
+"Wir verfolgen dich nicht, du kannst uns helfen, indem du uns sagst was dich "
+"überzeugt hat uns auszuprobieren:"
+
+msgctxt "reasons-to-use-duckduckgo"
+msgid "We don't track you. Ever."
+msgstr "Wir verfolgen dich nicht. Niemals."
+
+#. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
+msgctxt "Header above terms-of-service decision card on Duck.ai"
+msgid "We don't track you. That's our Privacy Policy in a nutshell."
+msgstr ""
+
+#. Description for the audio identification highlight in the dictation consent modal.
+msgid "We don't use your voice to identify you."
+msgstr ""
+
+#. Description in consent disclaimer informing that we do not use the user's voice from the voice chat session to identify them.
+msgctxt "voice chat"
+msgid "We don't use your voice to identify you."
+msgstr ""
+
+msgctxt "homepage onboarding"
+msgid "We don’t follow you around with ads."
+msgstr "Wir verfolgen dich nicht mittels Werbung."
+
+msgctxt "homepage onboarding"
+msgid "We don’t store your personal information. Ever."
+msgstr "Wir speichern Deine persönlichen Daten nicht. Niemals."
+
+msgctxt "homepage onboarding"
+msgid ""
+"We don’t store your search history. We therefore have nothing to sell to "
+"advertisers that track you across the Internet."
+msgstr ""
+"Wir speichern Deinen Suchverlauf nicht. Daher können wir nichts an "
+"Werbetreibende verkaufen, die Dich quer durch das Internet verfolgen."
+
+msgctxt "homepage onboarding"
+msgid "We don’t track you in or out of private browsing mode."
+msgstr ""
+"Wir verfolgen dich nicht, egal ob du den privaten Surf-Modus aktiviert hast "
+"oder nicht."
+
+#. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
+msgctxt "Header above terms-of-service decision card on Duck.ai"
+msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
+msgstr ""
+
+#. Displayed when the user's voice chat session is ended because of being inactive for too long.
+msgctxt "voice chat error"
+msgid "We ended the chat due to inactivity. Want to try again?"
+msgstr ""
+
+#. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
+msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
+msgid ""
+"We have agreements with all AI providers to ensure your chats aren't used to "
+"train AIs."
+msgstr ""
+
+msgctxt "homepage ATB modal"
+msgid "We keep your search history private"
+msgstr ""
+
+#. Displayed when the voice chat connection is lost and the session ends.
+msgctxt "voice chat error"
+msgid "We lost the connection, please try again later."
+msgstr ""
+
+#. We store chats for 15 minutes in the BE. If the user tries to fetch it after the 15 minutes elapsed or if we had an issue saving it we show them this error message so they can re-submit their prompt.
+msgctxt "AI Chat: Error message for unsaved or expired chats saved in sync"
+msgid "We lost the connection. Please try sending your message again."
+msgstr ""
+
+#. Message asking the user to disable their ad blocker, with a link to how our ads don't track you. The placeholders are for the start and end tags of that link (e.g. <a href="%">, </a>)
+msgid ""
+"We make money from %sprivacy-respecting search ads%s, not by exploiting your "
+"data."
+msgstr ""
+
+#. Message describing how DuckDuckGo users location access anonymously to provide better search results.
+msgctxt "precise_user_location"
+msgid ""
+"We only use your anonymous location to deliver better results, closer to "
+"you. You can always change your mind later."
+msgstr ""
+
+msgctxt "Feedback prompt"
+msgid ""
+"We rely on your anonymous feedback to make DuckDuckGo better for everyone."
+msgstr ""
+
+msgctxt "homepage ATB modal"
+msgid "We stop anyone from getting your search history, including us."
+msgstr ""
+
+#. Message that appears after submitting a feedback form.
+msgctxt "feedback form"
+msgid "We use feedback like this to improve DuckDuckGo."
+msgstr ""
+
+#. Placeholder can be Apple Maps, TripAdvisor, and/or Foursquare
+msgctxt "feedback form"
+msgid ""
+"We use feedback like this to improve DuckDuckGo. Suggestions will be "
+"incorporated at the discretion of %s. Corrections may not show up in results "
+"right away."
+msgstr ""
+
+msgctxt "homepage ATB modal"
+msgid "We'll block trackers trying to collect your data as you browse."
+msgstr ""
+
+#. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
+msgctxt "noresults"
+msgid ""
+"We're aware of this issue and are currently working to resolve it. If you "
+"continue to see this error, please reach out to %s."
+msgstr ""
+
+#. Inform the user we're still having errors and that we will investigate the issue
+msgctxt "noresults"
+msgid ""
+"We're aware of this issue and are currently working to resolve it. Sometimes "
+"clearing your browser's cache can help."
+msgstr ""
+
+#. Header for a feedback form for new users.
+msgctxt "new user poll"
+msgid "We're honored to have you on the Duck Side"
+msgstr "Wir fühlen uns geehrt dich auf der Duck Side zu haben"
+
+#. Error modal body line 3.
+msgctxt "duckai_migration"
+msgid ""
+"We're sorry for this inconvenience. We’re working hard to make your "
+"experience better."
+msgstr ""
+
+#. Body text explaining the service update requires a page reload.
+msgctxt "duckai_migration"
+msgid ""
+"We've updated the Duck.ai service. For the change to take effect, we need to "
+"reload the page."
+msgstr ""
+
+#. Instant Answer Tab Name
+msgid "Weather"
+msgstr "Wetter"
+
+#. Informs the user where the forecast is for, e.g. 'Weather for London, UK'.
+msgctxt "forecast"
+msgid "Weather for %s%s%s"
+msgstr ""
+
+#. Text for a button that, when clicked, takes the user to the DuckDuckGo's web search page. The button includes a search icon. It's ok to leave it in English if that's the expectation in your language.
+msgctxt "AI Chat web button"
+msgid "Web"
+msgstr ""
+
+#. Category a user can select on a feedback form.
+msgctxt "feedback form"
+msgid "Web Links"
+msgstr "Verknüpfungen"
+
+#. Label for the web search option in the Tools dropdown menu in the Duck.ai chat input toolbar.
+msgctxt "Label for the Web Search tool entry in the Tools dropdown menu"
+msgid "Web Search"
+msgstr ""
+
+#. Text for a label indicating that the AI (Artificial Intelligence) model has support for web search, in the context that the user can ask the AI to search the web for information.
+msgctxt "duck.ai model card"
+msgid "Web search"
+msgstr ""
+
+msgctxt "maps_places"
+msgid "Website"
+msgstr "Webseite"
+
+#. Category of feedback a user can select on a feedback form.
+msgctxt "feedback form"
+msgid "Website is incorrect"
+msgstr ""
+
+#. Category of feedback a user can select on a feedback form.
+msgctxt "feedback form"
+msgid "Website is missing"
+msgstr ""
+
+#. Shown as confirmation that a website link was removed from a list.
+msgctxt "new tab page"
+msgid "Website removed"
+msgstr ""
+
+#. Weekday abbreviation (short for 'Wednesday')
+msgctxt "maps_places"
+msgid "Wed"
+msgstr ""
+
+#. Weekday in plural form
+msgctxt "maps_places"
+msgid "Wednesdays"
+msgstr ""
+
+#. Used to indicate which week the game belongs to, e.g. Week 2
+msgctxt "Sports module"
+msgid "Week"
+msgstr ""
+
+#. Label for the weekly usage limit row in the Usage section of Duck.ai settings.
+msgctxt "Duck.ai settings usage section"
+msgid "Weekly limit"
+msgstr ""
+
+#. Displayed in the Duck.ai usage limit banner for subscribers when the weekly usage limit has been reached.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Weekly limit reached"
+msgstr ""
+
+#. Displayed in the Duck.ai usage limit banner for subscribers when the weekly usage limit has been reached.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Weekly usage limit reached"
+msgstr ""
+
+#. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
+msgctxt "Error message for fixed-window Duck.ai usage limit"
+msgid "Weekly usage limit reached. You can continue this chat after %s."
+msgstr ""
+
+#. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
+msgctxt "Error message for fixed-window Duck.ai usage limit"
+msgid ""
+"Weekly usage limit reached. You can keep chatting by using your monthly "
+"limit."
+msgstr ""
+
+msgctxt "settings"
+msgid "Welcome Message"
+msgstr "Willkommensnachricht"
+
+#. Welcome message displayed when the chat is opened.
+msgctxt "Welcome message in chat"
+msgid ""
+"Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
+"not used to train AI models."
+msgstr ""
+
+#. Welcome message displayed when the chat is opened.
+msgctxt "Welcome message in chat"
+msgid ""
+"Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
+"anonymized by us and not used to train AI models."
+msgstr ""
+
+#. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
+msgctxt "Welcome message in chat"
+msgid ""
+"Welcome to DuckDuckGo AI Chat! This chat session is powered by %s’s %s. All "
+"of your chats here are private, and are never stored by DuckDuckGo or used "
+"to train AI models."
+msgstr ""
+
+#. Intro message on import screen.
+msgctxt "duckai_migration"
+msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
+msgstr ""
+
+#. Intro message on import screen.
+msgctxt "duckai_migration"
+msgid "Welcome to new Duck.ai, it's time to import your chats"
+msgstr ""
+
+#. Welcome message for new DuckDuckGo users.
+msgctxt "homepage onboarding"
+msgid "Welcome to the Duck Side!"
+msgstr "Willkommen auf der Duck-Seite"
+
+#. The name of the Welsh language
+msgctxt "language_name"
+msgid "Welsh"
+msgstr ""
+
+#. The title displayed when prompting for the user to provide feedback on the third party map app directions experience
+msgctxt "Third party map app picker feedback dialog"
+msgid "Were directions helpful?"
+msgstr ""
+
+msgctxt "Sports module"
+msgid "West"
+msgstr ""
+
+#. For US leagues that divide teams in two conferences, short version used e.g. in the Team module subtitle in NBA
+msgctxt "Sports module"
+msgid "Western"
+msgstr ""
+
+#. For US leagues that divide teams in two conferences, used e.g. in the Standings table in NBA
+msgctxt "Sports module"
+msgid "Western Conference"
+msgstr ""
+
+#. Inform the users that "something" went wrong and we are unable to show any results.
+msgctxt "noresults"
+msgid "We’re currently experiencing an issue with DuckDuckGo Search."
+msgstr ""
+
+#. Inform the users that "something" went wrong even though we were able to show some organic results.
+msgctxt "noresults"
+msgid "We’re experiencing a temporary issue."
+msgstr ""
+
+#. Inform the users that "something" went wrong and we are unable to show any results.
+msgctxt "noresults"
+msgid "We’re experiencing an outage."
+msgstr ""
+
+#. Body message shown in a fatal error modal when Duck.ai fails to load.
+msgctxt "duckai_fatal_error"
+msgid ""
+"We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
+"reloading the page."
+msgstr ""
+
+#. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
+msgctxt "Feedback prompt"
+msgid "What AI model would you like us to add? (optional)"
+msgstr ""
+
+#. Text for a prompt suggestion for providing arguments, counter-arguments, and rebuttals to the concept of a plant-based diet.
+msgctxt "Full sentence for improving arguments"
+msgid ""
+"What are some arguments, counter-arguments, and rebuttals to the concept of "
+"a plant-based diet?"
+msgstr ""
+
+#. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
+msgctxt "Full sentence for preparing for a purchase"
+msgid "What are some factors to consider when purchasing a computer monitor?"
+msgstr ""
+
+#. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
+msgctxt "Full sentence for planning a trip"
+msgid "What are some must-see attractions in Paris for a first-time visitor?"
+msgstr ""
+
+#. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
+msgctxt "Full sentence for finding a better word"
+msgid ""
+"What are some options for the word ‘better’ in the context of “We really "
+"need to do better.”"
+msgstr ""
+
+#. Text for a prompt suggestion for uncovering pros and cons of annuities.
+msgctxt "Full sentence for uncovering pros and cons"
+msgid "What are some pros and cons of annuities?"
+msgstr ""
+
+#. Auto-submitted prompt when user clicks Learn More on the RetentionBrowserPromo banner.
+msgctxt "User prompt seeded by Learn More CTA"
+msgid ""
+"What are the benefits of downloading the DuckDuckGo browser for someone "
+"interested in using Duck.ai? Only reference official DuckDuckGo sources. "
+"Break up the response into clear sections with titles, with a focus on Duck."
+"ai integrations, and privacy protections. Keep it quite short, simple, and "
+"easy to understand for people with or without much AI, or technical, "
+"experience."
+msgstr ""
+
+#. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the counterarguments?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the hours & location?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the hours & location?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key contributions?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key contributions of this paper?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key contributions?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key contributions?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key details?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key details?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key points?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key points covered in this video?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key points?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key points?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the key takeaways?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key takeaways from this article?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the key takeaways?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the key takeaways?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the key things I will learn from this course?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main counterarguments or criticisms of this?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the main questions this page answers?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What should I order?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the must-try dishes here?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the hours & location?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid ""
+"What are the opening hours, location, and contact details for this place?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What are the pros and cons of this product?"
+msgstr ""
+
+#. Page-suggestion chip label "What are the pros and cons?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What are the pros and cons?"
+msgstr ""
+
+#. Heading on the Search Assist feedback form shown when the user gives negative feedback, asking what they disliked about the answer.
+msgctxt "feedback form"
+msgid "What bothered you most?"
+msgstr ""
+
+#. Question in a feedback form.
+msgctxt "new user poll"
+msgid "What brought you back today?"
+msgstr "Was hat dich heute zurückgebracht?"
+
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
+#. Question on a feedback form.
+msgctxt "feedback form"
+msgid "What could be better?"
+msgstr "Was könnte besser sein?"
+
+#. Question on a feedback form.
+msgctxt "feedback form"
+msgid "What did you like about this?"
+msgstr ""
+
+#. Question on a feedback form.
+msgctxt "feedback form"
+msgid "What did you like about this? (optional)"
+msgstr ""
+
+#. Question on a feedback form.
+msgctxt "feedback form"
+msgid "What did you like?"
+msgstr "Was mochtest du?"
+
+#. Question on a feedback form.
+msgctxt "feedback form"
+msgid "What didn’t you like about this?"
+msgstr ""
+
+#. Question on a feedback form.
+msgctxt "feedback form"
+msgid "What didn’t you like about this? (optional)"
+msgstr ""
+
+msgctxt "Feedback prompt"
+msgid "What do you think of Maps?"
+msgstr ""
+
+#. Question on a feedback form.
+msgctxt "feedback form"
+msgid "What do you think of the information shown?"
+msgstr ""
+
+msgctxt "Feedback prompt"
+msgid "What do you think of these results?"
+msgstr ""
+
+#. An invitation for users to leave feedback on an image displayed on the DuckDuckGo search engine
+msgctxt "Feedback prompt"
+msgid "What do you think of this image?"
+msgstr ""
+
+#. An invitation for users to leave feedback on a response displayed on the DuckDuckGo search engine
+msgctxt "Feedback prompt"
+msgid "What do you think of this response?"
+msgstr ""
+
+#. Placeholder is a domain name (e.g., nationalgeographic.com)
+msgctxt "Feedback prompt"
+msgid "What do you think of this result from %s?"
+msgstr ""
+
+#. Question on feedback form seen when giving feedback on a specific organic result. The placeholder is for a domain wrapped in <strong> tags. Example: What do you think of this result from <strong>wikipedia.com</strong>?
+msgctxt "feedback form"
+msgid "What do you think of this result from %s?"
+msgstr ""
+
+#. An invitation for users to leave feedback on a result displayed on the DuckDuckGo search engine
+msgctxt "Feedback prompt"
+msgid "What do you think of this result?"
+msgstr ""
+
+#. Text for a prompt suggestion for defining the term 'atria' in the context of a medical article.
+msgctxt "Full sentence for defining a term"
+msgid "What does atria mean in the context of a medical article?"
+msgstr ""
+
+#. Page-suggestion chip label "What does this answer?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What does this answer?"
+msgstr ""
+
+#. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
+msgctxt "Feedback prompt"
+msgid "What feature would you like us to add? (optional)"
+msgstr ""
+
+#. Header above a list of types of information that gets saved by the cloud save feature.
+msgctxt "cloudsave"
+msgid "What information gets saved?"
+msgstr "Welche Informationen werden gespeichert?"
+
+#. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What interview questions might come up for this role?"
+msgstr ""
+
+#. Text explaining how the cloud save feature works.
+msgctxt "cloudsave"
+msgid ""
+"What is the Cloud Save bookmarklet and how does it differ from the URL "
+"parameter bookmarklet?"
+msgstr ""
+
+#. Text for a prompt suggestion for looking up the capital city of Albania.
+msgctxt "Full sentence for looking up basic facts"
+msgid "What is the capital city of Albania?"
+msgstr ""
+
+#. Prompt sent to the AI when the user taps the "What's the verdict?" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "What is the overall verdict and rating for this?"
+msgstr ""
+
+#. Link to a page with additional information.
+msgid "What is this?"
+msgstr "Was ist das?"
+
+#. Question in a feedback form for new users.
+msgctxt "new user poll"
+msgid "What led you to DuckDuckGo?"
+msgstr "Was hat dich zu DuckDuckGo gebracht?"
+
+#. Label that appears next to quotes from user reviews of businesses.
+msgctxt "maps_places"
+msgid "What people say"
+msgstr ""
+
+msgctxt "maps_places"
+msgid "What people say:"
+msgstr ""
+
+#. Page-suggestion chip label "What should I order?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What should I order?"
+msgstr ""
+
+#. Heading on the Search Assist feedback form shown when the user gives positive feedback, asking what they liked about the answer.
+msgctxt "feedback form"
+msgid "What stood out?"
+msgstr ""
+
+#. Question on a feedback form for a negative feedback response.
+msgctxt "feedback form"
+msgid "What was wrong with the response? (optional)"
+msgstr ""
+
+#. Page-suggestion chip label "What will I learn?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I learn?"
+msgstr ""
+
+#. Page-suggestion chip label "What will I need?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What will I need?"
+msgstr ""
+
+msgctxt "Feedback prompt"
+msgid "What would you like to provide feedback on?"
+msgstr ""
+
+#. Explains the benefits of using our custom video player, the Duck Player
+msgid ""
+"What you watch in DuckDuckGo won't influence your recommendations on YouTube."
+msgstr ""
+
+#. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
+msgctxt "SERP footer content"
+msgid "What's New"
+msgstr ""
+
+#. Page-suggestion chip label "What's the verdict?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "What's the verdict?"
+msgstr ""
+
+#. Link to a page featuring the most recent updates from DuckDuckGo.
+msgid "What’s New"
+msgstr ""
+
+#. Text for a prompt suggestion for identifying top product brands when buying an electric guitar for a beginner.
+msgctxt "Full sentence for identifying product brands"
+msgid ""
+"When buying an electric guitar for a beginner, what are the top product "
+"brands I should consider?"
+msgstr ""
+
+msgctxt "settings"
+msgid "When enabled, Duck.ai will show instant answers in the chat."
+msgstr ""
+
+#. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
+msgctxt "Movie/TV Show Title instant answer"
+msgid "Where To Watch"
+msgstr ""
+
+#. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
+msgctxt "Where to watch instant answer"
+msgid "Where To Watch <strong>%s</strong>"
+msgstr ""
+
+#. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
+msgid "Where it says Homepage click %sSet to Current Page%s."
+msgstr "Klicke dort, wo Homepage steht, auf %sAuf aktuelle Seite setzen%s. "
+
+#. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
+msgctxt "Where to watch instant answer"
+msgid "Where to Watch <strong>%s</strong>"
+msgstr ""
+
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (Optional)"
+msgstr ""
+
+#. An invitation for users to leave feedback
+msgctxt "Feedback prompt"
+msgid "Which features are missing? (optional)"
+msgstr ""
+
+#. https://duckduckgo.com/params under "Color Settings" under "Header: " and under "Background: "
+msgid "White"
+msgstr "Weiss"
+
+#. Filters the color of images in search results.
+msgctxt "color"
+msgid "White"
+msgstr "Weiss"
+
+#. Link to an about us page.
+msgid "Who We Are"
+msgstr "Wer wir sind"
+
+#. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
+msgctxt "Page suggestion prompt"
+msgid "Who are the main cast and crew, and what else are they known for?"
+msgstr ""
+
+#. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
+msgctxt "Page suggestion chip label"
+msgid "Who is this person?"
+msgstr ""
+
+#. Header above a collection of privacy-related links.
+msgid "Why Privacy"
+msgstr "Warum Privatsphäre"
+
+#. Link text that opens a help page explaining the Duck.ai migration.
+msgctxt "duckai_migration"
+msgid "Why am I seeing this?"
+msgstr ""
+
+#. Cricket scorecard: wickets full name (tooltip)
+msgctxt "Sports module"
+msgid "Wickets"
+msgstr ""
+
+#. Filters the shape of images in search results.
+msgctxt "image-layout"
+msgid "Wide"
+msgstr "Weit"
+
+#. http://i.imgur.com/twR2utt.png
+msgctxt "settingsvalue"
+msgid "Wide"
+msgstr "Breit"
+
+#. http://i.imgur.com/SOkVdkM.png
+msgctxt "width"
+msgid "Wide"
+msgstr "Breit"
+
+#. https://duckduckgo.com/params under "Look & Feel Settings"
+msgid "Width:"
+msgstr "Breite:"
+
+#. Category a user can select on a feedback form.
+msgctxt "feedback form"
+msgid "Wikipedia info"
+msgstr ""
+
+#. Title of a tab that displays a list of wild card standings for a sports league (https://en.wikipedia.org/wiki/Wild_card_(sports)#Major_League_Baseball)
+msgctxt "Sports module"
+msgid "Wild Card"
+msgstr ""
+
+#. Indicates this is the gap between a leading team and another team in the Wild Card View (https://en.wikipedia.org/wiki/Games_behind#Wild_card_race)
+msgctxt "Sports module"
+msgid "Wild Card Games Behind"
+msgstr ""
+
+#. In the context of the National Hockey League (NHL), title for a table of teams ordered based on their classification towards winning a Wild Card slot into playoffs
+msgctxt "Sports module"
+msgid "Wild Card Teams"
+msgstr ""
+
+#. Element title explaining this is the win loss record for team, e.g. 10-5
+msgctxt "Sports module"
+msgid "Win/Loss Record"
+msgstr ""
+
+#. Indicates that there's wind in the weather forecast.
+msgctxt "forecast"
+msgid "Wind"
+msgstr "Wind"
+
+#. Refers to the DuckDuckGo browser for Windows.
+msgid "Windows Browser"
+msgstr ""
+
+#. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
+msgctxt "Weather IA"
+msgid "Windy"
+msgstr ""
+
+#. Text inicating the winner of a World Cup Qualifying match that is not yet known. E.g. 'Winner of UEFA Path D'
+msgctxt "Sports module"
+msgid "Winner of %s Path %s"
+msgstr ""
+
+#. Text indicating the winner of a World Cup game when that team is not yet known
+msgctxt "Sports module"
+msgid "Winner of Game %s"
+msgstr ""
+
+#. Golf tournament card: winner label
+msgctxt "Sports module"
+msgid "Winner:"
+msgstr ""
+
+#. Indicates this is the percentage of wins for this team
+msgctxt "Sports module"
+msgid "Winning Percentage"
+msgstr ""
+
+#. Indicates this is the number of wins for this team
+msgctxt "Sports module"
+msgid "Wins"
+msgstr ""
+
+#. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
+msgctxt "Weather IA"
+msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
+msgstr ""
+
+#. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
+msgctxt "AI Chat model switch dropdown section header"
+msgid "Without zero provider visibility"
+msgstr ""
+
+#. Label for the global number of confirmed Covid 19 cases
+msgctxt "Covid 19 module"
+msgid "World"
+msgstr ""
+
+#. Title of the annual championship series of Major League Baseball (MLB)
+msgctxt "Sports module"
+msgid "World Series"
+msgstr ""
+
+#. Link to map
+msgctxt "Covid 19 module"
+msgid "Worldwide Coverage Map"
+msgstr ""
+
+#. Text for a prompt suggestion for writing code with a basic loop structure in Python.
+msgctxt "Full sentence for writing code"
+msgid "Write a basic loop structure in Python"
+msgstr ""
+
+#. Text for a prompt suggestion for writing code with a basic loop structure in Python.
+msgctxt "Full sentence for writing code"
+msgid "Write a basic loop structure in Python for me."
+msgstr ""
+
+#. Short string representing a prompt suggestion for writing an email.
+msgctxt "Brief for writing an email"
+msgid "Write an email"
+msgstr ""
+
+#. Short string representing a prompt suggestion for writing code.
+msgctxt "Brief for writing code"
+msgid "Write code"
+msgstr ""
+
+#. Label for the option prompting the AI assistant to adopt a role of a writer in its responses.
+msgctxt "Assistant role option label for Writer"
+msgid "Writer"
+msgstr ""
+
+#. Label for the option prompting the AI assistant to treat the user as if they are a writer.
+msgctxt "User role option for writer role"
+msgid "Writer"
+msgstr ""
+
+#. Label for the list of song writers name e.g. 'Written by: Freddy Mercury'
+msgctxt "lyrics_module"
+msgid "Written by"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Wrong album"
+msgstr ""
+
+#. Negative feedback category a user can select on the Search Assist feedback form, meaning the answer was incorrect.
+msgctxt "feedback form"
+msgid "Wrong answer"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Wrong artist"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Wrong conversion"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Wrong currency"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Wrong image"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Wrong information"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Wrong language"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Wrong location"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Wrong map area"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Wrong map location"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Wrong or missing address"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Wrong or missing hours"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Wrong or missing phone number"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Wrong or missing website"
+msgstr ""
+
+#. Category of feedback a user can select on a feedback form.
+msgctxt "feedback form"
+msgid "Wrong place is shown"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Wrong release date"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Wrong routes"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Wrong song title"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Wrong start or end"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Wrong streaming option"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Wrong timezone conversion"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Wrong title"
+msgstr ""
+
+#. Button label for selecting chart of prices for the year to date
+msgctxt "Stocks module"
+msgid "YTD"
+msgstr ""
+
+#. https://duckduckgo.com/params under "Color Settings" under "Highlight: "
+msgid "Yellow"
+msgstr "Gelb"
+
+#. Filters the color of images in search results.
+msgctxt "color"
+msgid "Yellow"
+msgstr "Gelb"
+
+#. Rugby match stats
+msgctxt "Sports module"
+msgid "Yellow Cards"
+msgstr ""
+
+#. A feedback suggestion
+msgctxt "Feedback prompt"
+msgid "Yelp ad not relevant"
+msgstr ""
+
+msgid "Yemen "
+msgstr ""
+
+msgid "Yes"
+msgstr "Ja"
+
+#. Response a user can select in a feedback form, indicating that they're new to DuckDuckGo.
+msgctxt "new user poll"
+msgid "Yes, new user!"
+msgstr "Ja, neuer Benutzer!"
+
+#. Text explaining that deleted data is deleted permanently and cannot be recovered.
+msgctxt "cloudsave"
+msgid ""
+"Yes, we throw away data when you’re done with it, and it cannot be recovered."
+msgstr ""
+
+#. Option for the filter-by-date search.
+msgid "Yesterday"
+msgstr "Gestern"
+
+#. Heading for the highlight card explaining the chat feature.
+msgctxt "Title for the chat card in the How Duck.ai Works panel"
+msgid "You Chat"
+msgstr ""
+
+#. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
+msgctxt "Disclaimer bellow chat input - desktop"
+msgid ""
+"You are chatting with %s. AI chats may display inaccurate or offensive "
+"information."
+msgstr ""
+
+#. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
+msgctxt "noresults"
+msgid ""
+"You can %s or search directly on other search engines from DuckDuckGo using "
+"%s search shortcuts."
+msgstr ""
+
+#. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
+msgctxt "Information about direct access to DuckDuckGo AI Chat"
+msgid "You can access DuckDuckGo AI Chat directly at %s."
+msgstr ""
+
+#. Search Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Search Assist.
+msgctxt "duckassist"
+msgid ""
+"You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
+msgstr ""
+
+#. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
+msgctxt "duckassist"
+msgid ""
+"You can adjust how Assist works or turn it off anytime in %sSearch "
+"Settings%s."
+msgstr ""
+
+msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
+msgstr ""
+
+msgid ""
+"You can also use %sDuckDuckGo AI Chat%s to answer questions or summarize "
+"text."
+msgstr ""
+
+#. Error message displayed when the user tries to attach more text selections than are allowed. Placeholder is the maximum number of text selections. E.g. You can attach up to 5 text selections.
+msgctxt "Error message when text selection count exceeds the limit"
+msgid "You can attach up to %s text selections."
+msgstr ""
+
+#. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
+msgid ""
+"You can change how frequently you see Search Assist, or turn it off "
+"entirely, in %sSearch Settings%s."
+msgstr ""
+
+#. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
+msgctxt "Third party map app picker feedback dialog"
+msgid "You can change this any time in %sSearch Settings%s"
+msgstr ""
+
+#. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
+msgctxt "Error message for fixed-window Duck.ai usage limit"
+msgid "You can continue this chat when your limit resets on %s."
+msgstr ""
+
+#. Text explaning how to change a passphrase.
+msgctxt "cloudsave"
+msgid ""
+"You can do this by saving your settings under a different passphrase, "
+"optionally deleting the first set."
+msgstr ""
+"Du kannst das Kennwort ändern, indem du die Einstellungen mit einem neuen "
+"Kennwort speicherst und ggf. die ersten Einstellungen löschst."
+
+#. Prefix for filename location sentence.
+msgctxt "duckai_migration"
+msgid "You can find the"
+msgstr ""
+
+#. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
+msgctxt "duckai_migration"
+msgid "You can find the <b>%s</b> file in your downloads folder."
+msgstr ""
+
+#. A link to the settings to where the user can hide the private search reminder from the filter bar of search results
+msgid "You can hide this reminder in %sSearch Settings%s"
+msgstr ""
+
+#. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
+msgctxt "Error message for fixed-window Duck.ai usage limit"
+msgid "You can keep chatting by using your monthly limit."
+msgstr ""
+
+#. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
+msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
+msgid "You can now save up to 100 chats on this device. Chat away!"
+msgstr ""
+
+#. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
+msgctxt "Error message when file count exceeds conversation limit"
+msgid "You can only attach %s files per conversation"
+msgstr ""
+
+#. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
+msgctxt "Error message when file count exceeds conversation limit"
+msgid "You can only attach %s files per conversation."
+msgstr ""
+
+#. Error message displayed when the user has select more images than are allowed to be uploaded. Placeholder is the number of images that are allowed. E.g. You can only attach 3 images per chat
+msgctxt "Error message when input exceeds image upload limit"
+msgid "You can only attach %s images at a time"
+msgstr ""
+
+#. Error message displayed when the user has select more images than are allowed to be uploaded. Placeholder is the number of images that are allowed. E.g. You can only attach 3 images per chat
+msgctxt "Error message when input exceeds image upload limit"
+msgid "You can only attach %s images at a time."
+msgstr ""
+
+#. Error message displayed when the user has attached more images across the conversation than allowed. Placeholder is the maximum number of images. E.g. You can only attach 5 images per conversation
+msgctxt "Error message when total image count exceeds conversation limit"
+msgid "You can only attach %s images per conversation"
+msgstr ""
+
+#. Error message displayed when the user has attached more images across the conversation than allowed. Placeholder is the maximum number of images. E.g. You can only attach 5 images per conversation
+msgctxt "Error message when total image count exceeds conversation limit"
+msgid "You can only attach %s images per conversation."
+msgstr ""
+
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
+#. Error message displayed when the user has select more images than are allowed to be uploaded.
+msgctxt "Error message when input exceeds image upload limit"
+msgid "You can only attach 1 image at a time"
+msgstr ""
+
+#. Error message displayed when the user has select more images than are allowed to be uploaded.
+msgctxt "Error message when input exceeds image upload limit"
+msgid "You can only attach 1 image at a time."
+msgstr ""
+
+#. Message that appears when a site is blocked unsuccessfully
+msgctxt "Organic result context menu"
+msgid ""
+"You can only block up to %s sites. To block %s, you'll need to unblock "
+"another site first."
+msgstr ""
+
+#. Text explaining the benefits of the cloud save feature.
+msgctxt "cloudsave"
+msgid "You can restore your settings after deleting cookies."
+msgstr ""
+
+#. Text explaining the benefits of the cloud save feature.
+msgctxt "cloudsave"
+msgid "You can share your settings among computers and browsers."
+msgstr ""
+"Du kannst deine Einstellungen zwischen Computern und Browsern austauschen."
+
+#. Alternative option description on export screen.
+msgctxt "duckai_migration"
+msgid "You can start fresh on new Duck.ai."
+msgstr ""
+
+#. Alternative option description on export screen.
+msgctxt "duckai_migration"
+msgid "You can start fresh on the new domain (duck.ai)."
+msgstr ""
+
+#. Alternative description on import screen.
+msgctxt "duckai_migration"
+msgid "You can start fresh on this new domain (duck.ai)."
+msgstr ""
+
+#. Text explaining the benefits of the cloud save feature.
+msgctxt "cloudsave"
+msgid "You can store several sets of settings for different purposes."
+msgstr ""
+"Du kannst mehrere Einstellungskonfigurationen für verschiedene "
+"Anwendungszwecke speichern."
+
+#. Instructions for user once they've failed the bot challenge
+msgctxt "Anomaly modal"
+msgid "You have %s attempts left."
+msgstr ""
+
+#. Instructions for user once they've failed the bot challenge
+msgctxt "Anomaly modal"
+msgid "You have 1 attempt left."
+msgstr ""
+
+#. Description for the modal shown to users who have just upgraded to the Pro plan, explaining what they now have access to. %s is replaced with the name of a Pro-exclusive AI model (e.g. 'Claude Opus 4.6').
+msgctxt "Description of the post-upgrade success modal"
+msgid ""
+"You now have access to %s, higher AI reasoning, and 2x higher usage limits "
+"than Plus."
+msgstr ""
+
+#. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
+msgctxt "Description text for the subscription welcome modal"
+msgid ""
+"You now have access to advanced AI models. You can access the VPN and other "
+"DuckDuckGo subscription protections in the DuckDuckGo browser."
+msgstr ""
+
+#. Welcome message that appears after the DuckDuckGo extension is installed.
+msgctxt "welcome message"
+msgid "You now have the DuckDuckGo extension!"
+msgstr "Du hast nun die DuckDuckGo Erweiterung!"
+
+#. Body message indicating app is up to date.
+msgctxt "duckai_migration"
+msgid "You now have the latest version of Duck.ai."
+msgstr ""
+
+#. Explains the consequence of revoking a paired device and reassures that local chats and the server backup remain.
+msgctxt "Body copy for the Remove Device confirmation modal"
+msgid ""
+"You will no longer be able to access your saved chats from this browser. The "
+"last 30 chats will still remain available in local storage. This will not "
+"delete your chats from the encrypted server."
+msgstr ""
+
+#. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
+msgctxt "Body copy for the turn-off Sync & Backup confirmation dialog"
+msgid ""
+"You will no longer be able to access your saved chats from this browser. The "
+"last 30 chats will still remain available in local storage. This will not "
+"delete your chats from the encrypted server."
+msgstr ""
+
+#. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
+msgid "You won't see this message again unless you clear your browser data."
+msgstr ""
+
+#. The second paragraph of a pop up where we explain how to update the browser manually.
+msgctxt "Update browser banner"
+msgid ""
+"You'll receive automatic DuckDuckGo app updates once you have the latest "
+"version."
+msgstr ""
+
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
+#. shown when DDG is selected after eu preference menu on android
+msgctxt "welcome message eu search preference android"
+msgid ""
+"You're now searching privately in Chrome. Use our app instead of Chrome to "
+"browse privately too. It’s already installed and can:"
+msgstr ""
+"Du suchst nun privat in Chrome. Nutze unsere App anstatt Chrome umauch "
+"privat zu browsen. Es ist bereits installiert und kann:"
+
+#. Confirmation message that appears after the DuckDuckGo browser extension is installed.
+msgid "You're now searching with privacy!"
+msgstr "Du suchst jetzt mit Privatsphäre!"
+
+#. Confirmation message that appears after the DuckDuckGo browser extension is installed.
+msgid ""
+"You're now searching with privacy. %sGet tips to reduce your footprint even "
+"more."
+msgstr ""
+"Du suchst jetzt mit Privatsphäre. %sSehe dir Tipps an, um deinen Fussabdruck "
+"noch weiter zu reduzieren."
+
+#. Title of a notice thanking the user for turning off their adblocker
+msgid "You're the best!"
+msgstr ""
+
+#. A few versions of our native macOS browser were broken and did not automatically update. We want to encourage users to update to the latest version. This message will only show for users on an out of date version and will disappear when the browser is updated
+msgctxt "Update browser banner"
+msgid "You're using an outdated version of DuckDuckGo for Mac."
+msgstr ""
+
+#. Label for multiple sites being blocked
+msgctxt "Organic result context menu"
+msgid "You've blocked %s sites"
+msgstr ""
+
+#. Label for a single site being blocked
+msgctxt "Organic result context menu"
+msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
+msgstr ""
+
+#. Title shown when a user has reached their image generation limit.
+msgctxt "Title for image generation limit reached message"
+msgid "You've reached the image creation limit"
+msgstr ""
+
+#. Title shown when a user has reached their image generation edit limit.
+msgctxt "Title for image generation edit limit reached message"
+msgid "You've reached the maximum number of edits for this image"
+msgstr ""
+
+#. Displayed when the user has reached the maximum number of messages for a given moment, and should try again later when they might be able to send more messages again.
+msgctxt "Error message for user limit"
+msgid ""
+"You've reached the maximum number of messages for the moment. Please try "
+"again later."
+msgstr ""
+
+#. Description shown when the user has reached the maximum voice chat duration.
+msgctxt "voice chat duration limit modal"
+msgid "You've reached the maximum voice chat duration for a single session."
+msgstr ""
+
+#. Description shown when the user has reached the daily voice chat limit.
+msgctxt "voice chat limit modal"
+msgid ""
+"You've reached the voice chat limit for today. Please try again tomorrow."
+msgstr ""
+
+#. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
+msgid "You've reached your dictation usage limit. Try again later."
+msgstr ""
+
+#. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
+msgctxt "Sync file storage limit modal description"
+msgid ""
+"You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
+"Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
+msgstr ""
+
+#. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
+msgctxt "Sync file storage limit modal description"
+msgid ""
+"You've run out of Sync & Backup storage for Duck.ai chats. Delete the %s "
+"oldest chats with attachments to resume Sync. Pinned chats will not be "
+"deleted."
+msgstr ""
+
+#. Title shown when user has reached the sync storage limit.
+msgctxt "Sync limit modal title"
+msgid "You've run out of storage"
+msgstr ""
+
+#. A privacy disclaimer that appears above YouTube videos.
+msgid ""
+"YouTube (owned by Google) does not let you watch videos anonymously. As "
+"such, watching YouTube videos here will be tracked by YouTube/Google."
+msgstr ""
+"YouTube (von Google) lässt dich diese Video nicht anonym ansehen. Somit wird "
+"das Ansehen von Videos hier von YouTube/Google verfolgt."
+
+#. Label for a privacy disclaimer related to YouTube videos
+msgid "YouTube Privacy Warning"
+msgstr "YouTube Privatsphärewarnung"
+
+#. Label below a video that's available under the YouTube license.
+msgctxt "video-license"
+msgid "YouTube Standard"
+msgstr "YouTube Standard"
+
+msgctxt "homepage ATB modal"
+msgid "Your DuckDuckGo search history is private"
+msgstr ""
+
+#. Label on a map indicating the user's current location.
+msgctxt "directions"
+msgid "Your Location"
+msgstr "Dein Standort"
+
+#. Disclaimer telling users their precise geolocation remains private. More at https://help.duckduckgo.com/duckduckgo-help-pages/privacy/anonymous-localized-results/
+msgctxt "maps_places"
+msgid "Your actual location remains private"
+msgstr ""
+
+#. Description of the location prompt
+msgctxt "DuckChat location prompt"
+msgid "Your actual location remains private."
+msgstr ""
+
+#. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
+msgctxt "Body copy for the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync. Your %s most recent chats will be available in local "
+"storage on these browsers:"
+msgstr ""
+
+#. Explains the consequence of deleting all server data; followed by the device list.
+msgctxt "Body copy for the Delete Server Data confirmation modal"
+msgid ""
+"Your backup will be deleted from DuckDuckGo's server. All devices will be "
+"disconnected from sync. Your 100 most recent chats will be available in "
+"local storage on these browsers:"
+msgstr ""
+
+#. List item indicating that a site exclusion filter is currently active for the search
+msgctxt "noresults"
+msgid "Your blocked sites"
+msgstr ""
+
+#. Floating text over a tick next to search results which indicates if a link has been visited.
+msgid "Your browser indicates if you've visited this link"
+msgstr "Dein Browser zeigt an, ob Du den Link bereits besucht hast."
+
+msgctxt "new tab page"
+msgid "Your browser provides a list of your most-visited sites."
+msgstr ""
+
+#. Used as a description in a menu
+msgctxt "new tab page"
+msgid ""
+"Your browser provides a list of your most-visited sites. DuckDuckGo never "
+"has access to this data."
+msgstr ""
+
+msgctxt "new tab page"
+msgid ""
+"Your browser provides the list of most-visited sites. DuckDuckGo never has "
+"access to this data."
+msgstr ""
+"Die Liste mit den meistbesuchten Seiten wird von deinem Browser "
+"bereitgestellt. DuckDuckGo hat keinen Zugriff auf diese Daten."
+
+#. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
+msgctxt "Disclaimer bellow chat input - desktop"
+msgid ""
+"Your chat with %s is private. AI chats may display inaccurate or offensive "
+"information."
+msgstr ""
+
+#. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
+msgctxt "Body for the Sync & Backup setup success screen"
+msgid "Your chats are now being saved."
+msgstr ""
+
+#. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
+msgctxt "Promotional text emphasizing privacy of user chats"
+msgid "Your chats are private, and are never saved or used to train AI models"
+msgstr ""
+
+#. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
+msgctxt "Promotional text emphasizing privacy of user chats"
+msgid "Your chats are private, and are never used to train AI models"
+msgstr ""
+
+#. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
+msgctxt "Active Privacy protection description"
+msgid ""
+"Your chats are private, anonymized by us, and not used to train AI models."
+msgstr ""
+
+#. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
+msgctxt "Body text for privacy protection modal"
+msgid ""
+"Your chats are private, anonymized by us, and not used to train AI models."
+msgstr ""
+
+#. Text for a menu item that describes the privacy protection feature.
+msgctxt "Menu item description"
+msgid ""
+"Your chats are private, never saved by us, and not used to train AI models."
+msgstr ""
+
+#. Body text of the modal that provides information about the active privacy protection.
+msgctxt "Modal body for privacy"
+msgid ""
+"Your chats are private, never saved by us, and not used to train AI models."
+msgstr ""
+
+#. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
+msgctxt "Chat history about modal list item"
+msgid "Your chats are saved on this device only."
+msgstr ""
+
+#. Privacy reassurance and instructions intro.
+msgctxt "duckai_migration"
+msgid ""
+"Your chats are still private, anonymized by us, and not used to train AI "
+"models. Follow these steps to keep your chat history."
+msgstr ""
+
+#. Body shown after import completes.
+msgctxt "duckai_migration"
+msgid ""
+"Your chats have been imported. Go ahead and pick up where you left off in "
+"Duck.ai."
+msgstr ""
+
+#. Body copy shown on the joiner device's success screen after a successful pairing.
+msgctxt "Description for the joiner-device success screen"
+msgid "Your chats will now sync between these devices."
+msgstr ""
+
+#. Body copy shown on the success screen after a successful pairing.
+msgctxt "Description for the success screen"
+msgid "Your chats will now sync between these devices."
+msgstr ""
+
+#. Description explaining why delegation is needed for image generation.
+msgctxt "DuckChat image generation delegation prompt"
+msgid "Your current model doesn't support image generation."
+msgstr ""
+
+msgctxt "homepage ATB modal"
+msgid "Your data shouldn’t be for sale."
+msgstr "Deine Daten sollten nicht zum Verkauf stehen."
+
+#. Disclaimer below an email address field explaining that the user's email address will only be used for their newsletter subscription.
+msgctxt "newsletter email collection"
+msgid ""
+"Your email address will not be shared, %sor associated with anonymous "
+"searches. [%sExample message%s]"
+msgstr ""
+"Deine E-Mail-Adresse wird nicht weitergegeben, %soder mit anonymen "
+"Suchanfragen verknüpft. [%sBeispielnachricht%s]"
+
+#. A prompt for the user to provide feedback on the third party map app directions experience
+msgctxt "Third party map app picker feedback dialog"
+msgid "Your feedback helps us improve DuckDuckGo."
+msgstr ""
+
+#. Reassures the user that their thumbs up/down feedback is anonymous and not used for model training.
+msgctxt ""
+"Subtitle of the one-time popover shown above the thumbs up/down buttons on "
+"an AI response"
+msgid "Your feedback is anonymized and not used to train AI."
+msgstr ""
+
+#. Explains that the User's Location is always private to DuckDuckGo.
+msgctxt "precise_user_location"
+msgid "Your location is always private to DuckDuckGo"
+msgstr ""
+
+#. Label for the input field where user can specify how the AI assistant should refer to itself. Example: 'Your name (is): Fred'
+msgctxt "Label for assistant name input"
+msgid "Your name"
+msgstr ""
+
+#. Label for the input field where users specify how they want to be referred to. Example: 'Your nickname (is): John'
+msgctxt "Label for user name input"
+msgid "Your nickname"
+msgstr ""
+
+#. Text explaining how the cloud save feature works.
+msgctxt "cloudsave"
+msgid ""
+"Your passphrase generates a 512-bit key by using the Secure Hash Algorithm "
+"known as %sSHA-2%s. Only the key and associated settings file leave your "
+"browser. We save the settings file using the key as the name. DuckDuckGo "
+"never knows your passphrase."
+msgstr ""
+
+#. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
+msgid "Your privacy, our priority."
+msgstr ""
+
+#. Description explaining how DuckDuckGo anonymizes user prompts by stripping metadata before forwarding to AI model providers.
+msgctxt "Privacy claim description in Duck.ai chat"
+msgid ""
+"Your prompts are relayed through DuckDuckGo servers and stripped of "
+"personally identifiable metadata, so model providers can't tie your "
+"conversations back to you."
+msgstr ""
+
+#. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
+msgid "Your protection, our priority."
+msgstr ""
+
+#. Text explaining that recent chats are accessible and can be cleared anytime from that place in the interface.
+msgctxt "Popover text for recent chats onboarding"
+msgid ""
+"Your recent chats live here! You can refer to your chats or clear them "
+"anytime."
+msgstr ""
+
+#. Message on a feedback form.
+msgctxt "new user poll"
+msgid "Your response is 100% anonymous."
+msgstr "Deine Antwort ist 100% anonym."
+
+#. Label indicating the assistant's role. Example: 'Your role (is a): travel guide'
+msgctxt "Label for assistant role selection"
+msgid "Your role"
+msgstr ""
+
+#. Label indicating the user's role. The role is used by the AI assistant to modify its responses. Example: 'Your role (is a): parent'
+msgctxt "Label for user role selection"
+msgid "Your role"
+msgstr ""
+
+#. An item in the ads tooltip that explains that your searches can’t be tied back to you.
+msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
+msgstr ""
+
+#. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Install the "
+"%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
+msgstr ""
+
+#. Confirms the recovery succeeded. The Next CTA closes the sheet.
+msgctxt "Body copy on the recover-data success sheet"
+msgid "Your synced chats are being restored to this device."
+msgstr ""
+
+msgctxt "homepage ATB modal"
+msgid "You’re Searching Privately with DuckDuckGo."
+msgstr ""
+
+#. shown when DDG is selected after eu preference menu on android
+msgctxt "welcome message eu search preference android"
+msgid ""
+"You’re now searching privately in Chrome. Use our browser instead of Chrome "
+"for more protection. It’s already installed and can:"
+msgstr ""
+
+#. Displayed when the user has exceeded the maximum message size.
+msgctxt "Error message for input limit"
+msgid ""
+"You’ve exceeded the maximum message size. Please shorten your message and "
+"try again."
+msgstr ""
+
+#. Displayed when the user has reached the maximum chat length in a conversation.
+msgctxt "Error message for conversation limit"
+msgid ""
+"You’ve reached the maximum chat length in this conversation. Clear this "
+"conversation with the Fire Button to continue."
+msgstr ""
+
+#. Displayed when the user has reached the maximum chat length in a conversation.
+msgctxt "Error message for conversation limit"
+msgid ""
+"You’ve reached the maximum chat length in this conversation. Start a new "
+"chat to continue."
+msgstr ""
+
+#. Description shown when the user has reached the maximum voice chat duration.
+msgctxt "voice chat duration limit modal"
+msgid "You’ve reached the maximum duration for a single session."
+msgstr ""
+
+#. Displayed when the user has reached the maximum number of messages for one day.
+msgctxt "Error message for user limit"
+msgid ""
+"You’ve reached the maximum number of messages for one day. Please continue "
+"this chat tomorrow."
+msgstr ""
+
+#. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
+msgctxt "voice chat limit modal"
+msgid "You’ve reached the voice chat limit for now. Please try again later."
+msgstr ""
+
+#. The name of the Yucatec Maya language
+msgctxt "language_name"
+msgid "Yucatec Maya"
+msgstr ""
+
+msgid "Zambia"
+msgstr ""
+
+#. Title for the data retention highlight in the dictation consent modal.
+msgid "Zero data retention"
+msgstr ""
+
+#. Title for the privacy claim that indicates the AI model provider does not retain any chat data.
+msgctxt "Privacy claim title in Duck.ai chat"
+msgid "Zero data retention"
+msgstr ""
+
+#. Title for the privacy claim that indicates the AI model provider does not retain any chat data.
+msgctxt "Privacy claim title in Duck.ai chat"
+msgid "Zero data retention for this chat"
+msgstr ""
+
+#. Text that indicates that an AI Model runs in a Trusted Execution Environment the model provider cannot access user data. Please stick to a short translation as this is used in a small label.
+msgctxt ""
+"Label copy indicating that an AI Model runs in an encrypted environment"
+msgid "Zero provider visibility"
+msgstr ""
+
+#. Title for the privacy claim that the model provider cannot access user data because inference runs in an encrypted environment.
+msgctxt "Privacy claim title in Duck.ai chat for encrypted models"
+msgid "Zero provider visibility"
+msgstr ""
+
+msgid "Zimbabwe"
+msgstr ""
+
+#. From the guide in the Feedback page.
+msgid "advertising"
+msgstr "werben"
+
+#. Used to separate links to different websites in a list of websites. For example: 'Wikipedia and Encyclopedia Brittanica'
+msgid "and"
+msgstr ""
+
+#. Used in 0-click box for product results, e.g. <a href="https://duckduckgo.com/?q=9780061353246">https://duckduckgo.com/?q=9780061353246</a>
+msgid "by %s"
+msgstr "von %s"
+
+#. Label of which AI provider the current AI Model comes from. Example: 'by OpenAI'
+msgctxt "AI provider label in the side menu item"
+msgid "by %s"
+msgstr ""
+
+#. Footer attribution text where %s is a link to the DuckDuckGo about page. The link text is the brand name 'DuckDuckGo'.
+msgctxt "Sidebar footer"
+msgid "by %s"
+msgstr ""
+
+#. Label indicating something is made by a specific brand. The placeholder value is a brand name. For example 'by Microsoft'
+msgctxt "made_by"
+msgid "by %s"
+msgstr "von %s"
+
+#. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
+msgctxt "Footer banner text in the How Duck.ai Works panel"
+msgid "by DuckDuckGo — online protection trusted by millions every day."
+msgstr ""
+
+#. An abreviated unit of time indicating an age, e.g. "2d"
+msgid "d"
+msgstr ""
+
+#. An abreviated unit of time indicating an age, e.g. "2d"
+msgctxt "Discussions IA"
+msgid "d"
+msgstr ""
+
+#. An abbreviated form of "day" that can be displayed in a small space e.g. "1d"
+msgctxt "published date for videos"
+msgid "d"
+msgstr ""
+
+#. Describing a unit of time in the context of a period ago, e.g. "1 *day* ago"
+msgid "day"
+msgstr ""
+
+#. Describing a unit of time in the context of a period ago, e.g. "2 *days* ago"
+msgid "days"
+msgstr ""
+
+#. https://duckduckgo.com/params under "Color Settings" under all
+#. under "Look & Feel Settings"  under "Size:" and "Text link: "
+msgctxt "setting"
+msgid "default"
+msgstr "Standart"
+
+msgid "email"
+msgstr "E-Mail"
+
+#. Suffix for filename location sentence.
+msgctxt "duckai_migration"
+msgid "file in your downloads folder."
+msgstr ""
+
+#. Can somebody provide the context?
+msgid "for"
+msgstr "für"
+
+#. Label that specifies which price the hotel rate starts from, ex: From $237
+msgctxt "Single Place Hotel Offers Module"
+msgid "from"
+msgstr ""
+
+#. An abreviated unit of time indicating an age, e.g. "2h"
+msgid "h"
+msgstr ""
+
+#. An abreviated unit of time indicating an age, e.g. "2h"
+msgctxt "Discussions IA"
+msgid "h"
+msgstr ""
+
+#. An abbreviated form of "hour" that can be displayed in a small space e.g. "1h"
+msgctxt "published date for videos"
+msgid "h"
+msgstr ""
+
+msgctxt "nonjsversion"
+msgid "here"
+msgstr "hier"
+
+#. Initial greeting message shown when a voice chat session starts.
+msgctxt "voice chat"
+msgid "hi, how can I help you today?"
+msgstr ""
+
+#. Describing a unit of time in the context of a period ago, e.g. "1 *hour* ago"
+msgid "hour"
+msgstr ""
+
+#. Describing a unit of time in the context of a period ago, e.g. "2 *hours* ago"
+msgid "hours"
+msgstr ""
+
+#. Refers to the DuckDuckGo browser for iOS.
+msgid "iOS Browser"
+msgstr ""
+
+#. Appearing next to SPORTS_STATUS_GAME_WITHIN_SERIES, indicates that an upcoming game of a series only be played if necessary E.g. Game 6 (if necessary)
+msgctxt "Sports module"
+msgid "if necessary"
+msgstr ""
+
+#. Abbreviate 1000s in a number. E.g. 1,000 becomes 1k
+msgctxt "Stocks module"
+msgid "k"
+msgstr ""
+
+#. Abbreviation for kilometres per hour
+msgctxt "forecast"
+msgid "kph"
+msgstr ""
+
+#. Indicates this is a team logo, e.g. 'Patriots logo'
+msgctxt "Sports module"
+msgid "logo"
+msgstr ""
+
+#. An abreviated unit of time indicating an age, e.g. "2m"
+msgid "m"
+msgstr ""
+
+#. An abreviated unit of time indicating an age, e.g. "2m"
+msgctxt "Discussions IA"
+msgid "m"
+msgstr ""
+
+#. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
+msgctxt "published date for videos"
+msgid "m"
+msgstr ""
+
+#. Aria label for the button that opens the menu in the mobile variant.
+msgctxt "Aria label for the menu button"
+msgid "menu"
+msgstr ""
+
+#. The word 'menu' used in the pinned chats education text
+msgctxt "Pinned chats education row in Duck.ai"
+msgid "menu"
+msgstr ""
+
+#. Describing a unit of time in the context of a period ago, e.g. "1 *minute* ago"
+msgid "minute"
+msgstr ""
+
+#. Describing a unit of time in the context of a period ago, e.g. "2 *minutes* ago"
+msgid "minutes"
+msgstr ""
+
+#. An abreviated unit of time indicating an age, e.g. "2mo"
+msgid "mo"
+msgstr ""
+
+#. An abreviated unit of time indicating an age, e.g. "2mo"
+msgctxt "Discussions IA"
+msgid "mo"
+msgstr ""
+
+#. An abbreviated form of "month" that can be displayed in a small space e.g. "1mo"
+msgctxt "published date for videos"
+msgid "mo"
+msgstr ""
+
+#. Describing a unit of time in the context of a period ago, e.g. "1 *month* ago"
+msgid "month"
+msgstr ""
+
+#. Describing a unit of time in the context of a period ago, e.g. "2 *months* ago"
+msgid "months"
+msgstr ""
+
+#. Abbreviation for miles per hour
+msgctxt "forecast"
+msgid "mph"
+msgstr ""
+
+#. https://duckduckgo.com/50x.html?e=2
+#. p.s.(tsester): i found it out by searching "  "
+msgid "no search"
+msgstr "keine Suche"
+
+#. Will be used in the sentence, 'Check official website for rates and availability.' but needs to be a separate token so we can make it a link
+msgctxt "Single Place Hotel Offers Module"
+msgid "official website"
+msgstr ""
+
+#. Used for the <em>color settings</em> into the <a href="https://duckduckgo.com/params.html">URL params page</a> as the last available value for the color parameter.
+#. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
+msgid ""
+"or write out the color code you want, e.g. %s (%s is an encoded %s char)."
+msgstr ""
+"oder schreibe den Farbcode den du willst, z.B. %s (%s ist eine kodierte %s "
+"Zeichenfolge)"
+
+#. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "
+msgid "or write out the font you want"
+msgstr "oder trage die gewünschte Schriftart ein"
+
+#. Link text on the Block domain success modal that links to the DuckDuckGo browser download page.
+msgctxt "settings"
+msgid "our free browser."
+msgstr ""
+
+#. Message displayed sometimes at top of results -- in the context of safe search.
+msgid "permanently"
+msgstr "permanent"
+
+#. Label inside the clickable privacy button on the chat empty state heading. Displayed alongside a shield icon.
+msgctxt "Privacy button label in Duck.ai chat empty state"
+msgid "private"
+msgstr ""
+
+#. Inserted into 'All chats are [private]' as a clickable button that opens the privacy modal. Must grammatically agree with 'chats' in the parent sentence (e.g. gender/number inflection in languages that require it).
+msgctxt "Privacy button label in the Duck.ai empty state heading"
+msgid "private"
+msgstr ""
+
+#. This word is inserted into the sentence 'All chats are [private].' as a clickable link that opens the privacy protection modal. It must grammatically agree with 'chats' in the parent sentence (e.g. gender/number inflection in languages that require it).
+msgctxt "Privacy link label in Duck.ai disclaimer below chat input"
+msgid "private"
+msgstr ""
+
+msgid "private search"
+msgstr "private Suche"
+
+#. Label inside the clickable privacy button on the image generation empty state heading. Displayed alongside a shield icon.
+msgctxt "Privacy button label in Duck.ai image generation empty state"
+msgid "privately"
+msgstr ""
+
+#. An abreviated unit of time indicating an age, e.g. "2s"
+msgid "s"
+msgstr ""
+
+#. An abreviated unit of time indicating an age, e.g. "2s"
+msgctxt "Discussions IA"
+msgid "s"
+msgstr ""
+
+#. The English version is not capitalized...
+msgid "search too long"
+msgstr "Suchanfrage zu lang"
+
+#. Describing a unit of time in the context of a period ago, e.g. "1 *second* ago"
+msgid "second"
+msgstr ""
+
+#. Describing a unit of time in the context of a period ago, e.g. "2 *seconds* ago"
+msgid "seconds"
+msgstr ""
+
+msgid "site encryption"
+msgstr "Webseitenverschlüsselung"
+
+#. Message displayed sometimes at top of results -- in the context of safe search.
+msgid "temporarily"
+msgstr "temporär"
+
+#. Source (section, article and site) of the answer generated by duckassist (an instant answer based on generative AI)
+msgid "the %s section of the %s %s article"
+msgstr ""
+
+msgid "there was an error."
+msgstr "Es ist ein Fehler aufgetreten."
+
+msgctxt "moreinfo"
+msgid "this help page"
+msgstr "die Hilfeseite"
+
+#. A place open/closed till [HOUR], for example: 'Open till 7 PM'
+msgctxt "maps_places"
+msgid "till %s"
+msgstr ""
+
+#. Text that follows the 'Try our browser' link, completing the sentence.
+msgctxt "settings"
+msgid "to never lose your settings."
+msgstr ""
+
+msgid "too many search terms"
+msgstr "zu viele Suchbegriffe"
+
+#. Link on the homepage in the context of the No Tracking and donttrack.us
+msgctxt "donttrackus"
+msgid "track"
+msgstr "verfolgen"
+
+#. Used in 0-click box for product results, e.g. <a href="https://duckduckgo.com/?q=superbad+dvd">https://duckduckgo.com/?q=superbad+dvd</a>
+msgctxt "zci-product"
+msgid "track"
+msgstr "Titel"
+
+msgid "tracker blocking"
+msgstr "Trackerblockierung"
+
+#. Inform the users that "something" went wrong and discourage the user from immediately reloading the page.
+msgctxt "noresults"
+msgid "try again later"
+msgstr ""
+
+#. A link that will allow users to reload the page, show when no search results loaded due to an error
+msgctxt "noresults"
+msgid "try your search again"
+msgstr ""
+
+#. Link text for the help page link in the dictation consent modal.
+msgid "voice chat and dictation help page"
+msgstr ""
+
+#. Link text for the help page link in the dictation consent modal.
+msgid "voice chat help page"
+msgstr ""
+
+#. Link text for the voice chat help page. Will be used wrapped in a link in the placeholder of another sentence. Example: 'See our <a>voice chat help page</a> before getting started.'
+msgctxt "voice chat"
+msgid "voice chat help page"
+msgstr ""
+
+#. Used to indicate a matchup between teams, e.g. Team A vs Team B
+msgctxt "Sports module"
+msgid "vs"
+msgstr ""
+
+#. An abreviated unit of time indicating an age, e.g. "2w"
+msgid "w"
+msgstr ""
+
+#. An abreviated unit of time indicating an age, e.g. "2w"
+msgctxt "Discussions IA"
+msgid "w"
+msgstr ""
+
+#. Describing a unit of time in the context of a period ago, e.g. "1 *week* ago"
+msgid "week"
+msgstr ""
+
+#. Describing a unit of time in the context of a period ago, e.g. "2 *weeks* ago"
+msgid "weeks"
+msgstr ""
+
+#. An abreviated unit of time indicating an age, e.g. "2y"
+msgid "y"
+msgstr ""
+
+#. An abreviated unit of time indicating an age, e.g. "2y"
+msgctxt "Discussions IA"
+msgid "y"
+msgstr ""
+
+#. Describing a unit of time in the context of a period ago, e.g. "1 *year* ago"
+msgid "year"
+msgstr ""
+
+#. Describing a unit of time in the context of a period ago, e.g. "2 *years* ago"
+msgid "years"
+msgstr ""
+
+#. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
+msgctxt "published date for videos"
+msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
+msgstr ""
+
+#~ msgctxt "SERP footer content"
+#~ msgid "%s Billion Searches"
+#~ msgstr "%s Milliarden Suchen"
+
+#~ msgctxt "reasons-to-use-duckduckgo"
+#~ msgid "Block advertising trackers."
+#~ msgstr "Blockiere Werbetracker"
+
+#~ msgctxt "SERP footer content"
+#~ msgid "Check out our privacy device guides."
+#~ msgstr ""
+#~ "Schau dir unsere Anleitungen für Privatsphäre auf deinen Geräten an."
+
+#~ msgctxt "showcase_privacy"
+#~ msgid "Check out our privacy device guides."
+#~ msgstr "Schau dir unsere Datenschutzanleitungen für Geräte an "
+
+#~ msgctxt "attribution"
+#~ msgid "Credits"
+#~ msgstr "Danksagung"
+
+#~ msgid "Develop"
+#~ msgstr "Entwickeln"
+
+#~ msgctxt "SERP footer content"
+#~ msgid "Discover shortcuts to go to search results on other sites."
+#~ msgstr ""
+#~ "Entdecke Abkürzungen, um zu den Suchergebnissen auf anderen Websites zu "
+#~ "gelangen."
+
+#~ msgctxt "SERP footer content"
+#~ msgid "Don't Track Us"
+#~ msgstr "Verfolge uns nicht"
+
+#~ msgctxt "SERP footer content"
+#~ msgid "Donating for Privacy"
+#~ msgstr "Spenden für den Datenschutz"
+
+#~ msgctxt "SERP footer content"
+#~ msgid "Escape The Filter Bubble"
+#~ msgstr "Entfliehe der Filterblase"
+
+#~ msgctxt "SERP footer content"
+#~ msgid "Fine-tune Your Search"
+#~ msgstr "Verfeinere deine Suche"
+
+#~ msgctxt "SERP footer content"
+#~ msgid "Get New Themes"
+#~ msgstr "Hole neue Designs"
+
+#~ msgctxt "SERP footer content"
+#~ msgid "Get Started at Duck.com"
+#~ msgstr "Erste Schritte bei duck.com"
+
+#~ msgctxt "SERP footer content"
+#~ msgid "Get to DuckDuckGo faster. Share duck.com with your friends."
+#~ msgstr "Komme schneller zu DuckDuckGo. Teile duck.com mit deinen Freunden"
+
+#~ msgctxt "new tab page"
+#~ msgid "Hide Most Visited Sites"
+#~ msgstr "Verstecke die meistbesuchten Seiten"
+
+#~ msgctxt "SERP footer content"
+#~ msgid "How We Are Profitable"
+#~ msgstr "Wie sind wir profitabel"
+
+#~ msgid "Items"
+#~ msgstr "Elemente"
+
+#~ msgctxt "reasons-to-use-duckduckgo"
+#~ msgid "Keep your search history private."
+#~ msgstr "Behalte deinen Suchverlauf privat."
+
+#~ msgctxt "SERP footer content"
+#~ msgid "Learn About Bangs"
+#~ msgstr "Erfahre mehr über Bangs"
+
+#~ msgctxt "SERP footer content"
+#~ msgid "Learn About DuckDuckGo"
+#~ msgstr "Erfahre mehr über DuckDuckGo"
+
+#~ msgctxt "SERP footer content"
+#~ msgid "Learn how to protect your privacy."
+#~ msgstr "Erfahre, wie wir deine Privatsphäre schützen."
+
+#~ msgctxt "SERP footer content"
+#~ msgid "Learn how to search like the pros."
+#~ msgstr "Lerne, wie man wie ein Profi sucht."
+
+#~ msgctxt "SERP footer content"
+#~ msgid "Learn how we're dedicated to keeping you safe online."
+#~ msgstr "Erfahre, wie wir uns dafür einsetzen, dass du online sicher bist."
+
+#~ msgctxt "SERP footer content"
+#~ msgid "Learn how you can free yourself from Google for good."
+#~ msgstr "Erfahre, wie du dich von Google befreien kannst."
+
+#~ msgid "Load Cloud Settings"
+#~ msgstr "Cloud-Einstellungen Laden"
+
+#~ msgid "Nearby"
+#~ msgstr "In der Nähe"
+
+#~ msgctxt "settings"
+#~ msgid "New Tab Page Most Visited Sites"
+#~ msgstr "Neuer Tab Seite meist besuchte Seiten"
+
+#~ msgctxt "SERP footer content"
+#~ msgid "Over %s in DuckDuckGo privacy donations."
+#~ msgstr "Über %s in DuckDuckGo Privatsphärenspenden."
+
+#~ msgctxt "attribution"
+#~ msgid "Producer"
+#~ msgstr "Produzent"
+
+#~ msgctxt "SERP footer content"
+#~ msgid "Protect Your Devices"
+#~ msgstr "Schütze deine Geräte"
+
+#~ msgctxt "showcase_privacy"
+#~ msgid "Protect Your Devices"
+#~ msgstr "Schütze deine Geräte"
+
+#~ msgctxt "SERP footer content"
+#~ msgid "Read about how Google influences what people click."
+#~ msgstr "Lese, wie Google beeinflusst auf was Leute klicken."
+
+#~ msgctxt "SERP footer content"
+#~ msgid "Say Goodbye To Google"
+#~ msgstr "Sage Tschüss zu Google"
+
+#~ msgctxt "visible"
+#~ msgid "Showing"
+#~ msgstr "Angezeigt"
+
+#~ msgctxt "SERP footer content"
+#~ msgid "Stay Informed"
+#~ msgstr "Bleibe informiert"
+
+#~ msgctxt "reasons-to-use-duckduckgo"
+#~ msgid "Take control of your personal data."
+#~ msgstr "Übernehme die Kontrolle über deine persönlichen Daten"
+
+#~ msgctxt "SERP footer content"
+#~ msgid "The world needs an alternative to the collect-it-all business model."
+#~ msgstr ""
+#~ "Die Welt braucht eine Alternative zum Collect-it-all-Geschäftsmodell."
+
+#~ msgctxt "translateus"
+#~ msgid "Translate"
+#~ msgstr "Übersetze"
+
+#~ msgctxt "SERP footer content"
+#~ msgid "We Protect Your Privacy"
+#~ msgstr "Wir schützen deine Privatsphäre"
+
+#~ msgctxt "SERP footer content"
+#~ msgid "We don't store your search history or follow you around the web."
+#~ msgstr ""
+#~ "Wir speichern weder deinen Suchverlauf noch verfolgen wir dich durchs "
+#~ "Internet."
+
+#~ msgctxt "SERP footer content"
+#~ msgid "We don't track you, but others do."
+#~ msgstr "Wir verfolgen dich nicht, aber andere schon."
+
+#~ msgctxt "SERP footer content"
+#~ msgid "We get a ton of searches, and all of them are anonymous."
+#~ msgstr "Wir bekommen eine Menge Suchanfragen, und alle sind anonym."
+
+#~ msgctxt "SERP footer content"
+#~ msgid "You're in control. Customize the look-and-feel of DuckDuckGo."
+#~ msgstr "Du hast die Kontrolle. Passe das Look-and-Feel von DuckDuckGo an."
+
+#~ msgid "not %s encoding"
+#~ msgstr "keine %s-Verschlüsselung"


### PR DESCRIPTION
The PO file was copied from Swiss German. I think that a South Tyrol flag would be nice.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broken locales.json would break locale metadata parsing/tests; otherwise this is additive locale metadata with no runtime logic changes in this diff.
> 
> **Overview**
> Adds **German (South Tyrol)** (`de_IT`, Deutsch (Südtirol)) to the supported locale list in **README** and registers it in **`locales.json`** with English/local names and `rtl: 0`.
> 
> The PR description notes translations were copied from Swiss German (`de_CH`); this diff only updates metadata/docs, not PO files under `locales/de_IT/`.
> 
> **Review note:** The **`locales.json`** edits look structurally wrong—the `de_IT` block is not a valid object (missing `{` / braces), and the **`el_GR`** entry’s closing braces were altered, which would break `decode_json` (see `t/01-meta.t`). The README locale bullet for **`de_DE`** also lost its list formatting when **`de_IT`** was inserted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9316a066fc7ebc482864ee796d7648b7e871b9b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->