### PR TITLE
Import new tokens - 2026-08-27-1507

### DIFF
--- a/duckduckgo.pot
+++ b/duckduckgo.pot
@@ -1167,6 +1167,12 @@ msgid "About our ads"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1290,6 +1296,20 @@ msgid "Ad is suspicious"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr ""
@@ -1313,6 +1333,27 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -1358,6 +1399,22 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -1443,6 +1500,12 @@ msgstr ""
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -1738,6 +1801,12 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -3369,6 +3438,14 @@ msgid "Cancel"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3851,9 +3928,21 @@ msgid "Chat response is offensive"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -3872,6 +3961,14 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -5416,6 +5513,12 @@ msgid "Current Streak"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5759,6 +5862,12 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -6166,6 +6275,12 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -7231,6 +7346,12 @@ msgid "Edit Prompt"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7444,6 +7565,12 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -8254,6 +8381,12 @@ msgid "Follow-up question"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -8758,6 +8891,12 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -9942,6 +10081,12 @@ msgstr ""
 
 # smartling.placeholder_format=C
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -11345,6 +11490,12 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -13457,6 +13608,12 @@ msgid "OK, got it!"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -15514,6 +15671,12 @@ msgid "Protected"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -15642,6 +15805,12 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -16834,6 +17003,12 @@ msgid "Save your chats across all your devices."
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17026,6 +17201,14 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -18141,6 +18324,12 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -19762,6 +19951,14 @@ msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -19853,6 +20050,12 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -20408,6 +20611,22 @@ msgid "This Week"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -20882,6 +21101,12 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -22655,6 +22880,14 @@ msgid ""
 msgstr ""
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr ""
 
@@ -24025,6 +24258,21 @@ msgid ""
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -25312,6 +25560,12 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 # smartling.placeholder_format=C

--- a/locales/af_ZA/LC_MESSAGES/duckduckgo.po
+++ b/locales/af_ZA/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: af_ZA\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1215,6 +1215,12 @@ msgid "About our ads"
 msgstr "Meer oor ons advertensies"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1344,6 +1350,20 @@ msgid "Ad is suspicious"
 msgstr "Advertensie is verdag"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Voeg DuckDuckGo by"
@@ -1369,6 +1389,27 @@ msgstr "Voeg DuckDuckGo by as ’n soekenjin"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Voeg DuckDuckGo by %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1414,6 +1455,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Voeg bladsy-inhoud by"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1499,6 +1556,12 @@ msgstr "Byvoegings"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Besig om afrondings by te voeg"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1802,6 +1865,12 @@ msgstr "Alle kleure"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Klaar!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3517,6 +3586,14 @@ msgid "Cancel"
 msgstr "Kanselleer"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4010,10 +4087,22 @@ msgid "Chat response is offensive"
 msgstr "Chat-antwoord is aanstootlik"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Gesels met %1$s"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4032,6 +4121,14 @@ msgstr "Kletsgesprekke"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Kletse"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5631,6 +5728,12 @@ msgid "Current Streak"
 msgstr "Huidige wenrekord"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5979,6 +6082,12 @@ msgstr "Vee kletse uit"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Skrap kletsgesprekke ouer as 30 dae"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6394,6 +6503,12 @@ msgstr "Wys vir ewig af"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Wys promosie van die hand"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7567,6 +7682,12 @@ msgid "Edit Prompt"
 msgstr "Wysig aanwysingsopdrag"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7788,6 +7909,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Geënkripteerde model"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8616,6 +8743,12 @@ msgid "Follow-up question"
 msgstr "Opvolgvraag"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9129,6 +9262,12 @@ msgstr ""
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr "Kry DuckDuckGo VPN, gevorderde Duck.ai en Identity Theft Restoration."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10361,6 +10500,12 @@ msgstr "Hoe is dit anoniem?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Hoe dit werk"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11806,6 +11951,12 @@ msgstr "Lynskrums gewen"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "Skakel verval oor 7 dae."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13927,6 +14078,12 @@ msgstr "Goed"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "Goed, het dit!"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16056,6 +16213,12 @@ msgid "Protected"
 msgstr "Is beskerm"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Beskerming. Privaatheid. Gemoedsrus."
@@ -16187,6 +16350,12 @@ msgstr "Reën"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Ranglys"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17421,6 +17590,12 @@ msgid "Save your chats across all your devices."
 msgstr "Stoor jou kletsgesprekke op al jou toestelle."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17620,6 +17795,14 @@ msgstr "Soek"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Soek"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18790,6 +18973,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Koop"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20445,6 +20634,14 @@ msgstr ""
 "Sync & Backup-data kan nie herwin word ná 18 maande van onaktiwiteit nie."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20558,6 +20755,12 @@ msgstr "Sinkroniseer met ’n nabygeleë toestel."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Sinchroniseer jou kletsgesprekke op al jou toestelle."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21146,6 +21349,22 @@ msgid "This Week"
 msgstr "Vandeesweek"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21681,6 +21900,12 @@ msgstr "Vandag"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Vandag"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23501,6 +23726,14 @@ msgstr ""
 "Advertensieklikke word deur TripAdvisor se advertensienetwerk bestuur."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Maagde-eilande"
 
@@ -24985,6 +25218,21 @@ msgstr ""
 "te lei nie. Skakel dit enige tyd aan of af in die ‘%1$s’-kieslys."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26391,6 +26639,12 @@ msgstr "m"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "m"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/ar_DZ/LC_MESSAGES/duckduckgo.po
+++ b/locales/ar_DZ/LC_MESSAGES/duckduckgo.po
@@ -979,6 +979,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1082,6 +1087,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr ""
@@ -1100,6 +1117,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1139,6 +1174,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1210,6 +1259,11 @@ msgstr "Translate 'Add-ons' into Arabic in Algeria"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1454,6 +1508,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2801,6 +2860,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3201,9 +3267,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3219,6 +3295,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4476,6 +4559,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4760,6 +4848,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5098,6 +5191,11 @@ msgstr "تجاهل إلى الأبد"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6000,6 +6098,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6177,6 +6280,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6842,6 +6950,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7260,6 +7373,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8242,6 +8360,11 @@ msgid "How is it anonymous?"
 msgstr "كيف يحترم الخصوصية؟"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9401,6 +9524,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11138,6 +11266,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12842,6 +12975,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12948,6 +13086,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13936,6 +14079,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14091,6 +14239,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15010,6 +15165,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16351,6 +16511,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16431,6 +16598,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16891,6 +17063,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17293,6 +17479,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18755,6 +18946,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19906,6 +20104,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20988,6 +21199,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/ar_EG/LC_MESSAGES/duckduckgo.po
+++ b/locales/ar_EG/LC_MESSAGES/duckduckgo.po
@@ -981,6 +981,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1084,6 +1089,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "أضف DuckDuckGo"
@@ -1102,6 +1119,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1141,6 +1176,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1212,6 +1261,11 @@ msgstr "إضافات"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1456,6 +1510,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2805,6 +2864,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3205,9 +3271,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3223,6 +3299,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4483,6 +4566,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4767,6 +4855,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5105,6 +5198,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6019,6 +6117,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6196,6 +6299,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6863,6 +6971,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7281,6 +7394,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8263,6 +8381,11 @@ msgid "How is it anonymous?"
 msgstr "كيف يكون البحث مغفل الهوية (هوية الباحث)؟"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9423,6 +9546,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11160,6 +11288,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12862,6 +12995,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12968,6 +13106,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13956,6 +14099,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14111,6 +14259,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15032,6 +15187,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16371,6 +16531,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16451,6 +16618,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16911,6 +17083,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17313,6 +17499,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18775,6 +18966,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19924,6 +20122,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21010,6 +21221,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/ar_JO/LC_MESSAGES/duckduckgo.po
+++ b/locales/ar_JO/LC_MESSAGES/duckduckgo.po
@@ -981,6 +981,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1084,6 +1089,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "اضافه DuckDuckGo"
@@ -1102,6 +1119,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1141,6 +1176,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1212,6 +1261,11 @@ msgstr "الاضافات"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1456,6 +1510,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2803,6 +2862,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3203,9 +3269,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3221,6 +3297,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4480,6 +4563,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4764,6 +4852,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5102,6 +5195,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6016,6 +6114,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6193,6 +6296,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6858,6 +6966,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7276,6 +7389,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8258,6 +8376,11 @@ msgid "How is it anonymous?"
 msgstr "كيف يكون مخفيا؟"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9413,6 +9536,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11150,6 +11278,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12850,6 +12983,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12956,6 +13094,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13944,6 +14087,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14099,6 +14247,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15016,6 +15171,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16355,6 +16515,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16435,6 +16602,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16895,6 +17067,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17297,6 +17483,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18759,6 +18950,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19908,6 +20106,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20991,6 +21202,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/ar_SA/LC_MESSAGES/duckduckgo.po
+++ b/locales/ar_SA/LC_MESSAGES/duckduckgo.po
@@ -981,6 +981,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1084,6 +1089,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "أضف DuckDuckGo"
@@ -1105,6 +1122,24 @@ msgstr "أضف DuckDuckGo كمحرك بحث "
 #, fuzzy
 msgid "Add DuckDuckGo to %s"
 msgstr "اضف دوك دوك جو الى %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1143,6 +1178,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1214,6 +1263,11 @@ msgstr "إضافات"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1458,6 +1512,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2805,6 +2864,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3205,9 +3271,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3223,6 +3299,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4485,6 +4568,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4769,6 +4857,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5107,6 +5200,11 @@ msgstr "تجاهل الى الابد"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6007,6 +6105,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6184,6 +6287,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6853,6 +6961,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7271,6 +7384,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8253,6 +8371,11 @@ msgid "How is it anonymous?"
 msgstr "كيف تحافظ الخدمة على خصوصيتي؟"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9412,6 +9535,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11151,6 +11279,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12856,6 +12989,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12962,6 +13100,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13950,6 +14093,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14107,6 +14255,13 @@ msgstr "بحث"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15028,6 +15183,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16369,6 +16529,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16449,6 +16616,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16909,6 +17081,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17311,6 +17497,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18777,6 +18968,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19930,6 +20128,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21016,6 +21227,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/ast_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/ast_ES/LC_MESSAGES/duckduckgo.po
@@ -973,6 +973,11 @@ msgstr "Tocante a nós"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1076,6 +1081,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "L'anunciu ye sospechosu"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr ""
@@ -1097,6 +1114,24 @@ msgstr ""
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Añadi DuckDuckGo a %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1135,6 +1170,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1206,6 +1255,11 @@ msgstr "Complementos"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1450,6 +1504,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2800,6 +2859,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3200,9 +3266,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3218,6 +3294,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4475,6 +4558,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4759,6 +4847,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5097,6 +5190,11 @@ msgstr "Escartar pa siempres"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -5993,6 +6091,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6170,6 +6273,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6835,6 +6943,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7253,6 +7366,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8235,6 +8353,11 @@ msgid "How is it anonymous?"
 msgstr ""
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9390,6 +9513,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11127,6 +11255,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12831,6 +12964,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12937,6 +13075,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13925,6 +14068,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14080,6 +14228,13 @@ msgstr "Guetar"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -14996,6 +15151,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16335,6 +16495,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16415,6 +16582,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16875,6 +17047,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17277,6 +17463,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18739,6 +18930,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19888,6 +20086,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20974,6 +21185,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/az_AZ/LC_MESSAGES/duckduckgo.po
+++ b/locales/az_AZ/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr "Bizim Haqqımızda"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "Reklam şübhəlidir"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "DuckDuckGo-nu Əlavə et"
@@ -1100,6 +1117,24 @@ msgstr "Axtarış motoru olaraq DuckDuckGo əlavə edin"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "%s üçün DuckDuckGo-nu əlavə edin"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr "Əlavələr"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1455,6 +1509,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2803,6 +2862,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3203,9 +3269,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3221,6 +3297,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4483,6 +4566,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4767,6 +4855,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5105,6 +5198,11 @@ msgstr "Həmişəlik burax"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6001,6 +6099,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6178,6 +6281,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6845,6 +6953,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7263,6 +7376,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8245,6 +8363,11 @@ msgid "How is it anonymous?"
 msgstr "Məxfilik necə təmin edilir?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9404,6 +9527,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11141,6 +11269,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12847,6 +12980,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12953,6 +13091,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13941,6 +14084,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14096,6 +14244,13 @@ msgstr "Axtarış"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15014,6 +15169,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16353,6 +16513,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16433,6 +16600,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16893,6 +17065,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17295,6 +17481,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18759,6 +18950,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19911,6 +20109,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21001,6 +21212,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/be_BY/LC_MESSAGES/duckduckgo.po
+++ b/locales/be_BY/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: be_BY\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1218,6 +1218,12 @@ msgid "About our ads"
 msgstr "Пра нашу рэкламу"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1347,6 +1353,20 @@ msgid "Ad is suspicious"
 msgstr "Аб'ява падазроная"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Дадаць DuckDuckGo"
@@ -1373,6 +1393,27 @@ msgstr "Дадаць DuckDuckGo у якасці пошукавай сістэм�
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Дадайце DuckDuckGo у %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1418,6 +1459,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Дадаць змесціва старонкі"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1503,6 +1560,12 @@ msgstr "Дадаткі"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Дадаванне фінальных штрыхоў"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1806,6 +1869,12 @@ msgstr "Усе колеры"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Усё гатова!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3522,6 +3591,14 @@ msgid "Cancel"
 msgstr "Скасаваць"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4015,10 +4092,22 @@ msgid "Chat response is offensive"
 msgstr "Адказ у чаце абразлівы"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Чат з %1$s"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4037,6 +4126,14 @@ msgstr "Чаты"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Чаты"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5639,6 +5736,12 @@ msgid "Current Streak"
 msgstr "Бягучая серыя"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5987,6 +6090,12 @@ msgstr "Выдаліць чаты"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Выдаліць чаты, старэйшыя за 30 дзён"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6401,6 +6510,12 @@ msgstr "Адхіліць назаўжды"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Адхіліць рэкламу"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7578,6 +7693,12 @@ msgid "Edit Prompt"
 msgstr "Рэдагаваць запыт"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7801,6 +7922,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Зашыфраваная мадэль"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8641,6 +8768,12 @@ msgid "Follow-up question"
 msgstr "Удакладняльнае пытанне"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9156,6 +9289,12 @@ msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
 "Атрымайце DuckDuckGo VPN, пашыраную версію Duck.ai і Identity Theft "
 "Restoration."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10389,6 +10528,12 @@ msgstr "Наколькі гэта ананімна?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Як гэта працуе"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11843,6 +11988,12 @@ msgstr "Выйграныя калідоры"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "Тэрмін дзеяння спасылкі заканчваецца праз 7 дзён."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13962,6 +14113,12 @@ msgstr "ОК"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "ОК, зразумела!"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16094,6 +16251,12 @@ msgid "Protected"
 msgstr "Абаронена"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Абарона. Прыватнасць. Спакой."
@@ -16225,6 +16388,12 @@ msgstr "Дождж"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Рэйтынгі"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17464,6 +17633,12 @@ msgid "Save your chats across all your devices."
 msgstr "Захоўвайце свае размовы на ўсіх прыладах."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17666,6 +17841,14 @@ msgstr "Шукаць"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Шукаць"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18852,6 +19035,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Купіць"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20506,6 +20695,14 @@ msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr "Даныя Sync & Backup нельга аднавіць пасля 18 месяцаў бяздзейнасці."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20620,6 +20817,12 @@ msgstr "Сінхранізаваць з прыладай паблізу."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Сінхранізуйце свае размовы на ўсіх прыладах."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21203,6 +21406,22 @@ msgid "This Week"
 msgstr "Гэты тыдзень"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21738,6 +21957,12 @@ msgstr "Сёння"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Сёння"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23578,6 +23803,14 @@ msgstr ""
 "апрацоўваюцца рэкламнай сеткай TripAdvisor."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Віргінскія астравы"
 
@@ -25060,6 +25293,21 @@ msgstr ""
 "штучнага інтэлекту. Уключы або адключы гэта ў любы час у меню '%1$s'."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26462,6 +26710,12 @@ msgstr "хв"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "хв"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/bg_BG/LC_MESSAGES/duckduckgo.po
+++ b/locales/bg_BG/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: bg_BG\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1226,6 +1226,12 @@ msgid "About our ads"
 msgstr "Относно нашите реклами"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1355,6 +1361,20 @@ msgid "Ad is suspicious"
 msgstr "Рекламата е подозрителна"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Добавете DuckDuckGo"
@@ -1381,6 +1401,27 @@ msgstr "Добавете DuckDuckGo като търсачка"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Добавете DuckDuckGo към %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1426,6 +1467,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Добавяне на съдържание на страницата"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1511,6 +1568,12 @@ msgstr "Разширения"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Добавяне на финални щрихи"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1815,6 +1878,12 @@ msgstr "Всички цветове"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Готово!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3533,6 +3602,14 @@ msgid "Cancel"
 msgstr "Отмяна"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4030,10 +4107,22 @@ msgid "Chat response is offensive"
 msgstr "Отговорът в чата е обиден"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Чат с %1$s"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4052,6 +4141,14 @@ msgstr "Чатове"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Чатове"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5661,6 +5758,12 @@ msgid "Current Streak"
 msgstr "Текуща серия"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -6009,6 +6112,12 @@ msgstr "Изтриване на чатовете"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Изтриване на чатове, по-стари от 30 дни"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6425,6 +6534,12 @@ msgstr "Отхвърли завинаги"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Пропусни промоцията"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7604,6 +7719,12 @@ msgid "Edit Prompt"
 msgstr "Редактиране на подкана"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7827,6 +7948,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Криптиран модел"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8671,6 +8798,12 @@ msgid "Follow-up question"
 msgstr "Допълнителен въпрос"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9189,6 +9322,12 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
 "Вземете DuckDuckGo VPN, усъвършенстван Duck.ai и Identity Theft Restoration."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10423,6 +10562,12 @@ msgstr "Как така е анонимно?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Как работи"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11878,6 +12023,12 @@ msgstr "Спечелени тъчове"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "Връзката изтича след 7 дни."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14002,6 +14153,12 @@ msgstr "ОК"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "Добре, разбрах!"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16132,6 +16289,12 @@ msgid "Protected"
 msgstr "Защитени"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Защита. Поверителност. Спокойствие."
@@ -16263,6 +16426,12 @@ msgstr "Дъжд"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Ранг"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17501,6 +17670,12 @@ msgid "Save your chats across all your devices."
 msgstr "Запазете чатовете на всички устройства."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17705,6 +17880,14 @@ msgstr "Търсене"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Търсене"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18894,6 +19077,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Купи"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20558,6 +20747,14 @@ msgstr ""
 "неактивност."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20673,6 +20870,12 @@ msgstr "Синхронизиране с близко устройство."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Синхронизирайте чатовете на всички устройства."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21257,6 +21460,22 @@ msgid "This Week"
 msgstr "Тази седмица"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21790,6 +22009,12 @@ msgstr "Днес"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Днес"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23627,6 +23852,14 @@ msgstr ""
 "Кликовете върху рекламите се управляват от рекламната мрежа на TripAdvisor."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Вирджински острови"
 
@@ -25115,6 +25348,21 @@ msgstr ""
 "изкуствен интелект. Включете или изключете по всяко време в менюто '%1$s'."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26519,6 +26767,12 @@ msgstr "м"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "м"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/bn_BD/LC_MESSAGES/duckduckgo.po
+++ b/locales/bn_BD/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr "আমাদের সম্পর্কে"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "DuckDuckGo যোগ করুন"
@@ -1100,6 +1117,24 @@ msgstr "সার্চ ইঞ্জিন হিসেবে DuckDuckGo-কে 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "%s -এ DuckDuckGo যোগ করুন"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr "এড-অনসমূহ"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1453,6 +1507,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2800,6 +2859,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3200,9 +3266,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3218,6 +3294,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4481,6 +4564,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4765,6 +4853,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5103,6 +5196,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6011,6 +6109,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6188,6 +6291,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6856,6 +6964,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7274,6 +7387,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8256,6 +8374,11 @@ msgid "How is it anonymous?"
 msgstr "এটি কিভাবে অজ্ঞাতনামা"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9415,6 +9538,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11153,6 +11281,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12857,6 +12990,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12963,6 +13101,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13951,6 +14094,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14106,6 +14254,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15027,6 +15182,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16367,6 +16527,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16447,6 +16614,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16907,6 +17079,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17310,6 +17496,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18774,6 +18965,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19923,6 +20121,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21010,6 +21221,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/bn_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/bn_IN/LC_MESSAGES/duckduckgo.po
@@ -980,6 +980,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1083,6 +1088,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr ""
@@ -1101,6 +1118,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1140,6 +1175,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1211,6 +1260,11 @@ msgstr "অতীরীক্ত কার্যকারিতা"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1455,6 +1509,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2802,6 +2861,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3202,9 +3268,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3220,6 +3296,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4479,6 +4562,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4763,6 +4851,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5101,6 +5194,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6009,6 +6107,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6186,6 +6289,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6851,6 +6959,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7269,6 +7382,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8251,6 +8369,11 @@ msgid "How is it anonymous?"
 msgstr "পরিচয় কিভাবে গুপ্ত রাখা হচ্ছে?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9406,6 +9529,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11143,6 +11271,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12843,6 +12976,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12949,6 +13087,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13937,6 +14080,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14092,6 +14240,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15009,6 +15164,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16348,6 +16508,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16428,6 +16595,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16888,6 +17060,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17290,6 +17476,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18752,6 +18943,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19901,6 +20099,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20985,6 +21196,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/bo_CN/LC_MESSAGES/duckduckgo.po
+++ b/locales/bo_CN/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr ""
@@ -1099,6 +1116,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr ""
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1453,6 +1507,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2800,6 +2859,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3200,9 +3266,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3218,6 +3294,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4475,6 +4558,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4759,6 +4847,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5097,6 +5190,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -5993,6 +6091,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6170,6 +6273,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6835,6 +6943,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7253,6 +7366,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8235,6 +8353,11 @@ msgid "How is it anonymous?"
 msgstr ""
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9388,6 +9511,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11125,6 +11253,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12825,6 +12958,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12931,6 +13069,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13919,6 +14062,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14074,6 +14222,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -14989,6 +15144,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16328,6 +16488,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16408,6 +16575,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16868,6 +17040,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17270,6 +17456,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18732,6 +18923,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19881,6 +20079,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20963,6 +21174,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/br_FR/LC_MESSAGES/duckduckgo.po
+++ b/locales/br_FR/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "kaout DuckDuckGo"
@@ -1099,6 +1116,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr "Askouezhioù"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1455,6 +1509,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2802,6 +2861,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3202,9 +3268,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3220,6 +3296,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4487,6 +4570,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4771,6 +4859,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5109,6 +5202,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6005,6 +6103,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6182,6 +6285,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6851,6 +6959,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7269,6 +7382,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8251,6 +8369,11 @@ msgid "How is it anonymous?"
 msgstr "Penaos eo dianv ?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9408,6 +9531,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11147,6 +11275,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12852,6 +12985,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12958,6 +13096,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13946,6 +14089,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14101,6 +14249,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15023,6 +15178,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16364,6 +16524,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16444,6 +16611,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16904,6 +17076,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17308,6 +17494,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18777,6 +18968,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19928,6 +20126,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21014,6 +21225,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/bs_BA/LC_MESSAGES/duckduckgo.po
+++ b/locales/bs_BA/LC_MESSAGES/duckduckgo.po
@@ -987,6 +987,11 @@ msgstr "O nama"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1090,6 +1095,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "Reklama je sumnjiva"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Dodaj DuckDuckGo"
@@ -1111,6 +1128,24 @@ msgstr "Dodajte DuckDuckGo kao pretraživač"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Dodaj DuckDuckGo u %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1149,6 +1184,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1220,6 +1269,11 @@ msgstr "Dodaci"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1465,6 +1519,11 @@ msgstr "Sve boje"
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2833,6 +2892,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3237,9 +3303,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3255,6 +3331,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4527,6 +4610,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr "Trenutni niz"
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4811,6 +4899,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5149,6 +5242,11 @@ msgstr "Trajno sakrij"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6059,6 +6157,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6239,6 +6342,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6911,6 +7019,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7329,6 +7442,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8317,6 +8435,11 @@ msgid "How is it anonymous?"
 msgstr "Kako je anonimno?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9497,6 +9620,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11235,6 +11363,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "U redu, razumijem!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12953,6 +13086,11 @@ msgstr "Zaštitite podatke na svakom uređaju."
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -13059,6 +13197,11 @@ msgstr "Kiša"
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -14052,6 +14195,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14211,6 +14359,13 @@ msgstr "Traži"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15139,6 +15294,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16490,6 +16650,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16570,6 +16737,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -17039,6 +17211,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17445,6 +17631,11 @@ msgstr "Danas"
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18916,6 +19107,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -20092,6 +20290,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21193,6 +21404,11 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "m"
 msgstr "m"
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.
 msgctxt "Aria label for the menu button"

--- a/locales/ca_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/ca_ES/LC_MESSAGES/duckduckgo.po
@@ -987,6 +987,11 @@ msgstr "Quant a nosaltres"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1090,6 +1095,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "L'anunci es sospitós"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Afegeix DuckDuckGo"
@@ -1111,6 +1128,24 @@ msgstr "Afegeix DuckDuckGo com a motor de cerca"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Afegeix DuckDuckGo al %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1149,6 +1184,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1220,6 +1269,11 @@ msgstr "Extensions"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1466,6 +1520,11 @@ msgstr "Tots els colors"
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2832,6 +2891,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3235,9 +3301,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3253,6 +3329,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4528,6 +4611,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr "Ratxa actual"
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4812,6 +4900,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5150,6 +5243,11 @@ msgstr "Ignora-ho sempre"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6060,6 +6158,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6242,6 +6345,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6917,6 +7025,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7335,6 +7448,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8326,6 +8444,11 @@ msgid "How is it anonymous?"
 msgstr "Com es manté anònim?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9510,6 +9633,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11248,6 +11376,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "Entesos!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12967,6 +13100,11 @@ msgstr "Protegiu les vostres dades a cada dispositiu."
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -13073,6 +13211,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -14065,6 +14208,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14229,6 +14377,13 @@ msgstr "Cerca"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15164,6 +15319,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16518,6 +16678,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16598,6 +16765,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -17068,6 +17240,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17474,6 +17660,11 @@ msgstr "Avui"
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18945,6 +19136,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -20118,6 +20316,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21220,6 +21431,11 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "m"
 msgstr "min"
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.
 msgctxt "Aria label for the menu button"

--- a/locales/cs_CZ/LC_MESSAGES/duckduckgo.po
+++ b/locales/cs_CZ/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: cs_CZ\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1212,6 +1212,12 @@ msgid "About our ads"
 msgstr "O našich reklamách"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1341,6 +1347,20 @@ msgid "Ad is suspicious"
 msgstr "Reklama je podezřelá"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Přidat DuckDuckGo"
@@ -1367,6 +1387,27 @@ msgstr "Přidej si DuckDuckGo mezi své vyhledávače"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Přidat DuckDuckGo do %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1412,6 +1453,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Přidat obsah stránky"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1497,6 +1554,12 @@ msgstr "Doplňky"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Už to bude"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1797,6 +1860,12 @@ msgstr "Všechny barvy"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Všechno je hotové!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3511,6 +3580,14 @@ msgid "Cancel"
 msgstr "Zrušit"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4004,10 +4081,22 @@ msgid "Chat response is offensive"
 msgstr "Odpověď chatu je urážlivá"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Chatuj s %1$s"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4026,6 +4115,14 @@ msgstr "Chaty"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Chaty"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5631,6 +5728,12 @@ msgid "Current Streak"
 msgstr "Aktuální série"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5978,6 +6081,12 @@ msgstr "Smazat chaty"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Vymazat chaty starší než 30 dní"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6391,6 +6500,12 @@ msgstr "Navždy skrýt"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Zavřít propagační akci"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7565,6 +7680,12 @@ msgid "Edit Prompt"
 msgstr "Upravit prompt"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7783,6 +7904,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Šifrovaný model"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8616,6 +8743,12 @@ msgid "Follow-up question"
 msgstr "Navazující otázka"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9129,6 +9262,12 @@ msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
 "Získáš VPN od DuckDuckGo, pokročilou Duck.ai a službu Identity Theft "
 "Restoration."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10360,6 +10499,12 @@ msgstr "Jak je zajištěna anonymita?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Jak to funguje"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11805,6 +11950,12 @@ msgstr "Vyhrané vhazování"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "Platnost odkazu skončí za 7 dní."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13925,6 +14076,12 @@ msgid "OK, got it!"
 msgstr "Dobře, rozumím!"
 
 # smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -16042,6 +16199,12 @@ msgid "Protected"
 msgstr "Chráněno"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Soukromí.Ochrana.Pocit jistoty."
@@ -16172,6 +16335,12 @@ msgstr "Déšť"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Žebříčky"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17405,6 +17574,12 @@ msgid "Save your chats across all your devices."
 msgstr "Ukládej si chaty na všech svých zařízeních."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17604,6 +17779,14 @@ msgstr "Hledat"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Hledat"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18774,6 +18957,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Do obchodu"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20421,6 +20610,14 @@ msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr "Data Sync & Backup nelze obnovit po 18 měsících nečinnosti."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20533,6 +20730,12 @@ msgstr "Synchronizovat s blízkým zařízením."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Synchronizuj své chaty na všech svých zařízeních."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21115,6 +21318,22 @@ msgid "This Week"
 msgstr "Tento týden"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21644,6 +21863,12 @@ msgstr "Dnes"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Dnes"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23466,6 +23691,14 @@ msgstr ""
 "spravuje reklamní síť společnosti TripAdvisor."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Panenské ostrovy"
 
@@ -24939,6 +25172,21 @@ msgstr ""
 "AI. Můžeš ji kdykoli zapnout nebo vypnout v nabídce ‚%1$s’."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26326,6 +26574,12 @@ msgstr "min."
 msgctxt "published date for videos"
 msgid "m"
 msgstr "min."
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/cy_GB/LC_MESSAGES/duckduckgo.po
+++ b/locales/cy_GB/LC_MESSAGES/duckduckgo.po
@@ -987,6 +987,11 @@ msgstr "Amdanom Ni"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1090,6 +1095,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "Mae'r hysbyseb yn amheus"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Ychwanegu DuckDuckGo"
@@ -1109,6 +1126,24 @@ msgstr "Ychwanegu DuckDuckGo fel injan chwilio"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Ychwanegu DuckDuckGo i %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1147,6 +1182,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1218,6 +1267,11 @@ msgstr "Ategolion"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1463,6 +1517,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2819,6 +2878,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3219,9 +3285,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3237,6 +3313,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4503,6 +4586,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4787,6 +4875,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5125,6 +5218,11 @@ msgstr "Diswyddo am byth"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6022,6 +6120,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6199,6 +6302,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6872,6 +6980,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7290,6 +7403,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8274,6 +8392,11 @@ msgid "How is it anonymous?"
 msgstr "Sut mae'n ddienw?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9437,6 +9560,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11185,6 +11313,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "Iawn 'te!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12899,6 +13032,11 @@ msgstr "Amddiffyn eich ddata ar pob dyfais."
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -13005,6 +13143,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13995,6 +14138,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14150,6 +14298,13 @@ msgstr "Chwilio"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15072,6 +15227,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16415,6 +16575,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16495,6 +16662,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16955,6 +17127,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17357,6 +17543,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18824,6 +19015,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19987,6 +20185,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21080,6 +21291,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/da_DK/LC_MESSAGES/duckduckgo.po
+++ b/locales/da_DK/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: da_DK\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1211,6 +1211,12 @@ msgid "About our ads"
 msgstr "Om vores annoncer"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1340,6 +1346,20 @@ msgid "Ad is suspicious"
 msgstr "Annoncen er mistænkelig"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Tilføj DuckDuckGo"
@@ -1366,6 +1386,27 @@ msgstr "Tilføj DuckDuckGo som søgemaskine"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Føj DuckDuckGo til %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1411,6 +1452,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Tilføj sideindhold"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1496,6 +1553,12 @@ msgstr "Tilføjelser"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Vi lægger sidste hånd på værket"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1799,6 +1862,12 @@ msgstr "Alle farver"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Helt færdig!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3507,6 +3576,14 @@ msgid "Cancel"
 msgstr "Annuller"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4002,10 +4079,22 @@ msgid "Chat response is offensive"
 msgstr "Chat-svaret er stødende"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Chat med %1$s"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4024,6 +4113,14 @@ msgstr "Chats"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Chats"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5616,6 +5713,12 @@ msgid "Current Streak"
 msgstr "Nuværende resultatliste"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5962,6 +6065,12 @@ msgstr "Slet chat"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Slet chats, der er ældre end 30 dage"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6375,6 +6484,12 @@ msgstr "Afvis for altid"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Afvis kampagne"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7544,6 +7659,12 @@ msgid "Edit Prompt"
 msgstr "Rediger prompt"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7766,6 +7887,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Krypteret model"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8594,6 +8721,12 @@ msgid "Follow-up question"
 msgstr "Opfølgende spørgsmål"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9105,6 +9238,12 @@ msgstr ""
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr "Få DuckDuckGo VPN, avanceret Duck.ai og Identity Theft Restoration."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10335,6 +10474,12 @@ msgstr "Hvordan er det anonymt?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Sådan fungerer det"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11783,6 +11928,12 @@ msgstr "Lineouts vundet"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "Linket udløber om 7 dage."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13899,6 +14050,12 @@ msgstr "Okay"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "Okay, forstået!"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16022,6 +16179,12 @@ msgid "Protected"
 msgstr "Beskyttet"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Beskyttelse. Fortrolighed. Ro i sindet."
@@ -16153,6 +16316,12 @@ msgstr "Regn"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Rangering"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17385,6 +17554,12 @@ msgid "Save your chats across all your devices."
 msgstr "Gem dine chats på alle dine enheder."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17584,6 +17759,14 @@ msgstr "Søg"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Søg"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18754,6 +18937,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Shop"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20409,6 +20598,14 @@ msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr "Sync & Backup-data kan ikke gendannes efter 18 måneders inaktivitet."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20522,6 +20719,12 @@ msgstr "Synkroniser med en enhed i nærheden."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Synkroniser dine chats på tværs af alle dine enheder."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21106,6 +21309,22 @@ msgid "This Week"
 msgstr "Denne uge"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21631,6 +21850,12 @@ msgstr "I dag"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "I dag"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23450,6 +23675,14 @@ msgstr ""
 "Annonceklik administreres af TripAdvisors annoncenetværk."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Jomfruøerne"
 
@@ -24927,6 +25160,21 @@ msgstr ""
 "Slå det til eller fra når som helst i menuen '%1$s'."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26319,6 +26567,12 @@ msgstr "m"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "m"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/de_CH/LC_MESSAGES/duckduckgo.po
+++ b/locales/de_CH/LC_MESSAGES/duckduckgo.po
@@ -982,6 +982,11 @@ msgstr "Über uns"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1085,6 +1090,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "Werbung ist verdächtig"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Füge DuckDuckGo an"
@@ -1106,6 +1123,24 @@ msgstr "Füge DuckDuckGo als Suchmaschine hinzu"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Füge DuckDuckGo zu %s hinzu"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1144,6 +1179,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1215,6 +1264,11 @@ msgstr "Erweiterungen"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1461,6 +1515,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2819,6 +2878,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3219,9 +3285,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3237,6 +3313,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4509,6 +4592,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4793,6 +4881,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5131,6 +5224,11 @@ msgstr "für immer Verbergen"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6027,6 +6125,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6204,6 +6307,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6873,6 +6981,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7291,6 +7404,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8278,6 +8396,11 @@ msgid "How is it anonymous?"
 msgstr "Wie ist es anonym?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9441,6 +9564,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11180,6 +11308,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "OK, verstanden!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12891,6 +13024,11 @@ msgstr "Schütze deine Daten auf allen Geräten"
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12997,6 +13135,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13985,6 +14128,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14144,6 +14292,13 @@ msgstr "Suche"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15074,6 +15229,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16415,6 +16575,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16495,6 +16662,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16963,6 +17135,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17369,6 +17555,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18840,6 +19031,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -20003,6 +20201,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21100,6 +21311,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/de_DE/LC_MESSAGES/duckduckgo.po
+++ b/locales/de_DE/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: de_DE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1221,6 +1221,12 @@ msgid "About our ads"
 msgstr "Über unsere Werbung"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1351,6 +1357,20 @@ msgid "Ad is suspicious"
 msgstr "Werbung is verdächtig"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "DuckDuckGo hinzufügen"
@@ -1377,6 +1397,27 @@ msgstr "DuckDuckGo als Suchmaschine hinzufügen"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "DuckDuckGo zu %1$s hinzufügen"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1422,6 +1463,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Seiteninhalt hinzufügen"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1507,6 +1564,12 @@ msgstr "Erweiterungen"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Fertigstellen der letzten Details"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1811,6 +1874,12 @@ msgstr "Alle Farben"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Alles erledigt!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3543,6 +3612,14 @@ msgid "Cancel"
 msgstr "Abbrechen"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4042,10 +4119,22 @@ msgid "Chat response is offensive"
 msgstr "Chat-Antwort ist anstößig"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Mit %1$s chatten"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4064,6 +4153,14 @@ msgstr "Chats"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Chats"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5670,6 +5767,12 @@ msgid "Current Streak"
 msgstr "Aktuelle Serie"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -6017,6 +6120,12 @@ msgstr "Chats löschen"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Chats älter als 30 Tage löschen"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6433,6 +6542,12 @@ msgstr "Für immer verwerfen"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Werbung verwerfen"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7620,6 +7735,12 @@ msgid "Edit Prompt"
 msgstr "Prompt bearbeiten"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7843,6 +7964,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Verschlüsseltes Modell"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8692,6 +8819,12 @@ msgid "Follow-up question"
 msgstr "Folgefrage"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9207,6 +9340,12 @@ msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
 "Hol dir DuckDuckGo-VPN, fortschrittliche Duck.ai-Funktionen und Identity "
 "Theft Restoration."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10449,6 +10588,12 @@ msgstr "Wieso ist es anonym?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Und so funktioniert's"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11904,6 +12049,12 @@ msgstr "Gewonnene Lineouts"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "Link läuft in 7 Tagen ab."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14029,6 +14180,12 @@ msgstr "OK"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "Verstanden!"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16167,6 +16324,12 @@ msgid "Protected"
 msgstr "Geschützt"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Schutz. Privatsphäre. Extra an Sicherheit."
@@ -16298,6 +16461,12 @@ msgstr "Regen"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Rankings"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17541,6 +17710,12 @@ msgid "Save your chats across all your devices."
 msgstr "Speichere deine Chats auf all deinen Geräten."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17745,6 +17920,14 @@ msgstr "Suche"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Suche"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18931,6 +19114,12 @@ msgstr "Umschalt+Eingabe"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Shop"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20607,6 +20796,14 @@ msgstr ""
 "wiederhergestellt werden."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20722,6 +20919,12 @@ msgstr "Mit einem Gerät in der Nähe synchronisieren."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Synchronisiere deine Chats auf all deinen Geräten."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21315,6 +21518,22 @@ msgid "This Week"
 msgstr "Diese Woche"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21857,6 +22076,12 @@ msgstr "Heute"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Heute"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23711,6 +23936,14 @@ msgstr ""
 "TripAdvisor verwaltet."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Jungferninseln"
 
@@ -25210,6 +25443,21 @@ msgstr ""
 "verwendet. Kann jederzeit im Menü „%1$s“ ein- oder ausgeschaltet werden."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26629,6 +26877,12 @@ msgstr "Min."
 msgctxt "published date for videos"
 msgid "m"
 msgstr "Min."
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/el_GR/LC_MESSAGES/duckduckgo.po
+++ b/locales/el_GR/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: el_GR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1237,6 +1237,12 @@ msgid "About our ads"
 msgstr "Σχετικά με τις διαφημίσεις μας"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1368,6 +1374,20 @@ msgid "Ad is suspicious"
 msgstr "Η διαφήμιση είναι ύποπτη"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Προσθήκη του DuckDuckGo"
@@ -1394,6 +1414,27 @@ msgstr "Προσθήκη του DuckDuckGo ως μηχανή αναζήτηση�
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Προσθήκη του DuckDuckGo στο %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1439,6 +1480,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Προσθήκη περιεχομένου σελίδας"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1526,6 +1583,12 @@ msgstr "Πρόσθετα"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Προσθέτοντας τις τελικές πινελιές"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1831,6 +1894,12 @@ msgstr "Όλα τα χρώματα"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Όλα έτοιμα!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3577,6 +3646,14 @@ msgid "Cancel"
 msgstr "Ακύρωση"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4077,10 +4154,22 @@ msgid "Chat response is offensive"
 msgstr "Η απάντηση στη συνομιλία είναι προσβλητική"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Συνομιλία με %1$s"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4099,6 +4188,14 @@ msgstr "Συνομιλίες"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Συνομιλίες"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5728,6 +5825,12 @@ msgid "Current Streak"
 msgstr "Τρέχον σερί"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -6076,6 +6179,12 @@ msgstr "Διαγραφή συνομιλιών"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Διαγραφή συνομιλιών παλαιότερων των 30 ημερών"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6495,6 +6604,12 @@ msgstr "Παράβλεψη για πάντα"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Κλείσιμο προσφοράς"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7703,6 +7818,12 @@ msgid "Edit Prompt"
 msgstr "Επεξεργασία προτροπής"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7928,6 +8049,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Κρυπτογραφημένο μοντέλο"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8784,6 +8911,12 @@ msgid "Follow-up question"
 msgstr "Συμπληρωματική ερώτηση"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9300,6 +9433,12 @@ msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
 "Αποκτήστε το DuckDuckGo VPN, το προηγμένο Duck.ai και το Identity Theft "
 "Restoration."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10548,6 +10687,12 @@ msgstr "Πώς διατηρεί την ανωνυμία του χρήστη;"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Πώς λειτουργεί"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -12016,6 +12161,12 @@ msgstr "Κερδισμένα λαϊνάουτ"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "Ο σύνδεσμος λήγει σε 7 ημέρες."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14144,6 +14295,12 @@ msgstr "Εντάξει"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "Εντάξει, κατάλαβα!"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16291,6 +16448,12 @@ msgid "Protected"
 msgstr "Προστατευμένο"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Προστασία. Ιδιωτικότητα. Ηρεμία."
@@ -16422,6 +16585,12 @@ msgstr "Βροχή"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Κατατάξεις"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17675,6 +17844,12 @@ msgid "Save your chats across all your devices."
 msgstr "Αποθηκεύστε τις συνομιλίες σας σε όλες τις συσκευές σας."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17886,6 +18061,14 @@ msgstr "Αναζήτηση"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Αναζήτηση"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -19097,6 +19280,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Αγοράστε"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20785,6 +20974,14 @@ msgstr ""
 "αδράνειας."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20902,6 +21099,12 @@ msgstr "Συγχρονισμός με κοντινή συσκευή."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Συγχρονίστε τις συνομιλίες σας σε όλες τις συσκευές σας."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21497,6 +21700,22 @@ msgid "This Week"
 msgstr "Αυτή την εβδομάδα"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -22050,6 +22269,12 @@ msgstr "Σήμερα"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Σήμερα"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23923,6 +24148,14 @@ msgstr ""
 "TripAdvisor."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Παρθένοι Νήσοι"
 
@@ -25435,6 +25668,21 @@ msgstr ""
 "το ή απενεργοποίησέ το οποιαδήποτε στιγμή στο μενού '%1$s'."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26869,6 +27117,12 @@ msgstr "λ."
 msgctxt "published date for videos"
 msgid "m"
 msgstr "λ."
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/en_AU/LC_MESSAGES/duckduckgo.po
+++ b/locales/en_AU/LC_MESSAGES/duckduckgo.po
@@ -980,6 +980,11 @@ msgstr "About Us"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1083,6 +1088,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "Ad is suspicious"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Add DuckDuckGo"
@@ -1102,6 +1119,24 @@ msgstr "Add DuckDuckGo as a search engine"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Add DuckDuckGo to %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1140,6 +1175,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1211,6 +1260,11 @@ msgstr "Add-ons"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1456,6 +1510,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2805,6 +2864,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3205,9 +3271,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3223,6 +3299,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4487,6 +4570,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4771,6 +4859,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5109,6 +5202,11 @@ msgstr "Dismiss forever"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6005,6 +6103,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6182,6 +6285,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6850,6 +6958,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7268,6 +7381,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8252,6 +8370,11 @@ msgid "How is it anonymous?"
 msgstr "How is it anonymous?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9411,6 +9534,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11148,6 +11276,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "OK, got it!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12856,6 +12989,11 @@ msgstr "Protect your data on every device."
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12962,6 +13100,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13950,6 +14093,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14107,6 +14255,13 @@ msgstr "Search"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15028,6 +15183,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16367,6 +16527,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16447,6 +16614,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16910,6 +17082,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17312,6 +17498,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18777,6 +18968,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19934,6 +20132,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21024,6 +21235,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/en_CA/LC_MESSAGES/duckduckgo.po
+++ b/locales/en_CA/LC_MESSAGES/duckduckgo.po
@@ -980,6 +980,11 @@ msgstr "About Us"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1083,6 +1088,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "Ad is suspicious"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Add DuckDuckGo"
@@ -1102,6 +1119,24 @@ msgstr "Add DuckDuckGo as a search engine"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Add DuckDuckGo to %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1140,6 +1175,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1211,6 +1260,11 @@ msgstr "Add-ons"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1456,6 +1510,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2805,6 +2864,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3205,9 +3271,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3223,6 +3299,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4487,6 +4570,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4771,6 +4859,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5109,6 +5202,11 @@ msgstr "Dismiss forever"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6005,6 +6103,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6182,6 +6285,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6850,6 +6958,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7268,6 +7381,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8252,6 +8370,11 @@ msgid "How is it anonymous?"
 msgstr "How is it anonymous?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9411,6 +9534,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11148,6 +11276,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "OK, got it!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12856,6 +12989,11 @@ msgstr "Protect your data on every device."
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12962,6 +13100,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13950,6 +14093,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14107,6 +14255,13 @@ msgstr "Search"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15028,6 +15183,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16367,6 +16527,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16447,6 +16614,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16910,6 +17082,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17312,6 +17498,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18777,6 +18968,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19934,6 +20132,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21024,6 +21235,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/en_GB/LC_MESSAGES/duckduckgo.po
+++ b/locales/en_GB/LC_MESSAGES/duckduckgo.po
@@ -980,6 +980,11 @@ msgstr "About Us"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1083,6 +1088,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "Ad is suspicious"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Add DuckDuckGo"
@@ -1102,6 +1119,24 @@ msgstr "Add DuckDuckGo as a search engine"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Add DuckDuckGo to %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1140,6 +1175,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1211,6 +1260,11 @@ msgstr "Add-ons"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1456,6 +1510,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2805,6 +2864,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3205,9 +3271,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3223,6 +3299,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4487,6 +4570,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4771,6 +4859,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5109,6 +5202,11 @@ msgstr "Dismiss forever"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6005,6 +6103,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6182,6 +6285,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6850,6 +6958,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7268,6 +7381,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8252,6 +8370,11 @@ msgid "How is it anonymous?"
 msgstr "How is it anonymous?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9411,6 +9534,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11148,6 +11276,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "OK, got it!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12856,6 +12989,11 @@ msgstr "Protect your data on every device."
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12962,6 +13100,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13950,6 +14093,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14107,6 +14255,13 @@ msgstr "Search"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15028,6 +15183,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16367,6 +16527,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16447,6 +16614,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16910,6 +17082,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17312,6 +17498,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18777,6 +18968,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19934,6 +20132,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21024,6 +21235,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/en_US/LC_MESSAGES/duckduckgo.po
+++ b/locales/en_US/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr ""
@@ -1099,6 +1116,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr ""
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1453,6 +1507,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2800,6 +2859,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3200,9 +3266,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3218,6 +3294,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4475,6 +4558,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4759,6 +4847,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5097,6 +5190,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -5993,6 +6091,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6170,6 +6273,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6835,6 +6943,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7253,6 +7366,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8235,6 +8353,11 @@ msgid "How is it anonymous?"
 msgstr ""
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9388,6 +9511,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11125,6 +11253,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12825,6 +12958,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12931,6 +13069,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13919,6 +14062,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14074,6 +14222,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -14989,6 +15144,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16328,6 +16488,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16408,6 +16575,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16868,6 +17040,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17270,6 +17456,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18732,6 +18923,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19881,6 +20079,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20963,6 +21174,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/eo_XX/LC_MESSAGES/duckduckgo.po
+++ b/locales/eo_XX/LC_MESSAGES/duckduckgo.po
@@ -984,6 +984,11 @@ msgstr "Pri Ni"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1087,6 +1092,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "Reklamo estas suspektata"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Aldonu DuckDuckGo"
@@ -1106,6 +1123,24 @@ msgstr "Aldonu DuckDuckGo kiel serĉilon"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Aldonu DuckDuckGo al %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1144,6 +1179,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1215,6 +1264,11 @@ msgstr "Aldonaĵoj"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1461,6 +1515,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2811,6 +2870,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3211,9 +3277,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3229,6 +3305,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4496,6 +4579,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4780,6 +4868,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5118,6 +5211,11 @@ msgstr "Rezignu porĉiame"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6014,6 +6112,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6191,6 +6294,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6859,6 +6967,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7277,6 +7390,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8261,6 +8379,11 @@ msgid "How is it anonymous?"
 msgstr "Kiel estas sennome?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9420,6 +9543,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11157,6 +11285,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "Bone, mi komprenas!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12865,6 +12998,11 @@ msgstr "Protekti viajn datumojn sur ĉiu aparato."
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12971,6 +13109,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13959,6 +14102,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14116,6 +14264,13 @@ msgstr "Serĉu"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15038,6 +15193,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16379,6 +16539,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16459,6 +16626,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16925,6 +17097,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17329,6 +17515,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18794,6 +18985,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19951,6 +20149,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21045,6 +21256,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/es_AR/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_AR/LC_MESSAGES/duckduckgo.po
@@ -980,6 +980,11 @@ msgstr "Acerca de nosotros"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1083,6 +1088,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "El anuncio es sospechoso"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Agregá DuckDuckGo"
@@ -1102,6 +1119,24 @@ msgstr "Agregá DuckDuckGo como motor de búsqueda"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Agregá DuckDuckGo a %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1140,6 +1175,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1211,6 +1260,11 @@ msgstr "Complementos"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1457,6 +1511,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2807,6 +2866,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3207,9 +3273,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3225,6 +3301,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4504,6 +4587,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4788,6 +4876,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5126,6 +5219,11 @@ msgstr "Omitir para siempre"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6022,6 +6120,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6199,6 +6302,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6870,6 +6978,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7288,6 +7401,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8274,6 +8392,11 @@ msgid "How is it anonymous?"
 msgstr "Por qué es anónimo?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9440,6 +9563,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11179,6 +11307,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "¡Ok, entendido!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12887,6 +13020,11 @@ msgstr "Protegé tus datos en cada dispositivo."
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12993,6 +13131,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13981,6 +14124,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14138,6 +14286,13 @@ msgstr "Buscar"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15070,6 +15225,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16410,6 +16570,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16490,6 +16657,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16954,6 +17126,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17358,6 +17544,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18831,6 +19022,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19991,6 +20189,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21086,6 +21297,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/es_CL/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_CL/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Agrega DuckDuckGo"
@@ -1100,6 +1117,24 @@ msgstr "Agrega DuckDuckGo como motor de búsqueda"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Añade DuckDuckGo a %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr "Complementos"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1455,6 +1509,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2802,6 +2861,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3202,9 +3268,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3220,6 +3296,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4491,6 +4574,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4775,6 +4863,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5113,6 +5206,11 @@ msgstr "Descartar para siempre"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6009,6 +6107,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6186,6 +6289,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6856,6 +6964,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7274,6 +7387,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8256,6 +8374,11 @@ msgid "How is it anonymous?"
 msgstr "¿Cómo es eso de anónimo?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9415,6 +9538,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11154,6 +11282,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12862,6 +12995,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12968,6 +13106,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13957,6 +14100,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14114,6 +14262,13 @@ msgstr "Buscar"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15046,6 +15201,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16385,6 +16545,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16465,6 +16632,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16925,6 +17097,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17329,6 +17515,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18801,6 +18992,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19952,6 +20150,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21040,6 +21251,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/es_CO/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_CO/LC_MESSAGES/duckduckgo.po
@@ -980,6 +980,11 @@ msgstr "Sobre nosotros"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1083,6 +1088,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "El anuncio es sospechoso"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Y DuckDuckGo"
@@ -1102,6 +1119,24 @@ msgstr "Agregue DuckDuckGo como un motor de búsqueda"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Añadir DuckDuckGo a %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1140,6 +1175,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1211,6 +1260,11 @@ msgstr "Complementos"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1457,6 +1511,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2806,6 +2865,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3206,9 +3272,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3224,6 +3300,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4499,6 +4582,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4783,6 +4871,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5121,6 +5214,11 @@ msgstr "Descartar por siempre"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6017,6 +6115,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6194,6 +6297,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6865,6 +6973,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7283,6 +7396,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8265,6 +8383,11 @@ msgid "How is it anonymous?"
 msgstr "¿Cómo se mantiene anónimo?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9425,6 +9548,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11164,6 +11292,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12872,6 +13005,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12978,6 +13116,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13966,6 +14109,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14124,6 +14272,13 @@ msgstr "Buscar"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15055,6 +15210,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16394,6 +16554,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16474,6 +16641,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16934,6 +17106,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17338,6 +17524,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18809,6 +19000,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19967,6 +20165,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21058,6 +21269,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/es_CR/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_CR/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Agregar DuckDuckGo"
@@ -1099,6 +1116,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr "Extensiones"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1453,6 +1507,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2800,6 +2859,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3201,9 +3267,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3219,6 +3295,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4478,6 +4561,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4762,6 +4850,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5100,6 +5193,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -5996,6 +6094,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6173,6 +6276,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6840,6 +6948,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7258,6 +7371,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8240,6 +8358,11 @@ msgid "How is it anonymous?"
 msgstr "¿Cómo es que es anónimo?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9397,6 +9520,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11134,6 +11262,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12834,6 +12967,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12940,6 +13078,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13928,6 +14071,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14083,6 +14231,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15002,6 +15157,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16341,6 +16501,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16421,6 +16588,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16881,6 +17053,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17283,6 +17469,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18746,6 +18937,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19895,6 +20093,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20985,6 +21196,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/es_EC/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_EC/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Añadir DuckDuckGo"
@@ -1099,6 +1116,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr "Complementarios"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1453,6 +1507,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2800,6 +2859,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3200,9 +3266,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3218,6 +3294,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4482,6 +4565,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4766,6 +4854,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5104,6 +5197,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6000,6 +6098,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6177,6 +6280,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6847,6 +6955,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7265,6 +7378,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8247,6 +8365,11 @@ msgid "How is it anonymous?"
 msgstr "¿Cómo es el anonimato?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9404,6 +9527,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11141,6 +11269,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12843,6 +12976,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12949,6 +13087,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13938,6 +14081,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14093,6 +14241,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15016,6 +15171,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16355,6 +16515,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16435,6 +16602,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16895,6 +17067,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17299,6 +17485,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18765,6 +18956,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19921,6 +20119,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21012,6 +21223,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/es_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_ES/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: es_ES\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1223,6 +1223,12 @@ msgid "About our ads"
 msgstr "Acerca de nuestros anuncios"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1352,6 +1358,20 @@ msgid "Ad is suspicious"
 msgstr "Anuncio sospechoso"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Añadir DuckDuckGo"
@@ -1378,6 +1398,27 @@ msgstr "Añadir DuckDuckGo como motor de búsqueda"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Añadir DuckDuckGo a %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1423,6 +1464,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Añadir contenido a la página"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1508,6 +1565,12 @@ msgstr "Addons"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Añadiendo los toques finales"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1812,6 +1875,12 @@ msgstr "Todos los colores"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "¡Todo listo!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3530,6 +3599,14 @@ msgid "Cancel"
 msgstr "Cancelar"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4026,10 +4103,22 @@ msgid "Chat response is offensive"
 msgstr "La respuesta del chat es ofensiva"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Chatea con %1$s"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4048,6 +4137,14 @@ msgstr "Chats"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Chats"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5658,6 +5755,12 @@ msgid "Current Streak"
 msgstr "Racha actual"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -6006,6 +6109,12 @@ msgstr "Borrar chats"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Borrar chats con una antigüedad superior a 30 días"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6419,6 +6528,12 @@ msgstr "Descartar para siempre"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Descartar promoción"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7608,6 +7723,12 @@ msgid "Edit Prompt"
 msgstr "Editar instrucción"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7830,6 +7951,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Modelo cifrado"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8677,6 +8804,12 @@ msgid "Follow-up question"
 msgstr "Pregunta de seguimiento"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9189,6 +9322,12 @@ msgstr ""
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr "Obtén DuckDuckGo VPN, Duck.ai avanzado e Identity Theft Restoration."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10423,6 +10562,12 @@ msgstr "¿Cómo se mantienen anónimos?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Cómo funciona"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11881,6 +12026,12 @@ msgstr "Touches ganadas"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "El enlace caduca en 7 días."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14005,6 +14156,12 @@ msgstr "Aceptar"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "Vale, ¡entendido!"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16133,6 +16290,12 @@ msgid "Protected"
 msgstr "Protegido"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Protección. Privacidad. Tranquilidad."
@@ -16264,6 +16427,12 @@ msgstr "Lluvia"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Clasificaciones"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17505,6 +17674,12 @@ msgid "Save your chats across all your devices."
 msgstr "Guarda tus chats en todos tus dispositivos."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17707,6 +17882,14 @@ msgstr "Buscar"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Buscar"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18908,6 +19091,12 @@ msgstr "Mayús+Intro"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Tienda"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20575,6 +20764,14 @@ msgstr ""
 "inactividad."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20689,6 +20886,12 @@ msgstr "Sincronizar con un dispositivo cercano."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Sincroniza tus chats en todos tus dispositivos."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21275,6 +21478,22 @@ msgid "This Week"
 msgstr "Esta semana"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21810,6 +22029,12 @@ msgstr "Hoy"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Hoy"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23635,6 +23860,14 @@ msgstr ""
 "anuncios de Microsoft gestiona los clics en los anuncios."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Islas Vírgenes"
 
@@ -25132,6 +25365,21 @@ msgstr ""
 "IA. Actívalo o desactívalo en cualquier momento en el menú «%1$s»."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26539,6 +26787,12 @@ msgstr "min"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "min"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/es_MX/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_MX/LC_MESSAGES/duckduckgo.po
@@ -982,6 +982,11 @@ msgstr "Acerca de nosotros"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1085,6 +1090,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "El anuncio es sospechoso"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Añade DuckDuckGo"
@@ -1104,6 +1121,24 @@ msgstr "Agrega DuckDuckGo como motor de búsqueda"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Agrega DuckDuckGo en %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1142,6 +1177,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1213,6 +1262,11 @@ msgstr "Complementos"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1458,6 +1512,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2815,6 +2874,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3216,9 +3282,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3234,6 +3310,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4508,6 +4591,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4792,6 +4880,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5130,6 +5223,11 @@ msgstr "Descartar para siempre"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6026,6 +6124,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6203,6 +6306,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6874,6 +6982,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7292,6 +7405,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8280,6 +8398,11 @@ msgid "How is it anonymous?"
 msgstr "¿Cómo es eso anónimo?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9444,6 +9567,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11185,6 +11313,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "¡Entendido!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12898,6 +13031,11 @@ msgstr "Protege tu información en cada dispositivo."
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -13004,6 +13142,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13992,6 +14135,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14149,6 +14297,13 @@ msgstr "Buscar"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15083,6 +15238,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16423,6 +16583,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16503,6 +16670,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16969,6 +17141,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17373,6 +17559,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18851,6 +19042,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -20011,6 +20209,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21107,6 +21318,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/es_PE/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_PE/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Añade DuckDuckGo"
@@ -1099,6 +1116,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr "Componentes adicionales "
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1455,6 +1509,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2802,6 +2861,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3202,9 +3268,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3220,6 +3296,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4487,6 +4570,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4771,6 +4859,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5109,6 +5202,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6005,6 +6103,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6182,6 +6285,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6849,6 +6957,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7267,6 +7380,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8249,6 +8367,11 @@ msgid "How is it anonymous?"
 msgstr "Como es esto anonimo?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9407,6 +9530,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11144,6 +11272,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12846,6 +12979,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12952,6 +13090,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13940,6 +14083,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14095,6 +14243,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15022,6 +15177,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16362,6 +16522,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16442,6 +16609,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16902,6 +17074,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17306,6 +17492,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18773,6 +18964,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19922,6 +20120,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21010,6 +21221,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/es_UY/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_UY/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Agregar DuckDuckGo"
@@ -1099,6 +1116,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr "Complementos"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1453,6 +1507,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2800,6 +2859,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3200,9 +3266,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3218,6 +3294,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4477,6 +4560,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4761,6 +4849,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5099,6 +5192,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -5995,6 +6093,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6172,6 +6275,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6839,6 +6947,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7257,6 +7370,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8239,6 +8357,11 @@ msgid "How is it anonymous?"
 msgstr "¿Cómo es anónimo?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9394,6 +9517,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11131,6 +11259,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12831,6 +12964,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12937,6 +13075,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13925,6 +14068,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14080,6 +14228,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -14997,6 +15152,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16336,6 +16496,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16416,6 +16583,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16876,6 +17048,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17278,6 +17464,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18741,6 +18932,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19890,6 +20088,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20977,6 +21188,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/es_VE/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_VE/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Agregar DuckDuckGo"
@@ -1099,6 +1116,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr "Complementos"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1455,6 +1509,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2802,6 +2861,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3204,9 +3270,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3222,6 +3298,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4484,6 +4567,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4768,6 +4856,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5106,6 +5199,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6002,6 +6100,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6179,6 +6282,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6848,6 +6956,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7266,6 +7379,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8248,6 +8366,11 @@ msgid "How is it anonymous?"
 msgstr "¿Cómo es anónimo?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9405,6 +9528,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11142,6 +11270,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12844,6 +12977,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12950,6 +13088,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13938,6 +14081,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14093,6 +14241,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15014,6 +15169,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16355,6 +16515,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16435,6 +16602,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16895,6 +17067,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17297,6 +17483,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18762,6 +18953,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19911,6 +20109,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20999,6 +21210,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/et_EE/LC_MESSAGES/duckduckgo.po
+++ b/locales/et_EE/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: et_EE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1212,6 +1212,12 @@ msgid "About our ads"
 msgstr "Meie reklaamide kohta"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1341,6 +1347,20 @@ msgid "Ad is suspicious"
 msgstr "Reklaam on kahtlane"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Lisa DuckDuckGo"
@@ -1367,6 +1387,27 @@ msgstr "Lisa DuckDuckGo otsingumootorina"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Lisa DuckDuckGo brauserisse %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1412,6 +1453,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Lisa lehe sisu"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1497,6 +1554,12 @@ msgstr "Lisandid"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Viimistlusdetailide lisamine"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1800,6 +1863,12 @@ msgstr "Kõik värvid"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Kõik valmis!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3516,6 +3585,14 @@ msgid "Cancel"
 msgstr "Tühista"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4008,10 +4085,22 @@ msgid "Chat response is offensive"
 msgstr "Vestluse vastus on solvav"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Vestle %1$s-ga"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4030,6 +4119,14 @@ msgstr "Vestlused"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Vestlused"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5624,6 +5721,12 @@ msgid "Current Streak"
 msgstr "Praegune seeria"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5971,6 +6074,12 @@ msgstr "Kustuta vestlused"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Kustuta vestlused, mis on vanemad kui 30 päeva"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6386,6 +6495,12 @@ msgstr "Tühista igaveseks"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Loobu reklaamist"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7555,6 +7670,12 @@ msgid "Edit Prompt"
 msgstr "Muuda käsklust"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7773,6 +7894,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Krüptitud mudel"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8599,6 +8726,12 @@ msgid "Follow-up question"
 msgstr "Lisaküsimus"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9113,6 +9246,12 @@ msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
 "Hangi DuckDuckGo VPN, täiustatud Duck.ai ja Identity Theft Restoration "
 "teenus."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10344,6 +10483,12 @@ msgstr "Mis moodi see on anonüümne?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Kuidas see töötab"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11785,6 +11930,12 @@ msgstr "Võidetud lahtimängud"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "Link aegub seitsme päeva pärast."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13906,6 +14057,12 @@ msgid "OK, got it!"
 msgstr "OK, sain aru!"
 
 # smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -16023,6 +16180,12 @@ msgid "Protected"
 msgstr "Kaitstud"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Kaitse Privaatsus Meelerahu."
@@ -16154,6 +16317,12 @@ msgstr "Vihm"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Paremusjärjestus"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17391,6 +17560,12 @@ msgid "Save your chats across all your devices."
 msgstr "Salvesta oma vestlused kõigis seadmetes."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17590,6 +17765,14 @@ msgstr "Otsing"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Otsing"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18758,6 +18941,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Pood"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20404,6 +20593,14 @@ msgstr ""
 "mitteaktiivsust."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20518,6 +20715,12 @@ msgstr "Sünkrooni lähedalasuva seadmega."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Sünkrooni oma vestlused kõigis oma seadmetes."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21098,6 +21301,22 @@ msgid "This Week"
 msgstr "Sel nädalal"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21619,6 +21838,12 @@ msgstr "Täna"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Täna"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23436,6 +23661,14 @@ msgstr ""
 "haldab TripAdvisori reklaamivõrgustik."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Neitsisaared"
 
@@ -24911,6 +25144,21 @@ msgstr ""
 "„%1$s“ menüüs."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26313,6 +26561,12 @@ msgstr "k"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "k"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/eu_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/eu_ES/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Gehitu DuckDuckGo"
@@ -1099,6 +1116,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr "Gehigarriak"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1453,6 +1507,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2800,6 +2859,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3200,9 +3266,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3218,6 +3294,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4477,6 +4560,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4761,6 +4849,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5099,6 +5192,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -5995,6 +6093,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6172,6 +6275,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6839,6 +6947,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7257,6 +7370,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8239,6 +8357,11 @@ msgid "How is it anonymous?"
 msgstr "Zer da izengabea?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9394,6 +9517,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11131,6 +11259,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12831,6 +12964,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12937,6 +13075,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13925,6 +14068,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14080,6 +14228,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -14997,6 +15152,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16336,6 +16496,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16416,6 +16583,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16876,6 +17048,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17278,6 +17464,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18740,6 +18931,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19889,6 +20087,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20977,6 +21188,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/fa_IR/LC_MESSAGES/duckduckgo.po
+++ b/locales/fa_IR/LC_MESSAGES/duckduckgo.po
@@ -983,6 +983,11 @@ msgstr "درباره ما"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1086,6 +1091,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "فرم انتقاد و پیشنهادات"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "افزودن DuckDuckGo"
@@ -1109,6 +1126,24 @@ msgstr "داک‌داک‌گو را به موتورهای جستجو اضافه 
 #, fuzzy
 msgid "Add DuckDuckGo to %s"
 msgstr "‫افزودن داک‌داک‌گو به %s‬"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1147,6 +1182,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1218,6 +1267,11 @@ msgstr "افزونه ها"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1463,6 +1517,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2817,6 +2876,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3217,9 +3283,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3235,6 +3311,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4505,6 +4588,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4789,6 +4877,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5127,6 +5220,11 @@ msgstr "دیگر نشان نده"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6037,6 +6135,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6214,6 +6317,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6889,6 +6997,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7307,6 +7420,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8299,6 +8417,11 @@ msgid "How is it anonymous?"
 msgstr "آیا تنظیمات من قابل ردگیری است؟"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9469,6 +9592,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11210,6 +11338,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "باشه فهمیدم!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12918,6 +13051,11 @@ msgstr "از داده‌های خود در هر دستگاهی محافظت کن
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -13024,6 +13162,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -14013,6 +14156,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14170,6 +14318,13 @@ msgstr "جستجو"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15108,6 +15263,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16451,6 +16611,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16531,6 +16698,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16997,6 +17169,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17399,6 +17585,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18874,6 +19065,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -20035,6 +20233,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21127,6 +21338,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/fi_FI/LC_MESSAGES/duckduckgo.po
+++ b/locales/fi_FI/LC_MESSAGES/duckduckgo.po
@@ -1211,6 +1211,12 @@ msgid "About our ads"
 msgstr "Tietoa mainoksistamme"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1340,6 +1346,20 @@ msgid "Ad is suspicious"
 msgstr "Mainos on epäilyttävä"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Lisää DuckDuckGo"
@@ -1365,6 +1385,27 @@ msgstr "Lisää DuckDuckGo hakukoneeksi"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Lisää DuckDuckGo selaimeen %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1410,6 +1451,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Lisää sivun sisältö"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1495,6 +1552,12 @@ msgstr "Laajennukset"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Tehdään viimeistelyjä"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1792,6 +1855,12 @@ msgstr "Kaikki värit"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Valmista!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3496,6 +3565,14 @@ msgid "Cancel"
 msgstr "Peruuta"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3989,10 +4066,22 @@ msgid "Chat response is offensive"
 msgstr "Chat-vastaus on loukkaava."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Keskustele %1$s:n kanssa"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4011,6 +4100,14 @@ msgstr "Keskustelut"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Keskustelut"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5599,6 +5696,12 @@ msgid "Current Streak"
 msgstr "Nykyinen putki"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5947,6 +6050,12 @@ msgstr "Poista keskustelut"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Poista yli 30 päivää vanhemmat keskustelut"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6362,6 +6471,12 @@ msgstr "Hylkää pysyvästi"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Kampanjan hylkääminen"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7525,6 +7640,12 @@ msgid "Edit Prompt"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7744,6 +7865,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Salattu malli"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8567,6 +8694,12 @@ msgid "Follow-up question"
 msgstr "Jatkokysymys"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9079,6 +9212,12 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -10285,6 +10424,12 @@ msgstr "Kuinka se voi olla anonyymiä?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Näin se toimii"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11725,6 +11870,12 @@ msgstr "Voitettujen linjapallojen määrä"
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -13847,6 +13998,12 @@ msgid "OK, got it!"
 msgstr "OK, selvä!"
 
 # smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -15948,6 +16105,12 @@ msgid "Protected"
 msgstr "Suojattu"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Suojausta. Tietosuojaa. takaavat mielenrauhan."
@@ -16079,6 +16242,12 @@ msgstr "Sadetta"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Sijoitukset"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17315,6 +17484,12 @@ msgid "Save your chats across all your devices."
 msgstr "Tallenna keskustelusi kaikkiin laitteisiisi."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17514,6 +17689,14 @@ msgstr "Etsi"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Etsi"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18688,6 +18871,12 @@ msgstr "Vaihtonäppäin + Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Osta"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20338,6 +20527,14 @@ msgstr ""
 "toimettomuuden jälkeen."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20451,6 +20648,12 @@ msgstr ""
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Synkronoi keskustelusi kaikkien laitteidesi välillä."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21031,6 +21234,22 @@ msgid "This Week"
 msgstr "Tämä viikko"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21552,6 +21771,12 @@ msgstr "Tänään"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Tänään"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23375,6 +23600,14 @@ msgstr ""
 "hallinnoi TripAdvisorin mainosverkosto."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Neitsytsaaret"
 
@@ -24828,6 +25061,21 @@ msgid ""
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26212,6 +26460,12 @@ msgstr "min"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "min"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/fr_BE/LC_MESSAGES/duckduckgo.po
+++ b/locales/fr_BE/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "Publicité suspecte"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Ajouter DuckDuckGo"
@@ -1100,6 +1117,24 @@ msgstr "Ajouter DuckDuckGo comme une moteur de recherche"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Ajouter DuckDuckGo à %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr "Extensions"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1455,6 +1509,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2802,6 +2861,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3202,9 +3268,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3220,6 +3296,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4493,6 +4576,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4777,6 +4865,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5115,6 +5208,11 @@ msgstr "Rejeter pour toujours"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6013,6 +6111,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6190,6 +6293,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6859,6 +6967,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7277,6 +7390,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8261,6 +8379,11 @@ msgid "How is it anonymous?"
 msgstr "Anonyme, c'est-à-dire ?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9422,6 +9545,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11162,6 +11290,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "C'est bon, je l'ai !"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12871,6 +13004,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12977,6 +13115,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13966,6 +14109,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14124,6 +14272,13 @@ msgstr "Recherche"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15058,6 +15213,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16399,6 +16559,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16479,6 +16646,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16939,6 +17111,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17342,6 +17528,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18815,6 +19006,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19973,6 +20171,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21068,6 +21279,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/fr_CA/LC_MESSAGES/duckduckgo.po
+++ b/locales/fr_CA/LC_MESSAGES/duckduckgo.po
@@ -979,6 +979,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1082,6 +1087,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "Cette pub est suspicieuse"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Ajouter DuckDuckGo"
@@ -1101,6 +1118,24 @@ msgstr "Ajouter DuckDuckGo comme moteur de recherche"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Ajoutez DuckDuckGo à %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1139,6 +1174,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1210,6 +1259,11 @@ msgstr "Extensions"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1456,6 +1510,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2805,6 +2864,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3205,9 +3271,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3223,6 +3299,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4497,6 +4580,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4781,6 +4869,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5119,6 +5212,11 @@ msgstr "Passer (pour toujours)"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6015,6 +6113,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6192,6 +6295,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6860,6 +6968,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7278,6 +7391,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8262,6 +8380,11 @@ msgid "How is it anonymous?"
 msgstr "Comment ça peut être anonyme?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9425,6 +9548,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11166,6 +11294,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "OK, j'ai compris!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12874,6 +13007,11 @@ msgstr "Protégez vos informations sur tous vos appareils."
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12980,6 +13118,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13969,6 +14112,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14126,6 +14274,13 @@ msgstr "Rechercher"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15059,6 +15214,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16398,6 +16558,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16478,6 +16645,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16938,6 +17110,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17342,6 +17528,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18817,6 +19008,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19979,6 +20177,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21077,6 +21288,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/fr_CH/LC_MESSAGES/duckduckgo.po
+++ b/locales/fr_CH/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Ajouter DuckDuckGo"
@@ -1100,6 +1117,24 @@ msgstr "Ajouter DuckDuckGo comme moteur de recherche"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Ajouter DuckDuckGo à %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr "Extensions"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1455,6 +1509,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2802,6 +2861,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3202,9 +3268,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3220,6 +3296,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4493,6 +4576,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4777,6 +4865,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5115,6 +5208,11 @@ msgstr "Ne plus jamais prendre en compte"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6011,6 +6109,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6188,6 +6291,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6857,6 +6965,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7275,6 +7388,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8257,6 +8375,11 @@ msgid "How is it anonymous?"
 msgstr "Anonyme, c'est-à-dire ?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9417,6 +9540,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11157,6 +11285,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12865,6 +12998,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12971,6 +13109,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13960,6 +14103,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14117,6 +14265,13 @@ msgstr "Recherche"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15049,6 +15204,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16390,6 +16550,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16470,6 +16637,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16930,6 +17102,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17334,6 +17520,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18806,6 +18997,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19960,6 +20158,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21050,6 +21261,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/fr_FR/LC_MESSAGES/duckduckgo.po
+++ b/locales/fr_FR/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: fr_FR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1225,6 +1225,12 @@ msgid "About our ads"
 msgstr "À propos de nos publicités"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1354,6 +1360,20 @@ msgid "Ad is suspicious"
 msgstr "Publicité suspecte"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Ajouter DuckDuckGo"
@@ -1380,6 +1400,27 @@ msgstr "Ajouter DuckDuckGo en tant que moteur de recherche"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Ajoutez DuckDuckGo à %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1425,6 +1466,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Ajouter le contenu de la page"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1511,6 +1568,12 @@ msgstr "Extensions"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Ajout des touches finales"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1817,6 +1880,12 @@ msgstr "Toutes les couleurs"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "C'est fait !"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3555,6 +3624,14 @@ msgid "Cancel"
 msgstr "Annuler"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4052,10 +4129,22 @@ msgid "Chat response is offensive"
 msgstr "La réponse du chat est offensante"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Discuter avec %1$s"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4074,6 +4163,14 @@ msgstr "Discussions"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Discussions"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5698,6 +5795,12 @@ msgid "Current Streak"
 msgstr "Série actuelle"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -6046,6 +6149,12 @@ msgstr "Supprimer les discussions"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Supprimer les discussions datant de plus de 30 jours"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6467,6 +6576,12 @@ msgstr "Ne plus afficher"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Ignorer la promotion"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7660,6 +7775,12 @@ msgid "Edit Prompt"
 msgstr "Modifier le prompt"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7884,6 +8005,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Modèle chiffré"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8729,6 +8856,12 @@ msgid "Follow-up question"
 msgstr "Question de suivi"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9245,6 +9378,12 @@ msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
 "Bénéficiez du VPN DuckDuckGo, du chat avancé Duck.ai et d'Identity Theft "
 "Restoration."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10490,6 +10629,12 @@ msgstr "Anonyme, c'est-à-dire ?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Comment ça fonctionne"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11949,6 +12094,12 @@ msgstr "Touches gagnées"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "Le lien expire dans 7 jours."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14075,6 +14226,12 @@ msgstr "Ok"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "C'est bon, je l'ai !"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16218,6 +16375,12 @@ msgid "Protected"
 msgstr "Protégé"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Protection. Confidentialité. Tranquillité d'esprit."
@@ -16349,6 +16512,12 @@ msgstr "Pluie"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Classements"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17597,6 +17766,12 @@ msgid "Save your chats across all your devices."
 msgstr "Enregistrez vos discussions sur tous vos appareils."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17807,6 +17982,14 @@ msgstr "Rechercher"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Rechercher"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -19010,6 +19193,12 @@ msgstr "Maj+Entrée"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Acheter"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20693,6 +20882,14 @@ msgstr ""
 "d'inactivité."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20809,6 +21006,12 @@ msgstr "Synchroniser avec un appareil à proximité."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Synchronisez vos discussions sur tous vos appareils."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21405,6 +21608,22 @@ msgid "This Week"
 msgstr "Cette semaine"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21956,6 +22175,12 @@ msgstr "Auj."
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Auj."
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23803,6 +24028,14 @@ msgstr ""
 "publicitaire de TripAdvisor."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Îles Vierges"
 
@@ -25310,6 +25543,21 @@ msgstr ""
 "à tout moment dans le menu « %1$s »."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26736,6 +26984,12 @@ msgstr "min"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "min"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/ga_IE/LC_MESSAGES/duckduckgo.po
+++ b/locales/ga_IE/LC_MESSAGES/duckduckgo.po
@@ -988,6 +988,11 @@ msgstr "Maidir Linn"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1091,6 +1096,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "Tá an fógra amhrasach"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Cuir DuckDuckGo leis"
@@ -1110,6 +1127,24 @@ msgstr "Abair DuckDuckGo agus an cuardach éagsúla"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Cuir DuckDuckGo le %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1148,6 +1183,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1219,6 +1268,11 @@ msgstr "Breiseáin"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1465,6 +1519,11 @@ msgstr "Gach dath"
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2815,6 +2874,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3218,9 +3284,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3236,6 +3312,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4513,6 +4596,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4797,6 +4885,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5135,6 +5228,11 @@ msgstr "Ruaig go deo é"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6032,6 +6130,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6209,6 +6312,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6882,6 +6990,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7300,6 +7413,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8285,6 +8403,11 @@ msgid "How is it anonymous?"
 msgstr "Conas mar atá sé anaithnid?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9452,6 +9575,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11196,6 +11324,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "Tuigim é!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12905,6 +13038,11 @@ msgstr "Cosain do chuid sonraí ar gach gléas."
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -13011,6 +13149,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13999,6 +14142,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14156,6 +14304,13 @@ msgstr "Cuardaigh"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15089,6 +15244,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16441,6 +16601,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16521,6 +16688,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16990,6 +17162,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17404,6 +17590,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18880,6 +19071,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -20043,6 +20241,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21143,6 +21354,11 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "m"
 msgstr "n"
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.
 msgctxt "Aria label for the menu button"

--- a/locales/gd_GB/LC_MESSAGES/duckduckgo.po
+++ b/locales/gd_GB/LC_MESSAGES/duckduckgo.po
@@ -980,6 +980,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1083,6 +1088,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Cuir DuckDuckGo ris"
@@ -1102,6 +1119,24 @@ msgstr "Cuir DuckDuckGo ris mar einnsean-luirg"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Cuir DuckDuckGo ri %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1140,6 +1175,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1211,6 +1260,11 @@ msgstr "Tuilleadain"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1458,6 +1512,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2805,6 +2864,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3206,9 +3272,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3224,6 +3300,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4499,6 +4582,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4783,6 +4871,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5121,6 +5214,11 @@ msgstr "Na seall seo a-rithist"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6019,6 +6117,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6196,6 +6299,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6868,6 +6976,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7286,6 +7399,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8268,6 +8386,11 @@ msgid "How is it anonymous?"
 msgstr "Gun urra? Ciamar?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9430,6 +9553,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11169,6 +11297,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12877,6 +13010,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12983,6 +13121,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13972,6 +14115,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14129,6 +14277,13 @@ msgstr "Lorg"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15057,6 +15212,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16398,6 +16558,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16478,6 +16645,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16938,6 +17110,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17343,6 +17529,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18813,6 +19004,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19975,6 +20173,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21073,6 +21284,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/gl_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/gl_ES/LC_MESSAGES/duckduckgo.po
@@ -985,6 +985,11 @@ msgstr "Sobre nós"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1088,6 +1093,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "Este anuncio é sospeitoso"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Engadir DuckDuckGo"
@@ -1109,6 +1126,24 @@ msgstr "Engadir DuckDuckGo como buscador"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Engadir DuckDuckGo a %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1147,6 +1182,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1218,6 +1267,11 @@ msgstr "Complementos"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1464,6 +1518,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2823,6 +2882,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3223,9 +3289,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3241,6 +3317,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4508,6 +4591,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4792,6 +4880,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5130,6 +5223,11 @@ msgstr "Rexeitar para sempre"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6026,6 +6124,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6203,6 +6306,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6873,6 +6981,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7291,6 +7404,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8278,6 +8396,11 @@ msgid "How is it anonymous?"
 msgstr "Como é anónimo?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9440,6 +9563,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11177,6 +11305,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "De acordo, comprendo!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12888,6 +13021,11 @@ msgstr "Protexa a súa información en calquera dispositivo."
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12994,6 +13132,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13982,6 +14125,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14139,6 +14287,13 @@ msgstr "Buscar"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15070,6 +15225,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16409,6 +16569,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16489,6 +16656,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16956,6 +17128,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17359,6 +17545,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18826,6 +19017,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19985,6 +20183,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21078,6 +21289,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/gu_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/gu_IN/LC_MESSAGES/duckduckgo.po
@@ -980,6 +980,11 @@ msgstr "અમારા વિષે"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1083,6 +1088,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "જાહેરાત શંકાસ્પદ છે"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "DuckDuckGo ઉમેરો"
@@ -1102,6 +1119,24 @@ msgstr ""
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "DuckDuckGo ને %s માં ઉમેરો"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1140,6 +1175,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1211,6 +1260,11 @@ msgstr "ઍડૉનો"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1455,6 +1509,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2802,6 +2861,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3202,9 +3268,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3220,6 +3296,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4477,6 +4560,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4761,6 +4849,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5099,6 +5192,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6003,6 +6101,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6180,6 +6283,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6845,6 +6953,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7263,6 +7376,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8245,6 +8363,11 @@ msgid "How is it anonymous?"
 msgstr "તે કેવી રીતે અનામિક છે?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9398,6 +9521,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11135,6 +11263,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12835,6 +12968,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12941,6 +13079,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13929,6 +14072,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14084,6 +14232,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15001,6 +15156,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16340,6 +16500,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16420,6 +16587,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16880,6 +17052,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17282,6 +17468,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18744,6 +18935,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19893,6 +20091,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20975,6 +21186,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/he_IL/LC_MESSAGES/duckduckgo.po
+++ b/locales/he_IL/LC_MESSAGES/duckduckgo.po
@@ -980,6 +980,11 @@ msgstr "אודותנו"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1083,6 +1088,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "הפרסומת זדונית"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "הוסף את DuckDuckGo"
@@ -1102,6 +1119,24 @@ msgstr "הוסף את DuckDuckGo כמנוע החיפוש"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "הוסף את DuckDuckGo ל%s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1140,6 +1175,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1211,6 +1260,11 @@ msgstr "תוספים"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1455,6 +1509,11 @@ msgstr "כל הצבעים"
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2805,6 +2864,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3205,9 +3271,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3223,6 +3299,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4487,6 +4570,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4771,6 +4859,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5109,6 +5202,11 @@ msgstr "התעלם לתמיד"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6005,6 +6103,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6182,6 +6285,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6848,6 +6956,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7266,6 +7379,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8248,6 +8366,11 @@ msgid "How is it anonymous?"
 msgstr "איך זה אנונימי, בדיוק?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9405,6 +9528,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11143,6 +11271,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "טוב, הבנתי!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12848,6 +12981,11 @@ msgstr "הגן על הנתונים שלך בכל מכשיר."
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12954,6 +13092,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13942,6 +14085,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14100,6 +14248,13 @@ msgstr "חפש"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15017,6 +15172,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16356,6 +16516,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16436,6 +16603,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16896,6 +17068,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17298,6 +17484,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18763,6 +18954,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19914,6 +20112,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21000,6 +21211,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/hi_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/hi_IN/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: hi_IN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1202,6 +1202,12 @@ msgid "About our ads"
 msgstr "हमारे विज्ञापनों के बारे में"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1331,6 +1337,20 @@ msgid "Ad is suspicious"
 msgstr "विज्ञापन सन्देहजनक है"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "DuckDuckGo जोड़ें"
@@ -1356,6 +1376,27 @@ msgstr "DuckDuckGo को खोज इंजन के रूप में ज�
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "DuckDuckGo को %1$s में जोड़ें"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1401,6 +1442,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "पेज कंटेंट जोड़ें"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1486,6 +1543,12 @@ msgstr "एड-ऑन"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "अंतिम तैयारी"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1786,6 +1849,12 @@ msgstr "सभी रंग"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "सब हो गया!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3488,6 +3557,14 @@ msgid "Cancel"
 msgstr "कैंसिल करें"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3977,10 +4054,22 @@ msgid "Chat response is offensive"
 msgstr "चैट में मिला जवाब आपत्तिजनक है"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "%1$s से चैट करें"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3999,6 +4088,14 @@ msgstr "चैट"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "चैट"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5584,6 +5681,12 @@ msgid "Current Streak"
 msgstr "मौजूदा स्ट्रीक"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5930,6 +6033,12 @@ msgstr "चैट डिलीट करें"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "30 दिन से पुरानी चैट डिलीट करें"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6343,6 +6452,12 @@ msgstr "हमेशा के लिए निरस्त करें"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "प्रमोशन हटाएं"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7502,6 +7617,12 @@ msgid "Edit Prompt"
 msgstr "प्रॉम्प्ट एडिट करें"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7722,6 +7843,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "एन्क्रिप्ट किया गया मॉडल"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8545,6 +8672,12 @@ msgid "Follow-up question"
 msgstr "फ़ॉलोअप सवाल"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9057,6 +9190,12 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
 "DuckDuckGo VPN, एडवांस्ड Duck.ai, और Identity Theft Restoration प्राप्त करें।"
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10280,6 +10419,12 @@ msgstr "यह अनाम कैसे है?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "यह कैसे काम करता है"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11713,6 +11858,12 @@ msgstr "लाइनआउट जीते"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "लिंक 7 दिनों में समाप्त हो जाएगा।"
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13830,6 +13981,12 @@ msgid "OK, got it!"
 msgstr "ठीक है, समझ गए!"
 
 # smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -15944,6 +16101,12 @@ msgid "Protected"
 msgstr "सुरक्षित"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "सुरक्षा। गोपनीयता। मन का सुकून।"
@@ -16074,6 +16237,12 @@ msgstr "बारिश"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "रैंकिंग"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17305,6 +17474,12 @@ msgid "Save your chats across all your devices."
 msgstr "अपनी चैट्स को अपने सभी डिवाइसों पर सेव करें।"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17505,6 +17680,14 @@ msgstr "खोजें"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "खोजें"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18664,6 +18847,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "शॉप"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20306,6 +20495,14 @@ msgstr ""
 "18 महीने तक निष्क्रिय रहने के बाद, Sync & Backup डेटा को रिकवर नहीं किया जा सकता।"
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20419,6 +20616,12 @@ msgstr "आस-पास के किसी डिवाइस के साथ
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "अपनी चैट्स को अपने सभी डिवाइसों पर सिंक करें।"
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -20994,6 +21197,22 @@ msgid "This Week"
 msgstr "इस सप्ताह"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21511,6 +21730,12 @@ msgstr "आज"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "आज"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23315,6 +23540,14 @@ msgstr ""
 "विज्ञापन नेटवर्क द्वारा प्रबंधित किए जाते हैं।"
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "वर्जिन आइलैंड्स"
 
@@ -24776,6 +25009,21 @@ msgstr ""
 "इस्तेमाल कभी नहीं किया जाता। '%1$s' मेन्यू में इसे कभी भी चालू या बंद करें।"
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26156,6 +26404,12 @@ msgstr "मि"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "मि"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/hr_HR/LC_MESSAGES/duckduckgo.po
+++ b/locales/hr_HR/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: hr_HR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1221,6 +1221,12 @@ msgid "About our ads"
 msgstr "O našim oglasima"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1350,6 +1356,20 @@ msgid "Ad is suspicious"
 msgstr "Oglas je sumnjiv"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Dodaj DuckDuckGo"
@@ -1376,6 +1396,27 @@ msgstr "Dodaj DuckDuckGo kao pretraživač"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Dodaj DuckDuckGo u %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1421,6 +1462,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Dodaj sadržaj stranice"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1506,6 +1563,12 @@ msgstr "Dodaci"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Dodavanje završnih detalja"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1810,6 +1873,12 @@ msgstr "Sve boje"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Gotovo!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3523,6 +3592,14 @@ msgid "Cancel"
 msgstr "Otkaži"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4018,10 +4095,22 @@ msgid "Chat response is offensive"
 msgstr "Odgovor na chatu je uvredljiv"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Razgovaraj s %1$s"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4040,6 +4129,14 @@ msgstr "Čavrljanja"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Čavrljanja"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5641,6 +5738,12 @@ msgid "Current Streak"
 msgstr "Trenutačni niz"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5989,6 +6092,12 @@ msgstr "Izbriši čavrljanja"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Izbriši čavrljanja starija od 30 dana"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6405,6 +6514,12 @@ msgstr "Zauvijek odbaci"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Odbaci promociju"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7579,6 +7694,12 @@ msgid "Edit Prompt"
 msgstr "Uredi upit"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7798,6 +7919,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Šifrirani model"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8631,6 +8758,12 @@ msgid "Follow-up question"
 msgstr "Dodatno pitanje"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9145,6 +9278,12 @@ msgstr ""
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr "Nabavi DuckDuckGo VPN, napredni Duck.ai i Identity Theft Restoration."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10376,6 +10515,12 @@ msgstr "Kako je osigurana anonimnost?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Kako funkcionira"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11822,6 +11967,12 @@ msgstr "Osvojeni lineouti"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "Poveznica istječe za 7 dana."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13941,6 +14092,12 @@ msgstr "U redu"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "U redu, shvaćam!"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16065,6 +16222,12 @@ msgid "Protected"
 msgstr "Zaštićeno"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Zaštita. Privatnost. Bezbrižnost."
@@ -16196,6 +16359,12 @@ msgstr "Kiša"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Ljestvica"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17435,6 +17604,12 @@ msgid "Save your chats across all your devices."
 msgstr "Spremi svoja čavrljanja na svim svojim uređajima."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17637,6 +17812,14 @@ msgstr "Traži"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Traži"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18818,6 +19001,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Trgovina"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20479,6 +20668,14 @@ msgstr ""
 "oporaviti nakon 18 (ili više) mjeseci neaktivnosti."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20591,6 +20788,12 @@ msgstr "Sinkronizacija s obližnjim uređajem."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Sinkroniziraj svoja čavrljanja na svim svojim uređajima."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21174,6 +21377,22 @@ msgid "This Week"
 msgstr "Ovaj tjedan"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21706,6 +21925,12 @@ msgstr "Danas"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Danas"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23532,6 +23757,14 @@ msgstr ""
 "oglasa upravlja TripAdvisorova oglasna mreža."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Djevičanski otoci"
 
@@ -25013,6 +25246,21 @@ msgstr ""
 "izborniku '%1$s'."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26415,6 +26663,12 @@ msgstr "m"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "m"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/hu_HU/LC_MESSAGES/duckduckgo.po
+++ b/locales/hu_HU/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: hu_HU\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1221,6 +1221,12 @@ msgid "About our ads"
 msgstr "Tudnivalók a hirdetéseinkről"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1352,6 +1358,20 @@ msgid "Ad is suspicious"
 msgstr "A hirdetés gyanús"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "DuckDuckGo hozzáadása"
@@ -1378,6 +1398,27 @@ msgstr "DuckDuckGo hozzáadása keresőmotorként"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "DuckDuckGo hozzáadása %1$s-bővítményként"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1423,6 +1464,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Oldal tartalmának hozzáadása"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1508,6 +1565,12 @@ msgstr "Kiegészítők"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Utolsó simítások hozzáadása"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1812,6 +1875,12 @@ msgstr "Minden szín"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Minden kész!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3539,6 +3608,14 @@ msgid "Cancel"
 msgstr "Mégse"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4035,10 +4112,22 @@ msgid "Chat response is offensive"
 msgstr "A csevegés válasza bántó"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Csevegési partner: %1$s"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4057,6 +4146,14 @@ msgstr "Csevegések"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Csevegések"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5677,6 +5774,12 @@ msgid "Current Streak"
 msgstr "Jelenlegi sorozat"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -6023,6 +6126,12 @@ msgstr "Csevegések törlése"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "30 napnál régebbi csevegések törlése"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6440,6 +6549,12 @@ msgstr "Végleges bezárás"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Promóció bezárása"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7628,6 +7743,12 @@ msgid "Edit Prompt"
 msgstr "Utasítás szerkesztése"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7851,6 +7972,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Titkosított modell"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8703,6 +8830,12 @@ msgid "Follow-up question"
 msgstr "Kapcsolódó kérdés"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9221,6 +9354,12 @@ msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
 "Vedd igénybe a DuckDuckGo VPN-t, a fejlett Duck.ai-t és a személyazonosság "
 "helyreállításához használható Identity Theft Restoration funkciókat."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10468,6 +10607,12 @@ msgstr "Mitől névtelen?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Működés leírása"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11931,6 +12076,12 @@ msgstr "Megnyert bedobások"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "A link 7 nap múlva lejár."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14054,6 +14205,12 @@ msgstr "OK"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "OK, vettem!"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16188,6 +16345,12 @@ msgid "Protected"
 msgstr "Védett"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Védelem. Adatvédelem. Nyugalom."
@@ -16319,6 +16482,12 @@ msgstr "Eső"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Ranglisták"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17560,6 +17729,12 @@ msgid "Save your chats across all your devices."
 msgstr "Csevegések mentése minden eszközön."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17768,6 +17943,14 @@ msgstr "Keresés"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Keresés"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18970,6 +19153,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Vásárlás"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20632,6 +20821,14 @@ msgstr ""
 "helyre."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20747,6 +20944,12 @@ msgstr "Szinkronizálj egy közeli eszközzel."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Csevegések szinkronizálása minden eszközön."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21335,6 +21538,22 @@ msgid "This Week"
 msgstr "Ezen a héten"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21871,6 +22090,12 @@ msgstr "Ma"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Ma"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23718,6 +23943,14 @@ msgstr ""
 "hirdetéskattintásokat a TripAdvisor hirdetési hálózata kezeli."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Virgin-szigetek"
 
@@ -25202,6 +25435,21 @@ msgstr ""
 "a(z) „%1$s” menüben."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26605,6 +26853,12 @@ msgstr "p"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "p"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/hy_AM/LC_MESSAGES/duckduckgo.po
+++ b/locales/hy_AM/LC_MESSAGES/duckduckgo.po
@@ -980,6 +980,11 @@ msgstr "Մեր մասին"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1083,6 +1088,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #  Marked fuzzy because of translated trademark
 #. Link to add the DuckDuckGo extension to the user's web browser.
 #, fuzzy
@@ -1106,6 +1123,24 @@ msgstr ""
 #, fuzzy
 msgid "Add DuckDuckGo to %s"
 msgstr "Ավելացնել DuckDuckGo֊ն %s֊ին"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1144,6 +1179,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1215,6 +1264,11 @@ msgstr "Հավելումներ"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1459,6 +1513,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2810,6 +2869,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3210,9 +3276,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3228,6 +3304,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4487,6 +4570,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4771,6 +4859,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5109,6 +5202,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6013,6 +6111,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6190,6 +6293,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6857,6 +6965,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7275,6 +7388,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8261,6 +8379,11 @@ msgid "How is it anonymous?"
 msgstr "Ինչպե՞ս է սա անստորագիր։"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9418,6 +9541,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11159,6 +11287,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "Լավ, հասկացա՛"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12863,6 +12996,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12969,6 +13107,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13957,6 +14100,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14112,6 +14260,13 @@ msgstr "Փնտրել"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15035,6 +15190,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16376,6 +16536,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16456,6 +16623,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16916,6 +17088,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17318,6 +17504,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18780,6 +18971,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19929,6 +20127,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21017,6 +21228,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/id_ID/LC_MESSAGES/duckduckgo.po
+++ b/locales/id_ID/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: id_ID\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1214,6 +1214,12 @@ msgid "About our ads"
 msgstr "Tentang iklan kami"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1343,6 +1349,20 @@ msgid "Ad is suspicious"
 msgstr "Iklannya mencurigakan"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Tambahkan DuckDuckGo"
@@ -1369,6 +1389,27 @@ msgstr "Tambahkan DuckDuckGo sebagai mesin pencari"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Tambahkan DuckDuckGo ke %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1414,6 +1455,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Tambahkan Konten Halaman"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1499,6 +1556,12 @@ msgstr "Pengaya"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Menambahkan sentuhan akhir"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1800,6 +1863,12 @@ msgstr "Semua warna"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Selesai!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3518,6 +3587,14 @@ msgid "Cancel"
 msgstr "Batalkan"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4011,10 +4088,22 @@ msgid "Chat response is offensive"
 msgstr "Tanggapan obrolan menyinggung"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Mengobrol dengan %1$s"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4033,6 +4122,14 @@ msgstr "Obrolan"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Obrolan"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5630,6 +5727,12 @@ msgid "Current Streak"
 msgstr "Catatan Saat Ini"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5978,6 +6081,12 @@ msgstr "Menghapus Obrolan"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Hapus Obrolan Lebih Lama Dari 30 Hari"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6394,6 +6503,12 @@ msgstr "Tutup selamanya"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Tolak promosi"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7575,6 +7690,12 @@ msgid "Edit Prompt"
 msgstr "Edit Prompt"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7796,6 +7917,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Model terenkripsi"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8629,6 +8756,12 @@ msgid "Follow-up question"
 msgstr "Pertanyaan lanjutan"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9143,6 +9276,12 @@ msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
 "Dapatkan VPN DuckDuckGo, Duck.ai tingkat lanjut, dan Identity Theft "
 "Restoration."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10374,6 +10513,12 @@ msgstr "Bagaimana sampai bisa anonim?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Cara Kerja"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11825,6 +11970,12 @@ msgstr "Lineout dimenangkan"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "Tautan kedaluwarsa dalam 7 hari."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13944,6 +14095,12 @@ msgstr "OKE"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "OKE, paham!"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16070,6 +16227,12 @@ msgid "Protected"
 msgstr "Dilindungi"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Perlindungan. Privasi. Ketenangan pikiran."
@@ -16201,6 +16364,12 @@ msgstr "Hujan"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Peringkat"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17439,6 +17608,12 @@ msgid "Save your chats across all your devices."
 msgstr "Simpan obrolanmu di semua perangkatmu."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17640,6 +17815,14 @@ msgstr "Cari"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Cari"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18815,6 +18998,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Belanja"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20476,6 +20665,14 @@ msgstr ""
 "Data Sync & Backup tidak dapat dipulihkan setelah 18 bulan tidak aktif."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20590,6 +20787,12 @@ msgstr "Sinkronkan dengan perangkat terdekat."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Sinkronkan obrolanmu di semua perangkatmu."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21178,6 +21381,22 @@ msgid "This Week"
 msgstr "Minggu ini"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21709,6 +21928,12 @@ msgstr "Hari Ini"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Hari Ini"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23536,6 +23761,14 @@ msgstr ""
 "dikelola oleh jaringan iklan TripAdvisor."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Kepulauan Virgin"
 
@@ -25019,6 +25252,21 @@ msgstr ""
 "melatih AI. Aktifkan atau matikan kapan saja di menu '%1$s'."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26430,6 +26678,12 @@ msgstr "m"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "m"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/io_XX/LC_MESSAGES/duckduckgo.po
+++ b/locales/io_XX/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Adjuntar DuckDuckGo"
@@ -1099,6 +1116,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr "Augmenti"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1453,6 +1507,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2800,6 +2859,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3200,9 +3266,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3218,6 +3294,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4477,6 +4560,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4761,6 +4849,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5099,6 +5192,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -5995,6 +6093,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6172,6 +6275,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6839,6 +6947,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7257,6 +7370,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8239,6 +8357,11 @@ msgid "How is it anonymous?"
 msgstr "Quale ico esas anonima?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9394,6 +9517,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11131,6 +11259,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12831,6 +12964,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12937,6 +13075,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13925,6 +14068,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14080,6 +14228,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -14995,6 +15150,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16334,6 +16494,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16414,6 +16581,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16874,6 +17046,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17276,6 +17462,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18738,6 +18929,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19887,6 +20085,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20973,6 +21184,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/is_IS/LC_MESSAGES/duckduckgo.po
+++ b/locales/is_IS/LC_MESSAGES/duckduckgo.po
@@ -979,6 +979,11 @@ msgstr "Um okkur"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1082,6 +1087,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "Auglýsingin er grunsamleg"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Bæta DuckDuckGo við"
@@ -1101,6 +1118,24 @@ msgstr "Bæta DuckDuckGo við sem leitarvél"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Bæta DuckDuckGo við %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1139,6 +1174,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1210,6 +1259,11 @@ msgstr "Viðbætur"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1454,6 +1508,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2803,6 +2862,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3203,9 +3269,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3221,6 +3297,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4480,6 +4563,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4764,6 +4852,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5102,6 +5195,11 @@ msgstr "Hunsa að eilífu"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -5999,6 +6097,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6176,6 +6279,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6841,6 +6949,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7259,6 +7372,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8241,6 +8359,11 @@ msgid "How is it anonymous?"
 msgstr "Hvernig er það nafnlaust?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9396,6 +9519,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11133,6 +11261,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "Allt í lagi, ég skil!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12837,6 +12970,11 @@ msgstr "Verndum upplýsingar þínar í öllum þínum tækjum."
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12943,6 +13081,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13931,6 +14074,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14086,6 +14234,13 @@ msgstr "Leita"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15002,6 +15157,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16344,6 +16504,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16424,6 +16591,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16888,6 +17060,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17292,6 +17478,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18757,6 +18948,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19906,6 +20104,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20990,6 +21201,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/it_IT/LC_MESSAGES/duckduckgo.po
+++ b/locales/it_IT/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: it_IT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1226,6 +1226,12 @@ msgid "About our ads"
 msgstr "Informazioni sui nostri annunci"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1355,6 +1361,20 @@ msgid "Ad is suspicious"
 msgstr "Questo annuncio è sospetto"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Aggiungi DuckDuckGo"
@@ -1381,6 +1401,27 @@ msgstr "Aggiungi DuckDuckGo come motore di ricerca"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Aggiungi DuckDuckGo a %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1426,6 +1467,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Aggiungi il contenuto della pagina"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1512,6 +1569,12 @@ msgstr "Add-on"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Aggiungere i tocchi finali"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1816,6 +1879,12 @@ msgstr "Tutti i colori"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Fatto."
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3546,6 +3615,14 @@ msgid "Cancel"
 msgstr "Annulla"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4042,10 +4119,22 @@ msgid "Chat response is offensive"
 msgstr "La risposta della chat è offensiva"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Chatta con %1$s"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4064,6 +4153,14 @@ msgstr "Chat"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Chat"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5672,6 +5769,12 @@ msgid "Current Streak"
 msgstr "Serie attuale"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -6020,6 +6123,12 @@ msgstr "Elimina chat"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Elimina le chat più vecchie di 30 giorni"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6436,6 +6545,12 @@ msgstr "Nascondi definitivamente"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Ignora la promozione"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7617,6 +7732,12 @@ msgid "Edit Prompt"
 msgstr "Modifica prompt"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7840,6 +7961,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Modello crittografato"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8688,6 +8815,12 @@ msgid "Follow-up question"
 msgstr "Domanda di approfondimento"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9201,6 +9334,12 @@ msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
 "Ottieni la VPN di DuckDuckGo, le funzionalità avanzate di Duck.ai e Identity "
 "Theft Restoration."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10437,6 +10576,12 @@ msgstr "Come può essere anonimo?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Come funziona"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11887,6 +12032,12 @@ msgstr "Rimesse laterali vinte"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "Il link scade tra 7 giorni."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14013,6 +14164,12 @@ msgstr "OK"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "OK, capito!"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16146,6 +16303,12 @@ msgid "Protected"
 msgstr "Protetto"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Protezione. Privacy.  Serenità."
@@ -16277,6 +16440,12 @@ msgstr "Pioggia"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Classifiche"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17521,6 +17690,12 @@ msgid "Save your chats across all your devices."
 msgstr "Salva le tue chat su tutti i tuoi dispositivi."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17723,6 +17898,14 @@ msgstr "Ricerca"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Ricerca"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18920,6 +19103,12 @@ msgstr "Shift+Invio"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Acquista"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20591,6 +20780,14 @@ msgstr ""
 "inattività."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20705,6 +20902,12 @@ msgstr "Sincronizza con un dispositivo nelle vicinanze."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Sincronizza le tue chat su tutti i tuoi dispositivi."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21298,6 +21501,22 @@ msgid "This Week"
 msgstr "Questa settimana"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21835,6 +22054,12 @@ msgstr "Oggi"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Oggi"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23668,6 +23893,14 @@ msgstr ""
 "clic sugli annunci sono gestiti dalla rete pubblicitaria di TripAdvisor."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Isole Vergini"
 
@@ -25157,6 +25390,21 @@ msgstr ""
 "per addestrare l'AI. Attiva o disattiva in qualsiasi momento nel menu “%1$s”."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26560,6 +26808,12 @@ msgstr "m"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "m"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/ja_JP/LC_MESSAGES/duckduckgo.po
+++ b/locales/ja_JP/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: ja_JP\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1211,6 +1211,12 @@ msgid "About our ads"
 msgstr "広告について"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1340,6 +1346,20 @@ msgid "Ad is suspicious"
 msgstr "怪しい広告"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "DuckDuckGo を追加する"
@@ -1366,6 +1386,27 @@ msgstr "DuckDuckGoを検索エンジンに追加する"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "%1$sにDuckDuckGoを追加"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1411,6 +1452,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "ページコンテンツを追加"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1496,6 +1553,12 @@ msgstr "アドオン"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "仕上げの調整を加える"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1800,6 +1863,12 @@ msgstr "すべての色"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "完了！"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3505,6 +3574,14 @@ msgid "Cancel"
 msgstr "キャンセル"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3997,10 +4074,22 @@ msgid "Chat response is offensive"
 msgstr "チャットの応答が不快だ"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "%1$sとチャット"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4019,6 +4108,14 @@ msgstr "チャット"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "チャット"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5621,6 +5718,12 @@ msgid "Current Streak"
 msgstr "連勝・連敗中"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5966,6 +6069,12 @@ msgstr "チャットを削除"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "30日より前のチャットを削除"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6380,6 +6489,12 @@ msgstr "今後表示しない"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "プロモーションを非表示"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7548,6 +7663,12 @@ msgid "Edit Prompt"
 msgstr "プロンプトを編集"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7767,6 +7888,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "暗号化モデル"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8595,6 +8722,12 @@ msgid "Follow-up question"
 msgstr "フォローアップの質問"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9109,6 +9242,12 @@ msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
 "DuckDuckGo VPN、高度なDuck.ai、Identity Theft Restoration（ID盗難後の復旧）機"
 "能を利用できます。"
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10341,6 +10480,12 @@ msgstr "どのように匿名を実現するのですか？"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "DuckDuckGoの仕組み"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11780,6 +11925,12 @@ msgstr "ラインアウト獲得"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "リンクは7日後に期限切れとなります。"
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13898,6 +14049,12 @@ msgid "OK, got it!"
 msgstr "OK、わかりました！"
 
 # smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -16008,6 +16165,12 @@ msgid "Protected"
 msgstr "保護されています"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "プライバシー。保護。安心。"
@@ -16139,6 +16302,12 @@ msgstr "雨"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "ランキング"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17366,6 +17535,12 @@ msgid "Save your chats across all your devices."
 msgstr "チャットをすべてのデバイスに保存します。"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17566,6 +17741,14 @@ msgstr "検索"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "検索"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18739,6 +18922,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "ショップ"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20388,6 +20577,14 @@ msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr "Sync & Backupのデータは18か月間アクティビティがないと復元できません。"
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20501,6 +20698,12 @@ msgstr "近くのデバイスと同期します。"
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "すべてのデバイスでチャットを同期します。"
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21081,6 +21284,22 @@ msgid "This Week"
 msgstr "今週"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21609,6 +21828,12 @@ msgstr "今日"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "今日"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23434,6 +23659,14 @@ msgstr ""
 "TripAdvisorの広告ネットワークで管理されています。"
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "ヴァージン諸島"
 
@@ -24898,6 +25131,21 @@ msgstr ""
 "りません。「%1$s」メニューでいつでもオン/オフを切り替えられます。"
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26287,6 +26535,12 @@ msgstr "分"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "分"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/ka_GE/LC_MESSAGES/duckduckgo.po
+++ b/locales/ka_GE/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr ""
@@ -1099,6 +1116,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr "ჩასადგმელები"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1453,6 +1507,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2800,6 +2859,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3200,9 +3266,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3218,6 +3294,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4477,6 +4560,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4761,6 +4849,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5099,6 +5192,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -5995,6 +6093,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6172,6 +6275,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6837,6 +6945,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7255,6 +7368,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8237,6 +8355,11 @@ msgid "How is it anonymous?"
 msgstr "როგორ არის ის ანონიმური?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9392,6 +9515,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11129,6 +11257,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12829,6 +12962,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12935,6 +13073,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13923,6 +14066,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14078,6 +14226,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -14993,6 +15148,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16332,6 +16492,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16412,6 +16579,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16872,6 +17044,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17274,6 +17460,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18736,6 +18927,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19885,6 +20083,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20967,6 +21178,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/kab_DZ/LC_MESSAGES/duckduckgo.po
+++ b/locales/kab_DZ/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr "Fell-aɣ"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "Adellel illa deg-s ccek"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Rnu DuckDuckGo"
@@ -1100,6 +1117,24 @@ msgstr "Rnu DuckDuckGo d amsedday n unadi"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Rnu DuckDuckGo ɣer %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr "Izegrar"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1455,6 +1509,11 @@ msgstr "Ini akk"
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2804,6 +2863,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3204,9 +3270,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3222,6 +3298,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4490,6 +4573,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4774,6 +4862,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5112,6 +5205,11 @@ msgstr "Ur ǧǧin ad yesken"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6008,6 +6106,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6185,6 +6288,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6854,6 +6962,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7272,6 +7385,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8256,6 +8374,11 @@ msgid "How is it anonymous?"
 msgstr "D udrig, d acu-t?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9415,6 +9538,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11152,6 +11280,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "IH, Awi-t-id!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12859,6 +12992,11 @@ msgstr "Mmesten isefka-iw deg yal ibenk."
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12965,6 +13103,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13953,6 +14096,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14111,6 +14259,13 @@ msgstr "Nadi"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15034,6 +15189,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16373,6 +16533,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16453,6 +16620,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16920,6 +17092,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17324,6 +17510,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18790,6 +18981,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19947,6 +20145,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21040,6 +21251,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/kn_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/kn_IN/LC_MESSAGES/duckduckgo.po
@@ -980,6 +980,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1083,6 +1088,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "DuckDuckGo ಸೇರಿಸಿ"
@@ -1101,6 +1118,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1140,6 +1175,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1211,6 +1260,11 @@ msgstr "ಆಡ್ ಆನ್ಸ್ (ಅಧಿಕಗಳು)"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1455,6 +1509,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2802,6 +2861,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3203,9 +3269,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3221,6 +3297,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4480,6 +4563,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4764,6 +4852,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5102,6 +5195,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6000,6 +6098,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6177,6 +6280,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6844,6 +6952,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7262,6 +7375,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8244,6 +8362,11 @@ msgid "How is it anonymous?"
 msgstr "ಹೇಗೆ ಇದು ಅನಾಮಧೇಯ?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9400,6 +9523,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11137,6 +11265,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12837,6 +12970,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12943,6 +13081,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13931,6 +14074,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14086,6 +14234,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15003,6 +15158,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16342,6 +16502,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16422,6 +16589,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16882,6 +17054,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17284,6 +17470,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18746,6 +18937,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19895,6 +20093,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20982,6 +21193,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/ko_KR/LC_MESSAGES/duckduckgo.po
+++ b/locales/ko_KR/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: ko_KR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1208,6 +1208,12 @@ msgid "About our ads"
 msgstr "DuckDuckGo 광고 소개"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1337,6 +1343,20 @@ msgid "Ad is suspicious"
 msgstr "사기 등이 의심되는 광고입니다."
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "DuckDuckGo 추가"
@@ -1363,6 +1383,27 @@ msgstr "검색 엔진으로 DuckDuckGo 추가하기"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "%1$s에 DuckDuckGo 확장 프로그램 추가"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1408,6 +1449,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "페이지 내용 추가"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1493,6 +1550,12 @@ msgstr "추가 기능"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "마지막 다듬기"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1794,6 +1857,12 @@ msgstr "모든 색상"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "다 됐어요!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3484,6 +3553,14 @@ msgid "Cancel"
 msgstr "취소"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3976,10 +4053,22 @@ msgid "Chat response is offensive"
 msgstr "채팅 응답이 불쾌"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "%1$s 모델과의 채팅"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3998,6 +4087,14 @@ msgstr "채팅"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "채팅"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5589,6 +5686,12 @@ msgid "Current Streak"
 msgstr "현재 성적"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5936,6 +6039,12 @@ msgstr "채팅 삭제"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "30일 이상 지난 채팅 삭제"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6349,6 +6458,12 @@ msgstr "영원히 보지 않기"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "프로모션 무시하기"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7510,6 +7625,12 @@ msgid "Edit Prompt"
 msgstr "프롬프트 수정"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7728,6 +7849,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "암호화된 모델"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8553,6 +8680,12 @@ msgid "Follow-up question"
 msgstr "후속 질문"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9064,6 +9197,12 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
 "DuckDuckGo VPN, 고급 Duck.ai, Identity Theft Restoration을 이용해 보세요."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10289,6 +10428,12 @@ msgstr "사용자 데이터가 어떻게 익명으로 유지되나요?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "주요 기능 소개"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11717,6 +11862,12 @@ msgstr "획득한 라인아웃"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "링크가 7일 후 만료됩니다."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13834,6 +13985,12 @@ msgid "OK, got it!"
 msgstr "확인"
 
 # smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -15943,6 +16100,12 @@ msgid "Protected"
 msgstr "보호됨"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "보호. 개인정보 보호. 마음의 평화."
@@ -16074,6 +16237,12 @@ msgstr "비"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "순위"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17299,6 +17468,12 @@ msgid "Save your chats across all your devices."
 msgstr "모든 기기에서 채팅 내용을 저장하세요."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17500,6 +17675,14 @@ msgstr "검색"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "검색"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18664,6 +18847,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "구매"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20297,6 +20486,14 @@ msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr "18개월 동안 휴면 상태였던 Sync & Backup 데이터는 복구할 수 없습니다."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20408,6 +20605,12 @@ msgstr "주변에 있는 기기와 동기화하세요."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "모든 기기에서 채팅을 동기화하세요."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -20982,6 +21185,22 @@ msgid "This Week"
 msgstr "이번 주"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21504,6 +21723,12 @@ msgstr "오늘"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "오늘"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23315,6 +23540,14 @@ msgstr ""
 "TripAdvisor의 광고 네트워크에서 관리합니다."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "버진 제도"
 
@@ -24775,6 +25008,21 @@ msgstr ""
 "'%1$s' 메뉴에서 언제든지 켜거나 끌 수 있습니다."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26146,6 +26394,12 @@ msgstr "분"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "분"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/ku/LC_MESSAGES/duckduckgo.po
+++ b/locales/ku/LC_MESSAGES/duckduckgo.po
@@ -983,6 +983,11 @@ msgstr "Derbarê Me"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1086,6 +1091,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "Reklam gumanbar e"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "DuckDuckGo tevlî bike"
@@ -1107,6 +1124,24 @@ msgstr "DuckDuckGo tevlî bike wekî motora lêgerînê"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "DuckDuckGo tevlî %s bike"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1145,6 +1180,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1216,6 +1265,11 @@ msgstr "Pêvek"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1461,6 +1515,11 @@ msgstr "Hemû reng"
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2828,6 +2887,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3230,9 +3296,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3248,6 +3324,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4521,6 +4604,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr "Encama Heyî"
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4805,6 +4893,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5143,6 +5236,11 @@ msgstr "Heya heyayê paşguh bike"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6050,6 +6148,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6230,6 +6333,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6900,6 +7008,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7318,6 +7431,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8306,6 +8424,11 @@ msgid "How is it anonymous?"
 msgstr "Çawa nenas e?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9485,6 +9608,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11224,6 +11352,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "BAŞ E, min fêm kir!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12943,6 +13076,11 @@ msgstr "Daneyên xwe li ser hemû amûran biparêze."
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -13049,6 +13187,11 @@ msgstr "Baran"
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -14042,6 +14185,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14201,6 +14349,13 @@ msgstr "Bigere"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15130,6 +15285,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16473,6 +16633,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16553,6 +16720,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -17022,6 +17194,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17427,6 +17613,11 @@ msgstr "Îro"
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18901,6 +19092,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -20078,6 +20276,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21179,6 +21390,11 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "m"
 msgstr "x"
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.
 msgctxt "Aria label for the menu button"

--- a/locales/kw_GB/LC_MESSAGES/duckduckgo.po
+++ b/locales/kw_GB/LC_MESSAGES/duckduckgo.po
@@ -979,6 +979,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1082,6 +1087,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Keworra DuckDuckGo"
@@ -1100,6 +1117,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1139,6 +1174,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1210,6 +1259,11 @@ msgstr "Keworransow"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1454,6 +1508,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2801,6 +2860,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3201,9 +3267,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3219,6 +3295,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4476,6 +4559,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4760,6 +4848,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5098,6 +5191,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -5994,6 +6092,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6171,6 +6274,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6836,6 +6944,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7254,6 +7367,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8236,6 +8354,11 @@ msgid "How is it anonymous?"
 msgstr "Fatel yw dihanow?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9391,6 +9514,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11128,6 +11256,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12828,6 +12961,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12934,6 +13072,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13922,6 +14065,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14077,6 +14225,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -14992,6 +15147,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16331,6 +16491,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16411,6 +16578,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16871,6 +17043,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17273,6 +17459,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18735,6 +18926,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19884,6 +20082,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20966,6 +21177,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/ky_KG/LC_MESSAGES/duckduckgo.po
+++ b/locales/ky_KG/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr ""
@@ -1099,6 +1116,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr "Кошумчалар"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1453,6 +1507,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2800,6 +2859,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3200,9 +3266,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3218,6 +3294,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4475,6 +4558,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4759,6 +4847,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5097,6 +5190,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -5993,6 +6091,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6170,6 +6273,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6835,6 +6943,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7253,6 +7366,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8235,6 +8353,11 @@ msgid "How is it anonymous?"
 msgstr "Кандайча анонимдүү?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9388,6 +9511,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11125,6 +11253,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12825,6 +12958,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12931,6 +13069,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13919,6 +14062,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14074,6 +14222,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -14989,6 +15144,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16328,6 +16488,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16408,6 +16575,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16868,6 +17040,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17270,6 +17456,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18732,6 +18923,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19881,6 +20079,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20963,6 +21174,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/ln_CD/LC_MESSAGES/duckduckgo.po
+++ b/locales/ln_CD/LC_MESSAGES/duckduckgo.po
@@ -979,6 +979,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1082,6 +1087,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr ""
@@ -1100,6 +1117,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1139,6 +1174,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1210,6 +1259,11 @@ msgstr "Ebakisi"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1454,6 +1508,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2801,6 +2860,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3201,9 +3267,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3219,6 +3295,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4476,6 +4559,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4760,6 +4848,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5098,6 +5191,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -5994,6 +6092,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6171,6 +6274,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6836,6 +6944,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7254,6 +7367,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8236,6 +8354,11 @@ msgid "How is it anonymous?"
 msgstr ""
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9389,6 +9512,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11126,6 +11254,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12826,6 +12959,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12932,6 +13070,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13920,6 +14063,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14075,6 +14223,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -14990,6 +15145,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16329,6 +16489,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16409,6 +16576,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16869,6 +17041,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17271,6 +17457,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18733,6 +18924,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19882,6 +20080,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20964,6 +21175,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/lt_LT/LC_MESSAGES/duckduckgo.po
+++ b/locales/lt_LT/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: lt_LT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1217,6 +1217,12 @@ msgid "About our ads"
 msgstr "Apie mūsų reklamas"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1346,6 +1352,20 @@ msgid "Ad is suspicious"
 msgstr "Reklama yra įtartina"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Pridėti „DuckDuckGo“"
@@ -1372,6 +1392,27 @@ msgstr "Pridėti „DuckDuckGo“ kaip paieškos sistemą"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Pridėti „DuckDuckGo“ prie %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1417,6 +1458,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Pridėti puslapio turinio"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1502,6 +1559,12 @@ msgstr "Priedai"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Atliekami baigiamieji veiksmai"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1804,6 +1867,12 @@ msgstr "Visos spalvos"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Viskas atlikta!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3513,6 +3582,14 @@ msgid "Cancel"
 msgstr "Atšaukti"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4005,10 +4082,22 @@ msgid "Chat response is offensive"
 msgstr "Pokalbio atsakymas įžeidžiantis"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Kalbėkite su „%1$s“"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4027,6 +4116,14 @@ msgstr "Pokalbiai"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Pokalbiai"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5630,6 +5727,12 @@ msgid "Current Streak"
 msgstr "Dabartinė serija"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5976,6 +6079,12 @@ msgstr "Ištrinti pokalbius"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Trinti senesnius nei 30 dienų pokalbius"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6388,6 +6497,12 @@ msgstr "Atmesti visam laikui"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Atsisakyti reklamos"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7569,6 +7684,12 @@ msgid "Edit Prompt"
 msgstr "Redaguoti užklausą"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7791,6 +7912,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Užšifruotas modelis"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8627,6 +8754,12 @@ msgid "Follow-up question"
 msgstr "Papildomas klausimas"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9141,6 +9274,12 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
 "Gauk „DuckDuckGo VPN“, pažangųjį „Duck.ai“ ir „Identity Theft Restoration“."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10378,6 +10517,12 @@ msgstr "Kaip tai anonimiška?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Kaip tai veikia"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11822,6 +11967,12 @@ msgstr "Laimėtos užribio grumtynės"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "Nuoroda baigia galioti po 7 dienų."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13939,6 +14090,12 @@ msgstr "Gerai"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "Gerai, supratau!"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16066,6 +16223,12 @@ msgid "Protected"
 msgstr "Apsaugotas"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Apsauga. Privatumas. Ramybės jausmas."
@@ -16197,6 +16360,12 @@ msgstr "Lietus"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Reitingai"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17435,6 +17604,12 @@ msgid "Save your chats across all your devices."
 msgstr "Išsaugok pokalbius visuose savo įrenginiuose."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17636,6 +17811,14 @@ msgstr "Paieška"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Paieška"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18818,6 +19001,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Apsipirkti"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20477,6 +20666,14 @@ msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr "„Sync & Backup“ duomenų negalima atkurti po 18 mėnesių neaktyvumo."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20591,6 +20788,12 @@ msgstr "Sinchronizuok su netoliese esančiu įrenginiu."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Sinchronizuok pokalbius visuose savo įrenginiuose."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21176,6 +21379,22 @@ msgid "This Week"
 msgstr "Ši savaitė"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21704,6 +21923,12 @@ msgstr "Šiandien"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Šiandien"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23538,6 +23763,14 @@ msgstr ""
 "„TripAdvisor“ skelbimų tinklas."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Mergelių salos"
 
@@ -25021,6 +25254,21 @@ msgstr ""
 "„%1$s“."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26413,6 +26661,12 @@ msgstr "min."
 msgctxt "published date for videos"
 msgid "m"
 msgstr "min."
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/lv_LV/LC_MESSAGES/duckduckgo.po
+++ b/locales/lv_LV/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: lv_LV\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1219,6 +1219,12 @@ msgid "About our ads"
 msgstr "Par mūsu reklāmām"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1348,6 +1354,20 @@ msgid "Ad is suspicious"
 msgstr "Reklāma ir aizdomīga"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Pievienot DuckDuckGo"
@@ -1374,6 +1394,27 @@ msgstr "Pievienot DuckDuckGo kā meklētājprogrammu"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Pievienot DuckDuckGo savam %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1419,6 +1460,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Pievienot lapas saturu"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1504,6 +1561,12 @@ msgstr "Paplašinājumi"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Apdares pieskārienu pievienošana"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1808,6 +1871,12 @@ msgstr "Visas krāsas"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Viss pabeigts!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3519,6 +3588,14 @@ msgid "Cancel"
 msgstr "Atcelt"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4012,10 +4089,22 @@ msgid "Chat response is offensive"
 msgstr "Tērzēšanas atbilde ir aizskaroša"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Tērzē ar %1$s"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4034,6 +4123,14 @@ msgstr "Sarakstes"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Sarakstes"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5643,6 +5740,12 @@ msgid "Current Streak"
 msgstr "Pašreizējā sērija"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5991,6 +6094,12 @@ msgstr "Dzēst tērzēšanas sarunas"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Dzēst tērzēšanas sarunas, kas vecākas par 30 dienām"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6407,6 +6516,12 @@ msgstr "Vairs nerādīt"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Noraidīt akciju"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7587,6 +7702,12 @@ msgid "Edit Prompt"
 msgstr "Rediģēt uzvedni"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7809,6 +7930,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Šifrēts modelis"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8648,6 +8775,12 @@ msgid "Follow-up question"
 msgstr "Papildjautājums"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9164,6 +9297,12 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
 "Iegūsti DuckDuckGo VPN, padziļināto Duck.ai un Identity Theft Restoration."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10399,6 +10538,12 @@ msgstr "Kā tiek nodrošināta anonimitāte?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Kā tas darbojas"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11848,6 +11993,12 @@ msgstr "Uzvarētās līnijas"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "Saites derīguma termiņš beigsies pēc 7 dienām."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13970,6 +14121,12 @@ msgstr "Labi"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "Labi, sapratu!"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16100,6 +16257,12 @@ msgid "Protected"
 msgstr "Aizsargāts"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Aizsardzība. Privātums. Sirds miers."
@@ -16231,6 +16394,12 @@ msgstr "Lietus"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Rangs"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17471,6 +17640,12 @@ msgid "Save your chats across all your devices."
 msgstr "Saglabā savas sarunas visās savās ierīcēs."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17674,6 +17849,14 @@ msgstr "Meklēt"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Meklēt"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18854,6 +19037,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Veikals"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20505,6 +20694,14 @@ msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr "Sync & Backup datus nevar atgūt pēc 18 mēnešu neaktivitātes."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20618,6 +20815,12 @@ msgstr "Sinhronizē ar tuvumā esošu ierīci."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Sinhronizē tērzēšanas sarunas visās savās ierīcēs."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21201,6 +21404,22 @@ msgid "This Week"
 msgstr "Šonedēļ"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21730,6 +21949,12 @@ msgstr "Šodien"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Šodien"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23559,6 +23784,14 @@ msgstr ""
 "TripAdvisor reklāmu tīkls."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Virdžīnu Salas"
 
@@ -25039,6 +25272,21 @@ msgstr ""
 "izmantotas MI apmācībai. Ieslēdz vai izslēdz to jebkurā laikā izvēlnē '%1$s'."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26440,6 +26688,12 @@ msgstr "min."
 msgctxt "published date for videos"
 msgid "m"
 msgstr "min."
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/ml_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/ml_IN/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: ml_IN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1207,6 +1207,12 @@ msgid "About our ads"
 msgstr "ഞങ്ങളുടെ പരസ്യങ്ങളെക്കുറിച്ച്"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1336,6 +1342,20 @@ msgid "Ad is suspicious"
 msgstr "സംശയാസ്പദമായ പരസ്യം"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "DuckDuckGo-യെ ചേർക്കുക"
@@ -1362,6 +1382,27 @@ msgstr "ഒരു തിരയൽ എഞ്ചിനായി DuckDuckGo ചേ�
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "%1$s-ലേക്ക് DuckDuckGo ചേർക്കുക"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1407,6 +1448,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "പേജ് ഉള്ളടക്കം ചേർക്കുക"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1492,6 +1549,12 @@ msgstr "ആഡ്-ഓണുകള്‍"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "അവസാന മിനുക്കുപണികൾ ചേർക്കുന്നു"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1795,6 +1858,12 @@ msgstr "എല്ലാ നിറങ്ങളും"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "എല്ലാം പൂർത്തിയായി!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3501,6 +3570,14 @@ msgid "Cancel"
 msgstr "റദ്ദാക്കുക"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3993,10 +4070,22 @@ msgid "Chat response is offensive"
 msgstr "ചാറ്റ് പ്രതികരണം കുറ്റകരമാണ്"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "%1$s-നൊപ്പം ചാറ്റ് ചെയ്യുക"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4015,6 +4104,14 @@ msgstr "ചാറ്റുകൾ"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "ചാറ്റുകൾ"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5609,6 +5706,12 @@ msgid "Current Streak"
 msgstr "നിലവിലെ സ്ട്രീക്ക്"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5953,6 +6056,12 @@ msgstr "ചാറ്റുകൾ ഇല്ലാതാക്കുക"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "30 ദിവസത്തിലധികം പഴക്കമുള്ള ചാറ്റുകൾ ഇല്ലാതാക്കുക"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6366,6 +6475,12 @@ msgstr "എന്നേക്കുമായി നിരസിക്കുക"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "പ്രൊമോഷൻ ഒഴിവാക്കുക"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7534,6 +7649,12 @@ msgid "Edit Prompt"
 msgstr "പ്രോംപ്റ്റ് എഡിറ്റ് ചെയ്യുക"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7756,6 +7877,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "എൻക്രിപ്റ്റ് ചെയ്ത മോഡൽ"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8585,6 +8712,12 @@ msgid "Follow-up question"
 msgstr "ഫോളോ-അപ്പ് ചോദ്യം"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9096,6 +9229,12 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
 "DuckDuckGo VPN, നൂതന Duck.ai, കൂടാതെ Identity Theft Restoration എന്നിവ നേടൂ."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10323,6 +10462,12 @@ msgstr "എങ്ങനെയാണ് ഇത് അജ്ഞാതമാവു�
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "ഇത് എങ്ങനെ പ്രവർത്തിക്കുന്നു"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11768,6 +11913,12 @@ msgstr "നേടിയ ലൈനൗട്ടുകൾ"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "ലിങ്ക് 7 ദിവസത്തിനുള്ളിൽ കാലഹരണപ്പെടുന്നു."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13885,6 +14036,12 @@ msgstr "ശരി"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "ശരി, കിട്ടി!"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16007,6 +16164,12 @@ msgid "Protected"
 msgstr "സംരക്ഷിതം"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "സംരക്ഷണം. സ്വകാര്യത. മനസ്സമാധാനം."
@@ -16138,6 +16301,12 @@ msgstr "മഴ"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "റാങ്കിംഗുകൾ"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17371,6 +17540,12 @@ msgid "Save your chats across all your devices."
 msgstr "നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിലും നിങ്ങളുടെ ചാറ്റുകൾ സംരക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17572,6 +17747,14 @@ msgstr "തിരയുക"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "തിരയുക"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18748,6 +18931,12 @@ msgstr "ഷിഫ്റ്റ്+എന്റർ"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "ഷോപ്പ് ചെയ്യുക"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20396,6 +20585,14 @@ msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr "Sync & Backup ഡാറ്റ 18 മാസത്തെ നിഷ്‌ക്രിയത്വത്തിന് ശേഷം വീണ്ടെടുക്കാൻ കഴിയില്ല."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20509,6 +20706,12 @@ msgstr "അടുത്തുള്ള ഒരു ഉപകരണവുമായ�
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിലും ചാറ്റുകൾ സമന്വയിപ്പിക്കുക."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21085,6 +21288,22 @@ msgid "This Week"
 msgstr "ഈ ആഴ്ച"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21605,6 +21824,12 @@ msgstr "ഇന്ന്"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "ഇന്ന്"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23428,6 +23653,14 @@ msgstr ""
 "നിയന്ത്രിക്കുന്നത് TripAdvisor ന്റെ പരസ്യ ശൃംഖലയാണ്."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "വിർജിൻ ദ്വീപുകൾ"
 
@@ -24902,6 +25135,21 @@ msgstr ""
 "ചെയ്യാം."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26293,6 +26541,12 @@ msgstr "മാ"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "മാ"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/mn_MN/LC_MESSAGES/duckduckgo.po
+++ b/locales/mn_MN/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr ""
@@ -1099,6 +1116,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr ""
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1453,6 +1507,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2800,6 +2859,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3200,9 +3266,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3218,6 +3294,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4475,6 +4558,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4759,6 +4847,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5097,6 +5190,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -5993,6 +6091,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6170,6 +6273,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6835,6 +6943,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7253,6 +7366,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8235,6 +8353,11 @@ msgid "How is it anonymous?"
 msgstr ""
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9388,6 +9511,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11125,6 +11253,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12825,6 +12958,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12931,6 +13069,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13919,6 +14062,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14074,6 +14222,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -14989,6 +15144,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16328,6 +16488,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16408,6 +16575,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16868,6 +17040,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17270,6 +17456,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18732,6 +18923,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19881,6 +20079,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20963,6 +21174,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/mr_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/mr_IN/LC_MESSAGES/duckduckgo.po
@@ -980,6 +980,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1083,6 +1088,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "DuckDuckGo जोडा."
@@ -1101,6 +1118,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1140,6 +1175,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1211,6 +1260,11 @@ msgstr ""
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1455,6 +1509,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2802,6 +2861,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3202,9 +3268,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3220,6 +3296,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4478,6 +4561,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4762,6 +4850,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5100,6 +5193,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6004,6 +6102,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6181,6 +6284,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6846,6 +6954,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7264,6 +7377,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8246,6 +8364,11 @@ msgid "How is it anonymous?"
 msgstr "हे निनावी कसे आहे?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9400,6 +9523,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11137,6 +11265,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12837,6 +12970,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12943,6 +13081,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13931,6 +14074,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14086,6 +14234,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15003,6 +15158,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16342,6 +16502,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16422,6 +16589,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16882,6 +17054,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17284,6 +17470,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18746,6 +18937,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19895,6 +20093,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20977,6 +21188,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/ms_MY/LC_MESSAGES/duckduckgo.po
+++ b/locales/ms_MY/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Tambah DuckDuckGo"
@@ -1099,6 +1116,24 @@ msgstr "Tambah DuckDuckGo sebagai enjin carian"
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr "Tambahan"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1455,6 +1509,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2802,6 +2861,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3204,9 +3270,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3222,6 +3298,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4486,6 +4569,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4770,6 +4858,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5108,6 +5201,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6004,6 +6102,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6181,6 +6284,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6849,6 +6957,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7267,6 +7380,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8249,6 +8367,11 @@ msgid "How is it anonymous?"
 msgstr "Kenapa ia tidak bernama?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9407,6 +9530,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11145,6 +11273,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12851,6 +12984,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12957,6 +13095,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13945,6 +14088,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14100,6 +14248,13 @@ msgstr "Cari"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15021,6 +15176,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16360,6 +16520,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16440,6 +16607,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16900,6 +17072,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17302,6 +17488,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18770,6 +18961,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19919,6 +20117,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21006,6 +21217,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/nb_NO/LC_MESSAGES/duckduckgo.po
+++ b/locales/nb_NO/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: nb\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1211,6 +1211,12 @@ msgid "About our ads"
 msgstr "Om annonsene våre"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1340,6 +1346,20 @@ msgid "Ad is suspicious"
 msgstr "Annonsen er mistenkelig"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Legg til DuckDuckGo"
@@ -1366,6 +1386,27 @@ msgstr "Legg til DuckDuckGo som søkemotor"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Legg til DuckDuckGo i %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1411,6 +1452,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Legg til sideinnhold"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1496,6 +1553,12 @@ msgstr "Utvidelser"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Legger siste hånd på verket"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1799,6 +1862,12 @@ msgstr "Alle farger"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Ferdig!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3502,6 +3571,14 @@ msgid "Cancel"
 msgstr "Avbryt"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3994,10 +4071,22 @@ msgid "Chat response is offensive"
 msgstr "Chattens svar er støtende"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Chat med %1$s"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4016,6 +4105,14 @@ msgstr "Chatter"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Chatter"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5611,6 +5708,12 @@ msgid "Current Streak"
 msgstr "Nåværende rekke"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5957,6 +6060,12 @@ msgstr "Slett chatter"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Slett chatter som er eldre enn 30 dager"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6371,6 +6480,12 @@ msgstr "Avslå for alltid"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Avvis kampanje"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7538,6 +7653,12 @@ msgid "Edit Prompt"
 msgstr "Rediger ledetekst"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7759,6 +7880,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Kryptert modell"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8587,6 +8714,12 @@ msgid "Follow-up question"
 msgstr "Oppfølgingsspørsmål"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9098,6 +9231,12 @@ msgstr ""
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr "Få DuckDuckGo VPN, avansert Duck.ai og Identity Theft Restoration."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10327,6 +10466,12 @@ msgstr "Hvordan er det anonymt?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Slik fungerer det"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11771,6 +11916,12 @@ msgstr "Antall lineouts vunnet"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "Lenken utløper om syv dager."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13888,6 +14039,12 @@ msgstr "OK"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "OK – forstått!"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16008,6 +16165,12 @@ msgid "Protected"
 msgstr "Beskyttet"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Beskyttelse. Personvern. Ro i sjelen."
@@ -16139,6 +16302,12 @@ msgstr "Regn"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Rangeringer"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17369,6 +17538,12 @@ msgid "Save your chats across all your devices."
 msgstr "Lagre chatter på alle enhetene dine."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17568,6 +17743,14 @@ msgstr "Søk"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Søk"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18741,6 +18924,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Gå til butikk"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20394,6 +20583,14 @@ msgstr ""
 "Sync & Backup-data kan ikke gjenopprettes etter 18 måneder med inaktivitet."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20507,6 +20704,12 @@ msgstr "Synkroniser med en enhet i nærheten."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Synkroniser chattene dine mellom alle enhetene dine."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21092,6 +21295,22 @@ msgid "This Week"
 msgstr "Denne uken"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21618,6 +21837,12 @@ msgstr "I dag"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "I dag"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23436,6 +23661,14 @@ msgstr ""
 "administreres av TripAdvisors annonsenettverk."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Jomfruøyene"
 
@@ -24910,6 +25143,21 @@ msgstr ""
 "det av eller på når som helst i «%1$s»-menyen."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26302,6 +26550,12 @@ msgstr "min"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "min"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/ne_NP/LC_MESSAGES/duckduckgo.po
+++ b/locales/ne_NP/LC_MESSAGES/duckduckgo.po
@@ -980,6 +980,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1083,6 +1088,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr ""
@@ -1101,6 +1118,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1140,6 +1175,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1211,6 +1260,11 @@ msgstr "जोडिएको"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1455,6 +1509,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2802,6 +2861,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3202,9 +3268,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3220,6 +3296,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4477,6 +4560,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4761,6 +4849,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5099,6 +5192,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6007,6 +6105,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6184,6 +6287,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6849,6 +6957,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7267,6 +7380,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8249,6 +8367,11 @@ msgid "How is it anonymous?"
 msgstr "यो कसरी अज्ञात छ?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9406,6 +9529,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11143,6 +11271,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12843,6 +12976,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12949,6 +13087,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13937,6 +14080,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14092,6 +14240,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15009,6 +15164,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16348,6 +16508,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16428,6 +16595,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16888,6 +17060,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17290,6 +17476,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18752,6 +18943,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19901,6 +20099,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20983,6 +21194,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/nl_BE/LC_MESSAGES/duckduckgo.po
+++ b/locales/nl_BE/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Voeg DuckDuckGo toe"
@@ -1100,6 +1117,24 @@ msgstr "Voeg DuckDuckGo toe als zoekmachine"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Voeg DuckDuckGo toe aan %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr ""
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1455,6 +1509,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2802,6 +2861,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3202,9 +3268,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3220,6 +3296,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4488,6 +4571,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4772,6 +4860,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5110,6 +5203,11 @@ msgstr "Niet meer tonen"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6006,6 +6104,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6183,6 +6286,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6851,6 +6959,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7269,6 +7382,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8251,6 +8369,11 @@ msgid "How is it anonymous?"
 msgstr "Hoe is het anoniem?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9408,6 +9531,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11145,6 +11273,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "OK! ik snap het!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12853,6 +12986,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12959,6 +13097,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13947,6 +14090,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14104,6 +14252,13 @@ msgstr "Zoeken"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15030,6 +15185,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16370,6 +16530,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16450,6 +16617,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16910,6 +17082,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17313,6 +17499,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18782,6 +18973,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19939,6 +20137,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21030,6 +21241,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/nl_NL/LC_MESSAGES/duckduckgo.po
+++ b/locales/nl_NL/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: nl_NL\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1217,6 +1217,12 @@ msgid "About our ads"
 msgstr "Over onze advertenties"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1346,6 +1352,20 @@ msgid "Ad is suspicious"
 msgstr "Advertentie is verdacht"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "DuckDuckGo toevoegen"
@@ -1372,6 +1392,27 @@ msgstr "Voeg DuckDuckGo toe als zoekmachine"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "DuckDuckGo toevoegen aan %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1417,6 +1458,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Pagina-inhoud toevoegen"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1502,6 +1559,12 @@ msgstr "Add-ons"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "De puntjes worden op de i gezet"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1804,6 +1867,12 @@ msgstr "Alle kleuren"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Helemaal klaar!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3527,6 +3596,14 @@ msgid "Cancel"
 msgstr "Annuleren"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4021,10 +4098,22 @@ msgid "Chat response is offensive"
 msgstr "Het antwoord in de chatservice is aanstootgevend"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Chatten met %1$s"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4043,6 +4132,14 @@ msgstr "Chats"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Chats"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5643,6 +5740,12 @@ msgid "Current Streak"
 msgstr "Huidige streak"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5990,6 +6093,12 @@ msgstr "Chats verwijderen"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Wis chats die ouder zijn dan 30 dagen"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6405,6 +6514,12 @@ msgstr "Verbergen"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Promotie sluiten"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7585,6 +7700,12 @@ msgid "Edit Prompt"
 msgstr "Prompt bewerken"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7808,6 +7929,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Versleuteld model"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8641,6 +8768,12 @@ msgid "Follow-up question"
 msgstr "Vervolgvraag"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9154,6 +9287,12 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
 "Krijg DuckDuckGo VPN, geavanceerde Duck.ai en Identity Theft Restoration."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10388,6 +10527,12 @@ msgstr "Waarom is het anoniem?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Hoe werkt het"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11839,6 +11984,12 @@ msgstr "Line-outs gewonnen"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "Link verloopt over 7 dagen."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13963,6 +14114,12 @@ msgstr "OK"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "Oké, ik snap het!"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16091,6 +16248,12 @@ msgid "Protected"
 msgstr "Beschermd"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Bescherming. Privacy.Gemoedsrust."
@@ -16222,6 +16385,12 @@ msgstr "Regen"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Scores"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17457,6 +17626,12 @@ msgid "Save your chats across all your devices."
 msgstr "Bewaar je chats op al je apparaten."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17661,6 +17836,14 @@ msgstr "Zoeken"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Zoeken"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18844,6 +19027,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Winkelen"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20514,6 +20703,14 @@ msgstr ""
 "inactiviteit."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20628,6 +20825,12 @@ msgstr "Synchroniseer met een apparaat in de buurt."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Synchroniseer je chats op al je apparaten."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21219,6 +21422,22 @@ msgid "This Week"
 msgstr "Deze week"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21760,6 +21979,12 @@ msgstr "Vandaag"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Vandaag"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23595,6 +23820,14 @@ msgstr ""
 "TripAdvisor."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Maagdeneilanden"
 
@@ -25077,6 +25310,21 @@ msgstr ""
 "trainen. Schakel het op elk gewenst moment in of uit in het menu '%1$s'."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26480,6 +26728,12 @@ msgstr "m"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "m"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/nn_NO/LC_MESSAGES/duckduckgo.po
+++ b/locales/nn_NO/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr "Om oss"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "Annonsa er mistenkjeleg"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Legg til DuckDuckGo"
@@ -1100,6 +1117,24 @@ msgstr "Legg til DuckDuckGo som søkjemotor"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Legg til DuckDuckGo i %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr "Utvidingar"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1455,6 +1509,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2802,6 +2861,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3202,9 +3268,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3220,6 +3296,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4486,6 +4569,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4770,6 +4858,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5108,6 +5201,11 @@ msgstr "Ikkje vis dette meir"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6004,6 +6102,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6181,6 +6284,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6850,6 +6958,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7268,6 +7381,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8250,6 +8368,11 @@ msgid "How is it anonymous?"
 msgstr "Korleis er det anonymt?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9405,6 +9528,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11142,6 +11270,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "OK, eg forstår det!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12850,6 +12983,11 @@ msgstr "Vern dine data på alle einingar."
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12956,6 +13094,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13944,6 +14087,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14101,6 +14249,13 @@ msgstr "Søk"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15025,6 +15180,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16364,6 +16524,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16444,6 +16611,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16904,6 +17076,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17308,6 +17494,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18774,6 +18965,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19933,6 +20131,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21023,6 +21234,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/od_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/od_IN/LC_MESSAGES/duckduckgo.po
@@ -981,6 +981,11 @@ msgstr "ଆମ ସମ୍ବନ୍ଧରେ"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1084,6 +1089,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "ବିଜ୍ଞାପନଟି ସନ୍ଦିଗ୍ଧ ଅଟେ"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "DuckDuckGo କୁ ଯୋଗ କରନ୍ତୁ"
@@ -1103,6 +1120,24 @@ msgstr "DuckDuckGo କୁ ଏକ ଖୋଜା ଇଞ୍ଜିନ ଭଳି ଯ�
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "DuckDuckGo କୁ %s ରେ ଯୋଡ଼ନ୍ତୁ"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1141,6 +1176,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1212,6 +1261,11 @@ msgstr "ଯୋଗୋପକରଣ"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1456,6 +1510,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2805,6 +2864,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3205,9 +3271,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3223,6 +3299,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4482,6 +4565,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4766,6 +4854,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5104,6 +5197,11 @@ msgstr "ସବୁଦିନପାଇଁ ଖାରଜ"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6000,6 +6098,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6177,6 +6280,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6845,6 +6953,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7263,6 +7376,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8247,6 +8365,11 @@ msgid "How is it anonymous?"
 msgstr "ଏହା ନାମହୀନ କିପରି?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9404,6 +9527,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11141,6 +11269,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "ଠିକ ଅଛି, ଆଣନ୍ତୁ!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12845,6 +12978,11 @@ msgstr "ଆପଣଙ୍କର ତଥ୍ୟକୁ ପ୍ରତ୍ୟେକ ଯନ
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12951,6 +13089,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13939,6 +14082,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14096,6 +14244,13 @@ msgstr "ଖୋଜନ୍ତୁ"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15020,6 +15175,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16359,6 +16519,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16439,6 +16606,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16905,6 +17077,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17307,6 +17493,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18773,6 +18964,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19930,6 +20128,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21022,6 +21233,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/pl_PL/LC_MESSAGES/duckduckgo.po
+++ b/locales/pl_PL/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: pl_PL\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1217,6 +1217,12 @@ msgid "About our ads"
 msgstr "Informacje o naszych reklamach"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1346,6 +1352,20 @@ msgid "Ad is suspicious"
 msgstr "Reklama jest podejrzana"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Dodaj DuckDuckGo"
@@ -1372,6 +1392,27 @@ msgstr "Dodaj DuckDuckGo jako wyszukiwarkę"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Dodaj DuckDuckGo do %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1417,6 +1458,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Dodaj zawartość strony"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1502,6 +1559,12 @@ msgstr "Rozszerzenia"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Dodawanie elementów wykończeniowych"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1806,6 +1869,12 @@ msgstr "Wszystkie kolory"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Wszystko gotowe!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3538,6 +3607,14 @@ msgid "Cancel"
 msgstr "Anuluj"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4032,10 +4109,22 @@ msgid "Chat response is offensive"
 msgstr "Odpowiedź czatu jest obraźliwa"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Porozmawiaj z %1$s"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4054,6 +4143,14 @@ msgstr "Czaty"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Czaty"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5660,6 +5757,12 @@ msgid "Current Streak"
 msgstr "Bieżąca seria"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -6007,6 +6110,12 @@ msgstr "Usuń czaty"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Usuń czaty starsze niż 30 dni"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6420,6 +6529,12 @@ msgstr "Odrzuć na zawsze"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Odrzuć promocję"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7603,6 +7718,12 @@ msgid "Edit Prompt"
 msgstr "Edytuj prompt"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7825,6 +7946,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Szyfrowany model"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8666,6 +8793,12 @@ msgid "Follow-up question"
 msgstr "Pytanie uzupełniające"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9182,6 +9315,12 @@ msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
 "Uzyskaj dostęp do usług DuckDuckGo VPN oraz Identity Theft Restoration i "
 "zaawansowanych funkcji Duck.ai."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10417,6 +10556,12 @@ msgstr "W jaki sposób jest to anonimowe?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Jak to działa"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11869,6 +12014,12 @@ msgstr "Wygrane auty"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "Link wygasa za 7 dni."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13988,6 +14139,12 @@ msgstr "OK"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "OK, rozumiem!"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16122,6 +16279,12 @@ msgid "Protected"
 msgstr "Chroniony"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Ochrona. Prywatność. Spokój."
@@ -16253,6 +16416,12 @@ msgstr "Deszcz"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Rankingi"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17497,6 +17666,12 @@ msgid "Save your chats across all your devices."
 msgstr "Zapisz czaty na wszystkich urządzeniach."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17697,6 +17872,14 @@ msgstr "Szukaj"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Szukaj"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18884,6 +19067,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Sklep"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20552,6 +20741,14 @@ msgstr ""
 "Danych Sync & Backup nie można odzyskać po 18 miesiącach braku aktywności."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20666,6 +20863,12 @@ msgstr "Synchronizuj z urządzeniem znajdującym się w pobliżu."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Synchronizuj czaty na wszystkich urządzeniach."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21250,6 +21453,22 @@ msgid "This Week"
 msgstr "W tym tygodniu"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21785,6 +22004,12 @@ msgstr "Dziś"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Dziś"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23620,6 +23845,14 @@ msgstr ""
 "reklam zarządzane jest przez sieć reklamową MicrosoftTripAdvisor."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Wyspy Dziewicze"
 
@@ -25107,6 +25340,21 @@ msgstr ""
 "menu %1$s."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26512,6 +26760,12 @@ msgstr "min"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "min"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/ps_AF/LC_MESSAGES/duckduckgo.po
+++ b/locales/ps_AF/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr ""
@@ -1099,6 +1116,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr ""
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1453,6 +1507,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2800,6 +2859,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3200,9 +3266,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3218,6 +3294,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4475,6 +4558,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4759,6 +4847,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5097,6 +5190,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -5993,6 +6091,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6170,6 +6273,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6835,6 +6943,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7253,6 +7366,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8235,6 +8353,11 @@ msgid "How is it anonymous?"
 msgstr ""
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9388,6 +9511,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11125,6 +11253,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12825,6 +12958,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12931,6 +13069,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13919,6 +14062,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14074,6 +14222,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -14989,6 +15144,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16328,6 +16488,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16408,6 +16575,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16868,6 +17040,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17270,6 +17456,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18732,6 +18923,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19881,6 +20079,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20963,6 +21174,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/pt_BR/LC_MESSAGES/duckduckgo.po
+++ b/locales/pt_BR/LC_MESSAGES/duckduckgo.po
@@ -986,6 +986,11 @@ msgstr "Sobre nós"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1089,6 +1094,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "O anúncio é suspeito"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Adicionar o DuckDuckGo"
@@ -1110,6 +1127,24 @@ msgstr "Adicione o DuckDuckGo como ferramenta de busca"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Adicionar o DuckDuckGo ao %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1148,6 +1183,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1219,6 +1268,11 @@ msgstr "Complementos"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1465,6 +1519,11 @@ msgstr "Todas coloridas"
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2831,6 +2890,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3231,9 +3297,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3249,6 +3325,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4522,6 +4605,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4806,6 +4894,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5144,6 +5237,11 @@ msgstr "Dispensar sempre"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6053,6 +6151,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6234,6 +6337,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6911,6 +7019,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7329,6 +7442,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8319,6 +8437,11 @@ msgid "How is it anonymous?"
 msgstr "Como o anonimato é garantido?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9493,6 +9616,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11233,6 +11361,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "OK, entendi!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12950,6 +13083,11 @@ msgstr "Proteja seus dados em todos os dispositivos."
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -13056,6 +13194,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -14044,6 +14187,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14204,6 +14352,13 @@ msgstr "Busca"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15140,6 +15295,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16489,6 +16649,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16569,6 +16736,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -17037,6 +17209,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17443,6 +17629,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18913,6 +19104,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -20080,6 +20278,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21183,6 +21394,11 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "m"
 msgstr "m"
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.
 msgctxt "Aria label for the menu button"

--- a/locales/pt_PT/LC_MESSAGES/duckduckgo.po
+++ b/locales/pt_PT/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: pt_PT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1221,6 +1221,12 @@ msgid "About our ads"
 msgstr "Sobre os nossos anúncios"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1351,6 +1357,20 @@ msgid "Ad is suspicious"
 msgstr "O anúncio é suspeito"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Adicionar o DuckDuckGo"
@@ -1377,6 +1397,27 @@ msgstr "Adicionar o DuckDuckGo como motor de busca"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Adicionar o DuckDuckGo a %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1422,6 +1463,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Adicionar Conteúdo da Página"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1507,6 +1564,12 @@ msgstr "Extras"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Adicionar os últimos retoques"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1811,6 +1874,12 @@ msgstr "Qualquer cor"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Já está!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3529,6 +3598,14 @@ msgid "Cancel"
 msgstr "Cancelar"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4024,10 +4101,22 @@ msgid "Chat response is offensive"
 msgstr "A resposta do chat é ofensiva"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Conversar com %1$s"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4046,6 +4135,14 @@ msgstr "Conversas"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Chats"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5649,6 +5746,12 @@ msgid "Current Streak"
 msgstr "Série Atual"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5996,6 +6099,12 @@ msgstr "Eliminar conversas"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Eliminar conversas com mais de 30 dias"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6409,6 +6518,12 @@ msgstr "Recusar para sempre"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Ignorar promoção"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7592,6 +7707,12 @@ msgid "Edit Prompt"
 msgstr "Editar pedido"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7815,6 +7936,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Modelo encriptado"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8662,6 +8789,12 @@ msgid "Follow-up question"
 msgstr "Pergunta de acompanhamento"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9176,6 +9309,12 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
 "Obtém a VPN da DuckDuckGo, Duck.ai avançado e Identity Theft Restoration."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10409,6 +10548,12 @@ msgstr "Como é anónimo?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Como funciona"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11854,6 +11999,12 @@ msgstr "Lineouts Ganhos"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "O link expira em 7 dias."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13977,6 +14128,12 @@ msgstr "OK"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "OK, percebido!"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16110,6 +16267,12 @@ msgid "Protected"
 msgstr "Protegido"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Proteção. Privacidade. Tranquilidade."
@@ -16241,6 +16404,12 @@ msgstr "Chuva"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Classificações"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17484,6 +17653,12 @@ msgid "Save your chats across all your devices."
 msgstr "Guarda as tuas conversas em todos os teus dispositivos."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17685,6 +17860,14 @@ msgstr "Pesquisar"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Pesquisar"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18876,6 +19059,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Comprar"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20545,6 +20734,14 @@ msgstr ""
 "inatividade."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20660,6 +20857,12 @@ msgstr "Sincroniza com um dispositivo próximo."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Sincroniza as tuas conversas em todos os teus dispositivos."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21246,6 +21449,22 @@ msgid "This Week"
 msgstr "Esta Semana"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21782,6 +22001,12 @@ msgstr "Hoje"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Hoje"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23616,6 +23841,14 @@ msgstr ""
 "cliques em anúncios são geridos pela rede de publicidade do TripAdvisor."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Ilhas Virgens"
 
@@ -25098,6 +25331,21 @@ msgstr ""
 "para treinar a IA. Ativa ou desativa em qualquer altura no menu \"%1$s\"."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26501,6 +26749,12 @@ msgstr "min"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "min"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/ro_RO/LC_MESSAGES/duckduckgo.po
+++ b/locales/ro_RO/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: ro_RO\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1224,6 +1224,12 @@ msgid "About our ads"
 msgstr "Despre reclamele noastre"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1353,6 +1359,20 @@ msgid "Ad is suspicious"
 msgstr "Reclama este suspectă"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Adaugă DuckDuckGo"
@@ -1379,6 +1399,27 @@ msgstr "Adaugă DuckDuckGo ca motor de căutare"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Adăugare DuckDuckGo la %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1424,6 +1465,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Adaugă conținutul paginii"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1511,6 +1568,12 @@ msgstr "Add-on-uri"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Adăugăm tușele finale"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1815,6 +1878,12 @@ msgstr "Toate culorile"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Gata!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3535,6 +3604,14 @@ msgid "Cancel"
 msgstr "Anulează"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4031,10 +4108,22 @@ msgid "Chat response is offensive"
 msgstr "Răspunsul prin chat este jignitor"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Discută cu %1$s"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4053,6 +4142,14 @@ msgstr "Chaturi"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Chaturi"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5661,6 +5758,12 @@ msgid "Current Streak"
 msgstr "Serie curentă"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -6009,6 +6112,12 @@ msgstr "Șterge chaturile"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Șterge chaturile mai vechi de 30 de zile"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6425,6 +6534,12 @@ msgstr "Ignoră pentru totdeauna"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Ignoră promoția"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7609,6 +7724,12 @@ msgid "Edit Prompt"
 msgstr "Editează promptul"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7830,6 +7951,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Model criptat"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8669,6 +8796,12 @@ msgid "Follow-up question"
 msgstr "Întrebare de continuare"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9181,6 +9314,12 @@ msgstr ""
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr "Obține DuckDuckGo VPN, Duck.ai avansat și Identity Theft Restoration."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10417,6 +10556,12 @@ msgstr "Cum rămân anonime?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Cum funcționează"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11861,6 +12006,12 @@ msgstr "Aruncări la margine câștigate"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "Linkul expiră peste 7 zile."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13982,6 +14133,12 @@ msgstr "OK"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "Ok, am înțeles!"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16109,6 +16266,12 @@ msgid "Protected"
 msgstr "Protejate"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Protecție. Confidențialitate. Liniște sufletească."
@@ -16240,6 +16403,12 @@ msgstr "Ploaie"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Clasamente"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17480,6 +17649,12 @@ msgid "Save your chats across all your devices."
 msgstr "Salvează-ți chaturile pe toate dispozitivele."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17682,6 +17857,14 @@ msgstr "Caută"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Caută"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18870,6 +19053,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Cumpără"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20540,6 +20729,14 @@ msgstr ""
 "Datele Sync & Backup nu pot fi recuperate după 18 luni de inactivitate."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20653,6 +20850,12 @@ msgstr "Sincronizează cu un dispozitiv din apropiere."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Sincronizează-ți chaturile pe toate dispozitivele."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21239,6 +21442,22 @@ msgid "This Week"
 msgstr "Săptămâna aceasta"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21775,6 +21994,12 @@ msgstr "Astăzi"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Astăzi"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23615,6 +23840,14 @@ msgstr ""
 "TripAdvisor."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Insulele Virgine"
 
@@ -25113,6 +25346,21 @@ msgstr ""
 "„%1$s”."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26512,6 +26760,12 @@ msgstr "m"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "m"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/ru_RU/LC_MESSAGES/duckduckgo.po
+++ b/locales/ru_RU/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: ru_RU\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1215,6 +1215,12 @@ msgid "About our ads"
 msgstr "О нашей рекламе"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1344,6 +1350,20 @@ msgid "Ad is suspicious"
 msgstr "Подозрительная реклама"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Добавить DuckDuckGo"
@@ -1370,6 +1390,27 @@ msgstr "Добавьте DuckDuckGo как поисковую систему"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Добавить DuckDuckGo в %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1415,6 +1456,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Добавить содержимое страницы"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1500,6 +1557,12 @@ msgstr "Дополнения"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Добавляю последние штрихи"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1803,6 +1866,12 @@ msgstr "Все цвета"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Всё готово!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3521,6 +3590,14 @@ msgid "Cancel"
 msgstr "Отменить"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4016,10 +4093,22 @@ msgid "Chat response is offensive"
 msgstr "Ответ носит оскорбительный характер"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Пообщаться с %1$s"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4038,6 +4127,14 @@ msgstr "Чаты"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Чаты"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5646,6 +5743,12 @@ msgid "Current Streak"
 msgstr "Текущая серия"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5994,6 +6097,12 @@ msgstr "Удалить чаты"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Удалить чаты старше 30 дней"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6406,6 +6515,12 @@ msgstr "Не показывать снова"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Закрыть рекламу"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7592,6 +7707,12 @@ msgid "Edit Prompt"
 msgstr "Редактировать запрос"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7817,6 +7938,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Зашифрованная модель"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8651,6 +8778,12 @@ msgid "Follow-up question"
 msgstr "Последующий вопрос"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9167,6 +9300,12 @@ msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
 "Получите VPN от DuckDuckGo, продвинутые модели в Duck.ai, а также доступ к "
 "функции Identity Theft Restoration."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10402,6 +10541,12 @@ msgstr "Насколько это анонимно?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Как это работает?"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11857,6 +12002,12 @@ msgstr "Выигранные лайнауты"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "Ссылка истекает через 7 дней."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13978,6 +14129,12 @@ msgstr "Хорошо"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "Хорошо, понятно!"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16108,6 +16265,12 @@ msgid "Protected"
 msgstr "Защищено"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Защита. Конфиденциальность. Спокойствие."
@@ -16239,6 +16402,12 @@ msgstr "Дождь"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Рейтинги"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17476,6 +17645,12 @@ msgid "Save your chats across all your devices."
 msgstr "Чаты сохраняются на всех устройствах."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17678,6 +17853,14 @@ msgstr "Поиск"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Поиск"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18859,6 +19042,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "За покупками"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20515,6 +20704,14 @@ msgstr ""
 "бездействия."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20629,6 +20826,12 @@ msgstr "Синхронизация с устройством поблизост�
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Чаты синхронизируются на всех устройствах."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21209,6 +21412,22 @@ msgid "This Week"
 msgstr "На этой неделе"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21744,6 +21963,12 @@ msgstr "Сегодня"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Сегодня"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23589,6 +23814,14 @@ msgstr ""
 "TripAdvisor."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Виргинские острова"
 
@@ -25058,6 +25291,21 @@ msgstr ""
 "Включить или отключить его можно в любой момент в меню «%1$s»."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26455,6 +26703,12 @@ msgstr "мин."
 msgctxt "published date for videos"
 msgid "m"
 msgstr "мин."
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/sc_IT/LC_MESSAGES/duckduckgo.po
+++ b/locales/sc_IT/LC_MESSAGES/duckduckgo.po
@@ -980,6 +980,11 @@ msgstr "A subra de nois"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1083,6 +1088,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "Publitzidade suspetosa"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Agiunghe DuckDuckGo"
@@ -1105,6 +1122,24 @@ msgstr "Agiunghe DuckDuckGo che a motore de chirca"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Agiunghe DuckDuckGo a %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1143,6 +1178,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1215,6 +1264,11 @@ msgstr "Cumplementos"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1462,6 +1516,11 @@ msgstr "Totu is colores"
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2829,6 +2888,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3234,9 +3300,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3252,6 +3328,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4553,6 +4636,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr "Sèrie atuale"
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4837,6 +4925,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5175,6 +5268,11 @@ msgstr "Iscarta sempre"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6087,6 +6185,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6268,6 +6371,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6946,6 +7054,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7364,6 +7477,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8360,6 +8478,11 @@ msgid "How is it anonymous?"
 msgstr "Comente est anònimu?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9547,6 +9670,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11290,6 +11418,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "AB, cumprèndidu!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -13016,6 +13149,11 @@ msgstr "Ampara is datos tuos in totu is dispositivos."
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -13122,6 +13260,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -14115,6 +14258,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14280,6 +14428,13 @@ msgstr "Chirca"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15237,6 +15392,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16590,6 +16750,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16670,6 +16837,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -17140,6 +17312,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17547,6 +17733,11 @@ msgstr "Oe"
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -19027,6 +19218,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -20199,6 +20397,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21307,6 +21518,11 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "m"
 msgstr "m"
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.
 msgctxt "Aria label for the menu button"

--- a/locales/si_LK/LC_MESSAGES/duckduckgo.po
+++ b/locales/si_LK/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: si_LK\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1210,6 +1210,12 @@ msgid "About our ads"
 msgstr "අපගේ දැන්වීම් ගැන"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1339,6 +1345,20 @@ msgid "Ad is suspicious"
 msgstr "දැන්වීම සැක සහිතයි"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "DuckDuckGo එකතු කරන්න"
@@ -1364,6 +1384,27 @@ msgstr "DuckDuckGo සෙවුම් පද්ධතියක් ලෙස එ�
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "%1$s වෙත DuckDuckGo එක් කරන්න"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1409,6 +1450,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "පිටු අන්තර්ගතය එක් කරන්න"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1494,6 +1551,12 @@ msgstr "ඇඩෝන"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "අවසන් සැරසීම් එකතු කිරීම"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1792,6 +1855,12 @@ msgstr "සියලු වර්ණ"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "සියල්ල සම්පූර්ණයි!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3477,6 +3546,14 @@ msgid "Cancel"
 msgstr "අවලංගු කරන්න"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3967,10 +4044,22 @@ msgid "Chat response is offensive"
 msgstr "මෙම පරිවර්තනය අහිතකරය"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "%1$s සමඟ කතාබස් කරන්න"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3989,6 +4078,14 @@ msgstr "කතාබස්"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "කතාබස්"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5575,6 +5672,12 @@ msgid "Current Streak"
 msgstr "වත්මන් රේඛාව"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5920,6 +6023,12 @@ msgstr "මකා දැමූ කතාබස්"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "දින 30කට වඩා පැරණි කතාබස් මකන්න"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6333,6 +6442,12 @@ msgstr "හැමදාටම නැති කරන්න"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "ප්‍රවර්ධනය ඉවත ලන්න"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7486,6 +7601,12 @@ msgid "Edit Prompt"
 msgstr "විමසුම සංස්කරණය කරන්න"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7704,6 +7825,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "ගුප්ත කේතිත ආකෘතිය"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8522,6 +8649,12 @@ msgid "Follow-up question"
 msgstr "පසු විපරම් ප්‍රශ්නය"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9032,6 +9165,12 @@ msgstr ""
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr "DuckDuckGo VPN, උසස් Duck.ai, සහ Identity Theft Restoration ලබා ගන්න."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10256,6 +10395,12 @@ msgstr "කෙසේද එය නිර්නාමික වන්නේ?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "එය ක්‍රියා කරන ආකාරය"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11688,6 +11833,12 @@ msgstr "ප්‍රතිවාදී සීමාවෙන් පන්දු 
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "සබැඳිය දින 7කින් කල් ඉකුත් වේ."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13804,6 +13955,12 @@ msgid "OK, got it!"
 msgstr "හරි, දැනුවත් උනා!"
 
 # smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -15903,6 +16060,12 @@ msgid "Protected"
 msgstr "ආරක්ෂිතයි"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "ආරක්ෂාව. පෞද්ගලිකත්වය. සිතේ සාමය."
@@ -16034,6 +16197,12 @@ msgstr "වැසි"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "ශ්රේණිගත කිරීම්"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17255,6 +17424,12 @@ msgid "Save your chats across all your devices."
 msgstr "ඔබගේ සියලු උපාංග හරහා ඔබේ කතාබස් සුරකින්න."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17453,6 +17628,14 @@ msgstr "සොයන්න"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "සොයන්න"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18613,6 +18796,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "සාප්පු සවාරි යාම"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20250,6 +20439,14 @@ msgstr ""
 "Sync & Backup දත්ත මාස 18ක කාලයක් තිස්සේ අකර්මණ්‍යව තිබූ පසු ඒවා ප්‍රතිසාධනය කළ නොහැක."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20361,6 +20558,12 @@ msgstr "සමීපස්ථ උපාංගයක් සමඟ සමමුහ
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "ඔබේ කතාබස් ඔබගේ සියලු උපාංග අතර සමමුහුර්ත කරන්න."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -20938,6 +21141,22 @@ msgid "This Week"
 msgstr "මේ සතියේ"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21451,6 +21670,12 @@ msgstr "අද"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "අද"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23259,6 +23484,14 @@ msgstr ""
 "දැන්වීම් ජාලය විසින් කළමනාකරණය කරනු ලැබේ."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "වර්ජින් දූපත්"
 
@@ -24712,6 +24945,21 @@ msgstr ""
 "නොකෙරේ. '%1$s' මෙනුව තුළ ඕනෑම වේලාවක එය සක්‍රිය හෝ අක්‍රිය කරන්න."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26076,6 +26324,12 @@ msgstr "විනා"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "විනා"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/sk_SK/LC_MESSAGES/duckduckgo.po
+++ b/locales/sk_SK/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: sk_SK\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1215,6 +1215,12 @@ msgid "About our ads"
 msgstr "O našich reklamách"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1344,6 +1350,20 @@ msgid "Ad is suspicious"
 msgstr "Reklama je podozrivá"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Pridať DuckDuckGo"
@@ -1370,6 +1390,27 @@ msgstr "Pridať DuckDuckGo ako vyhľadávač"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Pridať DuckDuckGo do prehliadača %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1415,6 +1456,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Pridať obsah stránky"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1500,6 +1557,12 @@ msgstr "Doplnky"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Pridanie dokončovacích prvkov"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1803,6 +1866,12 @@ msgstr "Všetky farby"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Všetko je hotové!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3521,6 +3590,14 @@ msgid "Cancel"
 msgstr "Zrušiť"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4015,10 +4092,22 @@ msgid "Chat response is offensive"
 msgstr "Táto odpoveď chatbota je urážlivá."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Chatovať s %1$s"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4037,6 +4126,14 @@ msgstr "Čety"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Čety"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5634,6 +5731,12 @@ msgid "Current Streak"
 msgstr "Aktuálna šnúra"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5982,6 +6085,12 @@ msgstr "Zmazať chaty"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Vymazať chaty staršie ako 30 dní"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6395,6 +6504,12 @@ msgstr "Skryť navždy"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Zrušiť propagáciu"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7570,6 +7685,12 @@ msgid "Edit Prompt"
 msgstr "Upraviť výzvu"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7791,6 +7912,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Šifrovaný model"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8627,6 +8754,12 @@ msgid "Follow-up question"
 msgstr "Doplňujúca otázka"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9140,6 +9273,12 @@ msgstr ""
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr "Získaj DuckDuckGo VPN, pokročilé Duck.ai a Identity Theft Restoration."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10371,6 +10510,12 @@ msgstr "Ako sa zabezpečuje anonymita?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Ako to funguje"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11821,6 +11966,12 @@ msgstr "Vyhrané auty"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "Platnosť odkazu vyprší o 7 dní."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13940,6 +14091,12 @@ msgstr "OK"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "OK, rozumiem!"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16068,6 +16225,12 @@ msgid "Protected"
 msgstr "Chránené"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Ochrana. Súkromie. Pokoj v duši."
@@ -16199,6 +16362,12 @@ msgstr "Dážď"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Rebríčky"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17431,6 +17600,12 @@ msgid "Save your chats across all your devices."
 msgstr "Ulož si svoje chaty na všetkých svojich zariadeniach."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17632,6 +17807,14 @@ msgstr "Vyhľadávanie"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Vyhľadávanie"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18813,6 +18996,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Obchod"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20474,6 +20663,14 @@ msgstr ""
 "nečinnosti."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20588,6 +20785,12 @@ msgstr "Synchronizácia s blízkym zariadením."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Synchronizuj svoje chaty na všetkých svojich zariadeniach."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21171,6 +21374,22 @@ msgid "This Week"
 msgstr "Tento týždeň"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21701,6 +21920,12 @@ msgstr "Dnes"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Dnes"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23533,6 +23758,14 @@ msgstr ""
 "spravuje reklamná sieť lokality TripAdvisor."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Panenské ostrovy"
 
@@ -25017,6 +25250,21 @@ msgstr ""
 "umelej inteligencie. Zapni alebo vypni kedykoľvek v ponuke „%1$s“."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26416,6 +26664,12 @@ msgstr "min"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "min"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/sl_SI/LC_MESSAGES/duckduckgo.po
+++ b/locales/sl_SI/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: sl_SI\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1217,6 +1217,12 @@ msgid "About our ads"
 msgstr "O naših oglasih"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1346,6 +1352,20 @@ msgid "Ad is suspicious"
 msgstr "Oglas je sumljiv"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Dodaj DuckDuckGo"
@@ -1372,6 +1392,27 @@ msgstr "Dodajte DuckDuckGo kot iskalnik"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Dodaj DuckDuckGo v %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1417,6 +1458,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Dodaj vsebino strani"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1502,6 +1559,12 @@ msgstr "Dodatki"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Še zadnji popravki"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1805,6 +1868,12 @@ msgstr "Vse barve"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Končano!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3519,6 +3588,14 @@ msgid "Cancel"
 msgstr "Prekliči"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4013,10 +4090,22 @@ msgid "Chat response is offensive"
 msgstr "Odziv v klepetu je žaljiv"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Klepetajte z modelom %1$s"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4035,6 +4124,14 @@ msgstr "Klepeti"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Klepeti"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5632,6 +5729,12 @@ msgid "Current Streak"
 msgstr "Trenutni niz"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5979,6 +6082,12 @@ msgstr "Izbriši klepete"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Izbriši klepete, starejše od 30 dni"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6398,6 +6507,12 @@ msgstr "Opusti za vedno"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Zavrni promocijo"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7574,6 +7689,12 @@ msgid "Edit Prompt"
 msgstr "Uredi poziv"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7794,6 +7915,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Šifrirani model"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8633,6 +8760,12 @@ msgid "Follow-up question"
 msgstr "Nadaljnje vprašanje"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9148,6 +9281,12 @@ msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
 "Pridobi DuckDuckGo VPN, napredni Duck.ai in zaščito Identity Theft "
 "Restoration."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10384,6 +10523,12 @@ msgstr "Kako je ta storitev anonimna?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Kako deluje"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11832,6 +11977,12 @@ msgstr "Osvojeni lineouti"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "Povezava poteče čez 7 dni."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13953,6 +14104,12 @@ msgstr "V redu"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "V redu, razumem!"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16081,6 +16238,12 @@ msgid "Protected"
 msgstr "Zaščiteno"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Zaščita. Zasebnost. Zaupanje."
@@ -16212,6 +16375,12 @@ msgstr "Dež"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Uvrstitve"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17450,6 +17619,12 @@ msgid "Save your chats across all your devices."
 msgstr "Shrani vaše klepete v vseh vaših napravah."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17654,6 +17829,14 @@ msgstr "Iskanje"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Iskanje"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18829,6 +19012,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Nakup"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20478,6 +20667,14 @@ msgstr ""
 "nedejavnosti."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20590,6 +20787,12 @@ msgstr "Sinhroniziraj z bližnjo napravo."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Sinhronizira vaše klepete v vseh vaših napravah."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21172,6 +21375,22 @@ msgid "This Week"
 msgstr "Ta teden"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21708,6 +21927,12 @@ msgstr "Danes"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Danes"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23539,6 +23764,14 @@ msgstr ""
 "oglaševalsko omrežje družbe TripAdvisor."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Deviški otoki"
 
@@ -25020,6 +25253,21 @@ msgstr ""
 "učenje UI. Kadar koli ga vklopite ali izklopite v meniju »%1$s«."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26416,6 +26664,12 @@ msgstr "min"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "min"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/sq_AL/LC_MESSAGES/duckduckgo.po
+++ b/locales/sq_AL/LC_MESSAGES/duckduckgo.po
@@ -981,6 +981,11 @@ msgstr "Rreth Nesh"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1084,6 +1089,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "Reklama është e dyshimtë"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Shtoni DuckDuckGo-në"
@@ -1106,6 +1123,24 @@ msgstr "Shtojeni DuckDuckGo-në si motor kërkimesh"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Shtojeni DuckDuckGo-në te %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1144,6 +1179,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1215,6 +1264,11 @@ msgstr "Shtesa"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1461,6 +1515,11 @@ msgstr "Krejt ngjyrat"
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2831,6 +2890,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3233,9 +3299,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3251,6 +3327,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4551,6 +4634,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4835,6 +4923,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5173,6 +5266,11 @@ msgstr "Hidhe tej përgjithmonë"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6088,6 +6186,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6269,6 +6372,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6950,6 +7058,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7369,6 +7482,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8361,6 +8479,11 @@ msgid "How is it anonymous?"
 msgstr "Si është anonim?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9550,6 +9673,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11290,6 +11418,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "OK, e mora vesh!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -13016,6 +13149,11 @@ msgstr "Mbroni të dhënat tuaja në çdo pajisje."
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -13123,6 +13261,11 @@ msgstr "Shi"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Renditje"
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
 msgid "Rated %s/5"
@@ -14117,6 +14260,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14281,6 +14429,13 @@ msgstr "Kërko"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15231,6 +15386,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16580,6 +16740,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16660,6 +16827,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -17132,6 +17304,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17539,6 +17725,11 @@ msgstr "Sot"
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -19023,6 +19214,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -20203,6 +20401,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21310,6 +21521,11 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "m"
 msgstr "m"
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.
 msgctxt "Aria label for the menu button"

--- a/locales/sr_RS/LC_MESSAGES/duckduckgo.po
+++ b/locales/sr_RS/LC_MESSAGES/duckduckgo.po
@@ -982,6 +982,11 @@ msgstr "О нама"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1085,6 +1090,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "Оглас је сумњив"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Додај DuckDuckGo"
@@ -1106,6 +1123,24 @@ msgstr "Додај DuckDuckGo као Ваш интернет претражив�
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Додај DuckDuckGo за %s "
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1144,6 +1179,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1215,6 +1264,11 @@ msgstr "Додаци"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1461,6 +1515,11 @@ msgstr "Све боје"
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2826,6 +2885,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3227,9 +3293,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3245,6 +3321,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4516,6 +4599,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4800,6 +4888,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5138,6 +5231,11 @@ msgstr "Одбаци заувек"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6045,6 +6143,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6226,6 +6329,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6897,6 +7005,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7315,6 +7428,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8306,6 +8424,11 @@ msgid "How is it anonymous?"
 msgstr "Како је то анонимно?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9482,6 +9605,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11223,6 +11351,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "ОК, разумео сам!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12938,6 +13071,11 @@ msgstr "Заштитите ваше податке на сваком уређа�
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -13044,6 +13182,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -14032,6 +14175,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14191,6 +14339,13 @@ msgstr "Претрага"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15119,6 +15274,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16463,6 +16623,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16543,6 +16710,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -17011,6 +17183,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17419,6 +17605,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18886,6 +19077,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -20052,6 +20250,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21153,6 +21364,11 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "m"
 msgstr "мин"
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.
 msgctxt "Aria label for the menu button"

--- a/locales/sv_SE/LC_MESSAGES/duckduckgo.po
+++ b/locales/sv_SE/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: sv_SE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1212,6 +1212,12 @@ msgid "About our ads"
 msgstr "Om våra annonser"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1341,6 +1347,20 @@ msgid "Ad is suspicious"
 msgstr "Annonsen är misstänkt"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Lägg till DuckDuckGo"
@@ -1366,6 +1386,27 @@ msgstr "Lägg till DuckDuckGo som sökmotor"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Lägg till DuckDuckGo i %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1411,6 +1452,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Lägg till sidans innehåll"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1496,6 +1553,12 @@ msgstr "Tillägg"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Lägger till de sista detaljerna"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1800,6 +1863,12 @@ msgstr "Alla färger"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Allt klart!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3509,6 +3578,14 @@ msgid "Cancel"
 msgstr "Avbryt"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4003,10 +4080,22 @@ msgid "Chat response is offensive"
 msgstr "Chattsvaret är stötande"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Chatta med %1$s"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4025,6 +4114,14 @@ msgstr "Chattar"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Chattar"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5625,6 +5722,12 @@ msgid "Current Streak"
 msgstr "Nuvarande streak"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5973,6 +6076,12 @@ msgstr "Radera chatt"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Radera chattar som är äldre än 30 dagar"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6387,6 +6496,12 @@ msgstr "Visa inte igen"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Stäng kampanj"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7557,6 +7672,12 @@ msgid "Edit Prompt"
 msgstr "Redigera prompt"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7777,6 +7898,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Krypterad modell"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8605,6 +8732,12 @@ msgid "Follow-up question"
 msgstr "Följdfråga"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9119,6 +9252,12 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
 "Skaffa DuckDuckGo VPN, avancerade Duck.ai och Identity Theft Restoration."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10352,6 +10491,12 @@ msgstr "På vilket sätt är det anonymt?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Så funkar det"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11796,6 +11941,12 @@ msgstr "Vunna lineouts"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "Länken går ut om 7 dagar."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13913,6 +14064,12 @@ msgstr "OK"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "Okej, uppfattat!"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16035,6 +16192,12 @@ msgid "Protected"
 msgstr "Skyddad"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Skydd. Integritet. Sinnesro."
@@ -16166,6 +16329,12 @@ msgstr "Regn"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Rankning"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17402,6 +17571,12 @@ msgid "Save your chats across all your devices."
 msgstr "Spara dina chattar på alla dina enheter."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17602,6 +17777,14 @@ msgstr "Sök"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Sök"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18771,6 +18954,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Butik"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20418,6 +20607,14 @@ msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr "Sync & Backup-data kan inte återställas efter 18 månaders inaktivitet."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20529,6 +20726,12 @@ msgstr "Synkronisera med en enhet i närheten."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Synkronisera dina chattar mellan alla dina enheter."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21112,6 +21315,22 @@ msgid "This Week"
 msgstr "Denna vecka"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21637,6 +21856,12 @@ msgstr "Idag"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Idag"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23458,6 +23683,14 @@ msgstr ""
 "av TripAdvisors annonsnätverk."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Jungfruöarna"
 
@@ -24933,6 +25166,21 @@ msgstr ""
 "Slå på eller stäng av det när som helst i menyn ”%1$s”."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26329,6 +26577,12 @@ msgstr "min"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "min"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/ta_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/ta_IN/LC_MESSAGES/duckduckgo.po
@@ -980,6 +980,11 @@ msgstr "எங்களைப் பற்றி"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1083,6 +1088,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "சந்தேகத்திற்குரிய விளம்பரம்"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #  Marked fuzzy because of translated trademark
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
@@ -1105,6 +1122,24 @@ msgstr "DuckDuckGoவை தேடுபொரியாக சேற்கவு
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "%s இல் DuckDuckGo வை சேர்க்க"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1143,6 +1178,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #  Marked fuzzy because of translated trademark
@@ -1215,6 +1264,11 @@ msgstr "துணை நிரல்கள்"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1461,6 +1515,11 @@ msgstr "அனைத்து வண்ணங்கள்"
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2824,6 +2883,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3227,9 +3293,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3245,6 +3321,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4513,6 +4596,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4797,6 +4885,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5135,6 +5228,11 @@ msgstr "நிரந்தரமாக நிராகரி"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6053,6 +6151,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6232,6 +6335,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6902,6 +7010,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7320,6 +7433,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8307,6 +8425,11 @@ msgid "How is it anonymous?"
 msgstr "இது எப்படி அநாமதேயமாக?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9482,6 +9605,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11226,6 +11354,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "சரி, கிடைத்தது!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12941,6 +13074,11 @@ msgstr "ஒவ்வொரு சாதனத்திலும் உங்க�
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -13047,6 +13185,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -14038,6 +14181,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14197,6 +14345,13 @@ msgstr "தேடு"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15132,6 +15287,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16476,6 +16636,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16556,6 +16723,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -17025,6 +17197,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17431,6 +17617,11 @@ msgstr "இன்று"
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18900,6 +19091,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -20069,6 +20267,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21170,6 +21381,11 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "m"
 msgstr "ம"
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.
 msgctxt "Aria label for the menu button"

--- a/locales/te_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/te_IN/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr "మా గురుంచి"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "ప్రకటన అనుమాస్పదమైనది"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "DuckDuckGoని చేర్చుకోండి"
@@ -1100,6 +1117,24 @@ msgstr "DuckDuckGoని సెర్చ్ ఇంజిన్‌గా చే�
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "DuckDuckGoని %sకు చేర్చుకోండి"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr "పొడగింతలు"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1454,6 +1508,11 @@ msgstr "అన్ని రంగులు"
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2803,6 +2862,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3203,9 +3269,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3221,6 +3297,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4479,6 +4562,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4763,6 +4851,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5101,6 +5194,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -5997,6 +6095,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6174,6 +6277,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6839,6 +6947,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7257,6 +7370,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8239,6 +8357,11 @@ msgid "How is it anonymous?"
 msgstr "ఇది ఏవిధంగా అజ్ఞాతంగా ఉంచుతుంది?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9395,6 +9518,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11134,6 +11262,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "సరే, అర్థమయ్యింది!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12834,6 +12967,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12940,6 +13078,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13928,6 +14071,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14083,6 +14231,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -14998,6 +15153,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16337,6 +16497,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16417,6 +16584,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16877,6 +17049,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17279,6 +17465,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18741,6 +18932,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19896,6 +20094,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20982,6 +21193,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/th_TH/LC_MESSAGES/duckduckgo.po
+++ b/locales/th_TH/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: th_TH\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1189,6 +1189,12 @@ msgid "About our ads"
 msgstr "เกี่ยวกับโฆษณาของเรา"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1314,6 +1320,20 @@ msgid "Ad is suspicious"
 msgstr "โฆษณาน่าสงสัย"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "เพิ่ม DuckDuckGo"
@@ -1340,6 +1360,27 @@ msgstr "เพิ่ม DuckDuckGo เป็นเครื่องมือค
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "เพิ่ม DuckDuckGo ลงใน %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1385,6 +1426,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "เพิ่มเนื้อหาในหน้า"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1470,6 +1527,12 @@ msgstr "ส่วนเสริม"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "การเก็บรายละเอียดขั้นสุดท้าย"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1767,6 +1830,12 @@ msgstr "ทุกสี"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "เสร็จเรียบร้อย!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3449,6 +3518,14 @@ msgid "Cancel"
 msgstr "ยกเลิก"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3935,10 +4012,22 @@ msgid "Chat response is offensive"
 msgstr "คำตอบของแชทไม่เหมาะสม"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "แชทกับ %1$s"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3957,6 +4046,14 @@ msgstr "แชท"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "แชท"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5529,6 +5626,12 @@ msgid "Current Streak"
 msgstr "สตรีคปัจจุบัน"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5873,6 +5976,12 @@ msgstr "ลบแชท"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "ลบแชทที่เก่ากว่า 30 วัน"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6286,6 +6395,12 @@ msgstr "ปิดตลอดไป"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "ปิดการเลื่อนระดับ"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7420,6 +7535,12 @@ msgid "Edit Prompt"
 msgstr "แก้ไขคำสั่ง"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7636,6 +7757,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "โมเดลที่เข้ารหัส"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8451,6 +8578,12 @@ msgid "Follow-up question"
 msgstr "คำถามเพิ่มเติม"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -8960,6 +9093,12 @@ msgstr ""
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr "รับ DuckDuckGo VPN, Duck.ai ขั้นสูง และ Identity Theft Restoration"
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10179,6 +10318,12 @@ msgstr "ทำไมกระบวนการนี้ไม่ระบุต
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "วิธีการทำงาน"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11609,6 +11754,12 @@ msgstr "ไลน์เอาต์ที่ได้"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "ลิงก์หมดอายุใน 7 วัน"
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13723,6 +13874,12 @@ msgid "OK, got it!"
 msgstr "เข้าใจแล้ว!"
 
 # smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -15814,6 +15971,12 @@ msgid "Protected"
 msgstr "ได้รับการปกป้อง"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "การป้องกัน ความเป็นส่วนตัว ความสบายใจ"
@@ -15943,6 +16106,12 @@ msgstr "ฝน"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "การจัดอันดับ"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17165,6 +17334,12 @@ msgid "Save your chats across all your devices."
 msgstr "บันทึกการแชทของคุณในอุปกรณ์ทั้งหมดของคุณ"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17361,6 +17536,14 @@ msgstr "ค้นหา"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "ค้นหา"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18512,6 +18695,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "ร้านค้า"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20139,6 +20328,14 @@ msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr "ข้อมูล Sync & Backup จะไม่สามารถกู้คืนได้หลังจากไม่ได้ใช้งานเป็นเวลา 18 เดือน"
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20248,6 +20445,12 @@ msgstr "ซิงค์กับอุปกรณ์ที่อยู่ใก
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "ซิงค์แชทของคุณในอุปกรณ์ทั้งหมดของคุณ"
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -20817,6 +21020,22 @@ msgid "This Week"
 msgstr "สัปดาห์นี้"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21325,6 +21544,12 @@ msgstr "วันนี้"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "วันนี้"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23118,6 +23343,14 @@ msgstr ""
 "การคลิกโฆษณาได้รับการจัดการโดยเครือข่ายโฆษณาของ TripAdvisor"
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "หมู่เกาะเวอร์จิน"
 
@@ -24539,6 +24772,21 @@ msgstr ""
 "เปิดหรือปิดใช้งานได้ตลอดเวลาในเมนู '%1$s'"
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -25884,6 +26132,12 @@ msgstr "นาที"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "นาที"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/tl_PH/LC_MESSAGES/duckduckgo.po
+++ b/locales/tl_PH/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Idagdag ang DuckDuckGo"
@@ -1099,6 +1116,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr "Mga add-on"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1453,6 +1507,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2800,6 +2859,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3200,9 +3266,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3218,6 +3294,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4477,6 +4560,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4761,6 +4849,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5099,6 +5192,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -5995,6 +6093,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6172,6 +6275,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6839,6 +6947,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7257,6 +7370,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8239,6 +8357,11 @@ msgid "How is it anonymous?"
 msgstr "Paano ito naging anonymous?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9396,6 +9519,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11133,6 +11261,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12833,6 +12966,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12939,6 +13077,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13927,6 +14070,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14082,6 +14230,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -14999,6 +15154,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16338,6 +16498,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16418,6 +16585,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16878,6 +17050,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17280,6 +17466,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18742,6 +18933,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19891,6 +20089,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20979,6 +21190,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/tokipona_XX/LC_MESSAGES/duckduckgo.po
+++ b/locales/tokipona_XX/LC_MESSAGES/duckduckgo.po
@@ -982,6 +982,11 @@ msgstr "o sona e mi"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1085,6 +1090,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "lipu esun li nasa"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "kepeken e ilo DuckDuckGo"
@@ -1104,6 +1121,24 @@ msgstr "sina o pali e ilo DuckDuckGo tawa e ilo tawa lukin"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "sina o pali e ilo DuckDuckGo lon %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1142,6 +1177,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1213,6 +1262,11 @@ msgstr "namako"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1459,6 +1513,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2807,6 +2866,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3207,9 +3273,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3225,6 +3301,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4492,6 +4575,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4776,6 +4864,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5114,6 +5207,11 @@ msgstr "o lukin ala lon tempo ale"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6011,6 +6109,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6188,6 +6291,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6857,6 +6965,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7275,6 +7388,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8260,6 +8378,11 @@ msgid "How is it anonymous?"
 msgstr "sona mi li pimeja kepeken nasin seme?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9421,6 +9544,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11158,6 +11286,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "pona!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12865,6 +12998,11 @@ msgstr "o awen e sitelen walo sin lon ijo ale."
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12971,6 +13109,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13959,6 +14102,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14117,6 +14265,13 @@ msgstr "lukin"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15043,6 +15198,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16382,6 +16542,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16462,6 +16629,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16924,6 +17096,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17328,6 +17514,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18796,6 +18987,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19951,6 +20149,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21044,6 +21255,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/tpi_PG/LC_MESSAGES/duckduckgo.po
+++ b/locales/tpi_PG/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr ""
@@ -1099,6 +1116,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr "Kisim mo."
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1453,6 +1507,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2800,6 +2859,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3200,9 +3266,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3218,6 +3294,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4475,6 +4558,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4759,6 +4847,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5097,6 +5190,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -5993,6 +6091,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6170,6 +6273,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6835,6 +6943,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7253,6 +7366,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8235,6 +8353,11 @@ msgid "How is it anonymous?"
 msgstr ""
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9388,6 +9511,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11125,6 +11253,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12825,6 +12958,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12931,6 +13069,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13919,6 +14062,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14074,6 +14222,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -14989,6 +15144,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16328,6 +16488,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16408,6 +16575,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16868,6 +17040,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17270,6 +17456,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18732,6 +18923,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19881,6 +20079,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20963,6 +21174,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/tr_TR/LC_MESSAGES/duckduckgo.po
+++ b/locales/tr_TR/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: tr_TR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1222,6 +1222,12 @@ msgid "About our ads"
 msgstr "Reklamlarımız hakkında"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1351,6 +1357,20 @@ msgid "Ad is suspicious"
 msgstr "Reklam şüpheli"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "DuckDuckGo'yu ekleyin"
@@ -1377,6 +1397,27 @@ msgstr "DuckDuckGo'yu arama motoru olarak ekleyin"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "DuckDuckGo'yu %1$s tarayıcısına ekleyin"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1422,6 +1463,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Sayfa İçeriği Ekle"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1507,6 +1564,12 @@ msgstr "Eklentiler"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Son dokunuşlar ekleniyor"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1810,6 +1873,12 @@ msgstr "Tüm renkler"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Hepsi tamam!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3533,6 +3602,14 @@ msgid "Cancel"
 msgstr "İptal"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4029,10 +4106,22 @@ msgid "Chat response is offensive"
 msgstr "Sohbet yanıtı rahatsız edici"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "%1$s ile sohbet edin"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4051,6 +4140,14 @@ msgstr "Sohbetler"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Sohbetler"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5660,6 +5757,12 @@ msgid "Current Streak"
 msgstr "Mevcut Seri"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -6007,6 +6110,12 @@ msgstr "Sohbetleri Sil"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "30 Günden Eski Sohbetleri Sil"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6424,6 +6533,12 @@ msgstr "Sonsuza dek kapat"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Promosyonu kapat"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7607,6 +7722,12 @@ msgid "Edit Prompt"
 msgstr "İstemi Düzenle"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7828,6 +7949,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Şifrelenmiş model"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8661,6 +8788,12 @@ msgid "Follow-up question"
 msgstr "Takip sorusu"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9175,6 +9308,12 @@ msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
 "DuckDuckGo VPN, gelişmiş Duck.ai ve Identity Theft Restoration özelliklerine "
 "sahip olun."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10409,6 +10548,12 @@ msgstr "Nasıl anonim oluyor?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "İşleyiş şekli"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11858,6 +12003,12 @@ msgstr "Kazanılan Kenar Atışları"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "Bağlantının süresi 7 gün içinde doluyor."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13981,6 +14132,12 @@ msgstr "Tamam"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "Tamam, anladım!"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16112,6 +16269,12 @@ msgid "Protected"
 msgstr "Korumalı"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Koruma. Gizlilik. İçiniz rahat olsun."
@@ -16243,6 +16406,12 @@ msgstr "Yağmur"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Sıralamalar"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17480,6 +17649,12 @@ msgid "Save your chats across all your devices."
 msgstr "Sohbetlerinizi tüm cihazlarınıza kaydedin."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17687,6 +17862,14 @@ msgstr "Ara"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Ara"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18882,6 +19065,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Alışveriş"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20539,6 +20728,14 @@ msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr "Sync & Backup verileri 18 ay kullanılmadıktan sonra kurtarılamaz."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20652,6 +20849,12 @@ msgstr "Yakındaki bir cihazla senkronize et."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Sohbetlerinizi tüm cihazlarınızda senkronize edin."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21238,6 +21441,22 @@ msgid "This Week"
 msgstr "Bu Hafta"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21767,6 +21986,12 @@ msgstr "Bugün"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Bugün"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23602,6 +23827,14 @@ msgstr ""
 "tıklamaları TripAdvisor'ın reklam ağı tarafından yönetilir."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Virgin Adaları"
 
@@ -25089,6 +25322,21 @@ msgstr ""
 "kullanılmaz. '%1$s' menüsünden istediğiniz zaman açıp kapatabilirsiniz."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26488,6 +26736,12 @@ msgstr "dk"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "dk"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/uk_UA/LC_MESSAGES/duckduckgo.po
+++ b/locales/uk_UA/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: uk_UA\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1215,6 +1215,12 @@ msgid "About our ads"
 msgstr "Про нашу рекламу"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1344,6 +1350,20 @@ msgid "Ad is suspicious"
 msgstr "Ця реклама підозріла"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Додати DuckDuckGo"
@@ -1370,6 +1390,27 @@ msgstr "Додати DuckDuckGo як пошукову систему"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Додати DuckDuckGo до %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1415,6 +1456,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Додати вміст сторінки"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1500,6 +1557,12 @@ msgstr "Додатки"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Додаю останні штрихи"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1803,6 +1866,12 @@ msgstr "Усі кольори"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Все готово!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3516,6 +3585,14 @@ msgid "Cancel"
 msgstr "Скасувати"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4007,10 +4084,22 @@ msgid "Chat response is offensive"
 msgstr "Відповідь у чаті образлива"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Чат з %1$s"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4029,6 +4118,14 @@ msgstr "Чати"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Чати"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5633,6 +5730,12 @@ msgid "Current Streak"
 msgstr "Поточна серія"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5981,6 +6084,12 @@ msgstr "Видалити чати"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Видалити чати, старші за 30 днів"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6394,6 +6503,12 @@ msgstr "Не показувати знову"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Відхилити рекламу"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7567,6 +7682,12 @@ msgid "Edit Prompt"
 msgstr "Редагувати запит"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7790,6 +7911,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Зашифрована модель"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8632,6 +8759,12 @@ msgid "Follow-up question"
 msgstr "Додаткове запитання"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9150,6 +9283,12 @@ msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
 "Отримайте DuckDuckGo VPN, розширений Duck.ai та послугу Identity Theft "
 "Restoration."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10384,6 +10523,12 @@ msgstr "Наскільки це анонімно?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Принципи роботи"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11836,6 +11981,12 @@ msgstr "Виграні коридори"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "Термін дії посилання закінчується через 7 днів."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13964,6 +14115,12 @@ msgid "OK, got it!"
 msgstr "Гаразд, зрозуміло!"
 
 # smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -16090,6 +16247,12 @@ msgid "Protected"
 msgstr "Захищено"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Захист. Конфіденційність. Спокій."
@@ -16221,6 +16384,12 @@ msgstr "Дощ"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Рейтинг"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17458,6 +17627,12 @@ msgid "Save your chats across all your devices."
 msgstr "Зберігайте чати на всіх своїх пристроях."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17659,6 +17834,14 @@ msgstr "Пошук"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Пошук"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18852,6 +19035,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Придбати"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20511,6 +20700,14 @@ msgstr ""
 "діяльності."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20625,6 +20822,12 @@ msgstr "Синхронізуйте з пристроєм поруч."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Синхронізуйте чати на всіх своїх пристроях."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21206,6 +21409,22 @@ msgid "This Week"
 msgstr "Цього тижня"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21735,6 +21954,12 @@ msgstr "Сьогодні"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Сьогодні"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23573,6 +23798,14 @@ msgstr ""
 "Клацаннями оголошень керує рекламна мережа TripAdvisor."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Віргінські острови"
 
@@ -25052,6 +25285,21 @@ msgstr ""
 "ШІ. Увімкніть або вимкніть його будь-коли в меню «%1$s»."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26447,6 +26695,12 @@ msgstr "хв"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "хв"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/ur_PK/LC_MESSAGES/duckduckgo.po
+++ b/locales/ur_PK/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "DuckDuckGo شامل کریں"
@@ -1099,6 +1116,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr "اضافی پلگ ان"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1455,6 +1509,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2802,6 +2861,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3202,9 +3268,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3220,6 +3296,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4479,6 +4562,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4763,6 +4851,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5101,6 +5194,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -5997,6 +6095,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6174,6 +6277,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6841,6 +6949,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7259,6 +7372,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8241,6 +8359,11 @@ msgid "How is it anonymous?"
 msgstr "یہ کس طرح گمنام ہے؟"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9402,6 +9525,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11141,6 +11269,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12841,6 +12974,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12947,6 +13085,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13935,6 +14078,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14090,6 +14238,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15007,6 +15162,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16346,6 +16506,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16426,6 +16593,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16886,6 +17058,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17288,6 +17474,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18750,6 +18941,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19899,6 +20097,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20985,6 +21196,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/vi_VN/LC_MESSAGES/duckduckgo.po
+++ b/locales/vi_VN/LC_MESSAGES/duckduckgo.po
@@ -980,6 +980,11 @@ msgstr "Về chúng tôi"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1083,6 +1088,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "Quảng cáo rất khả nghi"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Thêm DuckDuckGo"
@@ -1104,6 +1121,24 @@ msgstr "Thêm DuckDuckGo làm công cụ tìm kiếm"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Thêm DuckDuckGo vào %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1142,6 +1177,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1213,6 +1262,11 @@ msgstr "Các tiện ích"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1457,6 +1511,11 @@ msgstr "Tất cả màu sắc"
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2822,6 +2881,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3222,9 +3288,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3240,6 +3316,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4511,6 +4594,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4795,6 +4883,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5133,6 +5226,11 @@ msgstr "Hủy bỏ vĩnh viễn"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6040,6 +6138,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6219,6 +6322,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6888,6 +6996,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7306,6 +7419,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8292,6 +8410,11 @@ msgid "How is it anonymous?"
 msgstr "Nó ẩn danh như thế nào?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9461,6 +9584,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11198,6 +11326,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "OK, đã rõ!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12913,6 +13046,11 @@ msgstr "Bảo vệ dữ liệu của bạn trên mọi thiết bị."
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -13019,6 +13157,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -14007,6 +14150,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14166,6 +14314,13 @@ msgstr "Tìm kiếm"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15093,6 +15248,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16437,6 +16597,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16517,6 +16684,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16985,6 +17157,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17389,6 +17575,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18857,6 +19048,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -20024,6 +20222,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21124,6 +21335,11 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "m"
 msgstr "p"
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.
 msgctxt "Aria label for the menu button"

--- a/locales/zh_CN/LC_MESSAGES/duckduckgo.po
+++ b/locales/zh_CN/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1185,6 +1185,12 @@ msgid "About our ads"
 msgstr "关于我们的广告"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1308,6 +1314,20 @@ msgid "Ad is suspicious"
 msgstr "广告信息可疑"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "添加 DuckDuckGo"
@@ -1332,6 +1352,27 @@ msgstr "添加 DuckDuckGo 搜索引擎"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "将 DuckDuckGo 添加至 %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1377,6 +1418,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "添加页面内容"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1462,6 +1519,12 @@ msgstr "插件"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "添加最后的润色"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1759,6 +1822,12 @@ msgstr "不限颜色"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "全部完成！"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3425,6 +3494,14 @@ msgid "Cancel"
 msgstr "取消"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3911,10 +3988,22 @@ msgid "Chat response is offensive"
 msgstr "聊天回复令人反感"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "与 %1$s 聊天"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3933,6 +4022,14 @@ msgstr "聊天"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "聊天"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5501,6 +5598,12 @@ msgid "Current Streak"
 msgstr "当前连胜场数"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5845,6 +5948,12 @@ msgstr "删除聊天记录"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "删除超过 30 天的聊天记录"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6255,6 +6364,12 @@ msgstr "不再显示"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "关闭促销信息"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7379,6 +7494,12 @@ msgid "Edit Prompt"
 msgstr "编辑提示"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7595,6 +7716,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "加密模型"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8407,6 +8534,12 @@ msgid "Follow-up question"
 msgstr "后续问题"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -8917,6 +9050,12 @@ msgstr ""
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr "获取 DuckDuckGo VPN、高级 Duck.ai 和 Identity Theft Restoration 服务。"
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10130,6 +10269,12 @@ msgstr "这是匿名的吗？"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "如何使用"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11550,6 +11695,12 @@ msgstr "争边球获胜次数"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "链接将在 7 天后失效。"
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13664,6 +13815,12 @@ msgid "OK, got it!"
 msgstr "好的，知道了！"
 
 # smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -15750,6 +15907,12 @@ msgid "Protected"
 msgstr "受保护"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "保护。隐私。安心。"
@@ -15879,6 +16042,12 @@ msgstr "下雨"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "排名"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17094,6 +17263,12 @@ msgid "Save your chats across all your devices."
 msgstr "在所有设备上保留你的聊天记录。"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17292,6 +17467,14 @@ msgstr "搜索"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "搜索"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18437,6 +18620,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "购买"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20061,6 +20250,14 @@ msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr "Sync & Backup 数据在 18 个月未活动后将无法恢复。"
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20170,6 +20367,12 @@ msgstr "与附近设备同步。"
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "在所有设备上同步你的聊天记录。"
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -20733,6 +20936,22 @@ msgid "This Week"
 msgstr "本周"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21238,6 +21457,12 @@ msgstr "今天"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "今天"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23024,6 +23249,14 @@ msgstr ""
 "DuckDuckGo 会保护观看广告的隐私。广告点击量由 TripAdvisor 广告网络管理。"
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "维尔京群岛"
 
@@ -24437,6 +24670,21 @@ msgstr ""
 "在“%1$s”菜单中开启或关闭。"
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -25765,6 +26013,12 @@ msgstr "分钟"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "分钟"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/zh_TW/LC_MESSAGES/duckduckgo.po
+++ b/locales/zh_TW/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: zh_TW\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1185,6 +1185,12 @@ msgid "About our ads"
 msgstr "關於我們的廣告"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1308,6 +1314,20 @@ msgid "Ad is suspicious"
 msgstr "此廣告有可疑"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "新增DuckDuckGo"
@@ -1332,6 +1352,27 @@ msgstr "新增DuckDuckGo作為搜尋引擎"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "將DuckDuckGo新增至%1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1377,6 +1418,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "新增頁面內容"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1462,6 +1519,12 @@ msgstr "附加元件"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "進行最後的潤飾"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1759,6 +1822,12 @@ msgstr "所有顏色"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "全部完成！"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3428,6 +3497,14 @@ msgid "Cancel"
 msgstr "取消"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3914,10 +3991,22 @@ msgid "Chat response is offensive"
 msgstr "聊天回覆令人反感"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "與 %1$s 聊天"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3936,6 +4025,14 @@ msgstr "聊天"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "聊天"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5499,6 +5596,12 @@ msgid "Current Streak"
 msgstr "目前連勝 / 連敗"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5843,6 +5946,12 @@ msgstr "刪除聊天記錄"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "刪除超過 30 天的聊天記錄"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6253,6 +6362,12 @@ msgstr "知道了，不用再提醒"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "關閉促銷廣告"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7375,6 +7490,12 @@ msgid "Edit Prompt"
 msgstr "編輯提示"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7591,6 +7712,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "加密模型"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8406,6 +8533,12 @@ msgid "Follow-up question"
 msgstr "後續問題"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -8915,6 +9048,12 @@ msgstr ""
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr "取得 DuckDuckGo VPN、先進的 Duck.ai 以及 Identity Theft Restoration。"
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10125,6 +10264,12 @@ msgstr "如何保持匿名？"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "如何運作"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11545,6 +11690,12 @@ msgstr "邊線爭球成功次數"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "連結會在 7 天後到期。"
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13659,6 +13810,12 @@ msgid "OK, got it!"
 msgstr "好，瞭解！"
 
 # smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -15748,6 +15905,12 @@ msgid "Protected"
 msgstr "受到保護"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "防護。隱私。安心。"
@@ -15877,6 +16040,12 @@ msgstr "雨"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "排名"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17089,6 +17258,12 @@ msgid "Save your chats across all your devices."
 msgstr "將你的聊天記錄儲存到所有裝置上。"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17283,6 +17458,14 @@ msgstr "搜尋"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "搜尋"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18424,6 +18607,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "購物"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20048,6 +20237,14 @@ msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr "Sync & Backup 資料無活動 18 個月後將無法恢復。"
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20155,6 +20352,12 @@ msgstr "與附近裝置同步。"
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "將你的聊天記錄同步到所有裝置。"
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -20718,6 +20921,22 @@ msgid "This Week"
 msgstr "本週"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21224,6 +21443,12 @@ msgstr "今天"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "今天"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23011,6 +23236,14 @@ msgstr ""
 "理。"
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "維京群島"
 
@@ -24424,6 +24657,21 @@ msgstr ""
 "在「%1$s」選單中將其開啟或關閉。"
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -25752,6 +26000,12 @@ msgstr "分"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "分"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Localization-only catalog updates with empty translations; no runtime behavior or security logic changes in this diff.
> 
> **Overview**
> This PR **imports a batch of new gettext strings** into `duckduckgo.pot` and adds matching empty `msgstr` entries across locale `.po` files (with minor PO header reordering in some locales). There is **no application logic change** in the diff—only the translation catalog is updated for upcoming or recently shipped UI.
> 
> The new strings mainly cover **Duck.ai**: attach-menu and **tab-picker** flows (`Add`, `Add Tabs`, `Add File` / `Add Image`, tab search, Cancel), **chat history** “About” modals for local storage vs **Sync & Backup** (encryption, cross-device sync, browser-specific storage), **share modal** bullets (public link, generated images, encryption, follow-ups private, 7-day expiry with copy-saving), **delete chats and shared links**, and assorted **accessibility** labels (customize responses, edit message, survey dismiss, chat options menu, star ratings).
> 
> Smaller additions include **new tab page** Duck.ai discovery copy (`OPTIONAL`, shorter toggle headline), **Yelp ad badge** tooltip text parallel to TripAdvisor, and **merchandise easter-egg** strings (sunglasses header tooltip, `Shop Now` in the logo modal).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11202a034364d3b2f0065051d508ca634feddf5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->