### PR TITLE
Import new tokens - 2026-08-27-1539

### DIFF
--- a/duckduckgo.pot
+++ b/duckduckgo.pot
@@ -1167,6 +1167,12 @@ msgid "About our ads"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1290,6 +1296,20 @@ msgid "Ad is suspicious"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr ""
@@ -1313,6 +1333,27 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -1358,6 +1399,22 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -1443,6 +1500,12 @@ msgstr ""
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -1738,6 +1801,12 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -3369,6 +3438,14 @@ msgid "Cancel"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3851,9 +3928,21 @@ msgid "Chat response is offensive"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -3872,6 +3961,14 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -5416,6 +5513,12 @@ msgid "Current Streak"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5759,6 +5862,12 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -6166,6 +6275,12 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -7231,6 +7346,12 @@ msgid "Edit Prompt"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7444,6 +7565,12 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -8254,6 +8381,12 @@ msgid "Follow-up question"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -8758,6 +8891,12 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -9942,6 +10081,12 @@ msgstr ""
 
 # smartling.placeholder_format=C
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -11345,6 +11490,12 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -13457,6 +13608,12 @@ msgid "OK, got it!"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -15514,6 +15671,12 @@ msgid "Protected"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -15642,6 +15805,12 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -16834,6 +17003,12 @@ msgid "Save your chats across all your devices."
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17026,6 +17201,14 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -18141,6 +18324,12 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -19762,6 +19951,14 @@ msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -19853,6 +20050,12 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -20408,6 +20611,22 @@ msgid "This Week"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -20882,6 +21101,12 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -22655,6 +22880,14 @@ msgid ""
 msgstr ""
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr ""
 
@@ -24025,6 +24258,21 @@ msgid ""
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -25312,6 +25560,12 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 # smartling.placeholder_format=C

--- a/locales/af_ZA/LC_MESSAGES/duckduckgo.po
+++ b/locales/af_ZA/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: af_ZA\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -22,8 +22,7 @@ msgstr "!Knal-soeksnelsleutels"
 msgctxt ""
 "Body copy for the Remove Device confirmation modal; %s is the device name"
 msgid "\"%s\" will no longer be able to access your synced data."
-msgstr ""
-"\"%1$s\" sal nie meer toegang tot jou gesinkroniseerde data kan kry nie."
+msgstr "\"%1$s\" sal nie meer toegang tot jou gesinkroniseerde data kan kry nie."
 
 # smartling.placeholder_format=C
 #. Used to specify the rank of a team/player in a specific ranking in short form. This should be interpreted as 'Ranked number <rankNumber> in the <rankingName> ranking. Here you only need to translate the # symbol for ranked number. If your language doesn't provide a single-letter convention, please leave #.
@@ -443,8 +442,7 @@ msgstr "%1$s woorde"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr ""
-"%1$sKlik op %2$sVoeg by%3$sMerk %4$sLaat toe%5$s en klik dan op %6$sGoed%7$s"
+msgstr "%1$sKlik op %2$sVoeg by%3$sMerk %4$sLaat toe%5$s en klik dan op %6$sGoed%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -514,8 +512,7 @@ msgstr ""
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr ""
-"%1$sKom meer te wete%2$s oor hoe kletse privaat op jou toestel gestoor word."
+msgstr "%1$sKom meer te wete%2$s oor hoe kletse privaat op jou toestel gestoor word."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -880,8 +877,7 @@ msgstr "6-uur-gebruikslimiet is bereik."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"6-uur-gebruikslimiet is bereik. Jy kan hierdie kletsgesprek voortsit ná %1$s."
+msgstr "6-uur-gebruikslimiet is bereik. Jy kan hierdie kletsgesprek voortsit ná %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -1218,7 +1214,7 @@ msgstr "Meer oor ons advertensies"
 #. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
 msgctxt "Modal header for chat history with sync information"
 msgid "About Chat History with Sync & Backup"
-msgstr ""
+msgstr "Meer oor kletsgesprekgeskiedenis met Sync & Backup"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
@@ -1353,7 +1349,7 @@ msgstr "Advertensie is verdag"
 #. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
 msgctxt "Button to open menu for attaching images or page context to AI chat"
 msgid "Add"
-msgstr ""
+msgstr "Voeg by"
 
 # smartling.placeholder_format=C
 #. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
@@ -1361,7 +1357,7 @@ msgctxt ""
 "Primary button that attaches the tabs the user checked in the tab picker "
 "dialog"
 msgid "Add"
-msgstr ""
+msgstr "Voeg by"
 
 # smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
@@ -1376,8 +1372,7 @@ msgstr "Voeg DuckDuckGo-uitbreiding by"
 # smartling.placeholder_format=C
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
-msgstr ""
-"Voeg DuckDuckGo Privacy Essentials gratis by jou blaaier met een aflaai:"
+msgstr "Voeg DuckDuckGo Privacy Essentials gratis by jou blaaier met een aflaai:"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1395,13 +1390,13 @@ msgstr "Voeg DuckDuckGo by %1$s"
 msgctxt ""
 "Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
 msgid "Add File"
-msgstr ""
+msgstr "Voeg lêer by"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
 msgid "Add Image"
-msgstr ""
+msgstr "Voeg beeld by"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
@@ -1409,7 +1404,7 @@ msgctxt ""
 "Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
 "item)"
 msgid "Add Image or File"
-msgstr ""
+msgstr "Voeg beeld of lêer by"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1462,7 +1457,7 @@ msgctxt ""
 "Open the tab picker to attach browser tab content to the AI chat message "
 "(attach dropdown menu item)"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Voeg oortjies by"
 
 # smartling.placeholder_format=C
 #. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
@@ -1470,7 +1465,7 @@ msgctxt ""
 "Title and accessible name of the tab-picker dialog opened from the attach "
 "dropdown menu"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Voeg oortjies by"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1561,7 +1556,7 @@ msgstr "Besig om afrondings by te voeg"
 #. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
 msgctxt "Aria label for the additional instructions textarea"
 msgid "Additional instructions"
-msgstr ""
+msgstr "Bykomende instruksies"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1663,8 +1658,7 @@ msgctxt ""
 "Always-visible warning banner shown above the recommended models in the "
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
-msgstr ""
-"Gevorderde modelle kan limiete 2-5x vinniger as ander modelle opgebruik. %1$s"
+msgstr "Gevorderde modelle kan limiete 2-5x vinniger as ander modelle opgebruik. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1870,7 +1864,7 @@ msgstr "Klaar!"
 #. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the read-only textarea listing all AI instructions"
 msgid "All instructions"
-msgstr ""
+msgstr "Alle instruksies"
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -1884,8 +1878,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr ""
-"Alle modelverskaffers word verhoed om hul KI met jou gesprekke op te lei."
+msgstr "Alle modelverskaffers word verhoed om hul KI met jou gesprekke op te lei."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1963,8 +1956,7 @@ msgstr "Laat anonieme lêerhersiening vir hierdie kletsgesprek toe?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Laat advertensies toe wat privaatheid respekteer op DuckDuckGo Private Search"
+msgstr "Laat advertensies toe wat privaatheid respekteer op DuckDuckGo Private Search"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2297,8 +2289,7 @@ msgstr "Is jy nog daar?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"Is jy seker jy wil al jou kletse skoonmaak? Dit kan nie ontdoen word nie."
+msgstr "Is jy seker jy wil al jou kletse skoonmaak? Dit kan nie ontdoen word nie."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2516,8 +2507,8 @@ msgstr ""
 "verskyn: Nooit (verwyder Assist UI heeltemal uit soekresultate), Op aanvraag "
 "(wys slegs KI-gesteunde antwoorde as jy op die Assist-knoppie klik), Soms "
 "(wys slegs KI-gesteunde antwoorde wanneer dit baie relevant is) of Dikwels "
-"(wys meer gereeld op 'n wyer verskeidenheid soektogte). Vir nou is KI-"
-"gesteunde antwoorde slegs beskikbaar in die Amerikaanse (Engels) streek."
+"(wys meer gereeld op 'n wyer verskeidenheid soektogte). Vir nou is "
+"KI-gesteunde antwoorde slegs beskikbaar in die Amerikaanse (Engels) streek."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2633,8 +2624,7 @@ msgstr ""
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"Klank word nie deur ons of deur OpenAI gestoor nadat die klets eindig nie."
+msgstr "Klank word nie deur ons of deur OpenAI gestoor nadat die klets eindig nie."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
@@ -2682,8 +2672,7 @@ msgstr "Outo-antwoord"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr ""
-"Outomaties gegenereer gebaseer op gelyste bronne. Mag onakkuraathede bevat."
+msgstr "Outomaties gegenereer gebaseer op gelyste bronne. Mag onakkuraathede bevat."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -2888,8 +2877,7 @@ msgstr "Strepieskode"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr ""
-"Gebaseer op hierdie bladsy, is hierdie kursus die moeite werd om te volg?"
+msgstr "Gebaseer op hierdie bladsy, is hierdie kursus die moeite werd om te volg?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -3591,7 +3579,7 @@ msgctxt ""
 "Secondary button that dismisses the tab picker dialog without attaching "
 "anything"
 msgid "Cancel"
-msgstr ""
+msgstr "Kanselleer"
 
 # smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
@@ -3828,8 +3816,7 @@ msgstr "Verander hoe resultaat-URL'e vertoon word"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr ""
-"Verander hoe die opskrif vertoon word en die gedrag daarvan terwyl jy rollees"
+msgstr "Verander hoe die opskrif vertoon word en die gedrag daarvan terwyl jy rollees"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3981,10 +3968,10 @@ msgid ""
 msgstr ""
 "Met Chat (via ons Duck.ai-diens) kan jy anonieme gesprekke voer met "
 "derdeparty-KI-kletsmodelle, wat modelle van OpenAI, Anthropic en meer "
-"ondersteun. As jy hierdie instelling afskakel, sal die Chat-knoppies en -"
-"skakels op DuckDuckGo Search verberg word. Jy kan egter steeds toegang tot "
-"Chat kry wanneer hierdie instelling afgeskakel is, deur %1$shttps://duck."
-"ai%2$s direk te besoek."
+"ondersteun. As jy hierdie instelling afskakel, sal die Chat-knoppies en "
+"-skakels op DuckDuckGo Search verberg word. Jy kan egter steeds toegang tot "
+"Chat kry wanneer hierdie instelling afgeskakel is, deur "
+"%1$shttps://duck.ai%2$s direk te besoek."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4039,16 +4026,14 @@ msgstr "Gesels privaat"
 #. Mobile variant of DUCKCHAT_BROWSER_UPSELL_PROMO_TEXT. Shorter version for the promotional card encouraging third-party browser users to download the DuckDuckGo browser.
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
-msgstr ""
-"Gesels privaat op enige webwerf met Duck.ai ingebou in ons gratis blaaier."
+msgstr "Gesels privaat op enige webwerf met Duck.ai ingebou in ons gratis blaaier."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
-msgstr ""
-"Gesels privaat op enige webwerf met die Duck.ai-sybalk in ons gratis blaaier."
+msgstr "Gesels privaat op enige webwerf met die Duck.ai-sybalk in ons gratis blaaier."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4090,7 +4075,7 @@ msgstr "Chat-antwoord is aanstootlik"
 #. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
 msgctxt "Chat history about modal list item headline"
 msgid "Chat storage varies by browser"
-msgstr ""
+msgstr "Kletsgesprekberging verskil volgens blaaier"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4102,7 +4087,7 @@ msgstr "Gesels met %1$s"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Chat with popular AI models, anonymized by us."
-msgstr ""
+msgstr "Gesels met gewilde KI-modelle, geanonimiseer deur ons."
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4129,6 +4114,9 @@ msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
 msgstr ""
+"Kletsgesprekke word veilig op DuckDuckGo se bediener gestoor met "
+"end-tot-einde-enkripsie. Niemand behalwe jy kan jou data sien nie, nie eens "
+"ons nie."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4137,9 +4125,9 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"Kletse word plaaslik op jou toestel gestoor in plaas van op DuckDuckGo-"
-"bedieners of afgeleë bedieners. As jy kletsgeskiedenis deaktiveer, sal "
-"vasgespelde kletse uitgevee word."
+"Kletse word plaaslik op jou toestel gestoor in plaas van op "
+"DuckDuckGo-bedieners of afgeleë bedieners. As jy kletsgeskiedenis "
+"deaktiveer, sal vasgespelde kletse uitgevee word."
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -4689,8 +4677,7 @@ msgstr "Klik %1$sJa%2$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
-msgstr ""
-"Klik %1$sinstellings/hamburgerikoon %2$s in die Chrome-taakbalk (regs bo)."
+msgstr "Klik %1$sinstellings/hamburgerikoon %2$s in die Chrome-taakbalk (regs bo)."
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -5545,8 +5532,7 @@ msgstr "Costa Rica"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr ""
-"Kon nie jou herstelkode laai nie. Maak dit asseblief toe en probeer weer."
+msgstr "Kon nie jou herstelkode laai nie. Maak dit asseblief toe en probeer weer."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5731,7 +5717,7 @@ msgstr "Huidige wenrekord"
 #. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
 msgctxt "Suffix label indicating a tab is the currently active browser tab"
 msgid "Current Tab"
-msgstr ""
+msgstr "Huidige oortjie"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
@@ -6087,7 +6073,7 @@ msgstr "Skrap kletsgesprekke ouer as 30 dae"
 #. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
 msgctxt "Button text in the modal for deleting all recent chats"
 msgid "Delete Chats and Shared Links"
-msgstr ""
+msgstr "Wis kletsgesprekke en gedeelde skakels uit"
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6179,8 +6165,7 @@ msgstr "Wil jy oudste kletsgesprekke skrap om stoorplek te maak?"
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr ""
-"Wil jy oudste kletsgesprekke met aanhangsels skrap om stoorplek te maak?"
+msgstr "Wil jy oudste kletsgesprekke met aanhangsels skrap om stoorplek te maak?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
@@ -6244,8 +6229,7 @@ msgstr "Beskryf veranderinge gebaseer op die beeld"
 #. Placeholder text displayed in the input field when the user can make follow-up edits to a generated image.
 msgctxt "Placeholder text for the image generation input field for follow-ups"
 msgid "Describe changes to continue editing this image"
-msgstr ""
-"Beskryf veranderinge om voort te gaan met die redigering van hierdie beeld"
+msgstr "Beskryf veranderinge om voort te gaan met die redigering van hierdie beeld"
 
 # smartling.placeholder_format=C
 #. Title shown when the user first enters Image Generation mode, prompting them to describe the image they want to create.
@@ -6508,7 +6492,7 @@ msgstr "Wys promosie van die hand"
 #. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the close button on the survey banner"
 msgid "Dismiss survey"
-msgstr ""
+msgstr "Wys opname af"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6538,8 +6522,7 @@ msgstr "Vertoon taal"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Displays a checkmark to the left of results you've visited"
-msgstr ""
-"Vertoon 'n regmerkie aan die linkerkant van resultate wat jy besoek het"
+msgstr "Vertoon 'n regmerkie aan die linkerkant van resultate wat jy besoek het"
 
 # smartling.placeholder_format=C
 #. This is the description of a user setting
@@ -7060,8 +7043,8 @@ msgid ""
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 "Duck.ai laat jou privaat met gewilde KI-modelle gesels. As jy dit afskakel, "
-"word Duck.ai-knoppies en -skakels verberg, maar jy kan steeds %1$sduck."
-"ai%2$s direk besoek."
+"word Duck.ai-knoppies en -skakels verberg, maar jy kan steeds "
+"%1$sduck.ai%2$s direk besoek."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7141,9 +7124,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo KI, private KI-kletsbot, gratis KI-klets, anonieme KI-"
-"klets, KI-klets geen aanmelding, OpenAI, Anthropic, Llama, Mistral, oopbron "
-"KI-modelle, privaatheidsgefokusde KI, KI-klets geen rekening"
+"Duck.ai, DuckDuckGo KI, private KI-kletsbot, gratis KI-klets, anonieme "
+"KI-klets, KI-klets geen aanmelding, OpenAI, Anthropic, Llama, Mistral, "
+"oopbron KI-modelle, privaatheidsgefokusde KI, KI-klets geen rekening"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7312,8 +7295,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chat is tydelik onbeskikbaar. Probeer asseblief weer later."
+msgstr "DuckDuckGo AI Chat is tydelik onbeskikbaar. Probeer asseblief weer later."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7463,8 +7445,8 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"DuckDuckGo anonimiseer hierdie aanmeldings deur outomaties PII, soos name, e-"
-"posadresse, telefoonnommers en identifiserende metadata, te verwyder."
+"DuckDuckGo anonimiseer hierdie aanmeldings deur outomaties PII, soos name, "
+"e-posadresse, telefoonnommers en identifiserende metadata, te verwyder."
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -7570,8 +7552,7 @@ msgctxt ""
 "Description of the DuckDuckGo subscription setting when it is not available "
 "in the user region"
 msgid "DuckDuckGo subscriptions are not available to purchase in this region."
-msgstr ""
-"DuckDuckGo-intekeninge is nie in hierdie streek beskikbaar om te koop nie."
+msgstr "DuckDuckGo-intekeninge is nie in hierdie streek beskikbaar om te koop nie."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use 'ducky' tone in its responses. When this option is selected, the AI assistant speaks like a duck.
@@ -7685,7 +7666,7 @@ msgstr "Wysig aanwysingsopdrag"
 #. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the message-editing text area"
 msgid "Edit message"
-msgstr ""
+msgstr "Redigeer boodskap"
 
 # smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
@@ -7856,8 +7837,7 @@ msgstr "Aktiveer diktasie in Duck.ai"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr ""
-"Aktiveer liggingsinstellings op jou toestel om anonieme ligging te gebruik"
+msgstr "Aktiveer liggingsinstellings op jou toestel om anonieme ligging te gebruik"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -7914,7 +7894,7 @@ msgstr "Geënkripteerde model"
 #. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
 msgctxt "Share modal info bullet about encryption"
 msgid "Encrypted so DuckDuckGo can't read your chat."
-msgstr ""
+msgstr "Geënkripteer sodat DuckDuckGo nie jou kletsgesprek kan lees nie."
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8186,8 +8166,7 @@ msgstr "Vou kaart uit"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr ""
-"Kundig vervaardigde produkte vir mense wat 'n \"duck\" omgee vir privaatheid."
+msgstr "Kundig vervaardigde produkte vir mense wat 'n \"duck\" omgee vir privaatheid."
 
 # smartling.placeholder_format=C
 #. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
@@ -8471,8 +8450,8 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
 msgstr ""
-"Terugvoer soos joune het 'n direkte invloed op ons produkbywerkings en -"
-"verbeterings."
+"Terugvoer soos joune het 'n direkte invloed op ons produkbywerkings en "
+"-verbeterings."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8481,8 +8460,8 @@ msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
 msgstr ""
-"Terugvoer soos joune het 'n direkte invloed op ons produkbywerkings en -"
-"verbeterings. Hopelik kan ons ook die probleem aanspreek wat jy gedeel het."
+"Terugvoer soos joune het 'n direkte invloed op ons produkbywerkings en "
+"-verbeterings. Hopelik kan ons ook die probleem aanspreek wat jy gedeel het."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -8625,8 +8604,7 @@ msgstr "Vind <b>%1$s</b> in jou aflaaivouer"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr ""
-"Spoor DuckDuckGo op in die lys wat vertoon word en klik%1$sMaak verstek%2$s"
+msgstr "Spoor DuckDuckGo op in die lys wat vertoon word en klik%1$sMaak verstek%2$s"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8663,8 +8641,7 @@ msgstr "Vind resultate nader aan jou."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr ""
-"Vind resultate naby jou. %1$sJou ligging bly privaat, veilig en anoniem."
+msgstr "Vind resultate naby jou. %1$sJou ligging bly privaat, veilig en anoniem."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8746,7 +8723,7 @@ msgstr "Opvolgvraag"
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
-msgstr ""
+msgstr "Opvolgboodskappe bly privaat."
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8852,8 +8829,7 @@ msgstr "Gratis en privaat geselsies, geanonimiseer deur ons"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Gratis en privaat geselsies, geanonimiseer deur ons. Geen rekening nodig nie."
+msgstr "Gratis en privaat geselsies, geanonimiseer deur ons. Geen rekening nodig nie."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8966,8 +8942,8 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Kies <strong>DuckDuckGo</strong> &gt; <strong>Kyk of daar opdaterings is ..."
-"</strong> op die app se kieslysbalk op Mac. Kies dan <strong>Installeer "
+"Kies <strong>DuckDuckGo</strong> &gt; <strong>Kyk of daar opdaterings is "
+"...</strong> op die app se kieslysbalk op Mac. Kies dan <strong>Installeer "
 "opdatering</strong>."
 
 # smartling.placeholder_format=C
@@ -9267,7 +9243,7 @@ msgstr "Kry DuckDuckGo VPN, gevorderde Duck.ai en Identity Theft Restoration."
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
 msgctxt "Tooltip on the header logo for sunglasses searches"
 msgid "Get DuckDuckGo sunglasses and other gear."
-msgstr ""
+msgstr "Kry DuckDuckGo-sonbrille en ander benodigdhede."
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9380,8 +9356,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Kry toegang tot gevorderde KI-modelle in Duck.ai met 'n DuckDuckGo-"
-"intekening, wat ook ons VPN en ander premium "
+"Kry toegang tot gevorderde KI-modelle in Duck.ai met 'n "
+"DuckDuckGo-intekening, wat ook ons VPN en ander premium "
 "privaatheidsbeskermingsmaatreëls insluit."
 
 # smartling.placeholder_format=C
@@ -9451,8 +9427,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
-msgstr ""
-"Kry gratis probleemvrye privaatheidsbeskerming op jou blaaier met een aflaai:"
+msgstr "Kry gratis probleemvrye privaatheidsbeskerming op jou blaaier met een aflaai:"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -9489,8 +9464,8 @@ msgstr "Kry die app"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"Kry die gratis DuckDuckGo-blaaier %1$som advertensies op YouTube te blokkeer."
-"%2$s"
+"Kry die gratis DuckDuckGo-blaaier %1$som advertensies op YouTube te "
+"blokkeer.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9549,9 +9524,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die DuckDuckGo-"
-"app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n ander "
-"toestel › Kopieer tekskode%4$s"
+"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die "
+"DuckDuckGo-app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n "
+"ander toestel › Kopieer tekskode%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9560,9 +9535,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die DuckDuckGo-"
-"app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n ander "
-"toestel%4$s"
+"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die "
+"DuckDuckGo-app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n "
+"ander toestel%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9572,9 +9547,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die DuckDuckGo-"
-"app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n ander "
-"toestel%4$s en skandeer hierdie kode:"
+"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die "
+"DuckDuckGo-app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n "
+"ander toestel%4$s en skandeer hierdie kode:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9584,9 +9559,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die DuckDuckGo-"
-"app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n ander "
-"toestel%4$s. Of skandeer die QR-kode op jou Herstel-PDF."
+"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die "
+"DuckDuckGo-app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n "
+"ander toestel%4$s. Of skandeer die QR-kode op jou Herstel-PDF."
 
 # smartling.placeholder_format=C
 #. Path to the pairing code on the other device. Bold segments are UI path labels.
@@ -10136,8 +10111,7 @@ msgstr "Help jou vriende en familie om by die Duck-kant aan te sluit!"
 #. Text description for the Spread card in the SERP footer
 msgctxt "footer_card"
 msgid "Help your friends and family take back their privacy!"
-msgstr ""
-"Help jou vriende en familie om weer beheer oor hul privaatheid terug te neem!"
+msgstr "Help jou vriende en familie om weer beheer oor hul privaatheid terug te neem!"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -10274,8 +10248,7 @@ msgstr "Versteek jou e-posadres"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Hides search term from being shown in browser tab/history"
-msgstr ""
-"Dit verhoed die soekterm om in jou blaaier se oortjie/geskiedenis te vertoon"
+msgstr "Dit verhoed die soekterm om in jou blaaier se oortjie/geskiedenis te vertoon"
 
 # smartling.placeholder_format=C
 #. The highest stock price in a day
@@ -10505,7 +10478,7 @@ msgstr "Hoe dit werk"
 #. Headline in chat history about modals for the temporary encrypted server storage explanation.
 msgctxt "Chat history about modal list item headline"
 msgid "How it works"
-msgstr ""
+msgstr "Hoe dit werk"
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -10529,8 +10502,7 @@ msgstr "Hoe dikwels wil jy KI-gesteunde antwoorde sien?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr ""
-"Hoeveel van jou daaglikse en weeklikse limiete jy tot dusver gebruik het."
+msgstr "Hoeveel van jou daaglikse en weeklikse limiete jy tot dusver gebruik het."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10773,8 +10745,7 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"Indien jy ons steeds wil ondersteun, %1$shelp om DuckDuckGo te versprei%2$s"
+msgstr "Indien jy ons steeds wil ondersteun, %1$shelp om DuckDuckGo te versprei%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10923,8 +10894,8 @@ msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
 msgstr ""
-"Verbeter leesbaarheid van resultaat met bygewerkte URL-formaat, -plasing en -"
-"kleur"
+"Verbeter leesbaarheid van resultaat met bygewerkte URL-formaat, -plasing en "
+"-kleur"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -11354,8 +11325,7 @@ msgstr "Dit is vinnig, gratis en gee jou selfs meer aanlyn beskerming."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Jy mag my (baie ongereeld) vra oor my ervaring met die gebruik van DuckDuckGo"
+msgstr "Jy mag my (baie ongereeld) vra oor my ervaring met die gebruik van DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11873,8 +11843,7 @@ msgstr "Laat jou anoniem soek met DuckDuckGo"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr ""
-"Laat jou wissel tussen die indiening van soeknavrae en aanwysings aan Duck.ai"
+msgstr "Laat jou wissel tussen die indiening van soeknavrae en aanwysings aan Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11956,7 +11925,7 @@ msgstr "Skakel verval oor 7 dae."
 #. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days. People can save a chat copy."
-msgstr ""
+msgstr "Skakel verval oor 7 dae. Mense kan ’n kopie van die kletsgesprek stoor."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11972,8 +11941,7 @@ msgstr "Skakels:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
-"Gee die gereedskap, materiale of voorvereistes wat ek hiervoor benodig."
+msgstr "Gee die gereedskap, materiale of voorvereistes wat ek hiervoor benodig."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12629,8 +12597,7 @@ msgstr "Mikronesië"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr ""
-"Mikrofoontoegang is geweier. Gee asseblief mikrofoontoegang en probeer weer."
+msgstr "Mikrofoontoegang is geweier. Gee asseblief mikrofoontoegang en probeer weer."
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -13418,11 +13385,11 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"Nuwe aanporrings en antwoorde word geënkripteer en tydelik op ’n DuckDuckGo-"
-"bediener gestoor nadat dit gestuur is om te help om ’n klets te herstel as "
-"jy jou internetverbinding verloor. As jy kletsgeskiedenis deaktiveer, sal "
-"vasgespelde kletse uitgevee word en die tydelike berging van nuwe "
-"aanporrings en antwoorde deaktiveer."
+"Nuwe aanporrings en antwoorde word geënkripteer en tydelik op ’n "
+"DuckDuckGo-bediener gestoor nadat dit gestuur is om te help om ’n klets te "
+"herstel as jy jou internetverbinding verloor. As jy kletsgeskiedenis "
+"deaktiveer, sal vasgespelde kletse uitgevee word en die tydelike berging van "
+"nuwe aanporrings en antwoorde deaktiveer."
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -13737,8 +13704,7 @@ msgstr "Geen resultate gevind nie."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr ""
-"Geen spraak is bespeur nie. Probeer asseblief weer en praat in jou mikrofoon."
+msgstr "Geen spraak is bespeur nie. Probeer asseblief weer en praat in jou mikrofoon."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -14083,7 +14049,7 @@ msgstr "Goed, het dit!"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "OPTIONAL"
-msgstr ""
+msgstr "Opsioneel"
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -14577,8 +14543,7 @@ msgstr "Maak die paneel oop oor hoe Duck.ai werk."
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Maak die Safari-kieslys oop en kies %1$sInstellings vir DuckDuckGo...%2$s"
+msgstr "Maak die Safari-kieslys oop en kies %1$sInstellings vir DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -15223,8 +15188,8 @@ msgid ""
 msgstr ""
 "As jy jou soektog as 'n vraag en in 'n volsin fraseer, sal DuckAssist meer "
 "geneig wees om outomaties te verskyn en dikwels beter antwoorde lewer. Om "
-"dit af te skakel en die Assist-knoppie te verberg, kan jy na %1$sDuckAssist-"
-"instellings%2$s gaan."
+"dit af te skakel en die Assist-knoppie te verberg, kan jy na "
+"%1$sDuckAssist-instellings%2$s gaan."
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -15339,8 +15304,7 @@ msgstr "Vasgespeld"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
-"Vasgespelde kletsgesprekke sal boaan jou onlangse kletsgesprekke verskyn."
+msgstr "Vasgespelde kletsgesprekke sal boaan jou onlangse kletsgesprekke verskyn."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -16180,8 +16144,7 @@ msgstr "Vra my"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"Vra my om my geskatte ligging te gebruik om resultate in die omgewing te kry."
+msgstr "Vra my om my geskatte ligging te gebruik om resultate in die omgewing te kry."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -16216,7 +16179,7 @@ msgstr "Is beskerm"
 #. Headline in sync-enabled chat history about modals explaining encrypted server storage.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Protected with end-to-end encryption"
-msgstr ""
+msgstr "Beskerm met end-tot-einde-enkripsie"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -16355,7 +16318,7 @@ msgstr "Ranglys"
 #. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
 msgctxt "star rating on a product"
 msgid "Rated %s out of %s"
-msgstr ""
+msgstr "Is gegradeer as %1$s uit %2$s"
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -16454,15 +16417,13 @@ msgstr "Redenasievermoë kan beter antwoorde op ingewikkelde vrae gee."
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
-msgstr ""
-"Redenasievermoë is deegliker, maar bereik gebruikslimiete 2-5x gouer. %1$s"
+msgstr "Redenasievermoë is deegliker, maar bereik gebruikslimiete 2-5x gouer. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr ""
-"Redenasievermoë is deegliker, maar gebruik limiete 2-5x vinniger op. %1$s"
+msgstr "Redenasievermoë is deegliker, maar gebruik limiete 2-5x vinniger op. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -17580,8 +17541,8 @@ msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
 msgstr ""
-"Stoor jou Duck.ai-kletsgesprekke op jou verskillende toestelle met end-tot-"
-"end-enkripsie."
+"Stoor jou Duck.ai-kletsgesprekke op jou verskillende toestelle met "
+"end-tot-end-enkripsie."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17593,7 +17554,7 @@ msgstr "Stoor jou kletsgesprekke op al jou toestelle."
 #. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
 msgctxt "Chat history about modal list item headline"
 msgid "Save your chats on this device"
-msgstr ""
+msgstr "Stoor jou kletsgesprekke op hierdie toestel"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
@@ -17770,8 +17731,7 @@ msgstr "Rol af en soek %1$sjou blaaier%2$s op die lys."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr ""
-"Rol af na %1$sDuckDuckGo%2$s en laat dit toe om jou ligging te gebruik."
+msgstr "Rol af na %1$sDuckDuckGo%2$s en laat dit toe om jou ligging te gebruik."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -17802,7 +17762,7 @@ msgctxt ""
 "Placeholder and accessibility label for the search input in the tab picker "
 "dialog"
 msgid "Search"
-msgstr ""
+msgstr "Soek"
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18015,8 +17975,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"Soeknavrae word by bronadres ingesluit (indien af, sal soektogte POST-"
-"versoeke gebruik)"
+"Soeknavrae word by bronadres ingesluit (indien af, sal soektogte "
+"POST-versoeke gebruik)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -18165,8 +18125,8 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"Stoor jou gesprekke veilig op ons bediener met behulp van punt-tot-punt-"
-"enkripsie, en verkry toegang daartoe vanaf al jou toestelle."
+"Stoor jou gesprekke veilig op ons bediener met behulp van "
+"punt-tot-punt-enkripsie, en verkry toegang daartoe vanaf al jou toestelle."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -18299,8 +18259,7 @@ msgstr "Kyk na 'n paar van ons nuutste opdaterings"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr ""
-"Raadpleeg die %1$sURL-parameterverwysingsblad%2$s vir meer besonderhede."
+msgstr "Raadpleeg die %1$sURL-parameterverwysingsblad%2$s vir meer besonderhede."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -18327,8 +18286,7 @@ msgstr "Kies %1$s%2$s%3$s, dan %4$sSoekenjin%5$s"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
-msgstr ""
-"Kies %1$s'Instelling vir hierdie webwerf...'%2$s op die Safari-kieslys."
+msgstr "Kies %1$s'Instelling vir hierdie webwerf...'%2$s op die Safari-kieslys."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -18483,8 +18441,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"Kies %1$sjou blaaier%2$s in die lys en %3$slaat%4$s liggingstoegang toe"
+msgstr "Kies %1$sjou blaaier%2$s in die lys en %3$slaat%4$s liggingstoegang toe"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18732,8 +18689,7 @@ msgstr ""
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr ""
-"Stel jou ligging handmatig in, of sorg dat liggingsdienste geaktiveer is."
+msgstr "Stel jou ligging handmatig in, of sorg dat liggingsdienste geaktiveer is."
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -18834,8 +18790,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"Deel 'n ligging op stadsvlak met KI-modelle om relevansie te verbeter. Duck."
-"ai verklap nooit jou presiese ligging aan ons of KI-modelle nie."
+"Deel 'n ligging op stadsvlak met KI-modelle om relevansie te verbeter. "
+"Duck.ai verklap nooit jou presiese ligging aan ons of KI-modelle nie."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -18978,7 +18934,7 @@ msgstr "Koop"
 #. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
 msgctxt "Button in the merchandise logo modal (mobile)"
 msgid "Shop Now"
-msgstr ""
+msgstr "Koop nou"
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -19086,8 +19042,7 @@ msgstr "Wys DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"Wys DuckAssist meer gereeld. (Jy kan dit ook heeltemal %1$safskakel%2$s.)"
+msgstr "Wys DuckAssist meer gereeld. (Jy kan dit ook heeltemal %1$safskakel%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -19397,8 +19352,7 @@ msgstr "Wys voorstelle onder die soekkassie soos jy tik"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr ""
-"Wys die privaatheidsvoordele van die gebruik van DuckDuckGo op die tuisblad"
+msgstr "Wys die privaatheidsvoordele van die gebruik van DuckDuckGo op die tuisblad"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19413,8 +19367,7 @@ msgstr "Wys verwelkomingsboodskap bo-aan die bladsy met soekresultate"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Wys verwelkomingsboodskap vir gebruikers wat die EU Android-kieslys verkies"
+msgstr "Wys verwelkomingsboodskap vir gebruikers wat die EU Android-kieslys verkies"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -19486,8 +19439,7 @@ msgstr "Webwerfname"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr ""
-"Webwerfsoektog is tydelik onbeskikbaar. Ons is besig om 'n oplossing te vind."
+msgstr "Webwerfsoektog is tydelik onbeskikbaar. Ons is besig om 'n oplossing te vind."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19639,15 +19591,13 @@ msgstr "Iets het skeefgeloop"
 #. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
 msgctxt "Generic toast for share view load failures"
 msgid "Something went wrong loading this shared chat."
-msgstr ""
-"Iets het verkeerd geloop met die laai van hierdie gedeelde kletsgesprek."
+msgstr "Iets het verkeerd geloop met die laai van hierdie gedeelde kletsgesprek."
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr ""
-"Iets het skeefgeloop toe na die bediener gestoor is; probeer asseblief weer."
+msgstr "Iets het skeefgeloop toe na die bediener gestoor is; probeer asseblief weer."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
@@ -19685,8 +19635,7 @@ msgstr "Soms"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr ""
-"Jammer, ek kan nie help nie. Beskryf asseblief jou beeld op ’n ander manier."
+msgstr "Jammer, ek kan nie help nie. Beskryf asseblief jou beeld op ’n ander manier."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19743,8 +19692,8 @@ msgstr ""
 msgid ""
 "Sorry, we couldn't generate a richer answer. You can try asking Duck.ai."
 msgstr ""
-"Jammer, ons kon nie 'n ryker antwoord genereer nie. Jy kan probeer om Duck."
-"ai te vra."
+"Jammer, ons kon nie 'n ryker antwoord genereer nie. Jy kan probeer om "
+"Duck.ai te vra."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and that they could try to refresh the page to resolve the error. Placeholders are for markup, please ignore.
@@ -19760,8 +19709,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Jammer, ons kon nie jou terugvoer indien nie. Probeer asseblief weer later."
+msgstr "Jammer, ons kon nie jou terugvoer indien nie. Probeer asseblief weer later."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -20630,8 +20578,7 @@ msgstr "Sync & Backup is geaktiveer!"
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr ""
-"Sync & Backup-data kan nie herwin word ná 18 maande van onaktiwiteit nie."
+msgstr "Sync & Backup-data kan nie herwin word ná 18 maande van onaktiwiteit nie."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
@@ -20640,6 +20587,8 @@ msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
 msgstr ""
+"Sync & Backup stoor meer van jou kletsgesprekke en sinchroniseer dit met al "
+"jou toestelle."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20688,8 +20637,8 @@ msgid ""
 msgstr ""
 "Sinkronisasieherstelkode\n"
 "\n"
-"Die herstelkode stel jou in staat om jou wagwoorde, outovuldata en Duck.ai-"
-"kletsgesprekke oor verskillende toestelle te sinkroniseer, en jou "
+"Die herstelkode stel jou in staat om jou wagwoorde, outovuldata en "
+"Duck.ai-kletsgesprekke oor verskillende toestelle te sinkroniseer, en jou "
 "gesinkroniseerde data terug te kry as jy toegang tot ’n toestel verloor.\n"
 "\n"
 "Hou hierdie inligting veilig en seker.\n"
@@ -20760,7 +20709,7 @@ msgstr "Sinchroniseer jou kletsgesprekke op al jou toestelle."
 #. Headline in sync-enabled chat history about modals explaining cross-device sync.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Sync your chats across all your devices"
-msgstr ""
+msgstr "Sinchroniseer jou kletsgesprekke met al jou toestelle"
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21136,8 +21085,7 @@ msgstr "Die aangehegte lêers oorskry die totale groottelimiet van %1$s MB."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
 msgid "The audio could not be processed. Please try recording again."
-msgstr ""
-"Die klank kon nie verwerk word nie. Probeer asseblief om weer op te neem."
+msgstr "Die klank kon nie verwerk word nie. Probeer asseblief om weer op te neem."
 
 # smartling.placeholder_format=C
 #. Second paragraph explaining where the encryption key is stored on the entry screen.
@@ -21162,8 +21110,7 @@ msgstr ""
 #. Description explaining that the AI model provider does not store any chat data on their servers.
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid "The model provider does not save this chat on their servers."
-msgstr ""
-"Die modelverskaffer stoor nie hierdie kletsgesprek op die bedieners nie."
+msgstr "Die modelverskaffer stoor nie hierdie kletsgesprek op die bedieners nie."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -21254,8 +21201,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
 msgid "There's been an issue loading this answer. Please try again."
-msgstr ""
-"Daar was 'n probleem met die laai van hierdie antwoord. Probeer gerus weer."
+msgstr "Daar was 'n probleem met die laai van hierdie antwoord. Probeer gerus weer."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -21327,8 +21273,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Hierdie kitsantwoord is deur die %1$sDuckDuckHack%2$s-gemeenskap geskep."
+msgstr "Hierdie kitsantwoord is deur die %1$sDuckDuckHack%2$s-gemeenskap geskep."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -21357,12 +21302,14 @@ msgid ""
 "This chat and its generated images become public when you create and copy "
 "the link."
 msgstr ""
+"Hierdie kletsgesprek en die beelde wat daaruit gegenereer is, word openbaar "
+"wanneer jy die skakel skep en kopieer."
 
 # smartling.placeholder_format=C
 #. Explains that creating and copying a share link makes the selected chat content public.
 msgctxt "Share modal info bullet about public access"
 msgid "This chat becomes public when you create and copy the link."
-msgstr ""
+msgstr "Hierdie kletsgesprek word openbaar wanneer jy die skakel skep en kopieer."
 
 # smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
@@ -21464,8 +21411,7 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s"
-msgstr ""
-"Hierdie lêertipe word nie gesteun nie, heg asseblief 'n %1$s of %2$s aan"
+msgstr "Hierdie lêertipe word nie gesteun nie, heg asseblief 'n %1$s of %2$s aan"
 
 # smartling.placeholder_format=C
 #. Error message for unsupported file type when multiple types are accepted. First placeholder is a comma-separated list of all accepted types except the last (e.g. PNG, JPG, WebP, GIF). Second placeholder is the last accepted type (e.g. PDF). Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF
@@ -21473,8 +21419,7 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s."
-msgstr ""
-"Hierdie lêertipe word nie gesteun nie; heg asseblief 'n %1$s of %2$s aan."
+msgstr "Hierdie lêertipe word nie gesteun nie; heg asseblief 'n %1$s of %2$s aan."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to upload an unsupported file type and we know which types are accepted. Placeholder is a single accepted type. E.g. This file type is not supported, please attach a PDF
@@ -21595,8 +21540,7 @@ msgstr "Hierdie bladsy vereis Javascript om te funksioneer."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Hierdie bladsy se inhoud sal saam met jou boodskap na Duck.ai gestuur word."
+msgstr "Hierdie bladsy se inhoud sal saam met jou boodskap na Duck.ai gestuur word."
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21627,8 +21571,9 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"Hierdie instelling word in jou blaaier gestoor, wat beteken as jy duckduckgo."
-"com-blaaierdata skoonmaak, kan jy dalk weer KI-gesteunde antwoorde sien."
+"Hierdie instelling word in jou blaaier gestoor, wat beteken as jy "
+"duckduckgo.com-blaaierdata skoonmaak, kan jy dalk weer KI-gesteunde "
+"antwoorde sien."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21638,10 +21583,10 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"Hierdie instelling word in jou blaaier gestoor, wat beteken as jy duckduckgo."
-"com-blaaierdata skoonmaak, kan jy dalk weer KI-gesteunde antwoorde sien. Ons "
-"het egter ook 'n beginbladsy wat nooit KI-gesteunde antwoorde by %1$s wys "
-"nie."
+"Hierdie instelling word in jou blaaier gestoor, wat beteken as jy "
+"duckduckgo.com-blaaierdata skoonmaak, kan jy dalk weer KI-gesteunde "
+"antwoorde sien. Ons het egter ook 'n beginbladsy wat nooit KI-gesteunde "
+"antwoorde by %1$s wys nie."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
@@ -21726,8 +21671,7 @@ msgstr "Dit sal alle instellings wis. Gaan voort?"
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
 msgctxt "settings"
 msgid "This will reset your saved settings to default values. Continue?"
-msgstr ""
-"Dit sal jou bewaarde instellings na die verstekwaardes terugstel. Gaan voort?"
+msgstr "Dit sal jou bewaarde instellings na die verstekwaardes terugstel. Gaan voort?"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard column: holes completed in current round
@@ -21840,8 +21784,7 @@ msgstr "Om voort te gaan, moet jy instem tot Duck.ai se %1$s en %2$s"
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr ""
-"Om voort te gaan, moet jy instem tot DuckDuckGo AI Chat se %1$s en %2$s"
+msgstr "Om voort te gaan, moet jy instem tot DuckDuckGo AI Chat se %1$s en %2$s"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -21873,8 +21816,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"Om jou kletsgeskiedenis na Duck.ai oor te dra, werk asseblief jou DuckDuckGo-"
-"blaaier by tot die nuutste weergawe en probeer weer."
+"Om jou kletsgeskiedenis na Duck.ai oor te dra, werk asseblief jou "
+"DuckDuckGo-blaaier by tot die nuutste weergawe en probeer weer."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -21905,7 +21848,7 @@ msgstr "Vandag"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
-msgstr ""
+msgstr "Wissel na privaat KI-klets of %1$sdeaktiveer in instellings%2$s."
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -22409,8 +22352,7 @@ msgstr "Probeer om anonieme ligging te aktiveer vir meer akkurate resultate."
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Probeer eksperimenteer met elke model – hulle sal verskillende antwoorde gee."
+msgstr "Probeer eksperimenteer met elke model – hulle sal verskillende antwoorde gee."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -22772,8 +22714,7 @@ msgstr "Skakel %1$s\"Presiese Ligging\"%2$s aan vir meer akkurate resultate"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr ""
-"Skakel Duck Player aan om YouTube te kyk sonder geteikende advertensies"
+msgstr "Skakel Duck Player aan om YouTube te kyk sonder geteikende advertensies"
 
 # smartling.placeholder_format=C
 #. Button that enables the Search/Duck.ai toggle.
@@ -22984,14 +22925,13 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Onder %1$sAan die begin%2$s, kies %3$sTuisblad%4$s en voer in https://"
-"duckduckgo.com"
+"Onder %1$sAan die begin%2$s, kies %3$sTuisblad%4$s en voer in "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"Onder %1$sMaak oop met%2$s, kies %3$s’n spesifieke bladsy of bladsye%4$s"
+msgstr "Onder %1$sMaak oop met%2$s, kies %3$s’n spesifieke bladsy of bladsye%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -23018,8 +22958,7 @@ msgstr "Onder %1$sSoek%2$s-afdeling, klik %3$sBestuur soekenjins …%4$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr ""
-"Onder Aan die begin, kies %1$sMaak ’n spesifieke blad of stel blaaie oop%2$s"
+msgstr "Onder Aan die begin, kies %1$sMaak ’n spesifieke blad of stel blaaie oop%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -23125,8 +23064,7 @@ msgstr "Ontsluit met 'n DuckDuckGo-intekening"
 msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
-msgstr ""
-"Ontsluit gevorderde KI-modelle en hoër limiete met 'n DuckDuckGo-intekening"
+msgstr "Ontsluit gevorderde KI-modelle en hoër limiete met 'n DuckDuckGo-intekening"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -23195,8 +23133,7 @@ msgstr "Onbevestigde inligting"
 #. Text explaining the limit on the number of recent chats that can be stored. Example: 'Up to 30 of your most recent chats can be saved at a time.'
 msgctxt "Information about the limit of recent chats that can be saved"
 msgid "Up to %s of your most recent chats can be saved at a time."
-msgstr ""
-"Tot en met %1$s van jou mees onlangse kletse kan op 'n slag gestoor word."
+msgstr "Tot en met %1$s van jou mees onlangse kletse kan op 'n slag gestoor word."
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -23541,8 +23478,7 @@ msgstr "Gebruik jy openbare Wi-Fi? Gebruik ons VPN."
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr ""
-"Gebruik die Fire Button om ’n kletsgesprek te skrap van die geskiedenislys."
+msgstr "Gebruik die Fire Button om ’n kletsgesprek te skrap van die geskiedenislys."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -23703,8 +23639,7 @@ msgstr "Bekyk pryse vir jou verblyf"
 # smartling.placeholder_format=C
 #. A description for the ads tooltip that explains that viewing ads is privacy protected by DuckDuckGo.
 msgid "Viewing ads is privacy protected by DuckDuckGo."
-msgstr ""
-"Jou privaatheid word deur DuckDuckGo beskerm as jy na advertensies kyk."
+msgstr "Jou privaatheid word deur DuckDuckGo beskerm as jy na advertensies kyk."
 
 # smartling.placeholder_format=C
 msgctxt "Ads GDPR, internal use only. Do not change"
@@ -23732,6 +23667,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Yelp's ad network."
 msgstr ""
+"Jou privaatheid word deur DuckDuckGo beskerm as jy na advertensies kyk. "
+"Advertensieklikke word deur Yelp se advertensienetwerk bestuur."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -23762,8 +23699,7 @@ msgctxt "mobile promotion on desktop"
 msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
-msgstr ""
-"Besoek %1$sDuckDuckGo.com%2$s op jou tablet of foon en volg die aanwysings."
+msgstr "Besoek %1$sDuckDuckGo.com%2$s op jou tablet of foon en volg die aanwysings."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -23814,9 +23750,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"Besoek Duck.ai in jou ander blaaier of die DuckDuckGo-app en maak Duck.ai-"
-"instellings oop. Kies “Skakel aan” onder Sync & Backup en kies “Sinkroniseer "
-"met ’n ander toestel”. Of skandeer die QR op jou Herstel-PDF."
+"Besoek Duck.ai in jou ander blaaier of die DuckDuckGo-app en maak "
+"Duck.ai-instellings oop. Kies “Skakel aan” onder Sync & Backup en kies "
+"“Sinkroniseer met ’n ander toestel”. Of skandeer die QR op jou Herstel-PDF."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -24115,8 +24051,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr ""
-"Ons bewaar nie jou persoonlike inligting, of spoor jou na nie. Nooit nie."
+msgstr "Ons bewaar nie jou persoonlike inligting, of spoor jou na nie. Nooit nie."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24365,8 +24300,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr ""
-"Ons is jammer vir die ongerief. Ons werk hard om jou ervaring te verbeter."
+msgstr "Ons is jammer vir die ongerief. Ons werk hard om jou ervaring te verbeter."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -24622,8 +24556,7 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr ""
-"Wat is 'n paar faktore om te oorweeg vir die aankoop van 'n rekenaarmonitor?"
+msgstr "Wat is 'n paar faktore om te oorweeg vir die aankoop van 'n rekenaarmonitor?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
@@ -24667,10 +24600,11 @@ msgid ""
 "experience."
 msgstr ""
 "Wat is die voordele daarvan om die DuckDuckGo-blaaier af te laai vir iemand "
-"wat belangstel om Duck.ai te gebruik? Verwys slegs na amptelike DuckDuckGo-"
-"bronne. Verdeel die antwoord in duidelike afdelings met titels, met ’n fokus "
-"op Duck.ai-integrasies en privaatheidsbeskerming. Hou dit kort, eenvoudig en "
-"maklik om te verstaan vir mense met of sonder veel KI- of tegniese ervaring."
+"wat belangstel om Duck.ai te gebruik? Verwys slegs na amptelike "
+"DuckDuckGo-bronne. Verdeel die antwoord in duidelike afdelings met titels, "
+"met ’n fokus op Duck.ai-integrasies en privaatheidsbeskerming. Hou dit kort, "
+"eenvoudig en maklik om te verstaan vir mense met of sonder veel KI- of "
+"tegniese ervaring."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24755,8 +24689,7 @@ msgstr "Wat is die beste geregte wat jy hier kan probeer?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
-"Wat is die openingstye, ligging en kontakbesonderhede van hierdie plek?"
+msgstr "Wat is die openingstye, ligging en kontakbesonderhede van hierdie plek?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -24907,8 +24840,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Wat is die Cloud Save-boekmerkie en hoe verskil dit van die URL parameter-"
-"boekmerkie?"
+"Wat is die Cloud Save-boekmerkie en hoe verskil dit van die URL "
+"parameter-boekmerkie?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -25017,8 +24950,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"Wanneer dit geaktiveer is, sal Duck.ai kitsantwoorde in die kletsgesprek wys."
+msgstr "Wanneer dit geaktiveer is, sal Duck.ai kitsantwoorde in die kletsgesprek wys."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -25224,6 +25156,8 @@ msgid ""
 "With chat history on, up to %s of your most recent chats will be saved on "
 "this device."
 msgstr ""
+"Met kletsgeskiedenis aan, sal tot en met %1$s van jou mees onlangse "
+"kletsgesprekke op hierdie toestel gestoor word."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline in the About Chat History modal.
@@ -25231,6 +25165,8 @@ msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, your most recent chats will be saved on this device."
 msgstr ""
+"Met kletsgeskiedenis aan, sal jou mees onlangse kletsgesprekke op hierdie "
+"toestel gestoor word."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -25494,8 +25430,7 @@ msgstr "Ja, nuwe gebruiker!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr ""
-"Ja, ons gooi data weg as jy daarmee klaar is en dit kan nie herwin word nie."
+msgstr "Ja, ons gooi data weg as jy daarmee klaar is en dit kan nie herwin word nie."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -25555,8 +25490,7 @@ msgstr ""
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
-msgstr ""
-"Jy kan ook %1$sDuck.ai%2$s gebruik om vrae te beantwoord of teks op te som."
+msgstr "Jy kan ook %1$sDuck.ai%2$s gebruik om vrae te beantwoord of teks op te som."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -25632,8 +25566,7 @@ msgstr "Jy kan aanhou gesels deur jou maandelikse limiet te gebruik."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Jy kan nou tot 100 kletsgesprekke op hierdie toestel stoor. Gesels gerus!"
+msgstr "Jy kan nou tot 100 kletsgesprekke op hierdie toestel stoor. Gesels gerus!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -25734,8 +25667,7 @@ msgstr "Jy kan oor begin op hierdie nuwe domein (duck.ai)."
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can store several sets of settings for different purposes."
-msgstr ""
-"Jy kan verskillende stelle instellings stoor vir verskillende doeleindes."
+msgstr "Jy kan verskillende stelle instellings stoor vir verskillende doeleindes."
 
 # smartling.placeholder_format=C
 #. Instructions for user once they've failed the bot challenge
@@ -25817,8 +25749,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr ""
-"Jy sal hierdie boodskap nie weer sien nie tensy jy jou blaaierdata skoonmaak."
+msgstr "Jy sal hierdie boodskap nie weer sien nie tensy jy jou blaaierdata skoonmaak."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -25922,8 +25853,7 @@ msgstr "Jy het die maksimum stemkletsduur vir een sessie bereik."
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"Jy het die stemkletslimiet vir vandag bereik. Probeer asseblief weer môre."
+msgstr "Jy het die stemkletslimiet vir vandag bereik. Probeer asseblief weer môre."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -25996,8 +25926,7 @@ msgstr ""
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr ""
-"Jou Duck.ai-kletsgesprekke word met end-tot-end-enkripsie gesinchroniseer."
+msgstr "Jou Duck.ai-kletsgesprekke word met end-tot-end-enkripsie gesinchroniseer."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -26119,8 +26048,7 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr ""
-"Jou geselsies is privaat en word nooit gebruik om KI-modelle op te lei nie"
+msgstr "Jou geselsies is privaat en word nooit gebruik om KI-modelle op te lei nie"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -26128,8 +26056,8 @@ msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Jou geselsies is privaat, word deur ons geanonimiseer en nie gebruik om KI-"
-"modelle op te lei nie."
+"Jou geselsies is privaat, word deur ons geanonimiseer en nie gebruik om "
+"KI-modelle op te lei nie."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
@@ -26137,8 +26065,8 @@ msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Jou geselsies is privaat, word deur ons geanonimiseer en nie gebruik om KI-"
-"modelle op te lei nie."
+"Jou geselsies is privaat, word deur ons geanonimiseer en nie gebruik om "
+"KI-modelle op te lei nie."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -26230,8 +26158,7 @@ msgctxt ""
 "Subtitle of the one-time popover shown above the thumbs up/down buttons on "
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
-msgstr ""
-"Jou terugvoer word geanonimiseer en word nie gebruik om KI op te lei nie."
+msgstr "Jou terugvoer word geanonimiseer en word nie gebruik om KI op te lei nie."
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -26260,8 +26187,8 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"Jou kenfrase skep 'n 512-bissleutel deur middel van die Secure Hash-"
-"algoritme, ook bekend as %1$sSHA-2%2$s. Slegs die sleutel en gekoppelde "
+"Jou kenfrase skep 'n 512-bissleutel deur middel van die Secure "
+"Hash-algoritme, ook bekend as %1$sSHA-2%2$s. Slegs die sleutel en gekoppelde "
 "instellingslêer verlaat jou blaaier. Ons stoor die instellingslêer deur die "
 "sleutel as naam te gebruik. DuckDuckGo ken nooit jou kenfrase nie."
 
@@ -26498,8 +26425,7 @@ msgstr "deur %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"deur DuckDuckGo – aanlyn beskerming wat elke dag deur miljoene vertrou word."
+msgstr "deur DuckDuckGo – aanlyn beskerming wat elke dag deur miljoene vertrou word."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"
@@ -26644,7 +26570,7 @@ msgstr "m"
 #. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the chat options menu button"
 msgid "menu"
-msgstr ""
+msgstr "kieslys"
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/af_ZA/LC_MESSAGES/duckduckgo.po
+++ b/locales/af_ZA/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: af_ZA\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1215,6 +1215,12 @@ msgid "About our ads"
 msgstr "Meer oor ons advertensies"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1344,6 +1350,20 @@ msgid "Ad is suspicious"
 msgstr "Advertensie is verdag"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Voeg DuckDuckGo by"
@@ -1369,6 +1389,27 @@ msgstr "Voeg DuckDuckGo by as ’n soekenjin"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Voeg DuckDuckGo by %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1414,6 +1455,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Voeg bladsy-inhoud by"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1499,6 +1556,12 @@ msgstr "Byvoegings"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Besig om afrondings by te voeg"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1802,6 +1865,12 @@ msgstr "Alle kleure"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Klaar!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3517,6 +3586,14 @@ msgid "Cancel"
 msgstr "Kanselleer"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4010,10 +4087,22 @@ msgid "Chat response is offensive"
 msgstr "Chat-antwoord is aanstootlik"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Gesels met %1$s"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4032,6 +4121,14 @@ msgstr "Kletsgesprekke"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Kletse"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5631,6 +5728,12 @@ msgid "Current Streak"
 msgstr "Huidige wenrekord"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5979,6 +6082,12 @@ msgstr "Vee kletse uit"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Skrap kletsgesprekke ouer as 30 dae"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6394,6 +6503,12 @@ msgstr "Wys vir ewig af"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Wys promosie van die hand"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7567,6 +7682,12 @@ msgid "Edit Prompt"
 msgstr "Wysig aanwysingsopdrag"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7788,6 +7909,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Geënkripteerde model"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8616,6 +8743,12 @@ msgid "Follow-up question"
 msgstr "Opvolgvraag"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9129,6 +9262,12 @@ msgstr ""
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr "Kry DuckDuckGo VPN, gevorderde Duck.ai en Identity Theft Restoration."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10361,6 +10500,12 @@ msgstr "Hoe is dit anoniem?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Hoe dit werk"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11806,6 +11951,12 @@ msgstr "Lynskrums gewen"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "Skakel verval oor 7 dae."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13927,6 +14078,12 @@ msgstr "Goed"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "Goed, het dit!"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16056,6 +16213,12 @@ msgid "Protected"
 msgstr "Is beskerm"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Beskerming. Privaatheid. Gemoedsrus."
@@ -16187,6 +16350,12 @@ msgstr "Reën"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Ranglys"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17421,6 +17590,12 @@ msgid "Save your chats across all your devices."
 msgstr "Stoor jou kletsgesprekke op al jou toestelle."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17620,6 +17795,14 @@ msgstr "Soek"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Soek"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18790,6 +18973,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Koop"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20445,6 +20634,14 @@ msgstr ""
 "Sync & Backup-data kan nie herwin word ná 18 maande van onaktiwiteit nie."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20558,6 +20755,12 @@ msgstr "Sinkroniseer met ’n nabygeleë toestel."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Sinchroniseer jou kletsgesprekke op al jou toestelle."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21146,6 +21349,22 @@ msgid "This Week"
 msgstr "Vandeesweek"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21681,6 +21900,12 @@ msgstr "Vandag"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Vandag"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23501,6 +23726,14 @@ msgstr ""
 "Advertensieklikke word deur TripAdvisor se advertensienetwerk bestuur."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Maagde-eilande"
 
@@ -24985,6 +25218,21 @@ msgstr ""
 "te lei nie. Skakel dit enige tyd aan of af in die ‘%1$s’-kieslys."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26391,6 +26639,12 @@ msgstr "m"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "m"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/af_ZA/LC_MESSAGES/duckduckgo.po
+++ b/locales/af_ZA/LC_MESSAGES/duckduckgo.po
@@ -5153,7 +5153,7 @@ msgstr "Kompetisie"
 #. Positive feedback category a user can select on the Search Assist feedback form, meaning the answer was complete.
 msgctxt "feedback form"
 msgid "Complete"
-msgstr "Voltooi"
+msgstr "Volledig"
 
 # smartling.placeholder_format=C
 #. An option that completely disables the Assist feature.
@@ -18978,7 +18978,7 @@ msgstr "Kortste"
 #. Soccer match stats
 msgctxt "Sports module"
 msgid "Shots"
-msgstr "Doelskoppe"
+msgstr "Doelskoppogings"
 
 # smartling.placeholder_format=C
 #. Soccer match stats

--- a/locales/ar_DZ/LC_MESSAGES/duckduckgo.po
+++ b/locales/ar_DZ/LC_MESSAGES/duckduckgo.po
@@ -979,6 +979,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1082,6 +1087,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr ""
@@ -1100,6 +1117,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1139,6 +1174,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1210,6 +1259,11 @@ msgstr "Translate 'Add-ons' into Arabic in Algeria"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1454,6 +1508,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2801,6 +2860,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3201,9 +3267,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3219,6 +3295,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4476,6 +4559,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4760,6 +4848,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5098,6 +5191,11 @@ msgstr "تجاهل إلى الأبد"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6000,6 +6098,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6177,6 +6280,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6842,6 +6950,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7260,6 +7373,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8242,6 +8360,11 @@ msgid "How is it anonymous?"
 msgstr "كيف يحترم الخصوصية؟"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9401,6 +9524,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11138,6 +11266,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12842,6 +12975,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12948,6 +13086,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13936,6 +14079,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14091,6 +14239,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15010,6 +15165,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16351,6 +16511,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16431,6 +16598,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16891,6 +17063,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17293,6 +17479,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18755,6 +18946,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19906,6 +20104,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20988,6 +21199,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/ar_EG/LC_MESSAGES/duckduckgo.po
+++ b/locales/ar_EG/LC_MESSAGES/duckduckgo.po
@@ -981,6 +981,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1084,6 +1089,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "أضف DuckDuckGo"
@@ -1102,6 +1119,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1141,6 +1176,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1212,6 +1261,11 @@ msgstr "إضافات"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1456,6 +1510,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2805,6 +2864,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3205,9 +3271,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3223,6 +3299,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4483,6 +4566,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4767,6 +4855,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5105,6 +5198,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6019,6 +6117,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6196,6 +6299,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6863,6 +6971,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7281,6 +7394,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8263,6 +8381,11 @@ msgid "How is it anonymous?"
 msgstr "كيف يكون البحث مغفل الهوية (هوية الباحث)؟"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9423,6 +9546,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11160,6 +11288,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12862,6 +12995,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12968,6 +13106,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13956,6 +14099,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14111,6 +14259,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15032,6 +15187,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16371,6 +16531,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16451,6 +16618,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16911,6 +17083,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17313,6 +17499,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18775,6 +18966,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19924,6 +20122,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21010,6 +21221,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/ar_JO/LC_MESSAGES/duckduckgo.po
+++ b/locales/ar_JO/LC_MESSAGES/duckduckgo.po
@@ -981,6 +981,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1084,6 +1089,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "اضافه DuckDuckGo"
@@ -1102,6 +1119,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1141,6 +1176,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1212,6 +1261,11 @@ msgstr "الاضافات"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1456,6 +1510,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2803,6 +2862,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3203,9 +3269,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3221,6 +3297,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4480,6 +4563,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4764,6 +4852,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5102,6 +5195,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6016,6 +6114,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6193,6 +6296,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6858,6 +6966,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7276,6 +7389,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8258,6 +8376,11 @@ msgid "How is it anonymous?"
 msgstr "كيف يكون مخفيا؟"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9413,6 +9536,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11150,6 +11278,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12850,6 +12983,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12956,6 +13094,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13944,6 +14087,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14099,6 +14247,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15016,6 +15171,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16355,6 +16515,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16435,6 +16602,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16895,6 +17067,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17297,6 +17483,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18759,6 +18950,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19908,6 +20106,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20991,6 +21202,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/ar_SA/LC_MESSAGES/duckduckgo.po
+++ b/locales/ar_SA/LC_MESSAGES/duckduckgo.po
@@ -981,6 +981,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1084,6 +1089,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "أضف DuckDuckGo"
@@ -1105,6 +1122,24 @@ msgstr "أضف DuckDuckGo كمحرك بحث "
 #, fuzzy
 msgid "Add DuckDuckGo to %s"
 msgstr "اضف دوك دوك جو الى %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1143,6 +1178,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1214,6 +1263,11 @@ msgstr "إضافات"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1458,6 +1512,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2805,6 +2864,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3205,9 +3271,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3223,6 +3299,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4485,6 +4568,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4769,6 +4857,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5107,6 +5200,11 @@ msgstr "تجاهل الى الابد"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6007,6 +6105,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6184,6 +6287,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6853,6 +6961,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7271,6 +7384,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8253,6 +8371,11 @@ msgid "How is it anonymous?"
 msgstr "كيف تحافظ الخدمة على خصوصيتي؟"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9412,6 +9535,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11151,6 +11279,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12856,6 +12989,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12962,6 +13100,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13950,6 +14093,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14107,6 +14255,13 @@ msgstr "بحث"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15028,6 +15183,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16369,6 +16529,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16449,6 +16616,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16909,6 +17081,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17311,6 +17497,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18777,6 +18968,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19930,6 +20128,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21016,6 +21227,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/ast_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/ast_ES/LC_MESSAGES/duckduckgo.po
@@ -973,6 +973,11 @@ msgstr "Tocante a nós"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1076,6 +1081,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "L'anunciu ye sospechosu"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr ""
@@ -1097,6 +1114,24 @@ msgstr ""
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Añadi DuckDuckGo a %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1135,6 +1170,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1206,6 +1255,11 @@ msgstr "Complementos"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1450,6 +1504,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2800,6 +2859,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3200,9 +3266,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3218,6 +3294,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4475,6 +4558,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4759,6 +4847,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5097,6 +5190,11 @@ msgstr "Escartar pa siempres"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -5993,6 +6091,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6170,6 +6273,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6835,6 +6943,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7253,6 +7366,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8235,6 +8353,11 @@ msgid "How is it anonymous?"
 msgstr ""
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9390,6 +9513,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11127,6 +11255,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12831,6 +12964,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12937,6 +13075,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13925,6 +14068,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14080,6 +14228,13 @@ msgstr "Guetar"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -14996,6 +15151,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16335,6 +16495,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16415,6 +16582,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16875,6 +17047,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17277,6 +17463,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18739,6 +18930,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19888,6 +20086,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20974,6 +21185,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/az_AZ/LC_MESSAGES/duckduckgo.po
+++ b/locales/az_AZ/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr "Bizim Haqqımızda"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "Reklam şübhəlidir"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "DuckDuckGo-nu Əlavə et"
@@ -1100,6 +1117,24 @@ msgstr "Axtarış motoru olaraq DuckDuckGo əlavə edin"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "%s üçün DuckDuckGo-nu əlavə edin"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr "Əlavələr"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1455,6 +1509,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2803,6 +2862,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3203,9 +3269,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3221,6 +3297,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4483,6 +4566,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4767,6 +4855,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5105,6 +5198,11 @@ msgstr "Həmişəlik burax"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6001,6 +6099,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6178,6 +6281,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6845,6 +6953,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7263,6 +7376,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8245,6 +8363,11 @@ msgid "How is it anonymous?"
 msgstr "Məxfilik necə təmin edilir?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9404,6 +9527,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11141,6 +11269,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12847,6 +12980,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12953,6 +13091,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13941,6 +14084,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14096,6 +14244,13 @@ msgstr "Axtarış"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15014,6 +15169,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16353,6 +16513,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16433,6 +16600,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16893,6 +17065,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17295,6 +17481,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18759,6 +18950,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19911,6 +20109,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21001,6 +21212,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/be_BY/LC_MESSAGES/duckduckgo.po
+++ b/locales/be_BY/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: be_BY\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1218,6 +1218,12 @@ msgid "About our ads"
 msgstr "Пра нашу рэкламу"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1347,6 +1353,20 @@ msgid "Ad is suspicious"
 msgstr "Аб'ява падазроная"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Дадаць DuckDuckGo"
@@ -1373,6 +1393,27 @@ msgstr "Дадаць DuckDuckGo у якасці пошукавай сістэм�
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Дадайце DuckDuckGo у %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1418,6 +1459,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Дадаць змесціва старонкі"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1503,6 +1560,12 @@ msgstr "Дадаткі"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Дадаванне фінальных штрыхоў"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1806,6 +1869,12 @@ msgstr "Усе колеры"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Усё гатова!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3522,6 +3591,14 @@ msgid "Cancel"
 msgstr "Скасаваць"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4015,10 +4092,22 @@ msgid "Chat response is offensive"
 msgstr "Адказ у чаце абразлівы"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Чат з %1$s"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4037,6 +4126,14 @@ msgstr "Чаты"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Чаты"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5639,6 +5736,12 @@ msgid "Current Streak"
 msgstr "Бягучая серыя"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5987,6 +6090,12 @@ msgstr "Выдаліць чаты"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Выдаліць чаты, старэйшыя за 30 дзён"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6401,6 +6510,12 @@ msgstr "Адхіліць назаўжды"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Адхіліць рэкламу"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7578,6 +7693,12 @@ msgid "Edit Prompt"
 msgstr "Рэдагаваць запыт"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7801,6 +7922,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Зашыфраваная мадэль"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8641,6 +8768,12 @@ msgid "Follow-up question"
 msgstr "Удакладняльнае пытанне"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9156,6 +9289,12 @@ msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
 "Атрымайце DuckDuckGo VPN, пашыраную версію Duck.ai і Identity Theft "
 "Restoration."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10389,6 +10528,12 @@ msgstr "Наколькі гэта ананімна?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Як гэта працуе"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11843,6 +11988,12 @@ msgstr "Выйграныя калідоры"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "Тэрмін дзеяння спасылкі заканчваецца праз 7 дзён."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13962,6 +14113,12 @@ msgstr "ОК"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "ОК, зразумела!"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16094,6 +16251,12 @@ msgid "Protected"
 msgstr "Абаронена"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Абарона. Прыватнасць. Спакой."
@@ -16225,6 +16388,12 @@ msgstr "Дождж"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Рэйтынгі"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17464,6 +17633,12 @@ msgid "Save your chats across all your devices."
 msgstr "Захоўвайце свае размовы на ўсіх прыладах."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17666,6 +17841,14 @@ msgstr "Шукаць"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Шукаць"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18852,6 +19035,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Купіць"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20506,6 +20695,14 @@ msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr "Даныя Sync & Backup нельга аднавіць пасля 18 месяцаў бяздзейнасці."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20620,6 +20817,12 @@ msgstr "Сінхранізаваць з прыладай паблізу."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Сінхранізуйце свае размовы на ўсіх прыладах."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21203,6 +21406,22 @@ msgid "This Week"
 msgstr "Гэты тыдзень"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21738,6 +21957,12 @@ msgstr "Сёння"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Сёння"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23578,6 +23803,14 @@ msgstr ""
 "апрацоўваюцца рэкламнай сеткай TripAdvisor."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Віргінскія астравы"
 
@@ -25060,6 +25293,21 @@ msgstr ""
 "штучнага інтэлекту. Уключы або адключы гэта ў любы час у меню '%1$s'."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26462,6 +26710,12 @@ msgstr "хв"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "хв"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/be_BY/LC_MESSAGES/duckduckgo.po
+++ b/locales/be_BY/LC_MESSAGES/duckduckgo.po
@@ -2,16 +2,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: be_BY\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -308,8 +307,7 @@ msgstr "Рэйтынгі %1$s яшчэ недаступныя"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits 2-5x faster than other models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
-msgstr ""
-"%1$s дасягае лімітаў выкарыстання ў 2-5 разоў хутчэй за базавыя мадэлі. %2$s"
+msgstr "%1$s дасягае лімітаў выкарыстання ў 2-5 разоў хутчэй за базавыя мадэлі. %2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -494,8 +492,8 @@ msgstr "%1$sДаведацца больш%2$s."
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
-"%1$sДаведайцеся, як мы захоўваем прыватнасць даных вашага месцазнаходжання."
-"%2$s"
+"%1$sДаведайцеся, як мы захоўваем прыватнасць даных вашага "
+"месцазнаходжання.%2$s"
 
 # smartling.placeholder_format=C
 #. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
@@ -525,8 +523,7 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr ""
-"%1$sДоўгае націсканне%2$s значка праграмы DuckDuckGo на галоўным экране"
+msgstr "%1$sДоўгае націсканне%2$s значка праграмы DuckDuckGo на галоўным экране"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -1074,10 +1071,10 @@ msgid ""
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
 "У цяперашні час ў адказах з дапамогай штучнага інтэлекту не падтрымліваюцца "
-"непасрэдна дадатковыя пытанні. Аднак мы таксама прапануем сэрвіс %1$sDuck."
-"ai%2$s для дадатковых пытанняў і часта спасылаемся на яго. Гэта наш прыватны "
-"чат на базе штучнага інтэлекту, які падтрымлівае мадэлі чата ад OpenAI, "
-"Anthropic і іншых."
+"непасрэдна дадатковыя пытанні. Аднак мы таксама прапануем сэрвіс "
+"%1$sDuck.ai%2$s для дадатковых пытанняў і часта спасылаемся на яго. Гэта наш "
+"прыватны чат на базе штучнага інтэлекту, які падтрымлівае мадэлі чата ад "
+"OpenAI, Anthropic і іншых."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1221,7 +1218,7 @@ msgstr "Пра нашу рэкламу"
 #. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
 msgctxt "Modal header for chat history with sync information"
 msgid "About Chat History with Sync & Backup"
-msgstr ""
+msgstr "Пра гісторыю чатаў з Sync & Backup "
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
@@ -1356,7 +1353,7 @@ msgstr "Аб'ява падазроная"
 #. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
 msgctxt "Button to open menu for attaching images or page context to AI chat"
 msgid "Add"
-msgstr ""
+msgstr "Дадаць"
 
 # smartling.placeholder_format=C
 #. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
@@ -1364,7 +1361,7 @@ msgctxt ""
 "Primary button that attaches the tabs the user checked in the tab picker "
 "dialog"
 msgid "Add"
-msgstr ""
+msgstr "Дадаць"
 
 # smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
@@ -1399,13 +1396,13 @@ msgstr "Дадайце DuckDuckGo у %1$s"
 msgctxt ""
 "Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
 msgid "Add File"
-msgstr ""
+msgstr "Дадаць файл"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
 msgid "Add Image"
-msgstr ""
+msgstr "Дадаць відарыс"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
@@ -1413,7 +1410,7 @@ msgctxt ""
 "Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
 "item)"
 msgid "Add Image or File"
-msgstr ""
+msgstr "Дадаць відарыс або файл"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1466,7 +1463,7 @@ msgctxt ""
 "Open the tab picker to attach browser tab content to the AI chat message "
 "(attach dropdown menu item)"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Дадаць укладкі"
 
 # smartling.placeholder_format=C
 #. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
@@ -1474,7 +1471,7 @@ msgctxt ""
 "Title and accessible name of the tab-picker dialog opened from the attach "
 "dropdown menu"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Дадаць укладкі"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1565,7 +1562,7 @@ msgstr "Дадаванне фінальных штрыхоў"
 #. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
 msgctxt "Aria label for the additional instructions textarea"
 msgid "Additional instructions"
-msgstr ""
+msgstr "Дадатковыя інструкцыі"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1874,7 +1871,7 @@ msgstr "Усё гатова!"
 #. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the read-only textarea listing all AI instructions"
 msgid "All instructions"
-msgstr ""
+msgstr "Усе інструкцыі"
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -1888,8 +1885,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr ""
-"Усім пастаўшчыкам мадэляў забаронена навучаць свой AI на вашых размовах."
+msgstr "Усім пастаўшчыкам мадэляў забаронена навучаць свой AI на вашых размовах."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -2019,8 +2015,7 @@ msgstr "Ужо сінхранізавана."
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Also search privately on your iPad, iPhone, or Android!"
-msgstr ""
-"Таксама захоўвайце сваю прыватнасць падчас пошуку на iPad, iPhone ці Android!"
+msgstr "Таксама захоўвайце сваю прыватнасць падчас пошуку на iPad, iPhone ці Android!"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -2322,8 +2317,7 @@ msgctxt "Body text for disable chat history confirmation modal"
 msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
-msgstr ""
-"Сапраўды адключыць гісторыю? Гэта выдаліць усе чаты, у тым ліку замацаваныя."
+msgstr "Сапраўды адключыць гісторыю? Гэта выдаліць усе чаты, у тым ліку замацаваныя."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -3081,8 +3075,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr ""
-"Спіс блакіроўкі не з'яўляецца вычарпальным і можа ўтрымліваць недакладнасці."
+msgstr "Спіс блакіроўкі не з'яўляецца вычарпальным і можа ўтрымліваць недакладнасці."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3596,7 +3589,7 @@ msgctxt ""
 "Secondary button that dismisses the tab picker dialog without attaching "
 "anything"
 msgid "Cancel"
-msgstr ""
+msgstr "Скасаваць"
 
 # smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
@@ -3852,8 +3845,7 @@ msgstr "Змяняе колер фону на ўсім сайце"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr ""
-"Змяняе фонавы колер вынікаў пры навядзенні курсорам, модуляў і выпадных меню"
+msgstr "Змяняе фонавы колер вынікаў пры навядзенні курсорам, модуляў і выпадных меню"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -3986,8 +3978,8 @@ msgstr ""
 "мадэлямі чата на базе штучнага інтэлекту, якімі падтрымліваюцца мадэлі "
 "OpenAI, Anthropic і іншыя. Адключэнне гэтай налады схавае кнопкі і спасылкі "
 "чата ў DuckDuckGo Search. Тым не менш, можна атрымаць доступ да чата, калі "
-"гэты параметр выключаны. Для гэтага трэба перайсці на сайт %1$shttps://duck."
-"ai%2$s ."
+"гэты параметр выключаны. Для гэтага трэба перайсці на сайт "
+"%1$shttps://duck.ai%2$s ."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4052,8 +4044,8 @@ msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
 msgstr ""
-"Размаўляйце ў чаце прыватна на любым сайце з дапамогай бакавой панэлі Duck."
-"ai ў нашым бясплатным браўзеры."
+"Размаўляйце ў чаце прыватна на любым сайце з дапамогай бакавой панэлі "
+"Duck.ai ў нашым бясплатным браўзеры."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4095,7 +4087,7 @@ msgstr "Адказ у чаце абразлівы"
 #. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
 msgctxt "Chat history about modal list item headline"
 msgid "Chat storage varies by browser"
-msgstr ""
+msgstr "Сховішча чатаў залежыць ад браўзера"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4108,6 +4100,8 @@ msgstr "Чат з %1$s"
 msgctxt "new tab page"
 msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
+"Паразмаўляйце з папулярнымі мадэлямі штучнага інтэлекту, якія мы зрабілі "
+"ананімнымі."
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4134,6 +4128,8 @@ msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
 msgstr ""
+"Чаты надзейна захоўваюцца на серверы DuckDuckGo з выкарыстаннем скразнога "
+"шыфравання. Ніхто, акрамя вас, не можа бачыць вашы даныя, нават мы."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4253,8 +4249,7 @@ msgstr ""
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr ""
-"Праверце старонку стану, каб даведацца пра абнаўленні наконт гэтага збою."
+msgstr "Праверце старонку стану, каб даведацца пра абнаўленні наконт гэтага збою."
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4319,8 +4314,7 @@ msgstr "Выбар мадэляў штучнага інтэлекту, у тым
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr ""
-"Націсніце %1$sЗахаваць%2$s, каб мы і надалей абаранялі вашу прыватнасць."
+msgstr "Націсніце %1$sЗахаваць%2$s, каб мы і надалей абаранялі вашу прыватнасць."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -4740,8 +4734,7 @@ msgstr "Націсніце на %1$sПастаўшчыкі пошуку%2$s па
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sTools icon%s in the top-right of the browser"
-msgstr ""
-"Націсніце на %1$sзначок інструментаў%2$s у правым верхнім куце браўзера"
+msgstr "Націсніце на %1$sзначок інструментаў%2$s у правым верхнім куце браўзера"
 
 #  Firefox default search engine instruction
 # smartling.placeholder_format=C
@@ -5739,7 +5732,7 @@ msgstr "Бягучая серыя"
 #. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
 msgctxt "Suffix label indicating a tab is the currently active browser tab"
 msgid "Current Tab"
-msgstr ""
+msgstr "Бягучая ўкладка"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
@@ -6095,7 +6088,7 @@ msgstr "Выдаліць чаты, старэйшыя за 30 дзён"
 #. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
 msgctxt "Button text in the modal for deleting all recent chats"
 msgid "Delete Chats and Shared Links"
-msgstr ""
+msgstr "Выдаліць чаты і абагуленыя спасылкі"
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6515,7 +6508,7 @@ msgstr "Адхіліць рэкламу"
 #. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the close button on the survey banner"
 msgid "Dismiss survey"
-msgstr ""
+msgstr "Адхіліць апытанне"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7136,8 +7129,7 @@ msgstr "Duck.ai абноўлены!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.ai найлепш працуе ў нашай прыватнай і бясплатнай праграме DuckDuckGo!"
+msgstr "Duck.ai найлепш працуе ў нашай прыватнай і бясплатнай праграме DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7147,10 +7139,10 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, прыватны чат-бот AI, бясплатны AI-чат, ананімны AI-"
-"чат, AI-чат без рэгістрацыі, OpenAI, Anthropic, Llama, Mistral, мадэлі AI з "
-"адкрытым зыходным кодам, арыентаваны на прыватнасць AI, AI-чат без уліковага "
-"запісу"
+"Duck.ai, DuckDuckGo AI, прыватны чат-бот AI, бясплатны AI-чат, ананімны "
+"AI-чат, AI-чат без рэгістрацыі, OpenAI, Anthropic, Llama, Mistral, мадэлі AI "
+"з адкрытым зыходным кодам, арыентаваны на прыватнасць AI, AI-чат без "
+"уліковага запісу"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7316,8 +7308,7 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr ""
-"DuckDuckGo AI Chat часова недаступны. Абнавіце старонку і паўтарыце спробу."
+msgstr "DuckDuckGo AI Chat часова недаступны. Абнавіце старонку і паўтарыце спробу."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7696,7 +7687,7 @@ msgstr "Рэдагаваць запыт"
 #. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the message-editing text area"
 msgid "Edit message"
-msgstr ""
+msgstr "Рэдагаваць паведамленне"
 
 # smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
@@ -7927,7 +7918,7 @@ msgstr "Зашыфраваная мадэль"
 #. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
 msgctxt "Share modal info bullet about encryption"
 msgid "Encrypted so DuckDuckGo can't read your chat."
-msgstr ""
+msgstr "Зашыфравана, таму DuckDuckGo не можа прачытаць ваш чат."
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -7985,8 +7976,7 @@ msgstr "Падабаецца Duck.ai?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr ""
-"Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s."
+msgstr "Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7998,22 +7988,19 @@ msgstr "Упэўніцеся, што %1$sўключана%2$s налада \"С�
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr ""
-"Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s"
+msgstr "Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s."
-msgstr ""
-"Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sдазволіць%2$s."
+msgstr "Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sдазволіць%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure Location is set to %sAllow%s"
-msgstr ""
-"Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s"
+msgstr "Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -8031,8 +8018,7 @@ msgstr "Упэўніцеся, што %1$sдазволены%2$s доступ д�
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s"
-msgstr ""
-"Упэўніцеся, што ў браўзеры дазволены %1$sдоступ да месцазнаходжання%2$s"
+msgstr "Упэўніцеся, што ў браўзеры дазволены %1$sдоступ да месцазнаходжання%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -8146,8 +8132,7 @@ msgstr "Экватарыяльная Гвінея"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"Імгненна выдаляйце даныя прагляду з дапамогай кнопкі %1$sFire Button%2$s"
+msgstr "Імгненна выдаляйце даныя прагляду з дапамогай кнопкі %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -8207,8 +8192,7 @@ msgstr "Разгарнуць карту"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr ""
-"Прафесійна распрацаваныя вырабы для людзей, якім неабыякавая прыватнасць."
+msgstr "Прафесійна распрацаваныя вырабы для людзей, якім неабыякавая прыватнасць."
 
 # smartling.placeholder_format=C
 #. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
@@ -8590,8 +8574,7 @@ msgstr "Фільтры неэфектыўныя"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Filters out AI-generated images from image search results"
-msgstr ""
-"Фільтруе відарысы, створаныя штучным інтэлектам, з вынікаў пошуку відарысаў"
+msgstr "Фільтруе відарысы, створаныя штучным інтэлектам, з вынікаў пошуку відарысаў"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8771,7 +8754,7 @@ msgstr "Удакладняльнае пытанне"
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
-msgstr ""
+msgstr "Удакладняльныя пытанні застаюцца прыватнымі."
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8909,8 +8892,7 @@ msgstr "Можна абагульваць і выкарыстоўваць у к�
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr ""
-"Вызваліце месца, выдаліўшы свае чаты. Замацаваныя чаты не будуць выдалены."
+msgstr "Вызваліце месца, выдаліўшы свае чаты. Замацаваныя чаты не будуць выдалены."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -9294,7 +9276,7 @@ msgstr ""
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
 msgctxt "Tooltip on the header logo for sunglasses searches"
 msgid "Get DuckDuckGo sunglasses and other gear."
-msgstr ""
+msgstr "Атрымайце сонцаахоўныя акуляры DuckDuckGo і іншыя тавары."
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9479,8 +9461,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
-msgstr ""
-"У адной спампоўцы вы бясплатна атрымліваеце комплексную абарону прыватнасці:"
+msgstr "У адной спампоўцы вы бясплатна атрымліваеце комплексную абарону прыватнасці:"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -9540,8 +9521,7 @@ msgstr "Атрымаць гэту песню на:"
 # smartling.placeholder_format=C
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
-msgstr ""
-"Запрасіце сваіх сяброў перайсці да нас і тым самым дапамагчы нам расці!"
+msgstr "Запрасіце сваіх сяброў перайсці да нас і тым самым дапамагчы нам расці!"
 
 # smartling.placeholder_format=C
 #. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
@@ -10533,7 +10513,7 @@ msgstr "Як гэта працуе"
 #. Headline in chat history about modals for the temporary encrypted server storage explanation.
 msgctxt "Chat history about modal list item headline"
 msgid "How it works"
-msgstr ""
+msgstr "Як гэта працуе"
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -10559,8 +10539,7 @@ msgstr ""
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr ""
-"Колькі з вашых дзённых і тыднёвых лімітаў вы выкарысталі да гэтага часу."
+msgstr "Колькі з вашых дзённых і тыднёвых лімітаў вы выкарысталі да гэтага часу."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -11910,8 +11889,7 @@ msgstr "Дазваляе вам шукаць ананімна з дапамог�
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr ""
-"Дазваляе пераключацца паміж адпраўкай пошукавых запытаў і падказак у Duck.ai"
+msgstr "Дазваляе пераключацца паміж адпраўкай пошукавых запытаў і падказак у Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11994,6 +11972,8 @@ msgstr "Тэрмін дзеяння спасылкі заканчваецца п
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
+"Тэрмін дзеяння спасылкі заканчваецца праз 7 дзён. Карыстальнікі могуць "
+"захаваць копію чата."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -12306,8 +12286,7 @@ msgstr "Пераканайцеся, што ўсе словы напісаны п
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr ""
-"Не забудзьцеся пазначыць %1$s\"Зрабіць стандартнай пошукавай сістэмай\"%2$s"
+msgstr "Не забудзьцеся пазначыць %1$s\"Зрабіць стандартнай пошукавай сістэмай\"%2$s"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -13772,8 +13751,7 @@ msgstr "Вынікі не знойдзены."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr ""
-"Маўленне не выяўлена. Калі ласка, паспрабуйце яшчэ раз і гаварыце ў мікрафон."
+msgstr "Маўленне не выяўлена. Калі ласка, паспрабуйце яшчэ раз і гаварыце ў мікрафон."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -14118,7 +14096,7 @@ msgstr "ОК, зразумела!"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "OPTIONAL"
-msgstr ""
+msgstr "НЕАБАВЯЗКОВА"
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -14248,8 +14226,7 @@ msgstr "Аман"
 #. http://i.imgur.com/zQWKLIm.png
 msgctxt "settings"
 msgid "Omits objectionable (mostly adult) material"
-msgstr ""
-"Апускае спрэчнае змесціва (галоўным чынам, прызначанае \"для дарослых\")"
+msgstr "Апускае спрэчнае змесціва (галоўным чынам, прызначанае \"для дарослых\")"
 
 # smartling.placeholder_format=C
 msgid "On"
@@ -15421,8 +15398,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr ""
-"Выканайце наступнае заданне, каб пацвердзіць, што запыт выкананы чалавекам."
+msgstr "Выканайце наступнае заданне, каб пацвердзіць, што запыт выкананы чалавекам."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -15430,8 +15406,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr ""
-"Выканайце наступнае заданне, каб пацвердзіць, што пошук выкананы чалавекам."
+msgstr "Выканайце наступнае заданне, каб пацвердзіць, што пошук выкананы чалавекам."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -15459,8 +15434,7 @@ msgstr "Калі ласка, увядзіце кодавую фразу"
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
 msgctxt "Description for the wrong code error screen"
 msgid "Please make sure the correct code was entered or scanned."
-msgstr ""
-"Калі ласка, пераканайцеся, што быў уведзены або адсканаваны сапраўдны код."
+msgstr "Калі ласка, пераканайцеся, што быў уведзены або адсканаваны сапраўдны код."
 
 # smartling.placeholder_format=C
 #. Disclaimer text displayed in a modal that informs the user that starting a new chat with any AI model will delete their current chat session.
@@ -16254,7 +16228,7 @@ msgstr "Абаронена"
 #. Headline in sync-enabled chat history about modals explaining encrypted server storage.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Protected with end-to-end encryption"
-msgstr ""
+msgstr "Абаронена скразным шыфраваннем"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -16393,7 +16367,7 @@ msgstr "Рэйтынгі"
 #. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
 msgctxt "star rating on a product"
 msgid "Rated %s out of %s"
-msgstr ""
+msgstr "Мае ацэнку %1$s з %2$s"
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -16859,8 +16833,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"Перазагрузіце DuckDuckGo, выконваючы інструкцыі або націснуўшы кнопку &quot;"
-"Абнавіць&quot; ці &quot;Перазагрузіць&quot; у браўзеры."
+"Перазагрузіце DuckDuckGo, выконваючы інструкцыі або націснуўшы кнопку "
+"&quot;Абнавіць&quot; ці &quot;Перазагрузіць&quot; у браўзеры."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -17406,8 +17380,7 @@ msgstr "SE"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "SERP promotion for desktop browsers has been dismissed"
-msgstr ""
-"Рэклама браўзераў для камп'ютара на старонцы з вынікамі пошуку была закрыта"
+msgstr "Рэклама браўзераў для камп'ютара на старонцы з вынікамі пошуку была закрыта"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating that a game is in shootouts, e.g. in NHL (hockey)
@@ -17636,7 +17609,7 @@ msgstr "Захоўвайце свае размовы на ўсіх прылад�
 #. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
 msgctxt "Chat history about modal list item headline"
 msgid "Save your chats on this device"
-msgstr ""
+msgstr "Захоўвайце свае чаты на гэтай прыладзе"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
@@ -17848,7 +17821,7 @@ msgctxt ""
 "Placeholder and accessibility label for the search input in the tab picker "
 "dialog"
 msgid "Search"
-msgstr ""
+msgstr "Шукаць"
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -17988,8 +17961,7 @@ msgstr "Бачнасць пошуку"
 # smartling.placeholder_format=C
 #. Message prompting users to download the DuckDuckGo app.
 msgid "Search and browse privately with the DuckDuckGo app."
-msgstr ""
-"Шукайце і праглядайце інфармацыю ў прыватным рэжыме ў праграме DuckDuckGo."
+msgstr "Шукайце і праглядайце інфармацыю ў прыватным рэжыме ў праграме DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Category a user can select on a feedback form.
@@ -18064,8 +18036,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"Пошукавыя запыты ўключаны ў URL (калі выкл., пошук будзе выкарыстоўваць POST-"
-"запыты)"
+"Пошукавыя запыты ўключаны ў URL (калі выкл., пошук будзе выкарыстоўваць "
+"POST-запыты)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -18353,8 +18325,7 @@ msgstr "Паглядзіце апошнія абнаўленні"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr ""
-"Дадатковую інфармацыю глядзіце на старонцы %1$sПараметры URL-адраса%2$s ."
+msgstr "Дадатковую інфармацыю глядзіце на старонцы %1$sПараметры URL-адраса%2$s ."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -18433,8 +18404,7 @@ msgstr "Выберыце %1$sDuckDuckGo%2$s у спісе сайтаў пошу�
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr ""
-"Выберыце %1$sDuckDuckGo%2$s у раздзеле %3$sСтандартная пошукавая сістэма%4$s"
+msgstr "Выберыце %1$sDuckDuckGo%2$s у раздзеле %3$sСтандартная пошукавая сістэма%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -18615,8 +18585,7 @@ msgstr "Выбраны тэкст з %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr ""
-"Вылучаны тэкст занадта доўгі. Выберыце карацейшы ўрывак і паўтарыце спробу."
+msgstr "Вылучаны тэкст занадта доўгі. Выберыце карацейшы ўрывак і паўтарыце спробу."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -19040,7 +19009,7 @@ msgstr "Купіць"
 #. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
 msgctxt "Button in the merchandise logo modal (mobile)"
 msgid "Shop Now"
-msgstr ""
+msgstr "Купіць зараз"
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -19553,8 +19522,7 @@ msgstr "Пошук па сайце часова недаступны. Мы пр�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"Сайты, якія вы заблакіруеце, будуць схаваныя ва ўсіх вашых вынікаў пошуку"
+msgstr "Сайты, якія вы заблакіруеце, будуць схаваныя ва ўсіх вашых вынікаў пошуку"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19707,8 +19675,7 @@ msgstr "Адбылася памылка пры загрузцы гэтага с�
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr ""
-"Штосьці пайшло не так з запісам на сервер. Калі ласка, паўтарыце спробу."
+msgstr "Штосьці пайшло не так з запісам на сервер. Калі ласка, паўтарыце спробу."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
@@ -20087,15 +20054,13 @@ msgstr ""
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Заставайцеся абароненымі і інфармаванымі праз нашу рассылку пра прыватнасць."
+msgstr "Заставайцеся абароненымі і інфармаванымі праз нашу рассылку пра прыватнасць."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Заставайцеся абароненымі і інфармаванымі праз нашу рассылку пра прыватнасць."
+msgstr "Заставайцеся абароненымі і інфармаванымі праз нашу рассылку пра прыватнасць."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -20228,8 +20193,8 @@ msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
 msgstr ""
-"Падпішыцеся на DuckDuckGo, каб разблакіраваць больш высокія ліміты ў Duck."
-"ai, або вярніцеся пазней, каб стварыць больш відарысаў."
+"Падпішыцеся на DuckDuckGo, каб разблакіраваць больш высокія ліміты ў "
+"Duck.ai, або вярніцеся пазней, каб стварыць больш відарысаў."
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -20562,8 +20527,7 @@ msgstr "Пераключыць мадэль"
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
-msgstr ""
-"Пачніце выкарыстоўваць бясплатную мадэль у гэтым чаце або пачакайце да %1$s."
+msgstr "Пачніце выкарыстоўваць бясплатную мадэль у гэтым чаце або пачакайце да %1$s."
 
 # smartling.placeholder_format=C
 #. Button that switches the conversation to the second-opinion model. %s is the model name.
@@ -20700,7 +20664,7 @@ msgctxt "Chat history with sync modal list item description"
 msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
-msgstr ""
+msgstr "Sync & Backup захоўвае больш вашых чатаў і сінхранізуе іх на ўсіх прыладах."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20822,7 +20786,7 @@ msgstr "Сінхранізуйце свае размовы на ўсіх пры�
 #. Headline in sync-enabled chat history about modals explaining cross-device sync.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Sync your chats across all your devices"
-msgstr ""
+msgstr "Сінхранізацыя чатаў на розных прыладах"
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21414,12 +21378,14 @@ msgid ""
 "This chat and its generated images become public when you create and copy "
 "the link."
 msgstr ""
+"Гэты чат і створаныя ў ім выявы стануць агульнадаступнымі, калі вы створыце "
+"і скапіруеце спасылку."
 
 # smartling.placeholder_format=C
 #. Explains that creating and copying a share link makes the selected chat content public.
 msgctxt "Share modal info bullet about public access"
 msgid "This chat becomes public when you create and copy the link."
-msgstr ""
+msgstr "Гэты чат становіцца агульнадаступным, калі ствараецца і капіруецца спасылка."
 
 # smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
@@ -21651,8 +21617,7 @@ msgstr "Для работы гэтай старонкі патрабуецца J
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Змесціва гэтай старонкі будзе адпраўлена разам з паведамленнем у Duck.ai"
+msgstr "Змесціва гэтай старонкі будзе адпраўлена разам з паведамленнем у Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21734,15 +21699,13 @@ msgstr "Гэты пераклад няправільны"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Відэа пакуль што нельга паглядзець тут. Вы можаце яго паглядзець на %1$s."
+msgstr "Відэа пакуль што нельга паглядзець тут. Вы можаце яго паглядзець на %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"На гэтай старонцы не выкарыстоўваецца бяспечнае шыфраванае злучэнне (HTTPS)."
+msgstr "На гэтай старонцы не выкарыстоўваецца бяспечнае шыфраванае злучэнне (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21881,8 +21844,7 @@ msgstr "Падкрэсліванне загалоўка"
 # smartling.placeholder_format=C
 #. Informative header on a list of steps for the user to take to disable their adblocker
 msgid "To allowlist DuckDuckGo in other ad blocker extensions:"
-msgstr ""
-"Каб дадаць DuckDuckGo у белы спіс у іншых пашырэннях для блакіроўкі рэкламы:"
+msgstr "Каб дадаць DuckDuckGo у белы спіс у іншых пашырэннях для блакіроўкі рэкламы:"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to Duck.ai’s Privacy Policy and Terms of Service'
@@ -21907,8 +21869,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"Як раздрукаваць маршрут:%1$sВярніцеся на карту.%2$sВыберыце патрэбны маршрут."
-"%3$sНацісніце на значок друку.%4$s"
+"Як раздрукаваць маршрут:%1$sВярніцеся на карту.%2$sВыберыце патрэбны "
+"маршрут.%3$sНацісніце на значок друку.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -21963,6 +21925,8 @@ msgstr "Сёння"
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
+"Пераключыцеся на прыватны AI-чат або %1$sвыключыце гэту функцыю ў "
+"наладах%2$s."
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -22146,8 +22110,8 @@ msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
 msgstr ""
-"Тут паказваюцца звесткі пра спробы адсочвання, заблакіраваныя DuckDuckGo."
-"Спіс будзе абнаўляцца па меры вашага выкарыстання."
+"Тут паказваюцца звесткі пра спробы адсочвання, заблакіраваныя "
+"DuckDuckGo.Спіс будзе абнаўляцца па меры вашага выкарыстання."
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -22461,16 +22425,14 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Для больш дакладных вынікаў паспрабуйце ўключыць ананімнае месцазнаходжанне."
+msgstr "Для больш дакладных вынікаў паспрабуйце ўключыць ананімнае месцазнаходжанне."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Паспрабуйце паэксперыментаваць з кожнай мадэллю — яны дадуць розныя адказы."
+msgstr "Паспрабуйце паэксперыментаваць з кожнай мадэллю — яны дадуць розныя адказы."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -22563,8 +22525,7 @@ msgstr "Паспрабуйце наш браўзер,"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr ""
-"Паспрабуйце нашу хатнюю старонку, якая ніколі не паказвае гэтыя паведамленні:"
+msgstr "Паспрабуйце нашу хатнюю старонку, якая ніколі не паказвае гэтыя паведамленні:"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time; shown in the US. Invites the user to start a free trial of the paid subscription.
@@ -22645,15 +22606,13 @@ msgstr "Паспрабуйце новы прыватны галасавы чат
 #. Text for a promotional card that encourages users to try the recently added open-source AI models. The placeholders are the names of AI models like 'Try the recently added open-source Llama 3.1 and Mistral.'
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source %s and %s"
-msgstr ""
-"Паспрабуйце нядаўна дададзеныя мадэлі з адкрытым зыходным кодам: %1$s і %2$s"
+msgstr "Паспрабуйце нядаўна дададзеныя мадэлі з адкрытым зыходным кодам: %1$s і %2$s"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the recently added open-source AI models Llama 3.1 and Mixtral.
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source Llama 3.1 and Mixtral"
-msgstr ""
-"Паспрабуйце нядаўна дададзеныя Llama 3.1 і Mixtral з адкрытым зыходным кодам"
+msgstr "Паспрабуйце нядаўна дададзеныя Llama 3.1 і Mixtral з адкрытым зыходным кодам"
 
 # smartling.placeholder_format=C
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
@@ -23080,8 +23039,8 @@ msgstr ""
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"Пад раздзелам %1$sПошук%2$s націсніце %3$sКіраваць пошукавымі сістэмамі..."
-"%4$s"
+"Пад раздзелам %1$sПошук%2$s націсніце %3$sКіраваць пошукавымі "
+"сістэмамі...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -23205,15 +23164,13 @@ msgstr ""
 msgctxt ""
 "Text that shows users they can unlock advanced AI models with a subscription."
 msgid "Unlock advanced AI models with a %s"
-msgstr ""
-"Адкрыйце доступ да перадавых мадэляў штучнага інтэлекту з падпіскай (%1$s)"
+msgstr "Адкрыйце доступ да перадавых мадэляў штучнага інтэлекту з падпіскай (%1$s)"
 
 # smartling.placeholder_format=C
 #. Tooltip text shown when the user hovers over the free badge telling the user that they can unlock advanced AI (Artificial Intelligence) models with a DuckDuckGo subscription.
 msgctxt "Tooltip for the free badge"
 msgid "Unlock advanced AI models with a DuckDuckGo subscription"
-msgstr ""
-"Разблакіруйце перадавыя мадэлі штучнага інтэлекту з падпіскай DuckDuckGo"
+msgstr "Разблакіруйце перадавыя мадэлі штучнага інтэлекту з падпіскай DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
@@ -23231,8 +23188,7 @@ msgstr "Разблакіраваць перадавыя мадэлі"
 #. Upsell message shown in the voice chat duration limit modal for free users.
 msgctxt "voice chat duration limit modal"
 msgid "Unlock longer voice chats with a DuckDuckGo Subscription"
-msgstr ""
-"Разблакіруйце больш працяглыя галасавыя чаты, аформіўшы падпіску DuckDuckGo"
+msgstr "Разблакіруйце больш працяглыя галасавыя чаты, аформіўшы падпіску DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text informing the user that more capable AI models can be unlocked with a subscription, with a trailing call-to-action link. %s is replaced with either the 'Try for free' link (for unauthenticated users) or the 'Learn more' link (for authenticated users). The link opens the subscription modal. Example: Unlock more capable AI models with a DuckDuckGo subscription. Try for free
@@ -23473,8 +23429,7 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr ""
-"Абнавіцеся да Pro, каб адкрыць удвая большыя ліміты выкарыстання, чым у Plus"
+msgstr "Абнавіцеся да Pro, каб адкрыць удвая большыя ліміты выкарыстання, чым у Plus"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -23584,8 +23539,7 @@ msgstr "Выкарыстаць прыватны пошук DuckDuckGo"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"Скарыстайце DuckDuckGo для асабістага пошуку на iPad, iPhone ці Android!"
+msgstr "Скарыстайце DuckDuckGo для асабістага пошуку на iPad, iPhone ці Android!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -23644,8 +23598,7 @@ msgstr ""
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
 msgctxt "DuckChat location prompt"
 msgid "Use your approximate location for more accurate results?"
-msgstr ""
-"Выкарыстоўваць ваша прыблізнае месцазнаходжанне для больш дакладных вынікаў?"
+msgstr "Выкарыстоўваць ваша прыблізнае месцазнаходжанне для больш дакладных вынікаў?"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes before every user message in the downloaded file, indicating which message it is out of the total number of messages. Example: 'User prompt 3 of 5'
@@ -23809,6 +23762,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Yelp's ad network."
 msgstr ""
+"Прыватнасць прагляду рэкламы абараняецца DuckDuckGo. Націсканні на рэкламу "
+"апрацоўваюцца рэкламнай сеткай Yelp."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -23856,8 +23811,8 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"Наведайце Duck.ai ў іншым браўзеры і перайдзіце ў раздзел %1$sНалады Duck."
-"ai%2$s > %3$sSync & Backup%4$s > %5$sКіраванне%6$s, а затым выберыце "
+"Наведайце Duck.ai ў іншым браўзеры і перайдзіце ў раздзел %1$sНалады "
+"Duck.ai%2$s > %3$sSync & Backup%4$s > %5$sКіраванне%6$s, а затым выберыце "
 "%7$sСінхранізаваць з іншай прыладай%8$s."
 
 # smartling.placeholder_format=C
@@ -24173,8 +24128,7 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"Мы не можам прачытаць далучаныя файлы, бо прынамсі адзін з іх зашыфраваны."
+msgstr "Мы не можам прачытаць далучаныя файлы, бо прынамсі адзін з іх зашыфраваны."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24396,8 +24350,8 @@ msgstr ""
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
 msgstr ""
-"Мы блакіруем трэкеры, якія спрабуюць збіраць вашы даныя падчас прагляду вэб-"
-"старонак."
+"Мы блакіруем трэкеры, якія спрабуюць збіраць вашы даныя падчас прагляду "
+"вэб-старонак."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
@@ -24442,8 +24396,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr ""
-"Прабачце за гэтыя нязручнасці. Мы старанна працуем, каб палепшыць ваш досвед."
+msgstr "Прабачце за гэтыя нязручнасці. Мы старанна працуем, каб палепшыць ваш досвед."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -24703,8 +24656,7 @@ msgstr "Якія фактары варта ўлічваць пры куплі м
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr ""
-"Якія славутасці Парыжа трэба абавязкова наведаць тым, хто прыязджае ўпершыню?"
+msgstr "Якія славутасці Парыжа трэба абавязкова наведаць тым, хто прыязджае ўпершыню?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -24712,8 +24664,7 @@ msgctxt "Full sentence for finding a better word"
 msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
-msgstr ""
-"Якія варыянты слова \"лепш\" у кантэксце \"Нам сапраўды трэба зрабіць лепш\"."
+msgstr "Якія варыянты слова \"лепш\" у кантэксце \"Нам сапраўды трэба зрабіць лепш\"."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -25299,6 +25250,8 @@ msgid ""
 "With chat history on, up to %s of your most recent chats will be saved on "
 "this device."
 msgstr ""
+"Калі запіс гісторыі чатаў уключаны, да %1$s апошніх чатаў будзе захавана на "
+"гэтай прыладзе."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline in the About Chat History modal.
@@ -25306,6 +25259,8 @@ msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, your most recent chats will be saved on this device."
 msgstr ""
+"Калі запіс гісторыі чатаў уключаны, вашы апошнія чаты будуць захоўвацца на "
+"гэтай прыладзе."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -25987,16 +25942,14 @@ msgstr ""
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr ""
-"Вы дасягнулі максімальнай працягласці галасавога чата для аднаго сеансу."
+msgstr "Вы дасягнулі максімальнай працягласці галасавога чата для аднаго сеансу."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"Вы дасягнулі на сёння ліміту галасавога чата. Паспрабуйце яшчэ раз заўтра."
+msgstr "Вы дасягнулі на сёння ліміту галасавога чата. Паспрабуйце яшчэ раз заўтра."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -26255,8 +26208,8 @@ msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
 msgstr ""
-"Вашы чаты былі імпартаваны. Працягвайце з таго месца, дзе спыніліся, у Duck."
-"ai."
+"Вашы чаты былі імпартаваны. Працягвайце з таго месца, дзе спыніліся, у "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -26715,7 +26668,7 @@ msgstr "хв"
 #. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the chat options menu button"
 msgid "menu"
-msgstr ""
+msgstr "меню"
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/bg_BG/LC_MESSAGES/duckduckgo.po
+++ b/locales/bg_BG/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: bg_BG\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1226,6 +1226,12 @@ msgid "About our ads"
 msgstr "Относно нашите реклами"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1355,6 +1361,20 @@ msgid "Ad is suspicious"
 msgstr "Рекламата е подозрителна"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Добавете DuckDuckGo"
@@ -1381,6 +1401,27 @@ msgstr "Добавете DuckDuckGo като търсачка"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Добавете DuckDuckGo към %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1426,6 +1467,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Добавяне на съдържание на страницата"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1511,6 +1568,12 @@ msgstr "Разширения"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Добавяне на финални щрихи"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1815,6 +1878,12 @@ msgstr "Всички цветове"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Готово!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3533,6 +3602,14 @@ msgid "Cancel"
 msgstr "Отмяна"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4030,10 +4107,22 @@ msgid "Chat response is offensive"
 msgstr "Отговорът в чата е обиден"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Чат с %1$s"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4052,6 +4141,14 @@ msgstr "Чатове"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Чатове"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5661,6 +5758,12 @@ msgid "Current Streak"
 msgstr "Текуща серия"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -6009,6 +6112,12 @@ msgstr "Изтриване на чатовете"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Изтриване на чатове, по-стари от 30 дни"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6425,6 +6534,12 @@ msgstr "Отхвърли завинаги"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Пропусни промоцията"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7604,6 +7719,12 @@ msgid "Edit Prompt"
 msgstr "Редактиране на подкана"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7827,6 +7948,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Криптиран модел"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8671,6 +8798,12 @@ msgid "Follow-up question"
 msgstr "Допълнителен въпрос"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9189,6 +9322,12 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
 "Вземете DuckDuckGo VPN, усъвършенстван Duck.ai и Identity Theft Restoration."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10423,6 +10562,12 @@ msgstr "Как така е анонимно?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Как работи"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11878,6 +12023,12 @@ msgstr "Спечелени тъчове"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "Връзката изтича след 7 дни."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14002,6 +14153,12 @@ msgstr "ОК"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "Добре, разбрах!"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16132,6 +16289,12 @@ msgid "Protected"
 msgstr "Защитени"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Защита. Поверителност. Спокойствие."
@@ -16263,6 +16426,12 @@ msgstr "Дъжд"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Ранг"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17501,6 +17670,12 @@ msgid "Save your chats across all your devices."
 msgstr "Запазете чатовете на всички устройства."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17705,6 +17880,14 @@ msgstr "Търсене"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Търсене"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18894,6 +19077,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Купи"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20558,6 +20747,14 @@ msgstr ""
 "неактивност."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20673,6 +20870,12 @@ msgstr "Синхронизиране с близко устройство."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Синхронизирайте чатовете на всички устройства."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21257,6 +21460,22 @@ msgid "This Week"
 msgstr "Тази седмица"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21790,6 +22009,12 @@ msgstr "Днес"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Днес"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23627,6 +23852,14 @@ msgstr ""
 "Кликовете върху рекламите се управляват от рекламната мрежа на TripAdvisor."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Вирджински острови"
 
@@ -25115,6 +25348,21 @@ msgstr ""
 "изкуствен интелект. Включете или изключете по всяко време в менюто '%1$s'."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26519,6 +26767,12 @@ msgstr "м"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "м"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/bg_BG/LC_MESSAGES/duckduckgo.po
+++ b/locales/bg_BG/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: bg_BG\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -308,8 +308,7 @@ msgstr "Класирането на %1$s все още не е налично"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits 2-5x faster than other models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
-msgstr ""
-"%1$s достига лимитите за ползване 2-5 пъти по-бързо от основните модели. %2$s"
+msgstr "%1$s достига лимитите за ползване 2-5 пъти по-бързо от основните модели. %2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -379,8 +378,7 @@ msgstr "%1$s използвани"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
-"%1$s изразходва лимитите почти 2–5 пъти по-бързо от основните модели %2$s"
+msgstr "%1$s изразходва лимитите почти 2–5 пъти по-бързо от основните модели %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -496,8 +494,7 @@ msgstr "%1$sНаучи повече%2$s."
 #. Link to a page with more information about how anonymous location works.
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
-msgstr ""
-"%1$sНаучете как запазваме поверителността на вашето местоположение%2$s."
+msgstr "%1$sНаучете как запазваме поверителността на вашето местоположение%2$s."
 
 # smartling.placeholder_format=C
 #. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
@@ -1019,8 +1016,8 @@ msgstr ""
 "AI Chat ви позволява да провеждате анонимни разговори с модели за чат с "
 "изкуствен интелект на трети страни. Изключването на това ще скрие функцията "
 "AI Chat в DuckDuckGo Search. Все още можете да получите достъп до AI Chat, "
-"когато тази настройка е изключена, като посетите %1$sduckduckgo.com/"
-"aichat%2$s."
+"когато тази настройка е изключена, като посетите "
+"%1$sduckduckgo.com/aichat%2$s."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1229,7 +1226,7 @@ msgstr "Относно нашите реклами"
 #. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
 msgctxt "Modal header for chat history with sync information"
 msgid "About Chat History with Sync & Backup"
-msgstr ""
+msgstr "За историята на чата със Sync & Backup"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
@@ -1364,7 +1361,7 @@ msgstr "Рекламата е подозрителна"
 #. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
 msgctxt "Button to open menu for attaching images or page context to AI chat"
 msgid "Add"
-msgstr ""
+msgstr "Добавяне"
 
 # smartling.placeholder_format=C
 #. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
@@ -1372,7 +1369,7 @@ msgctxt ""
 "Primary button that attaches the tabs the user checked in the tab picker "
 "dialog"
 msgid "Add"
-msgstr ""
+msgstr "Добавяне"
 
 # smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
@@ -1407,13 +1404,13 @@ msgstr "Добавете DuckDuckGo към %1$s"
 msgctxt ""
 "Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
 msgid "Add File"
-msgstr ""
+msgstr "Добавяне на файл"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
 msgid "Add Image"
-msgstr ""
+msgstr "Добавяне на изображение"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
@@ -1421,7 +1418,7 @@ msgctxt ""
 "Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
 "item)"
 msgid "Add Image or File"
-msgstr ""
+msgstr "Добавяне на изображение или файл"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1474,7 +1471,7 @@ msgctxt ""
 "Open the tab picker to attach browser tab content to the AI chat message "
 "(attach dropdown menu item)"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Добавяне на раздели"
 
 # smartling.placeholder_format=C
 #. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
@@ -1482,7 +1479,7 @@ msgctxt ""
 "Title and accessible name of the tab-picker dialog opened from the attach "
 "dropdown menu"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Добавяне на раздели"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1573,7 +1570,7 @@ msgstr "Добавяне на финални щрихи"
 #. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
 msgctxt "Aria label for the additional instructions textarea"
 msgid "Additional instructions"
-msgstr ""
+msgstr "Допълнителни инструкции"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1666,8 +1663,8 @@ msgctxt ""
 msgid ""
 "Advanced models can reach usage limits 2–5x sooner than other models. %s"
 msgstr ""
-"Усъвършенстваните модели могат да достигнат лимитите за ползване 2–5 пъти по-"
-"бързо от другите модели. %1$s"
+"Усъвършенстваните модели могат да достигнат лимитите за ползване 2–5 пъти "
+"по-бързо от другите модели. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
@@ -1883,7 +1880,7 @@ msgstr "Готово!"
 #. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the read-only textarea listing all AI instructions"
 msgid "All instructions"
-msgstr ""
+msgstr "Всички инструкции"
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2319,8 +2316,7 @@ msgstr ""
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr ""
-"Сигурни ли сте, че искате да изчистите този разговор и да започнете нов?"
+msgstr "Сигурни ли сте, че искате да изчистите този разговор и да започнете нов?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2656,8 +2652,7 @@ msgstr "След приключване на чата аудиото не се �
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"След транскрибиране на чата аудиото не се съхранява от нас или от OpenAI."
+msgstr "След транскрибиране на чата аудиото не се съхранява от нас или от OpenAI."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -3607,7 +3602,7 @@ msgctxt ""
 "Secondary button that dismisses the tab picker dialog without attaching "
 "anything"
 msgid "Cancel"
-msgstr ""
+msgstr "Отмяна"
 
 # smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
@@ -3879,8 +3874,7 @@ msgstr "Променя фоновия цвят, когато курсорът б
 #. Description of a setting managing the color of search result snippet text.
 msgctxt "settings"
 msgid "Changes the color of descriptive content shown for results"
-msgstr ""
-"Променя цвета на описателното съдържание, което се показва с резултатите"
+msgstr "Променя цвета на описателното съдържание, което се показва с резултатите"
 
 # smartling.placeholder_format=C
 #. This is the description of a user setting
@@ -4110,7 +4104,7 @@ msgstr "Отговорът в чата е обиден"
 #. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
 msgctxt "Chat history about modal list item headline"
 msgid "Chat storage varies by browser"
-msgstr ""
+msgstr "Съхранението на чатовете зависи от браузъра"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4122,7 +4116,7 @@ msgstr "Чат с %1$s"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Chat with popular AI models, anonymized by us."
-msgstr ""
+msgstr "Чат с популярни AI модели, анонимизирани от нас."
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4149,6 +4143,8 @@ msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
 msgstr ""
+"Чатовете се съхраняват сигурно на сървъра на DuckDuckGo с криптиране от край "
+"до край. Никой освен Вас не може да види Вашите данни, дори ние."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4263,8 +4259,7 @@ msgstr "Проверете правописа"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr ""
-"Проверка на subreddit в DuckDuckGo за актуализации относно това прекъсване."
+msgstr "Проверка на subreddit в DuckDuckGo за актуализации относно това прекъсване."
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4673,8 +4668,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr ""
-"Щракнете върху %1$sПоверителност и услуги%2$s в лявата странична лента."
+msgstr "Щракнете върху %1$sПоверителност и услуги%2$s в лявата странична лента."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -4741,8 +4735,7 @@ msgstr "Щракнете върху %1$sБраузър%2$s в странично
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on %sChange Search Settings%s in the dropdown menu"
-msgstr ""
-"Щракнете върху %1$sПромяна на настройките за търсене%2$s в падащото меню"
+msgstr "Щракнете върху %1$sПромяна на настройките за търсене%2$s в падащото меню"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -4760,8 +4753,7 @@ msgstr "Щракнете върху %1$sТърсачки%2$s под Видове
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sTools icon%s in the top-right of the browser"
-msgstr ""
-"Щракнете върху %1$sиконата Настройки%2$s в горния десен ъгъл на браузъра"
+msgstr "Щракнете върху %1$sиконата Настройки%2$s в горния десен ъгъл на браузъра"
 
 #  Firefox default search engine instruction
 # smartling.placeholder_format=C
@@ -4836,8 +4828,7 @@ msgstr "Щракнете върху %1$sиконата за разрешения
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr ""
-"Щракнете върху иконата с пате в горната част на браузъра си, за да търсите!"
+msgstr "Щракнете върху иконата с пате в горната част на браузъра си, за да търсите!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -5467,8 +5458,7 @@ msgstr "Копиране"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"Копирайте и поставете %1$sabout:preferences#search%2$s в адресната лента"
+msgstr "Копирайте и поставете %1$sabout:preferences#search%2$s в адресната лента"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5575,8 +5565,7 @@ msgstr "Коста Рика"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr ""
-"Неуспешно зареждане на кода. Затворете този прозорец и опитайте отново."
+msgstr "Неуспешно зареждане на кода. Затворете този прозорец и опитайте отново."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5761,7 +5750,7 @@ msgstr "Текуща серия"
 #. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
 msgctxt "Suffix label indicating a tab is the currently active browser tab"
 msgid "Current Tab"
-msgstr ""
+msgstr "Текущ раздел"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
@@ -6117,7 +6106,7 @@ msgstr "Изтриване на чатове, по-стари от 30 дни"
 #. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
 msgctxt "Button text in the modal for deleting all recent chats"
 msgid "Delete Chats and Shared Links"
-msgstr ""
+msgstr "Изтриване на чатовете и споделените връзки"
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6444,8 +6433,7 @@ msgstr "Деактивиране и изключване"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr ""
-"Деактивиране на историята на чата и прекъсване на връзката със Sync & Backup?"
+msgstr "Деактивиране на историята на чата и прекъсване на връзката със Sync & Backup?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6539,7 +6527,7 @@ msgstr "Пропусни промоцията"
 #. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the close button on the survey banner"
 msgid "Dismiss survey"
-msgstr ""
+msgstr "Отхвърляне на анкетата"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6652,8 +6640,7 @@ msgstr "Не виждате DuckDuckGo в списъка?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr ""
-"Не го виждате? %1$s%2$s%3$sНатиснете тук, за да го изтеглите отново%4$s"
+msgstr "Не го виждате? %1$s%2$s%3$sНатиснете тук, за да го изтеглите отново%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6977,8 +6964,7 @@ msgstr "Условия за ползване на Duck.ai"
 #. The HTML <title> for Duck.ai.
 msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
-msgstr ""
-"Duck.ai от DuckDuckGo. Поверителен чат с изкуствен интелект. Безплатен."
+msgstr "Duck.ai от DuckDuckGo. Поверителен чат с изкуствен интелект. Безплатен."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -7024,8 +7010,7 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"Duck.ai е най-добър в нашия поверителен и безплатен браузър DuckDuckGo!"
+msgstr "Duck.ai е най-добър в нашия поверителен и безплатен браузър DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -7075,8 +7060,7 @@ msgstr ""
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr ""
-"Duck.ai е временно недостъпен. Моля, опреснете страницата и опитайте отново."
+msgstr "Duck.ai е временно недостъпен. Моля, опреснете страницата и опитайте отново."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7107,8 +7091,8 @@ msgstr ""
 "интелект на трети страни, включително модели от OpenAI, Anthropic и други. "
 "Ако изключите тази настройка, бутоните и връзките на Duck.ai в DuckDuckGo "
 "Search ще се скрият. Въпреки това можете да получите достъп до Duck.ai, "
-"когато тази настройка е изключена, като посетите директно %1$shttps://duck."
-"ai%2$s ."
+"когато тази настройка е изключена, като посетите директно "
+"%1$shttps://duck.ai%2$s ."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -7348,8 +7332,8 @@ msgstr ""
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
 msgstr ""
-"Функцията DuckDuckGo AI Chat е временно недостъпна. Моля, опитайте отново по-"
-"късно."
+"Функцията DuckDuckGo AI Chat е временно недостъпна. Моля, опитайте отново "
+"по-късно."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7722,7 +7706,7 @@ msgstr "Редактиране на подкана"
 #. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the message-editing text area"
 msgid "Edit message"
-msgstr ""
+msgstr "Редактиране на съобщение"
 
 # smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
@@ -7953,7 +7937,7 @@ msgstr "Криптиран модел"
 #. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
 msgctxt "Share modal info bullet about encryption"
 msgid "Encrypted so DuckDuckGo can't read your chat."
-msgstr ""
+msgstr "Криптирано, така че DuckDuckGo да не може да прочете Вашия чат."
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8019,15 +8003,13 @@ msgstr ""
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr ""
-"Уверете се, че функцията \"Услуги за местоположение\" е %1$sактивирана%2$s."
+msgstr "Уверете се, че функцията \"Услуги за местоположение\" е %1$sактивирана%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr ""
-"Уверете се, че функцията „Местоположение“ е зададена на %1$s„разрешаване“%2$s"
+msgstr "Уверете се, че функцията „Местоположение“ е зададена на %1$s„разрешаване“%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -8057,15 +8039,13 @@ msgstr "Уверете се, че достъпът до местоположен
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s"
-msgstr ""
-"Уверете се, че на браузъра е разрешен %1$sдостъпът до местоположението%2$s"
+msgstr "Уверете се, че на браузъра е разрешен %1$sдостъпът до местоположението%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s."
-msgstr ""
-"Уверете се, че браузърът има разрешен %1$sдостъп до местоположение%2$s."
+msgstr "Уверете се, че браузърът има разрешен %1$sдостъп до местоположение%2$s."
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
@@ -8171,8 +8151,7 @@ msgstr "Екваториална Гвинея"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"Изтрийте светкавично данните за сърфирането с нашия %1$sбутон Fire Button%2$s"
+msgstr "Изтрийте светкавично данните за сърфирането с нашия %1$sбутон Fire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -8280,8 +8259,7 @@ msgstr "Обясни приетия отговор с прости думи."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr ""
-"Обясни ми основните принципи на черните дупки на ниво гимназиален етап."
+msgstr "Обясни ми основните принципи на черните дупки на ниво гимназиален етап."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -8359,8 +8337,7 @@ msgstr "Разгледайте Duck.ai"
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
-msgstr ""
-"Разгледайте най-новите актуализации на продукти и функции на DuckDuckGo."
+msgstr "Разгледайте най-новите актуализации на продукти и функции на DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8665,8 +8642,7 @@ msgstr "Финансов консултант"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr ""
-"Намерете %1$sDuckDuckGo%2$s и щракнете върху%3$sНаправи по подразбиране%4$s"
+msgstr "Намерете %1$sDuckDuckGo%2$s и щракнете върху%3$sНаправи по подразбиране%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8801,7 +8777,7 @@ msgstr "Допълнителен въпрос"
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
-msgstr ""
+msgstr "Следващите съобщения остават поверителни."
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8907,8 +8883,7 @@ msgstr "Безплатни и поверителни чатове, аноним�
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Безплатни и поверителни чатове, анонимизирани от нас. Не е необходим акаунт."
+msgstr "Безплатни и поверителни чатове, анонимизирани от нас. Не е необходим акаунт."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9154,15 +9129,13 @@ msgstr "Общо предназначение"
 #. Text with short description for an AI (Artificial Intelligence) Model that has a high moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with high built-in moderation"
-msgstr ""
-"Изкуствен интелект с общо предназначение с високо ниво на вградена модерация"
+msgstr "Изкуствен интелект с общо предназначение с високо ниво на вградена модерация"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a low moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with low built-in moderation"
-msgstr ""
-"Изкуствен интелект с общо предназначение с ниско ниво на вградена модерация"
+msgstr "Изкуствен интелект с общо предназначение с ниско ниво на вградена модерация"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a medium moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
@@ -9320,14 +9293,13 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr ""
-"Вземете DuckDuckGo VPN, усъвършенстван Duck.ai и Identity Theft Restoration."
+msgstr "Вземете DuckDuckGo VPN, усъвършенстван Duck.ai и Identity Theft Restoration."
 
 # smartling.placeholder_format=C
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
 msgctxt "Tooltip on the header logo for sunglasses searches"
 msgid "Get DuckDuckGo sunglasses and other gear."
-msgstr ""
+msgstr "Вземете слънчеви очила и други артикули с марката DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9663,8 +9635,7 @@ msgstr ""
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr ""
-"Отидете на %1$s„Поверителност и сигурност > Услуги за местоположение“%2$s"
+msgstr "Отидете на %1$s„Поверителност и сигурност > Услуги за местоположение“%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -10336,8 +10307,7 @@ msgstr "Скриване на Вашия имейл адрес"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Hides search term from being shown in browser tab/history"
-msgstr ""
-"Скрива търсената дума, за да не се показва в раздела/историята на браузъра"
+msgstr "Скрива търсената дума, за да не се показва в раздела/историята на браузъра"
 
 # smartling.placeholder_format=C
 #. The highest stock price in a day
@@ -10567,7 +10537,7 @@ msgstr "Как работи"
 #. Headline in chat history about modals for the temporary encrypted server storage explanation.
 msgctxt "Chat history about modal list item headline"
 msgid "How it works"
-msgstr ""
+msgstr "Как работи"
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -10605,8 +10575,7 @@ msgstr "Колко често искате да виждате отговори�
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How often do you want to see AI-assisted answers?"
-msgstr ""
-"Колко често искаш да виждаш отговори, подпомогнати от изкуствен интелект?"
+msgstr "Колко често искаш да виждаш отговори, подпомогнати от изкуствен интелект?"
 
 # smartling.placeholder_format=C
 #. Section title above the frequency radio options in the Search Assist settings modal.
@@ -10744,8 +10713,8 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"Харесва ми книгата „Името на вятъра“. Кажи ми какви други добри книги/"
-"поредици има, които приличат най-много на нея, и защо?"
+"Харесва ми книгата „Името на вятъра“. Кажи ми какви други добри "
+"книги/поредици има, които приличат най-много на нея, и защо?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -11371,8 +11340,7 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr ""
-"Това място добро ли е? Обобщи репутацията му въз основа на отзиви и оценки."
+msgstr "Това място добро ли е? Обобщи репутацията му въз основа на отзиви и оценки."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -11422,8 +11390,7 @@ msgstr "Той е бърз, безплатен и осигурява още по
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Няма проблем (много рядко) да ме питате за мнението ми относно DuckDuckGo"
+msgstr "Няма проблем (много рядко) да ме питате за мнението ми относно DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -12003,8 +11970,7 @@ msgstr "Ограничено съхранение на данни за този 
 #. Description of a setting managing the length of search result snippet text.
 msgctxt "settings"
 msgid "Limits the amount of descriptive content shown for results"
-msgstr ""
-"Ограничава количеството описателно съдържание, което се показва с резултатите"
+msgstr "Ограничава количеството описателно съдържание, което се показва с резултатите"
 
 # smartling.placeholder_format=C
 #. i.e. a type of image comprised of lines without gradiations in shade or hue
@@ -12028,7 +11994,7 @@ msgstr "Връзката изтича след 7 дни."
 #. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days. People can save a chat copy."
-msgstr ""
+msgstr "Връзката изтича след 7 дни. Хората могат да запазят копие на чата."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -12157,8 +12123,7 @@ msgstr "Зареждане на още резултати с изображен�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr ""
-"При превъртане зарежда повече резултати в изображения, видео и пазаруване"
+msgstr "При превъртане зарежда повече резултати в изображения, видео и пазаруване"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -12187,8 +12152,7 @@ msgstr "Местоположение"
 #. Message informing users that location-based search is private.
 msgctxt "precise_user_location"
 msgid "Location information is stored only on your device."
-msgstr ""
-"Информацията за местоположението се съхранява само на вашето устройство."
+msgstr "Информацията за местоположението се съхранява само на вашето устройство."
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -14158,7 +14122,7 @@ msgstr "Добре, разбрах!"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "OPTIONAL"
-msgstr ""
+msgstr "ПО ИЗБОР"
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -14657,8 +14621,7 @@ msgstr "Отваряне на панела Как работи Duck.ai"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Отворете менюто на Safari и изберете %1$s„Настройки за DuckDuckGo“...%2$s"
+msgstr "Отворете менюто на Safari и изберете %1$s„Настройки за DuckDuckGo“...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -15289,9 +15252,9 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"Ако формулирате своето търсене като въпрос и в пълно изречение, е по-"
-"вероятно DuckAssist да се появи и често допринася за по-добри отговори. За "
-"да настроите как да работи тази функция или да я изключите, отидете на "
+"Ако формулирате своето търсене като въпрос и в пълно изречение, е "
+"по-вероятно DuckAssist да се появи и често допринася за по-добри отговори. "
+"За да настроите как да работи тази функция или да я изключите, отидете на "
 "%1$sНастройки на DuckAssist%2$s."
 
 # smartling.placeholder_format=C
@@ -15420,8 +15383,7 @@ msgstr "Закачени"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
-"Закачените чатове ще се показват най-отгоре в списъка с последни чатове."
+msgstr "Закачените чатове ще се показват най-отгоре в списъка с последни чатове."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -16292,7 +16254,7 @@ msgstr "Защитени"
 #. Headline in sync-enabled chat history about modals explaining encrypted server storage.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Protected with end-to-end encryption"
-msgstr ""
+msgstr "Защитено с криптиране от край до край"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -16431,7 +16393,7 @@ msgstr "Ранг"
 #. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
 msgctxt "star rating on a product"
 msgid "Rated %s out of %s"
-msgstr ""
+msgstr "Оценка %1$s от %2$s"
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -16531,15 +16493,14 @@ msgstr "С обосновка може да получите по-подробн
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
 msgstr ""
-"Обосновката е по-задълбочена, но достига лимитите за ползване 2–5 пъти по-"
-"бързо. %1$s"
+"Обосновката е по-задълбочена, но достига лимитите за ползване 2–5 пъти "
+"по-бързо. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr ""
-"Обосновката е по-задълбочена, но изчерпва лимитите 2-5 пъти по-бързо. %1$s"
+msgstr "Обосновката е по-задълбочена, но изчерпва лимитите 2-5 пъти по-бързо. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -16908,8 +16869,7 @@ msgstr "Запомни моя избор"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Запомни моя избор (това може да бъде променено в %1$s%2$s%3$sНастройки%4$s)"
+msgstr "Запомни моя избор (това може да бъде променено в %1$s%2$s%3$sНастройки%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -17673,7 +17633,7 @@ msgstr "Запазете чатовете на всички устройства
 #. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
 msgctxt "Chat history about modal list item headline"
 msgid "Save your chats on this device"
-msgstr ""
+msgstr "Запазване на чатовете на това устройство"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
@@ -17807,15 +17767,13 @@ msgstr "Шотландия"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Scroll down and click %sView advanced settings%s"
-msgstr ""
-"Превъртете надолу и щракнете върху %1$sПреглед на разширените настройки%2$s"
+msgstr "Превъртете надолу и щракнете върху %1$sПреглед на разширените настройки%2$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr ""
-"Превъртете надолу и щракнете върху %1$sПреглед на разширените настройки%2$s."
+msgstr "Превъртете надолу и щракнете върху %1$sПреглед на разширените настройки%2$s."
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -17887,7 +17845,7 @@ msgctxt ""
 "Placeholder and accessibility label for the search input in the tab picker "
 "dialog"
 msgid "Search"
-msgstr ""
+msgstr "Търсене"
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18262,8 +18220,7 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr ""
-"Съхранява се сигурно на сървъра на DuckDuckGo с криптиране от край до край."
+msgstr "Съхранява се сигурно на сървъра на DuckDuckGo с криптиране от край до край."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -18390,8 +18347,7 @@ msgstr "Вижте някои от най-новите ни актуализац
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr ""
-"За повече подробности вижте %1$sстраницата за справка за URL параметър%2$s."
+msgstr "За повече подробности вижте %1$sстраницата за справка за URL параметър%2$s."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -18431,8 +18387,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Изберете %1$sDuckDuckGo%2$s и натиснете %3$sДобавяне по подразбиране%4$s!"
+msgstr "Изберете %1$sDuckDuckGo%2$s и натиснете %3$sДобавяне по подразбиране%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -18453,8 +18408,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr ""
-"Изберете %1$sDuckDuckGo%2$s в падащия списък като търсачка по подразбиране"
+msgstr "Изберете %1$sDuckDuckGo%2$s в падащия списък като търсачка по подразбиране"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
@@ -18937,8 +18891,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"Споделете местоположение на ниво град с AI моделите, за да получавате по-"
-"подходящи отговори. Duck.ai никога не разкрива точното Ви местоположение "
+"Споделете местоположение на ниво град с AI моделите, за да получавате "
+"по-подходящи отговори. Duck.ai никога не разкрива точното Ви местоположение "
 "нито на нас, нито на AI моделите."
 
 # smartling.placeholder_format=C
@@ -19082,7 +19036,7 @@ msgstr "Купи"
 #. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
 msgctxt "Button in the merchandise logo modal (mobile)"
 msgid "Shop Now"
-msgstr ""
+msgstr "Купете сега"
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -19375,8 +19329,7 @@ msgstr "Показване на страничната лента"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
-"Показва съвети стъпка по стъпка за извличане на максимална полза от Duck.ai."
+msgstr "Показва съвети стъпка по стъпка за извличане на максимална полза от Duck.ai."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -19474,8 +19427,7 @@ msgstr "Показва периодично напомняне за добавя
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Показва периодично напомняне за добавяне на DuckDuckGo към устройствата ви"
+msgstr "Показва периодично напомняне за добавяне на DuckDuckGo към устройствата ви"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19493,8 +19445,7 @@ msgstr "Показва номерата на страниците в края н
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows sign-up form for the DuckDuckGo privacy newsletters"
-msgstr ""
-"Показва формуляр за регистриране за бюлетините за поверителност на DuckDuckGo"
+msgstr "Показва формуляр за регистриране за бюлетините за поверителност на DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/94erFcS.png
@@ -19517,14 +19468,12 @@ msgstr "Показва фона на бутона за търсене"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message on top of the search results page"
-msgstr ""
-"Показва приветствие в горната част на страницата с резултати от търсенето"
+msgstr "Показва приветствие в горната част на страницата с резултати от търсенето"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Показва приветствие за потребителите с меню за предпочитания за Android в ЕС"
+msgstr "Показва приветствие за потребителите с меню за предпочитания за Android в ЕС"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -19596,14 +19545,12 @@ msgstr "Имена на сайтове"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr ""
-"Търсенето в сайта е временно недостъпно. Работим за разрешаване на проблема."
+msgstr "Търсенето в сайта е временно недостъпно. Работим за разрешаване на проблема."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"Сайтовете, които блокирате, ще бъдат скрити от всички резултати от търсенето."
+msgstr "Сайтовете, които блокирате, ще бъдат скрити от всички резултати от търсенето."
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19762,8 +19709,7 @@ msgstr "Нещо се обърка при запазването на сървъ
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr ""
-"Нещо се обърка при активирането на Sync & Backup. Моля, опитайте отново."
+msgstr "Нещо се обърка при активирането на Sync & Backup. Моля, опитайте отново."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -19793,8 +19739,7 @@ msgstr "Понякога"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr ""
-"Съжалявам, не мога да помогна, моля, опишете изображението по друг начин."
+msgstr "Съжалявам, не мога да помогна, моля, опишете изображението по друг начин."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19869,8 +19814,8 @@ msgstr ""
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
 msgstr ""
-"За съжаление, не успяхме да подадем вашия отзив. Моля, опитайте отново по-"
-"късно."
+"За съжаление, не успяхме да подадем вашия отзив. Моля, опитайте отново "
+"по-късно."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -20186,8 +20131,7 @@ msgstr "Спрете скритите тракери, които се спота
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Спрете повечето от скритите тракери, които се спотайват в други уебсайтове."
+msgstr "Спрете повечето от скритите тракери, които се спотайват в други уебсайтове."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20753,6 +20697,8 @@ msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
 msgstr ""
+"Sync & Backup запазва повече от чатовете и ги синхронизира на всички "
+"устройства."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20875,7 +20821,7 @@ msgstr "Синхронизирайте чатовете на всички уст
 #. Headline in sync-enabled chat history about modals explaining cross-device sync.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Sync your chats across all your devices"
-msgstr ""
+msgstr "Синхронизирайте чатовете на всички устройства"
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -20995,8 +20941,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
-"Попълнете тази анонимна анкета, за да ни кажете как можем да подобрим Duck."
-"ai."
+"Попълнете тази анонимна анкета, за да ни кажете как можем да подобрим "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -21366,8 +21312,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
 msgid "There's been an issue loading this answer. Please try again."
-msgstr ""
-"Възникна проблем при зареждането на този отговор. Моля, опитайте отново."
+msgstr "Възникна проблем при зареждането на този отговор. Моля, опитайте отново."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -21421,8 +21366,7 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr ""
-"Този AI модел вече не е наличен. Опитайте да започнете нов чат с друг модел."
+msgstr "Този AI модел вече не е наличен. Опитайте да започнете нов чат с друг модел."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -21438,8 +21382,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Този незабавен отговор бе създаден от общността на %1$sDuckDuckHack%2$s."
+msgstr "Този незабавен отговор бе създаден от общността на %1$sDuckDuckHack%2$s."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -21468,12 +21411,14 @@ msgid ""
 "This chat and its generated images become public when you create and copy "
 "the link."
 msgstr ""
+"Този чат и генерираните от него изображения стават публични, когато "
+"създадете и копирате връзката."
 
 # smartling.placeholder_format=C
 #. Explains that creating and copying a share link makes the selected chat content public.
 msgctxt "Share modal info bullet about public access"
 msgid "This chat becomes public when you create and copy the link."
-msgstr ""
+msgstr "Този чат става публичен, когато създадете и копирате връзката."
 
 # smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
@@ -21784,8 +21729,7 @@ msgstr "Този превод е грешен"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Все още не можете да гледате това видео тук. Можете да го гледате в %1$s."
+msgstr "Все още не можете да гледате това видео тук. Можете да го гледате в %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -22014,7 +21958,7 @@ msgstr "Днес"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
-msgstr ""
+msgstr "Превключете към частен чат с AI или го %1$sдеактивирайте в настройките%2$s."
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -22245,8 +22189,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"Преведи това изречение от английски на френски: „Как да стигна до най-"
-"близкото кино?“"
+"Преведи това изречение от английски на френски: „Как да стигна до "
+"най-близкото кино?“"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -22255,8 +22199,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"Преведи това изречение от български на английски: „Как да стигна до най-"
-"близкото кино?“"
+"Преведи това изречение от български на английски: „Как да стигна до "
+"най-близкото кино?“"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -22374,8 +22318,7 @@ msgstr "Изпробвайте %1$s — първият ни модел с нул
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
-msgstr ""
-"Опитайте %1$sDuck.ai%2$s, нашата частна услуга за чат с изкуствен интелект:"
+msgstr "Опитайте %1$sDuck.ai%2$s, нашата частна услуга за чат с изкуствен интелект:"
 
 # smartling.placeholder_format=C
 #. Button text to retry loading an explore more question that failed
@@ -22616,8 +22559,7 @@ msgstr "Изпробвайте нашия браузър"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr ""
-"Опитайте нашата начална страница, която никога не показва тези съобщения:"
+msgstr "Опитайте нашата начална страница, която никога не показва тези съобщения:"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time; shown in the US. Invites the user to start a free trial of the paid subscription.
@@ -23114,8 +23056,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"Под %1$sСТАРТИРАНЕ > Начална страница%2$s въведете: https://duckduckgo.com"
+msgstr "Под %1$sСТАРТИРАНЕ > Начална страница%2$s въведете: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23133,8 +23074,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr ""
-"В раздела %1$sТърсене%2$s щракнете върху %3$sУправляване на търсачките...%4$s"
+msgstr "В раздела %1$sТърсене%2$s щракнете върху %3$sУправляване на търсачките...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -23693,8 +23633,7 @@ msgstr ""
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
 msgctxt "DuckChat location prompt"
 msgid "Use your approximate location for more accurate results?"
-msgstr ""
-"Да се използва приблизителното Ви местоположение за по-точни резултати?"
+msgstr "Да се използва приблизителното Ви местоположение за по-точни резултати?"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes before every user message in the downloaded file, indicating which message it is out of the total number of messages. Example: 'User prompt 3 of 5'
@@ -23858,6 +23797,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Yelp's ad network."
 msgstr ""
+"DuckDuckGo защитава Вашата поверителност при разглеждане на реклами. "
+"Кликовете върху рекламите се управляват от рекламната мрежа на Yelp."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -24180,8 +24121,8 @@ msgstr "Ние анонимизираме"
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
 msgstr ""
-"Можем да анонимизираме%1$s вашето местоположение%2$s, за да ви показваме по-"
-"точни резултати."
+"Можем да анонимизираме%1$s вашето местоположение%2$s, за да ви показваме "
+"по-точни резултати."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -24293,8 +24234,7 @@ msgstr "Ние не ви проследяваме. Никога."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr ""
-"Ние не Ви проследяваме. Това е нашата Политика за поверителност накратко."
+msgstr "Ние не Ви проследяваме. Това е нашата Политика за поверителност накратко."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -24335,8 +24275,7 @@ msgstr "Не ви следим нито във, нито извън режима
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr ""
-"Ние не Ви проследяваме. Това е нашата Политика за поверителност накратко…"
+msgstr "Ние не Ви проследяваме. Това е нашата Политика за поверителност накратко…"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -24493,8 +24432,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr ""
-"Съжаляваме за това неудобство. Работим усилено, за да подобрим изживяването."
+msgstr "Съжаляваме за това неудобство. Работим усилено, за да подобрим изживяването."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -24659,8 +24597,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"Добре дошли в новия Duck.ai! Вече можете да импортирате изтеглените чатове."
+msgstr "Добре дошли в новия Duck.ai! Вече можете да импортирате изтеглените чатове."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24751,15 +24688,13 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr ""
-"Какви фактори трябва да се имам предвид, когато купувам монитор за компютър?"
+msgstr "Какви фактори трябва да се имам предвид, когато купувам монитор за компютър?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr ""
-"Кои атракции трябва да види един турист, който посещава Париж за първи път?"
+msgstr "Кои атракции трябва да види един турист, който посещава Париж за първи път?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -24884,8 +24819,7 @@ msgstr "Кои са ястията, които задължително тряб
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
-"Какво е работното време, местоположението и данните за контакт на това място?"
+msgstr "Какво е работното време, местоположението и данните за контакт на това място?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -25354,6 +25288,8 @@ msgid ""
 "With chat history on, up to %s of your most recent chats will be saved on "
 "this device."
 msgstr ""
+"Когато историята на чатовете е включена, на това устройство ще се запазват "
+"до %1$s от най-новите чатове."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline in the About Chat History modal.
@@ -25361,6 +25297,8 @@ msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, your most recent chats will be saved on this device."
 msgstr ""
+"Когато историята на чатовете е включена, най-новите чатове ще се запазват на "
+"това устройство."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -25762,8 +25700,7 @@ msgstr "Можете да продължите този чат, като изп�
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Вече можете да запазите до 100 чата на това устройство. Разговаряйте на воля!"
+msgstr "Вече можете да запазите до 100 чата на това устройство. Разговаряйте на воля!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -25840,8 +25777,7 @@ msgstr "Можете да възстановите настройките си, 
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can share your settings among computers and browsers."
-msgstr ""
-"Можете да споделяте и използвате настройките си с други компютри и браузъри."
+msgstr "Можете да споделяте и използвате настройките си с други компютри и браузъри."
 
 # smartling.placeholder_format=C
 #. Alternative option description on export screen.
@@ -26038,15 +25974,14 @@ msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
 msgstr ""
-"Достигнахте максималния брой съобщения за момента. Моля, опитайте отново по-"
-"късно."
+"Достигнахте максималния брой съобщения за момента. Моля, опитайте отново "
+"по-късно."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr ""
-"Достигнали сте максималната продължителност на гласовия чат за една сесия."
+msgstr "Достигнали сте максималната продължителност на гласовия чат за една сесия."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
@@ -26058,8 +25993,7 @@ msgstr "Достигнали сте лимита за гласов чат за �
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"Достигнали сте лимита за използване на диктовка. Опитайте отново по-късно."
+msgstr "Достигнали сте лимита за използване на диктовка. Опитайте отново по-късно."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -26068,8 +26002,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"Мястото за съхранение на Sync & Backup за чатове с прикачени файлове в Duck."
-"ai е недостатъчно. Изтрийте %1$s най-стари чатове, за да възобновите "
+"Мястото за съхранение на Sync & Backup за чатове с прикачени файлове в "
+"Duck.ai е недостатъчно. Изтрийте %1$s най-стари чатове, за да възобновите "
 "синхронизирането. Закачените чатове няма да бъдат изтрити."
 
 # smartling.placeholder_format=C
@@ -26097,8 +26031,8 @@ msgid ""
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
 "YouTube (притежаван от Google) не позволява да гледате видео анонимно. "
-"Следователно гледането на YouTube видео тук ще бъде следено от YouTube/"
-"Google."
+"Следователно гледането на YouTube видео тук ще бъде следено от "
+"YouTube/Google."
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -26250,8 +26184,7 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr ""
-"Чатовете са поверителни и никога не се използват за обучение на AI модели"
+msgstr "Чатовете са поверителни и никога не се използват за обучение на AI модели"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -26312,8 +26245,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr ""
-"Чатовете са импортирани. Продължете оттам, откъдето сте спрели в Duck.ai."
+msgstr "Чатовете са импортирани. Продължете оттам, откъдето сте спрели в Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -26542,8 +26474,7 @@ msgstr ""
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr ""
-"Достигнахте лимита за гласов чат засега. Моля, опитайте отново по-късно."
+msgstr "Достигнахте лимита за гласов чат засега. Моля, опитайте отново по-късно."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -26626,8 +26557,7 @@ msgstr "от %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"от DuckDuckGo — онлайн защита, на която милиони се доверяват всеки ден."
+msgstr "от DuckDuckGo — онлайн защита, на която милиони се доверяват всеки ден."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"
@@ -26772,7 +26702,7 @@ msgstr "м"
 #. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the chat options menu button"
 msgid "menu"
-msgstr ""
+msgstr "меню"
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/bn_BD/LC_MESSAGES/duckduckgo.po
+++ b/locales/bn_BD/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr "আমাদের সম্পর্কে"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "DuckDuckGo যোগ করুন"
@@ -1100,6 +1117,24 @@ msgstr "সার্চ ইঞ্জিন হিসেবে DuckDuckGo-কে 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "%s -এ DuckDuckGo যোগ করুন"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr "এড-অনসমূহ"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1453,6 +1507,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2800,6 +2859,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3200,9 +3266,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3218,6 +3294,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4481,6 +4564,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4765,6 +4853,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5103,6 +5196,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6011,6 +6109,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6188,6 +6291,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6856,6 +6964,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7274,6 +7387,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8256,6 +8374,11 @@ msgid "How is it anonymous?"
 msgstr "এটি কিভাবে অজ্ঞাতনামা"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9415,6 +9538,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11153,6 +11281,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12857,6 +12990,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12963,6 +13101,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13951,6 +14094,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14106,6 +14254,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15027,6 +15182,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16367,6 +16527,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16447,6 +16614,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16907,6 +17079,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17310,6 +17496,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18774,6 +18965,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19923,6 +20121,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21010,6 +21221,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/bn_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/bn_IN/LC_MESSAGES/duckduckgo.po
@@ -980,6 +980,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1083,6 +1088,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr ""
@@ -1101,6 +1118,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1140,6 +1175,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1211,6 +1260,11 @@ msgstr "অতীরীক্ত কার্যকারিতা"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1455,6 +1509,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2802,6 +2861,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3202,9 +3268,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3220,6 +3296,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4479,6 +4562,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4763,6 +4851,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5101,6 +5194,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6009,6 +6107,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6186,6 +6289,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6851,6 +6959,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7269,6 +7382,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8251,6 +8369,11 @@ msgid "How is it anonymous?"
 msgstr "পরিচয় কিভাবে গুপ্ত রাখা হচ্ছে?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9406,6 +9529,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11143,6 +11271,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12843,6 +12976,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12949,6 +13087,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13937,6 +14080,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14092,6 +14240,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15009,6 +15164,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16348,6 +16508,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16428,6 +16595,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16888,6 +17060,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17290,6 +17476,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18752,6 +18943,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19901,6 +20099,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20985,6 +21196,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/bo_CN/LC_MESSAGES/duckduckgo.po
+++ b/locales/bo_CN/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr ""
@@ -1099,6 +1116,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr ""
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1453,6 +1507,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2800,6 +2859,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3200,9 +3266,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3218,6 +3294,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4475,6 +4558,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4759,6 +4847,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5097,6 +5190,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -5993,6 +6091,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6170,6 +6273,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6835,6 +6943,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7253,6 +7366,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8235,6 +8353,11 @@ msgid "How is it anonymous?"
 msgstr ""
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9388,6 +9511,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11125,6 +11253,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12825,6 +12958,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12931,6 +13069,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13919,6 +14062,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14074,6 +14222,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -14989,6 +15144,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16328,6 +16488,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16408,6 +16575,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16868,6 +17040,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17270,6 +17456,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18732,6 +18923,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19881,6 +20079,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20963,6 +21174,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/br_FR/LC_MESSAGES/duckduckgo.po
+++ b/locales/br_FR/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "kaout DuckDuckGo"
@@ -1099,6 +1116,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr "Askouezhioù"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1455,6 +1509,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2802,6 +2861,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3202,9 +3268,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3220,6 +3296,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4487,6 +4570,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4771,6 +4859,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5109,6 +5202,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6005,6 +6103,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6182,6 +6285,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6851,6 +6959,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7269,6 +7382,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8251,6 +8369,11 @@ msgid "How is it anonymous?"
 msgstr "Penaos eo dianv ?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9408,6 +9531,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11147,6 +11275,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12852,6 +12985,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12958,6 +13096,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13946,6 +14089,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14101,6 +14249,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15023,6 +15178,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16364,6 +16524,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16444,6 +16611,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16904,6 +17076,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17308,6 +17494,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18777,6 +18968,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19928,6 +20126,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21014,6 +21225,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/bs_BA/LC_MESSAGES/duckduckgo.po
+++ b/locales/bs_BA/LC_MESSAGES/duckduckgo.po
@@ -987,6 +987,11 @@ msgstr "O nama"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1090,6 +1095,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "Reklama je sumnjiva"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Dodaj DuckDuckGo"
@@ -1111,6 +1128,24 @@ msgstr "Dodajte DuckDuckGo kao pretraživač"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Dodaj DuckDuckGo u %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1149,6 +1184,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1220,6 +1269,11 @@ msgstr "Dodaci"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1465,6 +1519,11 @@ msgstr "Sve boje"
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2833,6 +2892,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3237,9 +3303,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3255,6 +3331,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4527,6 +4610,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr "Trenutni niz"
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4811,6 +4899,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5149,6 +5242,11 @@ msgstr "Trajno sakrij"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6059,6 +6157,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6239,6 +6342,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6911,6 +7019,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7329,6 +7442,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8317,6 +8435,11 @@ msgid "How is it anonymous?"
 msgstr "Kako je anonimno?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9497,6 +9620,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11235,6 +11363,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "U redu, razumijem!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12953,6 +13086,11 @@ msgstr "Zaštitite podatke na svakom uređaju."
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -13059,6 +13197,11 @@ msgstr "Kiša"
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -14052,6 +14195,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14211,6 +14359,13 @@ msgstr "Traži"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15139,6 +15294,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16490,6 +16650,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16570,6 +16737,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -17039,6 +17211,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17445,6 +17631,11 @@ msgstr "Danas"
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18916,6 +19107,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -20092,6 +20290,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21193,6 +21404,11 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "m"
 msgstr "m"
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.
 msgctxt "Aria label for the menu button"

--- a/locales/ca_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/ca_ES/LC_MESSAGES/duckduckgo.po
@@ -987,6 +987,11 @@ msgstr "Quant a nosaltres"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1090,6 +1095,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "L'anunci es sospitós"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Afegeix DuckDuckGo"
@@ -1111,6 +1128,24 @@ msgstr "Afegeix DuckDuckGo com a motor de cerca"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Afegeix DuckDuckGo al %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1149,6 +1184,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1220,6 +1269,11 @@ msgstr "Extensions"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1466,6 +1520,11 @@ msgstr "Tots els colors"
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2832,6 +2891,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3235,9 +3301,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3253,6 +3329,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4528,6 +4611,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr "Ratxa actual"
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4812,6 +4900,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5150,6 +5243,11 @@ msgstr "Ignora-ho sempre"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6060,6 +6158,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6242,6 +6345,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6917,6 +7025,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7335,6 +7448,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8326,6 +8444,11 @@ msgid "How is it anonymous?"
 msgstr "Com es manté anònim?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9510,6 +9633,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11248,6 +11376,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "Entesos!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12967,6 +13100,11 @@ msgstr "Protegiu les vostres dades a cada dispositiu."
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -13073,6 +13211,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -14065,6 +14208,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14229,6 +14377,13 @@ msgstr "Cerca"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15164,6 +15319,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16518,6 +16678,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16598,6 +16765,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -17068,6 +17240,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17474,6 +17660,11 @@ msgstr "Avui"
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18945,6 +19136,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -20118,6 +20316,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21220,6 +21431,11 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "m"
 msgstr "min"
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.
 msgctxt "Aria label for the menu button"

--- a/locales/cs_CZ/LC_MESSAGES/duckduckgo.po
+++ b/locales/cs_CZ/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: cs_CZ\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -106,8 +106,7 @@ msgstr "Počet pokusů: %1$s"
 # smartling.placeholder_format=C
 #. A summary description of how many tracking attempts where blocked, when there was more than 1. Eg: '1,028 attempts blocked by DuckDuckGo in the last 24 hours'
 msgid "%s attempts blocked by DuckDuckGo in the last 24 hours"
-msgstr ""
-"Počet pokusů zablokovaných službou DuckDuckGo za posledních 24 hodin: %1$s"
+msgstr "Počet pokusů zablokovaných službou DuckDuckGo za posledních 24 hodin: %1$s"
 
 # smartling.placeholder_format=C
 #. A label that indicates a specific search result has been blocked by the safe search filter. The placeholder value is the name of the search result that was blocked.
@@ -515,8 +514,7 @@ msgstr ""
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr ""
-"%1$sPřečti si víc%2$s o tom, jak se chaty soukromě ukládají na tvé zařízení."
+msgstr "%1$sPřečti si víc%2$s o tom, jak se chaty soukromě ukládají na tvé zařízení."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -528,8 +526,7 @@ msgstr "%1$sPodrž%2$s ikonu aplikace DuckDuckGo na domovské obrazovce"
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr ""
-"%1$sJejda!%2$s%3$sNěco se pokazilo. %4$sObnov stránku%5$s a zkus to znovu."
+msgstr "%1$sJejda!%2$s%3$sNěco se pokazilo. %4$sObnov stránku%5$s a zkus to znovu."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -880,8 +877,7 @@ msgstr "Byl vyčerpán 6hodinový limit využití."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Byl vyčerpán 6hodinový limit využití. V tomto chatu můžeš pokračovat za %1$s."
+msgstr "Byl vyčerpán 6hodinový limit využití. V tomto chatu můžeš pokračovat za %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -952,8 +948,7 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"Je dostupná nová verze AI Chatu! Pokud chceš pokračovat, obnov stránku."
+msgstr "Je dostupná nová verze AI Chatu! Pokud chceš pokračovat, obnov stránku."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
@@ -1215,7 +1210,7 @@ msgstr "O našich reklamách"
 #. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
 msgctxt "Modal header for chat history with sync information"
 msgid "About Chat History with Sync & Backup"
-msgstr ""
+msgstr "O Historii chatu se zapnutou funkcí Sync & Backup"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
@@ -1350,7 +1345,7 @@ msgstr "Reklama je podezřelá"
 #. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
 msgctxt "Button to open menu for attaching images or page context to AI chat"
 msgid "Add"
-msgstr ""
+msgstr "Přidat"
 
 # smartling.placeholder_format=C
 #. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
@@ -1358,7 +1353,7 @@ msgctxt ""
 "Primary button that attaches the tabs the user checked in the tab picker "
 "dialog"
 msgid "Add"
-msgstr ""
+msgstr "Přidat"
 
 # smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
@@ -1393,13 +1388,13 @@ msgstr "Přidat DuckDuckGo do %1$s"
 msgctxt ""
 "Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
 msgid "Add File"
-msgstr ""
+msgstr "Přidat soubor"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
 msgid "Add Image"
-msgstr ""
+msgstr "Přidat obrázek"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
@@ -1407,7 +1402,7 @@ msgctxt ""
 "Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
 "item)"
 msgid "Add Image or File"
-msgstr ""
+msgstr "Přidat obrázek nebo soubor"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1460,7 +1455,7 @@ msgctxt ""
 "Open the tab picker to attach browser tab content to the AI chat message "
 "(attach dropdown menu item)"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Přidat karty"
 
 # smartling.placeholder_format=C
 #. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
@@ -1468,7 +1463,7 @@ msgctxt ""
 "Title and accessible name of the tab-picker dialog opened from the attach "
 "dropdown menu"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Přidat karty"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1559,7 +1554,7 @@ msgstr "Už to bude"
 #. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
 msgctxt "Aria label for the additional instructions textarea"
 msgid "Additional instructions"
-msgstr ""
+msgstr "Další instrukce"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1661,8 +1656,7 @@ msgctxt ""
 "Always-visible warning banner shown above the recommended models in the "
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
-msgstr ""
-"Pokročilé modely můžou limity vyčerpat 2–5× rychleji než jiné modely. %1$s"
+msgstr "Pokročilé modely můžou limity vyčerpat 2–5× rychleji než jiné modely. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1865,7 +1859,7 @@ msgstr "Všechno je hotové!"
 #. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the read-only textarea listing all AI instructions"
 msgid "All instructions"
-msgstr ""
+msgstr "Všechny instrukce"
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -1959,8 +1953,7 @@ msgstr "Povolit anonymní kontrolu souborů pro tento chat?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Povolit na DuckDuckGo Private Search reklamy, které respektují soukromí"
+msgstr "Povolit na DuckDuckGo Private Search reklamy, které respektují soukromí"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2293,8 +2286,7 @@ msgstr "Jsi tam ještě?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"Opravdu chceš vymazat všechny své chaty? Tenhle krok se nedá vrátit zpět."
+msgstr "Opravdu chceš vymazat všechny své chaty? Tenhle krok se nedá vrátit zpět."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -3432,8 +3424,7 @@ msgstr "Kliknutím na „%1$s“ odsouhlasíš naše %2$s."
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr ""
-"Kliknutím na „%1$s“ vyjadřuješ souhlas s podmínkami Duck.ai, viz %2$s a %3$s."
+msgstr "Kliknutím na „%1$s“ vyjadřuješ souhlas s podmínkami Duck.ai, viz %2$s a %3$s."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3512,8 +3503,7 @@ msgstr "Kamerun"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr ""
-"Můžeš vytvořit několik jednoduchých receptů z kuřete, brokolice a rýže?"
+msgstr "Můžeš vytvořit několik jednoduchých receptů z kuřete, brokolice a rýže?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3585,7 +3575,7 @@ msgctxt ""
 "Secondary button that dismisses the tab picker dialog without attaching "
 "anything"
 msgid "Cancel"
-msgstr ""
+msgstr "Zrušit"
 
 # smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
@@ -4084,7 +4074,7 @@ msgstr "Odpověď chatu je urážlivá"
 #. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
 msgctxt "Chat history about modal list item headline"
 msgid "Chat storage varies by browser"
-msgstr ""
+msgstr "Ukládání chatů se liší podle prohlížeče"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4096,7 +4086,7 @@ msgstr "Chatuj s %1$s"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Chat with popular AI models, anonymized by us."
-msgstr ""
+msgstr "Chatuj s oblíbenými AI modely, které anonymizujeme."
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4123,6 +4113,8 @@ msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
 msgstr ""
+"Chaty se bezpečně ukládají na serveru DuckDuckGo se šifrováním end-to-end. "
+"Nikdo kromě tebe tvoje data neuvidí, dokonce ani my."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4636,15 +4628,13 @@ msgstr "Klikni %1$ssem%2$s a stáhni si rozšíření DuckDuckGo"
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr ""
-"Klikni na %1$sOtevřít%2$s a stáhni si a otevři rozšíření DuckDuckGo Safari"
+msgstr "Klikni na %1$sOtevřít%2$s a stáhni si a otevři rozšíření DuckDuckGo Safari"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr ""
-"V levém postranním panelu klepni na tlačítko %1$sSoukromí a služby%2$s."
+msgstr "V levém postranním panelu klepni na tlačítko %1$sSoukromí a služby%2$s."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -5731,7 +5721,7 @@ msgstr "Aktuální série"
 #. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
 msgctxt "Suffix label indicating a tab is the currently active browser tab"
 msgid "Current Tab"
-msgstr ""
+msgstr "Aktuální karta"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
@@ -5886,8 +5876,7 @@ msgstr "Byl vyčerpán denní limit"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Byl vyčerpán denní limit využití. V tomto chatu můžeš pokračovat za %1$s."
+msgstr "Byl vyčerpán denní limit využití. V tomto chatu můžeš pokračovat za %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -6086,7 +6075,7 @@ msgstr "Vymazat chaty starší než 30 dní"
 #. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
 msgctxt "Button text in the modal for deleting all recent chats"
 msgid "Delete Chats and Shared Links"
-msgstr ""
+msgstr "Smazat chaty a sdílené odkazy"
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6505,7 +6494,7 @@ msgstr "Zavřít propagační akci"
 #. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the close button on the survey banner"
 msgid "Dismiss survey"
-msgstr ""
+msgstr "Odmítnout průzkum"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6618,8 +6607,7 @@ msgstr "Nevidíš v seznamu DuckDuckGo?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr ""
-"Nedaří se ti soubor najít? %1$s%2$s%3$sKliknutím sem zopakuj stahování%4$s"
+msgstr "Nedaří se ti soubor najít? %1$s%2$s%3$sKliknutím sem zopakuj stahování%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6988,8 +6976,7 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"Duck.ai je nejlepší v našem soukromém a bezplatném prohlížeči DuckDuckGo!"
+msgstr "Duck.ai je nejlepší v našem soukromém a bezplatném prohlížeči DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -7077,8 +7064,7 @@ msgstr ""
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
 msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid "Duck.ai may display inaccurate or offensive information."
-msgstr ""
-"Duck.ai může zobrazovat může zobrazovat nepřesné nebo pohoršující informace."
+msgstr "Duck.ai může zobrazovat může zobrazovat nepřesné nebo pohoršující informace."
 
 # smartling.placeholder_format=C
 #. Error modal body line 2.
@@ -7127,8 +7113,7 @@ msgstr "Upgrade Duck.ai je hotový!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.ai funguje nejlíp v naší soukromé a bezplatné aplikaci DuckDuckGo!"
+msgstr "Duck.ai funguje nejlíp v naší soukromé a bezplatné aplikaci DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7305,8 +7290,7 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr ""
-"DuckDuckGo AI Chat je dočasně nedostupný. Obnov stránku a zkus to znovu."
+msgstr "DuckDuckGo AI Chat je dočasně nedostupný. Obnov stránku a zkus to znovu."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7683,7 +7667,7 @@ msgstr "Upravit prompt"
 #. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the message-editing text area"
 msgid "Edit message"
-msgstr ""
+msgstr "Upravit zprávu"
 
 # smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
@@ -7909,7 +7893,7 @@ msgstr "Šifrovaný model"
 #. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
 msgctxt "Share modal info bullet about encryption"
 msgid "Encrypted so DuckDuckGo can't read your chat."
-msgstr ""
+msgstr "Zašifrováno, takže DuckDuckGo si tvoje chaty nemůže číst."
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8121,8 +8105,7 @@ msgstr "Rovníková Guinea"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"Pomocí tlačítka %1$sFire Button%2$s můžeš bleskově vymazat data o prohlížení."
+msgstr "Pomocí tlačítka %1$sFire Button%2$s můžeš bleskově vymazat data o prohlížení."
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -8486,8 +8469,7 @@ msgstr ""
 msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
-msgstr ""
-"Nastavení můžeš změnit níže. Pak jednoduše zkopíruj kód do svojí stránky."
+msgstr "Nastavení můžeš změnit níže. Pak jednoduše zkopíruj kód do svojí stránky."
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8564,8 +8546,7 @@ msgstr "Filtry nefungují"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Filters out AI-generated images from image search results"
-msgstr ""
-"Odstraní obrázky vytvořené umělou inteligencí z výsledků vyhledávání obrázků"
+msgstr "Odstraní obrázky vytvořené umělou inteligencí z výsledků vyhledávání obrázků"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8734,8 +8715,7 @@ msgstr ""
 #. Privacy reassurance and instructions intro.
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
-msgstr ""
-"Postupuj podle těchto kroků a přesuň své chaty na novou doménu Duck.ai."
+msgstr "Postupuj podle těchto kroků a přesuň své chaty na novou doménu Duck.ai."
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8746,7 +8726,7 @@ msgstr "Navazující otázka"
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
-msgstr ""
+msgstr "Navazující zprávy zůstávají soukromé."
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8852,8 +8832,7 @@ msgstr "Bezplatné a soukromé chaty, které anonymizujeme"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Bezplatné a soukromé chaty, které anonymizujeme. Není potřeba žádný účet."
+msgstr "Bezplatné a soukromé chaty, které anonymizujeme. Není potřeba žádný účet."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9267,7 +9246,7 @@ msgstr ""
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
 msgctxt "Tooltip on the header logo for sunglasses searches"
 msgid "Get DuckDuckGo sunglasses and other gear."
-msgstr ""
+msgstr "Pořiď si sluneční brýle DuckDuckGo a další vybavení."
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9488,8 +9467,8 @@ msgstr "Stáhnout aplikaci"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"Nainstaluj si bezplatný prohlížeč DuckDuckGo %1$sa blokuj reklamy na YouTube."
-"%2$s"
+"Nainstaluj si bezplatný prohlížeč DuckDuckGo %1$sa blokuj reklamy na "
+"YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -10504,7 +10483,7 @@ msgstr "Jak to funguje"
 #. Headline in chat history about modals for the temporary encrypted server storage explanation.
 msgctxt "Chat history about modal list item headline"
 msgid "How it works"
-msgstr ""
+msgstr "Jak to funguje"
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -10522,8 +10501,7 @@ msgstr "Jak to funguje"
 #. Header for the assist settings modal where the user can choose how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How much do you want AI-assisted answers to appear?"
-msgstr ""
-"Jak často chceš, aby se objevovaly odpovědi s podporou umělé inteligence?"
+msgstr "Jak často chceš, aby se objevovaly odpovědi s podporou umělé inteligence?"
 
 # smartling.placeholder_format=C
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
@@ -10771,8 +10749,7 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"Pokud nás stále chceš podpořit, %1$spoděl se o DuckDuckGo s ostatními%2$s"
+msgstr "Pokud nás stále chceš podpořit, %1$spoděl se o DuckDuckGo s ostatními%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10781,8 +10758,7 @@ msgstr ""
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr ""
-"Pokud chceš používat DuckDuckGo bez JavaScriptu, použij verzi %1$s nebo %2$s."
+msgstr "Pokud chceš používat DuckDuckGo bez JavaScriptu, použij verzi %1$s nebo %2$s."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -11301,8 +11277,7 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr ""
-"Stojí to tady za něco? Shrň pověst podniku na základě recenzí a hodnocení."
+msgstr "Stojí to tady za něco? Shrň pověst podniku na základě recenzí a hodnocení."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -11872,8 +11847,7 @@ msgstr "Umožní ti anonymně vyhledávat pomocí DuckDuckGo"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr ""
-"Umožní ti přepínat mezi odesíláním vyhledávacích dotazů a promptů do Duck.ai"
+msgstr "Umožní ti přepínat mezi odesíláním vyhledávacích dotazů a promptů do Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11955,7 +11929,7 @@ msgstr "Platnost odkazu skončí za 7 dní."
 #. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days. People can save a chat copy."
-msgstr ""
+msgstr "Platnost odkazu skončí za 7 dní. Lidé si mohou uložit kopii chatu."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -12268,8 +12242,7 @@ msgstr "Ujisti se, že jsou všechna slova napsaná správně."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr ""
-"Zaškrtni možnost %1$sNastavit jako výchozího poskytovatele vyhledávání%2$s"
+msgstr "Zaškrtni možnost %1$sNastavit jako výchozího poskytovatele vyhledávání%2$s"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -12861,8 +12834,7 @@ msgstr "Byl vyčerpán měsíční limit"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Byl vyčerpán měsíční limit využití. V tomto chatu můžeš pokračovat za %1$s."
+msgstr "Byl vyčerpán měsíční limit využití. V tomto chatu můžeš pokračovat za %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -13733,8 +13705,7 @@ msgstr "Nebyly nalezeny žádné výsledky."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr ""
-"Nebyla zaznamenána žádná řeč. Zkus to prosím znovu a mluv do mikrofonu."
+msgstr "Nebyla zaznamenána žádná řeč. Zkus to prosím znovu a mluv do mikrofonu."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -14079,7 +14050,7 @@ msgstr "Dobře, rozumím!"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "OPTIONAL"
-msgstr ""
+msgstr "NEPOVINNÉ"
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -14350,8 +14321,7 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr ""
-"Jejda! Při překládání tohoto textu došlo k neočekávané chybě. Zkus to znovu."
+msgstr "Jejda! Při překládání tohoto textu došlo k neočekávané chybě. Zkus to znovu."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -14426,8 +14396,7 @@ msgstr "Otevřít %1$sNastavení%2$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open 'Location', and ensure location is %senabled%s."
-msgstr ""
-"Otevři možnost Poloha a ujisti se, že je přístup k poloze %1$spovolený%2$s."
+msgstr "Otevři možnost Poloha a ujisti se, že je přístup k poloze %1$spovolený%2$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -16166,8 +16135,7 @@ msgstr "Upozornit"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"Vyzvat mě, abych použil/a svou přibližnou polohu a získal/a výsledky v okolí."
+msgstr "Vyzvat mě, abych použil/a svou přibližnou polohu a získal/a výsledky v okolí."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -16202,7 +16170,7 @@ msgstr "Chráněno"
 #. Headline in sync-enabled chat history about modals explaining encrypted server storage.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Protected with end-to-end encryption"
-msgstr ""
+msgstr "Chráněno end-to-end šifrováním"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -16215,8 +16183,7 @@ msgctxt "Full sentence for critiquing writing"
 msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
-msgstr ""
-"Dej mi několik návrhů, jak následující text zestručnit. [Sem vlož svůj text.]"
+msgstr "Dej mi několik návrhů, jak následující text zestručnit. [Sem vlož svůj text.]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -16340,7 +16307,7 @@ msgstr "Žebříčky"
 #. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
 msgctxt "star rating on a product"
 msgid "Rated %s out of %s"
-msgstr ""
+msgstr "Hodnocení %1$s z %2$s"
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17347,8 +17314,7 @@ msgstr "SV"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "SERP promotion for desktop browsers has been dismissed"
-msgstr ""
-"Propagace na stránce s výsledky vyhledávání pro desktopový prohlížeč zavřena"
+msgstr "Propagace na stránce s výsledky vyhledávání pro desktopový prohlížeč zavřena"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating that a game is in shootouts, e.g. in NHL (hockey)
@@ -17415,8 +17381,7 @@ msgstr "Bezpečné vyhledávání zablokovalo výsledky pro %1$s."
 # smartling.placeholder_format=C
 #. A label above search results that lets the user know the safe search filter blocked some of the results from showing. The placeholder value is the user's search term.
 msgid "Safe search blocked some results for %s."
-msgstr ""
-"Bezpečné vyhledávání zablokovalo některé výsledky hledání pro dotaz %1$s."
+msgstr "Bezpečné vyhledávání zablokovalo některé výsledky hledání pro dotaz %1$s."
 
 # smartling.placeholder_format=C
 #. Safe search lets you remove adult content from results on DuckDuckGo. This string is used to invite users to select the desired level of protection (e.g., strict, moderate, off)
@@ -17564,8 +17529,7 @@ msgstr "Ukládej až 30 svých nejnovějších chatů lokálně na své zaříze
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Ulož si chaty Duck.ai mezi svými zařízeními pomocí end-to-end šifrování."
+msgstr "Ulož si chaty Duck.ai mezi svými zařízeními pomocí end-to-end šifrování."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17577,7 +17541,7 @@ msgstr "Ukládej si chaty na všech svých zařízeních."
 #. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
 msgctxt "Chat history about modal list item headline"
 msgid "Save your chats on this device"
-msgstr ""
+msgstr "Ukládej si svoje chaty na tomhle zařízení"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
@@ -17754,8 +17718,7 @@ msgstr "Přejdi dolů a vyhledej %1$ssvůj prohlížeč%2$s v seznamu."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr ""
-"Přejdi dolů na položku %1$sDuckDuckGo%2$s a umožni jí používat tvou polohu."
+msgstr "Přejdi dolů na položku %1$sDuckDuckGo%2$s a umožni jí používat tvou polohu."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -17786,7 +17749,7 @@ msgctxt ""
 "Placeholder and accessibility label for the search input in the tab picker "
 "dialog"
 msgid "Search"
-msgstr ""
+msgstr "Hledat"
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18319,14 +18282,13 @@ msgstr "V Safari zvol %1$sNastavení pro tuto webovou stránku...%2$s."
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Vyber možnost %1$sPřizpůsobit%2$s a do vyhledávacího pole zadej %3$shttps://"
-"duckduckgo.com%4$s"
+"Vyber možnost %1$sPřizpůsobit%2$s a do vyhledávacího pole zadej "
+"%3$shttps://duckduckgo.com%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Vyber %1$sDuckDuckGo%2$s a klikni na %3$sNastavit jako výchozí prohlížeč%4$s!"
+msgstr "Vyber %1$sDuckDuckGo%2$s a klikni na %3$sNastavit jako výchozí prohlížeč%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -18468,8 +18430,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"V seznamu vyber %1$ssvůj prohlížeč%2$s a %3$spovol přístup k poloze%4$s"
+msgstr "V seznamu vyber %1$ssvůj prohlížeč%2$s a %3$spovol přístup k poloze%4$s"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18716,8 +18677,7 @@ msgstr ""
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr ""
-"Nastav polohu ručně nebo zkontroluj, jestli jsou povolené polohové služby."
+msgstr "Nastav polohu ručně nebo zkontroluj, jestli jsou povolené polohové služby."
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -18818,8 +18778,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"Sdílej polohu na úrovni města s modely AI, aby se zlepšila relevance. Duck."
-"ai nikdy neodhalí tvoji přesnou polohu nám ani modelům AI."
+"Sdílej polohu na úrovni města s modely AI, aby se zlepšila relevance. "
+"Duck.ai nikdy neodhalí tvoji přesnou polohu nám ani modelům AI."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -18962,7 +18922,7 @@ msgstr "Do obchodu"
 #. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
 msgctxt "Button in the merchandise logo modal (mobile)"
 msgid "Shop Now"
-msgstr ""
+msgstr "Do obchodu"
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -19795,8 +19755,7 @@ msgstr "Vymazaný zdrojový text"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr ""
-"Zdrojový text je na shrnutí příliš dlouhý. Zkus to znovu s kratším výběrem."
+msgstr "Zdrojový text je na shrnutí příliš dlouhý. Zkus to znovu s kratším výběrem."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -20616,6 +20575,8 @@ msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
 msgstr ""
+"Sync & Backup ukládá více tvých chatů a synchronizuje je na všech tvých "
+"zařízeních."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20735,7 +20696,7 @@ msgstr "Synchronizuj své chaty na všech svých zařízeních."
 #. Headline in sync-enabled chat history about modals explaining cross-device sync.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Sync your chats across all your devices"
-msgstr ""
+msgstr "Synchronizuj své chaty na všech svých zařízeních"
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -20854,8 +20815,7 @@ msgstr "Měj osobní údaje ve svých rukou!"
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr ""
-"Vyplň tento anonymní dotazník a dej nám vědět, jak můžeme Duck.ai vylepšit."
+msgstr "Vyplň tento anonymní dotazník a dej nám vědět, jak můžeme Duck.ai vylepšit."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -21060,15 +21020,13 @@ msgstr "Děkujeme za zpětnou vazbu!"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row!"
-msgstr ""
-"Děkujeme ti za trpělivost. Snažíme se všechny kachny dostat zase do řady."
+msgstr "Děkujeme ti za trpělivost. Snažíme se všechny kachny dostat zase do řady."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row."
-msgstr ""
-"Děkujeme ti za trpělivost. Snažíme se všechny kachny dostat zase do řady."
+msgstr "Děkujeme ti za trpělivost. Snažíme se všechny kachny dostat zase do řady."
 
 # smartling.placeholder_format=C
 #. Message indicating that the open lock icon in the address bar means that a website is not secure.
@@ -21128,8 +21086,7 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr ""
-"Poskytovatel modelu smaže veškerá data související s tímto chatem do 30 dnů."
+msgstr "Poskytovatel modelu smaže veškerá data související s tímto chatem do 30 dnů."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -21280,8 +21237,7 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr ""
-"Tenhle model AI už není dostupný. Zkus začít nový chat s jiným modelem."
+msgstr "Tenhle model AI už není dostupný. Zkus začít nový chat s jiným modelem."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -21326,12 +21282,14 @@ msgid ""
 "This chat and its generated images become public when you create and copy "
 "the link."
 msgstr ""
+"Tento chat a jeho vygenerované obrázky se stanou veřejnými, když vytvoříš a "
+"zkopíruješ odkaz."
 
 # smartling.placeholder_format=C
 #. Explains that creating and copying a share link makes the selected chat content public.
 msgctxt "Share modal info bullet about public access"
 msgid "This chat becomes public when you create and copy the link."
-msgstr ""
+msgstr "Když vytvoříš a zkopíruješ, stane se tento chat veřejným."
 
 # smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
@@ -21644,15 +21602,13 @@ msgstr "Tento překlad je špatný"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Toto video zde ještě není možné sledovat. Můžete se na něho podívat na %1$s."
+msgstr "Toto video zde ještě není možné sledovat. Můžete se na něho podívat na %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Tahle webová stránka nepoužívá zabezpečené, šifrované připojení (HTTPS)."
+msgstr "Tahle webová stránka nepoužívá zabezpečené, šifrované připojení (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21868,14 +21824,13 @@ msgstr "Dnes"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
-msgstr ""
+msgstr "Přepni na soukromý chat s AI, nebo si funkci %1$svypni v nastavení%2$s."
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
-msgstr ""
-"Přepnutím vyzkoušej soukromý chat s AI, nebo ho %1$svypni v nabídce %2$s.%3$s"
+msgstr "Přepnutím vyzkoušej soukromý chat s AI, nebo ho %1$svypni v nabídce %2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -22223,8 +22178,7 @@ msgstr "Zkus přejít na %1$s a podobné zprávy už ti nebudeme ukazovat."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Zkus %1$s, náš první model, ve kterém má poskytovatel nulovou viditelnost."
+msgstr "Zkus %1$s, náš první model, ve kterém má poskytovatel nulovou viditelnost."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -22958,8 +22912,8 @@ msgstr ""
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"Pod možností %1$sSpuštění > Domovská stránka%2$s zadej: https://duckduckgo."
-"com"
+"Pod možností %1$sSpuštění > Domovská stránka%2$s zadej: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22969,8 +22923,7 @@ msgstr "V nabídce %1$sNastavení vyhledávání%2$s zvol %3$sDuckDuckGo%4$s"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr ""
-"Pod %1$shledáním v adresním řádku pomocí %2$s vyber %3$sPřidat nový%4$s"
+msgstr "Pod %1$shledáním v adresním řádku pomocí %2$s vyber %3$sPřidat nový%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -23362,8 +23315,7 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr ""
-"Upgraduj na tarif Pro a aktivuj si dvojnásobné limity, než má tarif Plus"
+msgstr "Upgraduj na tarif Pro a aktivuj si dvojnásobné limity, než má tarif Plus"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -23473,8 +23425,7 @@ msgstr "Použít vyhledávač Private Search od DuckDuckGo"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"Používej soukromé vyhledávání DuckDuckGo na iPadu, iPhonu nebo Androidu"
+msgstr "Používej soukromé vyhledávání DuckDuckGo na iPadu, iPhonu nebo Androidu"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -23697,6 +23648,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Yelp's ad network."
 msgstr ""
+"Při zobrazování reklam chrání DuckDuckGo tvoje soukromí. Kliknutí na reklamy "
+"spravuje reklamní síť společnosti Yelp."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -24106,8 +24059,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr ""
-"Nesledujeme tě, takže by nám pomohlo, když nám řekneš, co tě přivádí zpátky:"
+msgstr "Nesledujeme tě, takže by nám pomohlo, když nám řekneš, co tě přivádí zpátky:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -24128,8 +24080,7 @@ msgstr "Nesledujeme tě. Nikdy."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr ""
-"My tě nesledujeme. To jsou naše Zásady ochrany osobních údajů v kostce."
+msgstr "My tě nesledujeme. To jsou naše Zásady ochrany osobních údajů v kostce."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -24170,8 +24121,7 @@ msgstr "Nesledujeme tě. Ani v anonymním režimu ani mimo něj."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr ""
-"My vás nesledujeme. To jsou naše Zásady ochrany osobních údajů v kostce…"
+msgstr "My vás nesledujeme. To jsou naše Zásady ochrany osobních údajů v kostce…"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -24436,8 +24386,7 @@ msgstr "Byl vyčerpán týdenní limit využití"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Byl vyčerpán týdenní limit využití. V tomto chatu můžeš pokračovat za %1$s."
+msgstr "Byl vyčerpán týdenní limit využití. V tomto chatu můžeš pokračovat za %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -24971,8 +24920,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"Když je možnost zapnutá, Duck.ai bude v chatu zobrazovat okamžité odpovědi."
+msgstr "Když je možnost zapnutá, Duck.ai bude v chatu zobrazovat okamžité odpovědi."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -25178,6 +25126,8 @@ msgid ""
 "With chat history on, up to %s of your most recent chats will be saved on "
 "this device."
 msgstr ""
+"Když je historie chatů zapnutá, uloží se na tomto zařízení až %1$s tvých "
+"nejnovějších chatů."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline in the About Chat History modal.
@@ -25185,6 +25135,8 @@ msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, your most recent chats will be saved on this device."
 msgstr ""
+"Když máš historii chatů zapnutou, tvoje nejnovější chaty se budou ukládat na "
+"tomhle zařízení."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -26124,8 +26076,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr ""
-"Import tvých chatů je hotový. Na Duck.ai můžeš pokračovat v rozdělané práci."
+msgstr "Import tvých chatů je hotový. Na Duck.ai můžeš pokračovat v rozdělané práci."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -26236,8 +26187,7 @@ msgctxt "Popover text for recent chats onboarding"
 msgid ""
 "Your recent chats live here! You can refer to your chats or clear them "
 "anytime."
-msgstr ""
-"Tady najdeš svoje nedávné chaty. Můžeš je kdykoli otevřít nebo vymazat."
+msgstr "Tady najdeš svoje nedávné chaty. Můžeš je kdykoli otevřít nebo vymazat."
 
 # smartling.placeholder_format=C
 #. Message on a feedback form.
@@ -26344,8 +26294,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr ""
-"Bylo dosaženo maximálního počtu zpráv za jeden den. V chatu pokračuj zítra."
+msgstr "Bylo dosaženo maximálního počtu zpráv za jeden den. V chatu pokračuj zítra."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -26579,7 +26528,7 @@ msgstr "min."
 #. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the chat options menu button"
 msgid "menu"
-msgstr ""
+msgstr "menu"
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.
@@ -26653,8 +26602,7 @@ msgstr "oficiálních webových stránkách"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr ""
-"nebo napište kód libovolné barvy, např. %1$s (%2$s je kód pro znak %3$s)."
+msgstr "nebo napište kód libovolné barvy, např. %1$s (%2$s je kód pro znak %3$s)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/cs_CZ/LC_MESSAGES/duckduckgo.po
+++ b/locales/cs_CZ/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: cs_CZ\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1212,6 +1212,12 @@ msgid "About our ads"
 msgstr "O našich reklamách"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1341,6 +1347,20 @@ msgid "Ad is suspicious"
 msgstr "Reklama je podezřelá"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Přidat DuckDuckGo"
@@ -1367,6 +1387,27 @@ msgstr "Přidej si DuckDuckGo mezi své vyhledávače"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Přidat DuckDuckGo do %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1412,6 +1453,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Přidat obsah stránky"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1497,6 +1554,12 @@ msgstr "Doplňky"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Už to bude"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1797,6 +1860,12 @@ msgstr "Všechny barvy"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Všechno je hotové!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3511,6 +3580,14 @@ msgid "Cancel"
 msgstr "Zrušit"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4004,10 +4081,22 @@ msgid "Chat response is offensive"
 msgstr "Odpověď chatu je urážlivá"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Chatuj s %1$s"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4026,6 +4115,14 @@ msgstr "Chaty"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Chaty"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5631,6 +5728,12 @@ msgid "Current Streak"
 msgstr "Aktuální série"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5978,6 +6081,12 @@ msgstr "Smazat chaty"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Vymazat chaty starší než 30 dní"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6391,6 +6500,12 @@ msgstr "Navždy skrýt"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Zavřít propagační akci"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7565,6 +7680,12 @@ msgid "Edit Prompt"
 msgstr "Upravit prompt"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7783,6 +7904,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Šifrovaný model"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8616,6 +8743,12 @@ msgid "Follow-up question"
 msgstr "Navazující otázka"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9129,6 +9262,12 @@ msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
 "Získáš VPN od DuckDuckGo, pokročilou Duck.ai a službu Identity Theft "
 "Restoration."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10360,6 +10499,12 @@ msgstr "Jak je zajištěna anonymita?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Jak to funguje"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11805,6 +11950,12 @@ msgstr "Vyhrané vhazování"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "Platnost odkazu skončí za 7 dní."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13925,6 +14076,12 @@ msgid "OK, got it!"
 msgstr "Dobře, rozumím!"
 
 # smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -16042,6 +16199,12 @@ msgid "Protected"
 msgstr "Chráněno"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Soukromí.Ochrana.Pocit jistoty."
@@ -16172,6 +16335,12 @@ msgstr "Déšť"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Žebříčky"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17405,6 +17574,12 @@ msgid "Save your chats across all your devices."
 msgstr "Ukládej si chaty na všech svých zařízeních."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17604,6 +17779,14 @@ msgstr "Hledat"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Hledat"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18774,6 +18957,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Do obchodu"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20421,6 +20610,14 @@ msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr "Data Sync & Backup nelze obnovit po 18 měsících nečinnosti."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20533,6 +20730,12 @@ msgstr "Synchronizovat s blízkým zařízením."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Synchronizuj své chaty na všech svých zařízeních."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21115,6 +21318,22 @@ msgid "This Week"
 msgstr "Tento týden"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21644,6 +21863,12 @@ msgstr "Dnes"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Dnes"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23466,6 +23691,14 @@ msgstr ""
 "spravuje reklamní síť společnosti TripAdvisor."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Panenské ostrovy"
 
@@ -24939,6 +25172,21 @@ msgstr ""
 "AI. Můžeš ji kdykoli zapnout nebo vypnout v nabídce ‚%1$s’."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26326,6 +26574,12 @@ msgstr "min."
 msgctxt "published date for videos"
 msgid "m"
 msgstr "min."
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/cs_CZ/LC_MESSAGES/duckduckgo.po
+++ b/locales/cs_CZ/LC_MESSAGES/duckduckgo.po
@@ -22518,7 +22518,7 @@ msgctxt ""
 "Description shown when a chat search in Duck.ai returns no matching chats, "
 "suggesting the user rephrase their query"
 msgid "Try using a different search term or phrase."
-msgstr "Zkuste použít jiný vyhledávací výraz nebo frázi."
+msgstr "Zkus použít jiný vyhledávací výraz nebo frázi."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, text prompting the user to try their prompt with a different AI model.

--- a/locales/cy_GB/LC_MESSAGES/duckduckgo.po
+++ b/locales/cy_GB/LC_MESSAGES/duckduckgo.po
@@ -987,6 +987,11 @@ msgstr "Amdanom Ni"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1090,6 +1095,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "Mae'r hysbyseb yn amheus"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Ychwanegu DuckDuckGo"
@@ -1109,6 +1126,24 @@ msgstr "Ychwanegu DuckDuckGo fel injan chwilio"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Ychwanegu DuckDuckGo i %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1147,6 +1182,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1218,6 +1267,11 @@ msgstr "Ategolion"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1463,6 +1517,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2819,6 +2878,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3219,9 +3285,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3237,6 +3313,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4503,6 +4586,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4787,6 +4875,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5125,6 +5218,11 @@ msgstr "Diswyddo am byth"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6022,6 +6120,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6199,6 +6302,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6872,6 +6980,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7290,6 +7403,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8274,6 +8392,11 @@ msgid "How is it anonymous?"
 msgstr "Sut mae'n ddienw?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9437,6 +9560,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11185,6 +11313,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "Iawn 'te!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12899,6 +13032,11 @@ msgstr "Amddiffyn eich ddata ar pob dyfais."
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -13005,6 +13143,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13995,6 +14138,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14150,6 +14298,13 @@ msgstr "Chwilio"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15072,6 +15227,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16415,6 +16575,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16495,6 +16662,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16955,6 +17127,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17357,6 +17543,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18824,6 +19015,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19987,6 +20185,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21080,6 +21291,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/da_DK/LC_MESSAGES/duckduckgo.po
+++ b/locales/da_DK/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: da_DK\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -308,8 +308,7 @@ msgstr "Rangeringer for %1$s er endnu ikke tilgængelige"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits 2-5x faster than other models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
-msgstr ""
-"%1$s når brugsgrænserne 2-5 gange hurtigere end grundlæggende modeller. %2$s"
+msgstr "%1$s når brugsgrænserne 2-5 gange hurtigere end grundlæggende modeller. %2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -445,8 +444,7 @@ msgstr "%1$s ord"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr ""
-"%1$sKlik %2$sTilføj%3$sTjek %4$sTillad%5$s, og klik derefter på %6$sOkay%7$s"
+msgstr "%1$sKlik %2$sTilføj%3$sTjek %4$sTillad%5$s, og klik derefter på %6$sOkay%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -508,8 +506,7 @@ msgstr "%1$sLæs mere%2$s"
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr ""
-"%1$sLæs mere%2$s om, hvordan chats gemmes privat på DuckDuckGos server."
+msgstr "%1$sLæs mere%2$s om, hvordan chats gemmes privat på DuckDuckGos server."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -878,8 +875,7 @@ msgstr "Grænsen på 6 timers brug er nået."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Grænsen på 6 timers brug er nået. Du kan fortsætte denne chat efter %1$s."
+msgstr "Grænsen på 6 timers brug er nået. Du kan fortsætte denne chat efter %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -950,16 +946,14 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"En ny version af AI Chat er tilgængelig! Opdater denne side for at fortsætte."
+msgstr "En ny version af AI Chat er tilgængelig! Opdater denne side for at fortsætte."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"En ny version af Duck.ai er tilgængelig! Opdater denne side for at fortsætte."
+msgstr "En ny version af Duck.ai er tilgængelig! Opdater denne side for at fortsætte."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1214,7 +1208,7 @@ msgstr "Om vores annoncer"
 #. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
 msgctxt "Modal header for chat history with sync information"
 msgid "About Chat History with Sync & Backup"
-msgstr ""
+msgstr "Om chathistorik med Sync & Backup"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
@@ -1349,7 +1343,7 @@ msgstr "Annoncen er mistænkelig"
 #. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
 msgctxt "Button to open menu for attaching images or page context to AI chat"
 msgid "Add"
-msgstr ""
+msgstr "Tilføj"
 
 # smartling.placeholder_format=C
 #. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
@@ -1357,7 +1351,7 @@ msgctxt ""
 "Primary button that attaches the tabs the user checked in the tab picker "
 "dialog"
 msgid "Add"
-msgstr ""
+msgstr "Tilføj"
 
 # smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
@@ -1392,13 +1386,13 @@ msgstr "Føj DuckDuckGo til %1$s"
 msgctxt ""
 "Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
 msgid "Add File"
-msgstr ""
+msgstr "Tilføj fil"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
 msgid "Add Image"
-msgstr ""
+msgstr "Tilføj billede"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
@@ -1406,7 +1400,7 @@ msgctxt ""
 "Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
 "item)"
 msgid "Add Image or File"
-msgstr ""
+msgstr "Tilføj billede eller fil"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1459,7 +1453,7 @@ msgctxt ""
 "Open the tab picker to attach browser tab content to the AI chat message "
 "(attach dropdown menu item)"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Tilføj faner"
 
 # smartling.placeholder_format=C
 #. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
@@ -1467,7 +1461,7 @@ msgctxt ""
 "Title and accessible name of the tab-picker dialog opened from the attach "
 "dropdown menu"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Tilføj faner"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1558,7 +1552,7 @@ msgstr "Vi lægger sidste hånd på værket"
 #. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
 msgctxt "Aria label for the additional instructions textarea"
 msgid "Additional instructions"
-msgstr ""
+msgstr "Yderligere anvisninger"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1867,7 +1861,7 @@ msgstr "Helt færdig!"
 #. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the read-only textarea listing all AI instructions"
 msgid "All instructions"
-msgstr ""
+msgstr "Alle anvisninger"
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -1881,8 +1875,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr ""
-"Alle modeludbydere er forhindret i at træne deres AI på jeres samtaler."
+msgstr "Alle modeludbydere er forhindret i at træne deres AI på jeres samtaler."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -2195,8 +2188,8 @@ msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
 msgstr ""
-"Eventuelle yderligere instruktioner, du vil have Duck.ai til at følge. f."
-"eks. Fortæl mig altid fakta om ænder"
+"Eventuelle yderligere instruktioner, du vil have Duck.ai til at følge. "
+"f.eks. Fortæl mig altid fakta om ænder"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2295,8 +2288,7 @@ msgstr "Er du der stadig?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"Er du sikker på, at du vil slette alle dine chats? Dette kan ikke fortrydes."
+msgstr "Er du sikker på, at du vil slette alle dine chats? Dette kan ikke fortrydes."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2308,8 +2300,7 @@ msgstr "Er du sikker på, at du vil rydde denne samtale og starte en ny?"
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
 msgctxt "Body text for delete chat confirmation modal"
 msgid "Are you sure you want to delete this chat? This cannot be undone."
-msgstr ""
-"Er du sikker på, at du vil slette denne chat? Dette kan ikke fortrydes."
+msgstr "Er du sikker på, at du vil slette denne chat? Dette kan ikke fortrydes."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable chat history, with a warning that it will also delete currently saved chats including pinned chats.
@@ -2516,8 +2507,8 @@ msgstr ""
 "skal vises: Aldrig (fjerner Assist UI fra søgeresultaterne), On-demand "
 "(viser kun AI-assisterede svar, hvis du klikker på knappen Assist), Nogle "
 "gange (viser kun AI-assisterede svar, når det er yderst relevant) eller Ofte "
-"(vises oftere på en bredere række af søgninger). Indtil videre er AI-"
-"assisterede svar kun tilgængelige i USA (engelsk)."
+"(vises oftere på en bredere række af søgninger). Indtil videre er "
+"AI-assisterede svar kun tilgængelige i USA (engelsk)."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -3061,8 +3052,8 @@ msgid ""
 "Block harmful sites, hide your IP address, plus get more premium protections "
 "with our subscription."
 msgstr ""
-"Blokér skadelige hjemmesider, skjul din IP-adresse, og få mere premium-"
-"beskyttelse med vores abonnement."
+"Blokér skadelige hjemmesider, skjul din IP-adresse, og få mere "
+"premium-beskyttelse med vores abonnement."
 
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
@@ -3581,7 +3572,7 @@ msgctxt ""
 "Secondary button that dismisses the tab picker dialog without attaching "
 "anything"
 msgid "Cancel"
-msgstr ""
+msgstr "Annuller"
 
 # smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
@@ -3818,8 +3809,7 @@ msgstr "Ændrer den måde, URL-resultaterne vises på"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr ""
-"Ændrer den måde overskriften vises på, samt dens opførsel, når du scroller"
+msgstr "Ændrer den måde overskriften vises på, samt dens opførsel, når du scroller"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -4082,7 +4072,7 @@ msgstr "Chat-svaret er stødende"
 #. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
 msgctxt "Chat history about modal list item headline"
 msgid "Chat storage varies by browser"
-msgstr ""
+msgstr "Chatlagring varierer fra browser til browser"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4094,7 +4084,7 @@ msgstr "Chat med %1$s"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Chat with popular AI models, anonymized by us."
-msgstr ""
+msgstr "Chat med populære AI-modeller, anonymiseret af os."
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4121,6 +4111,8 @@ msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
 msgstr ""
+"Chats gemmes sikkert på DuckDuckGos server med end-to-end-kryptering. Ingen "
+"andre end dig kan se dine data, ikke engang os."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4169,8 +4161,8 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"Chats med %1$s har nul udbydersynlighed, men alle filer, der uploades i Duck."
-"ai, gennemgås anonymt af en indholdsmodereringsudbyder for %2$s."
+"Chats med %1$s har nul udbydersynlighed, men alle filer, der uploades i "
+"Duck.ai, gennemgås anonymt af en indholdsmodereringsudbyder for %2$s."
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -4303,8 +4295,7 @@ msgstr "Vælg mellem flere AI-modeller, herunder %1$s og %2$s"
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr ""
-"Vælg %1$sbehold den%2$s for at fortsætte med at beskytte dit privatliv."
+msgstr "Vælg %1$sbehold den%2$s for at fortsætte med at beskytte dit privatliv."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -4754,8 +4745,8 @@ msgid ""
 "it remains in your browser until you click/tap %sReset All Settings%s."
 msgstr ""
 "Klik eller tryk på %1$sSlet mine oplysninger%2$s. Dette fjerner "
-"oplysningerne fra skyen, men de forbliver i din browser, indtil du klikker/"
-"trykker på %3$sNulstil alle indstillinger%4$s."
+"oplysningerne fra skyen, men de forbliver i din browser, indtil du "
+"klikker/trykker på %3$sNulstil alle indstillinger%4$s."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -5716,7 +5707,7 @@ msgstr "Nuværende resultatliste"
 #. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
 msgctxt "Suffix label indicating a tab is the currently active browser tab"
 msgid "Current Tab"
-msgstr ""
+msgstr "Aktuel fane"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
@@ -6070,7 +6061,7 @@ msgstr "Slet chats, der er ældre end 30 dage"
 #. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
 msgctxt "Button text in the modal for deleting all recent chats"
 msgid "Delete Chats and Shared Links"
-msgstr ""
+msgstr "Slet chats og delte links"
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6162,8 +6153,7 @@ msgstr "Vil du slette de ældste chats for at frigøre lagerplads?"
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr ""
-"Vil du slette de ældste chats med vedhæftede filer for at frigøre lagerplads?"
+msgstr "Vil du slette de ældste chats med vedhæftede filer for at frigøre lagerplads?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
@@ -6295,8 +6285,7 @@ msgstr "Diktering i Duck.ai"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr ""
-"Diktering er anonymiseret af os og bruges aldrig til at træne AI-modeller."
+msgstr "Diktering er anonymiseret af os og bruges aldrig til at træne AI-modeller."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6489,7 +6478,7 @@ msgstr "Afvis kampagne"
 #. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the close button on the survey banner"
 msgid "Dismiss survey"
-msgstr ""
+msgstr "Afvis undersøgelse"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6640,8 +6629,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
-"Vil du ikke have AI? %1$snoai.duckduckgo.com%2$s tilbyder ingen AI-"
-"funktioner, og AI-billeder filtreres fra. %3$sLæs mere%4$s"
+"Vil du ikke have AI? %1$snoai.duckduckgo.com%2$s tilbyder ingen "
+"AI-funktioner, og AI-billeder filtreres fra. %3$sLæs mere%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6650,8 +6639,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"Vil du ikke have AI? Besøg %1$snoai.duckduckgo.com%2$s for at søge uden AI-"
-"funktioner og med AI-billeder filtreret fra. %3$sLæs mere%4$s"
+"Vil du ikke have AI? Besøg %1$snoai.duckduckgo.com%2$s for at søge uden "
+"AI-funktioner og med AI-billeder filtreret fra. %3$sLæs mere%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -7050,11 +7039,12 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai giver dig mulighed for at have anonyme samtaler med tredjeparts-AI-"
-"chatmodeller, herunder modeller fra OpenAI, Anthropic og andre. Hvis du "
-"deaktiverer denne indstilling, vil Duck.ai-knapper og -links blive skjult på "
-"DuckDuckGo Search. Du kan dog stadig få adgang til Duck.ai, når denne "
-"indstilling er slået fra, ved at besøge %1$shttps://duck.ai%2$s direkte."
+"Duck.ai giver dig mulighed for at have anonyme samtaler med "
+"tredjeparts-AI-chatmodeller, herunder modeller fra OpenAI, Anthropic og "
+"andre. Hvis du deaktiverer denne indstilling, vil Duck.ai-knapper og -links "
+"blive skjult på DuckDuckGo Search. Du kan dog stadig få adgang til Duck.ai, "
+"når denne indstilling er slået fra, ved at besøge %1$shttps://duck.ai%2$s "
+"direkte."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -7120,8 +7110,8 @@ msgid ""
 "models, privacy focused AI, no account AI chat"
 msgstr ""
 "Duck.ai, DuckDuckGo AI, privat AI-chatbot, gratis AI-chat, anonym AI-chat, "
-"AI-chat uden tilmelding, OpenAI, Anthropic, Llama, Mistral, open-source AI-"
-"modeller, fortrolighedsfokuseret AI, privatlivsfokuseret AI, AI-chat uden "
+"AI-chat uden tilmelding, OpenAI, Anthropic, Llama, Mistral, open-source "
+"AI-modeller, fortrolighedsfokuseret AI, privatlivsfokuseret AI, AI-chat uden "
 "konto"
 
 # smartling.placeholder_format=C
@@ -7284,8 +7274,7 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr ""
-"DuckDuckGo AI Chat er midlertidigt utilgængelig. Opdater siden og prøv igen."
+msgstr "DuckDuckGo AI Chat er midlertidigt utilgængelig. Opdater siden og prøv igen."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7662,7 +7651,7 @@ msgstr "Rediger prompt"
 #. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the message-editing text area"
 msgid "Edit message"
-msgstr ""
+msgstr "Redigér besked"
 
 # smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
@@ -7833,8 +7822,7 @@ msgstr "Aktivér diktering i Duck.ai"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr ""
-"Aktivér placeringsindstillinger på din enhed for at bruge anonym placering"
+msgstr "Aktivér placeringsindstillinger på din enhed for at bruge anonym placering"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -7892,7 +7880,7 @@ msgstr "Krypteret model"
 #. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
 msgctxt "Share modal info bullet about encryption"
 msgid "Encrypted so DuckDuckGo can't read your chat."
-msgstr ""
+msgstr "Krypteret, så DuckDuckGo ikke kan læse din chat."
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -7950,8 +7938,7 @@ msgstr "Kan du lide Duck.ai?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr ""
-"Sørg for, at %1$s\"Tillad\"%2$s er valgt til indstillingen \"Placering\"."
+msgstr "Sørg for, at %1$s\"Tillad\"%2$s er valgt til indstillingen \"Placering\"."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -8211,8 +8198,7 @@ msgstr "Forklar det accepterede svar i simple termer."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr ""
-"Forklar de grundlæggende begreber om sorte huller for mig på gymnasieniveau."
+msgstr "Forklar de grundlæggende begreber om sorte huller for mig på gymnasieniveau."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -8450,8 +8436,8 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
 msgstr ""
-"Feedback som din har direkte indflydelse på vores produktopdateringer og -"
-"forbedringer."
+"Feedback som din har direkte indflydelse på vores produktopdateringer og "
+"-forbedringer."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8460,8 +8446,8 @@ msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
 msgstr ""
-"Feedback som din har direkte indflydelse på vores produktopdateringer og -"
-"forbedringer. Forhåbentlig kan vi også løse det problem, du delte."
+"Feedback som din har direkte indflydelse på vores produktopdateringer og "
+"-forbedringer. Forhåbentlig kan vi også løse det problem, du delte."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -8553,8 +8539,7 @@ msgstr "Filtrerer AI-genererede billeder fra billedsøgeresultater"
 msgctxt "settings"
 msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
-msgstr ""
-"Filtrerer AI-genererede billeder fra billedsøgeresultater. %1$sLæs mere%2$s"
+msgstr "Filtrerer AI-genererede billeder fra billedsøgeresultater. %1$sLæs mere%2$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8724,7 +8709,7 @@ msgstr "Opfølgende spørgsmål"
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
-msgstr ""
+msgstr "Opfølgninger forbliver private."
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8860,8 +8845,7 @@ msgstr "Gratis at dele og bruge kommercielt"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr ""
-"Frigør plads ved at slette dine chats. Fastgjorte chats bliver ikke slettet."
+msgstr "Frigør plads ved at slette dine chats. Fastgjorte chats bliver ikke slettet."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -9243,7 +9227,7 @@ msgstr "Få DuckDuckGo VPN, avanceret Duck.ai og Identity Theft Restoration."
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
 msgctxt "Tooltip on the header logo for sunglasses searches"
 msgid "Get DuckDuckGo sunglasses and other gear."
-msgstr ""
+msgstr "Få DuckDuckGo-solbriller og andet udstyr."
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9401,8 +9385,8 @@ msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
 msgstr ""
-"Få vores hurtige VPN uden logfiler, valgfri adgang til avancerede AI-"
-"modeller med højere chatgrænser og flere premium-beskyttelser."
+"Få vores hurtige VPN uden logfiler, valgfri adgang til avancerede "
+"AI-modeller med højere chatgrænser og flere premium-beskyttelser."
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9465,8 +9449,8 @@ msgstr "Hent appen"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"Hent den gratis DuckDuckGo-browser %1$sfor at blokere annoncer på YouTube."
-"%2$s"
+"Hent den gratis DuckDuckGo-browser %1$sfor at blokere annoncer på "
+"YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9525,9 +9509,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"Gå til %1$sDuck.ai-indstillinger%2$s i din anden browser, eller DuckDuckGo-"
-"appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en anden enhed "
-"› Kopiér tekstkode%4$s"
+"Gå til %1$sDuck.ai-indstillinger%2$s i din anden browser, eller "
+"DuckDuckGo-appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en "
+"anden enhed › Kopiér tekstkode%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9536,9 +9520,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"Gå til %1$sDuck.ai-Indstillinger%2$s i din anden browser, eller DuckDuckGo-"
-"appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en anden "
-"enhed%4$s"
+"Gå til %1$sDuck.ai-Indstillinger%2$s i din anden browser, eller "
+"DuckDuckGo-appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en "
+"anden enhed%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9548,9 +9532,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"Gå til %1$sDuck.ai-indstillinger%2$s i din anden browser, eller DuckDuckGo-"
-"appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en anden "
-"enhed%4$s, og scan denne kode:"
+"Gå til %1$sDuck.ai-indstillinger%2$s i din anden browser, eller "
+"DuckDuckGo-appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en "
+"anden enhed%4$s, og scan denne kode:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9560,9 +9544,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"Gå til %1$sDuck.ai-Indstillinger%2$s i din anden browser eller DuckDuckGo-"
-"appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en anden "
-"enhed%4$s. Eller scan QR-koden på din gendannelses-PDF."
+"Gå til %1$sDuck.ai-Indstillinger%2$s i din anden browser eller "
+"DuckDuckGo-appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en "
+"anden enhed%4$s. Eller scan QR-koden på din gendannelses-PDF."
 
 # smartling.placeholder_format=C
 #. Path to the pairing code on the other device. Bold segments are UI path labels.
@@ -10479,7 +10463,7 @@ msgstr "Sådan fungerer det"
 #. Headline in chat history about modals for the temporary encrypted server storage explanation.
 msgctxt "Chat history about modal list item headline"
 msgid "How it works"
-msgstr ""
+msgstr "Sådan fungerer det"
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -10503,8 +10487,7 @@ msgstr "Hvor tit vil du have, at AI-assisterede svar skal dukke op?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr ""
-"Hvor meget af dine daglige og ugentlige grænser du har brugt indtil videre."
+msgstr "Hvor meget af dine daglige og ugentlige grænser du har brugt indtil videre."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10945,8 +10928,7 @@ msgstr ""
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
-msgstr ""
-"Vælg %1$sVærktøjer%2$s i menuen i toppen af siden > %3$sIndstillinger%4$s"
+msgstr "Vælg %1$sVærktøjer%2$s i menuen i toppen af siden > %3$sIndstillinger%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -11850,8 +11832,7 @@ msgstr "Lader dig søge anonymt på internettet med DuckDuckGo"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr ""
-"Lader dig skifte mellem at indsende søgeforespørgsler og prompter til Duck.ai"
+msgstr "Lader dig skifte mellem at indsende søgeforespørgsler og prompter til Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11933,7 +11914,7 @@ msgstr "Linket udløber om 7 dage."
 #. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days. People can save a chat copy."
-msgstr ""
+msgstr "Linket udløber om 7 dage. Brugere kan gemme en kopi af chatten."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -12062,8 +12043,7 @@ msgstr "Indlæser flere billedresultater, mens du scroller"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr ""
-"Indlæser flere resultater i billeder, videoer og shopping, når du scroller"
+msgstr "Indlæser flere resultater i billeder, videoer og shopping, når du scroller"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -13392,10 +13372,11 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"Nye prompter og svar krypteres og gemmes midlertidigt på en DuckDuckGo-"
-"server efter afsendelse for at hjælpe med at gendanne en chat, hvis du "
-"mister din internetforbindelse. Deaktivering af chathistorikken sletter "
-"fastgjorte chats og deaktiverer midlertidig lagring af nye prompter og svar."
+"Nye prompter og svar krypteres og gemmes midlertidigt på en "
+"DuckDuckGo-server efter afsendelse for at hjælpe med at gendanne en chat, "
+"hvis du mister din internetforbindelse. Deaktivering af chathistorikken "
+"sletter fastgjorte chats og deaktiverer midlertidig lagring af nye prompter "
+"og svar."
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -14055,7 +14036,7 @@ msgstr "Okay, forstået!"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "OPTIONAL"
-msgstr ""
+msgstr "VALGFRIT"
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -14651,8 +14632,8 @@ msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
 msgstr ""
-"Andre søgemaskiner sporer dine søgninger, selv når du er i privat browsing-"
-"tilstand. Vi sporer dig ikke – punktum."
+"Andre søgemaskiner sporer dine søgninger, selv når du er i privat "
+"browsing-tilstand. Vi sporer dig ikke – punktum."
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -16182,7 +16163,7 @@ msgstr "Beskyttet"
 #. Headline in sync-enabled chat history about modals explaining encrypted server storage.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Protected with end-to-end encryption"
-msgstr ""
+msgstr "Beskyttet med end-to-end-kryptering"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -16321,7 +16302,7 @@ msgstr "Rangering"
 #. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
 msgctxt "star rating on a product"
 msgid "Rated %s out of %s"
-msgstr ""
+msgstr "Bedømt %1$s ud af %2$s"
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17557,7 +17538,7 @@ msgstr "Gem dine chats på alle dine enheder."
 #. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
 msgctxt "Chat history about modal list item headline"
 msgid "Save your chats on this device"
-msgstr ""
+msgstr "Gem dine chats på denne enhed"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
@@ -17740,8 +17721,7 @@ msgstr "Rul ned til %1$sDuckDuckGo%2$s, og lad den bruge din placering."
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr ""
-"Scroll ned til sektionen %1$sTjenester%2$s, og klik på %3$sAdresselinje%4$s."
+msgstr "Scroll ned til sektionen %1$sTjenester%2$s, og klik på %3$sAdresselinje%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -17766,7 +17746,7 @@ msgctxt ""
 "Placeholder and accessibility label for the search input in the tab picker "
 "dialog"
 msgid "Search"
-msgstr ""
+msgstr "Søg"
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -17979,8 +17959,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"Søgeforespørgsler indgår i URL (hvis slået fra, vil søgninger bruge POST-"
-"anmodninger)"
+"Søgeforespørgsler indgår i URL (hvis slået fra, vil søgninger bruge "
+"POST-anmodninger)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -18445,8 +18425,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"Vælg %1$sdin browser%2$s på listen, og %3$stillad%4$s placeringssadgang"
+msgstr "Vælg %1$sdin browser%2$s på listen, og %3$stillad%4$s placeringssadgang"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18770,8 +18749,7 @@ msgstr "Del"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Del DuckDuckGo, og hjælp dine venner med at få deres privatliv tilbage!"
+msgstr "Del DuckDuckGo, og hjælp dine venner med at få deres privatliv tilbage!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -18942,7 +18920,7 @@ msgstr "Shop"
 #. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
 msgctxt "Button in the merchandise logo modal (mobile)"
 msgid "Shop Now"
-msgstr ""
+msgstr "Shop nu"
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -19310,8 +19288,7 @@ msgstr "Viser vandrette linjer ved resultat-sideskift"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr ""
-"Viser links til vejledning i, hvordan du føjer DuckDuckGo til din browser"
+msgstr "Viser links til vejledning i, hvordan du føjer DuckDuckGo til din browser"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -19332,8 +19309,7 @@ msgstr "Viser lejlighedsvise påmindelser om at føje DuckDuckGo til din browser
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Viser lejlighedsvise påmindelser om at tilføje DuckDuckGo til dine enheder"
+msgstr "Viser lejlighedsvise påmindelser om at tilføje DuckDuckGo til dine enheder"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19351,8 +19327,7 @@ msgstr "Vis sidenumre ved resultat-sideskift"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows sign-up form for the DuckDuckGo privacy newsletters"
-msgstr ""
-"Vis tilmeldingsformular til DuckDuckGos nyhedsbreve om privatlivets fred"
+msgstr "Vis tilmeldingsformular til DuckDuckGos nyhedsbreve om privatlivets fred"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/94erFcS.png
@@ -19450,8 +19425,7 @@ msgstr "Navne på websteder"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr ""
-"Webstedssøgning er midlertidigt utilgængelig. Vi arbejder på en løsning."
+msgstr "Webstedssøgning er midlertidigt utilgængelig. Vi arbejder på en løsning."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19773,8 +19747,7 @@ msgstr "Kildetekst ryddet"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr ""
-"Kildeteksten er for lang til at opsummere. Prøv igen med et kortere valg."
+msgstr "Kildeteksten er for lang til at opsummere. Prøv igen med et kortere valg."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -19943,8 +19916,7 @@ msgstr "Start med et billede"
 #. Warning that starting fresh deletes conversations.
 msgctxt "duckai_migration"
 msgid "Starting fresh will delete all your past conversations."
-msgstr ""
-"Hvis du starter forfra, vil alle dine tidligere samtaler blive slettet."
+msgstr "Hvis du starter forfra, vil alle dine tidligere samtaler blive slettet."
 
 # smartling.placeholder_format=C
 #. Footnote warning that starting fresh deletes conversations.
@@ -19980,8 +19952,7 @@ msgstr "Bliv på DuckDuckGo"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr ""
-"Beskyt dig, og hold dig informeret med vores nyhedsbrev om privatlivets fred."
+msgstr "Beskyt dig, og hold dig informeret med vores nyhedsbrev om privatlivets fred."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -20604,6 +20575,8 @@ msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
 msgstr ""
+"Sync & Backup gemmer flere af dine chats og synkroniserer dem på tværs af "
+"alle dine enheder."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20724,7 +20697,7 @@ msgstr "Synkroniser dine chats på tværs af alle dine enheder."
 #. Headline in sync-enabled chat history about modals explaining cross-device sync.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Sync your chats across all your devices"
-msgstr ""
+msgstr "Synkroniser dine chats på tværs af alle dine enheder"
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21088,15 +21061,13 @@ msgstr "Gambia"
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB"
-msgstr ""
-"De vedhæftede filer overstiger grænsen for den samlede størrelse på %1$s MB"
+msgstr "De vedhæftede filer overstiger grænsen for den samlede størrelse på %1$s MB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB."
-msgstr ""
-"De vedhæftede filer overstiger grænsen for den samlede størrelse på %1$s MB."
+msgstr "De vedhæftede filer overstiger grænsen for den samlede størrelse på %1$s MB."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
@@ -21134,8 +21105,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider does not save this chat or any associated data on their "
 "servers."
-msgstr ""
-"Modeludbyderen gemmer ikke denne chat eller tilknyttede data på sine servere."
+msgstr "Modeludbyderen gemmer ikke denne chat eller tilknyttede data på sine servere."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -21287,8 +21257,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Dette Øjeblikkeligt svar er leveret af fællesskabet %1$sDuckDuckHack%2$s."
+msgstr "Dette Øjeblikkeligt svar er leveret af fællesskabet %1$sDuckDuckHack%2$s."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -21317,12 +21286,14 @@ msgid ""
 "This chat and its generated images become public when you create and copy "
 "the link."
 msgstr ""
+"Denne chat og dens genererede billeder bliver offentlige, når du opretter og "
+"kopierer linket."
 
 # smartling.placeholder_format=C
 #. Explains that creating and copying a share link makes the selected chat content public.
 msgctxt "Share modal info bullet about public access"
 msgid "This chat becomes public when you create and copy the link."
-msgstr ""
+msgstr "Denne chat bliver offentlig, når du opretter og kopierer linket."
 
 # smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
@@ -21463,16 +21434,14 @@ msgstr "Dette billede kunne ikke oprettes."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr ""
-"Denne billedtype understøttes ikke. Vedhæft en JPG, PNG, WebP eller GIF"
+msgstr "Denne billedtype understøttes ikke. Vedhæft en JPG, PNG, WebP eller GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr ""
-"Denne billedtype understøttes ikke. Vedhæft en JPG, PNG, WebP eller GIF."
+msgstr "Denne billedtype understøttes ikke. Vedhæft en JPG, PNG, WebP eller GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -21551,8 +21520,7 @@ msgstr "Denne side kræver JavaScript for at kunne fungere."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Indholdet af denne side vil blive sendt sammen med din besked til Duck.ai"
+msgstr "Indholdet af denne side vil blive sendt sammen med din besked til Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21631,8 +21599,7 @@ msgstr "Denne oversættelse er forkert"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Videoen er endnu ikke tilgængelig til visning her. Du kan se den på %1$s."
+msgstr "Videoen er endnu ikke tilgængelig til visning her. Du kan se den på %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -21855,7 +21822,7 @@ msgstr "I dag"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
-msgstr ""
+msgstr "Vælg privat AI-chat, eller %1$sdeaktiver i indstillinger%2$s."
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -22344,8 +22311,7 @@ msgstr "Prøv andre nøgleord."
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr ""
-"Prøv at deaktivere din adblocker på DuckDuckGo for at se flere resultater."
+msgstr "Prøv at deaktivere din adblocker på DuckDuckGo for at se flere resultater."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
@@ -22931,8 +22897,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Under %1$sVed opstart%2$s, vælg %3$sStartside%4$s og indtast: https://"
-"duckduckgo.com"
+"Under %1$sVed opstart%2$s, vælg %3$sStartside%4$s og indtast: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -22959,15 +22925,14 @@ msgstr "Under %1$sSøg i adressefeltet med%2$s vælger du %3$sTilføj ny%4$s"
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"Under %1$sSøge%2$s-sektionen klikker du på %3$sAdministrer søgemaskiner ..."
-"%4$s"
+"Under %1$sSøge%2$s-sektionen klikker du på %3$sAdministrer søgemaskiner "
+"...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr ""
-"Under \"Ved opstart\" vælger du %1$sÅbn en bestemt side eller sider%2$s"
+msgstr "Under \"Ved opstart\" vælger du %1$sÅbn en bestemt side eller sider%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -23074,8 +23039,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Lås op for avancerede AI-modeller og højere grænser med et DuckDuckGo-"
-"abonnement"
+"Lås op for avancerede AI-modeller og højere grænser med et "
+"DuckDuckGo-abonnement"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -23114,8 +23079,7 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr ""
-"Få adgang til mere avancerede AI-modeller med et DuckDuckGo-abonnement. %1$s"
+msgstr "Få adgang til mere avancerede AI-modeller med et DuckDuckGo-abonnement. %1$s"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -23346,8 +23310,7 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr ""
-"Opgrader til Pro for at låse op for dobbelt så høje forbrugsgrænser som Plus"
+msgstr "Opgrader til Pro for at låse op for dobbelt så høje forbrugsgrænser som Plus"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -23457,8 +23420,7 @@ msgstr "Brug DuckDuckGo Private Search"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"Brug DuckDuckGo Private Search på din iPad, iPhone eller Android-enhed!"
+msgstr "Brug DuckDuckGo Private Search på din iPad, iPhone eller Android-enhed!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -23681,6 +23643,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Yelp's ad network."
 msgstr ""
+"DuckDuckGo beskytter dine personoplysninger, når du ser annoncer. "
+"Annonceklik administreres af Yelps annoncenetværk."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -23764,9 +23728,10 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"Besøg Duck.ai i din anden browser eller DuckDuckGo-appen, og åbn Duck.ai-"
-"indstillinger. Vælg \"Slå til\" under Sync & Backup, og vælg \"Synkroniser "
-"med en anden enhed\". Eller scan QR-koden på din gendannelses-PDF."
+"Besøg Duck.ai i din anden browser eller DuckDuckGo-appen, og åbn "
+"Duck.ai-indstillinger. Vælg \"Slå til\" under Sync & Backup, og vælg "
+"\"Synkroniser med en anden enhed\". Eller scan QR-koden på din "
+"gendannelses-PDF."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23818,8 +23783,7 @@ msgstr "Stemmesamtale afsluttet"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr ""
-"Stemmechat er anonymiseret af os og bruges aldrig til at træne AI-modeller."
+msgstr "Stemmechat er anonymiseret af os og bruges aldrig til at træne AI-modeller."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -24044,8 +24008,7 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"Vi kan ikke læse de vedhæftede filer, fordi mindst én af dem er krypteret."
+msgstr "Vi kan ikke læse de vedhæftede filer, fordi mindst én af dem er krypteret."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24261,8 +24224,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr ""
-"Vi blokerer trackere, der forsøger at indsamle dine data, mens du browser."
+msgstr "Vi blokerer trackere, der forsøger at indsamle dine data, mens du browser."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
@@ -24306,8 +24268,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr ""
-"Vi beklager ulejligheden. Vi arbejder hårdt på at gøre din oplevelse bedre."
+msgstr "Vi beklager ulejligheden. Vi arbejder hårdt på at gøre din oplevelse bedre."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -24470,8 +24431,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"Velkommen til det nye Duck.ai! Du kan nu importere dine downloadede chats."
+msgstr "Velkommen til det nye Duck.ai! Du kan nu importere dine downloadede chats."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24562,15 +24522,13 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr ""
-"Hvad er nogle faktorer, der skal overvejes, når man køber en computerskærm?"
+msgstr "Hvad er nogle faktorer, der skal overvejes, når man køber en computerskærm?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr ""
-"Hvad er nogle must-see attraktioner i Paris for en førstegangsbesøgende?"
+msgstr "Hvad er nogle must-see attraktioner i Paris for en førstegangsbesøgende?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -24607,9 +24565,10 @@ msgid ""
 msgstr ""
 "Hvad er fordelene ved at downloade DuckDuckGo-browseren, hvis du er "
 "interesseret i at bruge Duck.ai? Referer kun officielle DuckDuckGo-kilder. "
-"Opdel svaret i klare sektioner med titler, med fokus på Duck.ai-"
-"integrationer og beskyttelse af privatlivet. Hold det kort, enkelt og "
-"letforståeligt for folk med eller uden betydelig AI- eller teknisk erfaring."
+"Opdel svaret i klare sektioner med titler, med fokus på "
+"Duck.ai-integrationer og beskyttelse af privatlivet. Hold det kort, enkelt "
+"og letforståeligt for folk med eller uden betydelig AI- eller teknisk "
+"erfaring."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24694,8 +24653,7 @@ msgstr "Hvilke retter bør man prøve her?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
-"Hvad er åbningstiderne, placeringen og kontaktoplysningerne for dette sted?"
+msgstr "Hvad er åbningstiderne, placeringen og kontaktoplysningerne for dette sted?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -24837,8 +24795,7 @@ msgstr "Hvilke informationer bliver gemt?"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr ""
-"Hvilke spørgsmål kan blive stillet under jobsamtalen til denne stilling?"
+msgstr "Hvilke spørgsmål kan blive stillet under jobsamtalen til denne stilling?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -24955,8 +24912,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"Når funktionen er aktiveret, vil Duck.ai vise Øjeblikkeligt svar i chatten."
+msgstr "Når funktionen er aktiveret, vil Duck.ai vise Øjeblikkeligt svar i chatten."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -25166,13 +25122,15 @@ msgid ""
 "With chat history on, up to %s of your most recent chats will be saved on "
 "this device."
 msgstr ""
+"Når chathistorik er slået til, gemmes op til %1$s af dine seneste chats på "
+"denne enhed."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline in the About Chat History modal.
 msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, your most recent chats will be saved on this device."
-msgstr ""
+msgstr "Når chathistorik er slået til, gemmes dine seneste chats på denne enhed."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -25457,8 +25415,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"Du chatter med %1$s. AI-chats kan vise unøjagtige eller stødende oplysninger."
+msgstr "Du chatter med %1$s. AI-chats kan vise unøjagtige eller stødende oplysninger."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -25754,8 +25711,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr ""
-"Du vil ikke se denne meddelelse igen, medmindre du rydder dine browserdata."
+msgstr "Du vil ikke se denne meddelelse igen, medmindre du rydder dine browserdata."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -25850,16 +25806,14 @@ msgstr "Du har nået det maksimale antal beskeder for nu. Prøv igen senere."
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr ""
-"Du har nået den maksimale varighed af stemmechat for en enkelt session."
+msgstr "Du har nået den maksimale varighed af stemmechat for en enkelt session."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"Du har nået grænsen for stemmechat for i dag. Prøv venligst igen i morgen."
+msgstr "Du har nået grænsen for stemmechat for i dag. Prøv venligst igen i morgen."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -26046,8 +26000,7 @@ msgstr "Dine chats bliver nu gemt."
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
-msgstr ""
-"Dine chats er private og hverken gemmes eller bruges til at træne AI-modeller"
+msgstr "Dine chats er private og hverken gemmes eller bruges til at træne AI-modeller"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
@@ -26061,8 +26014,8 @@ msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Dine chats er private, anonymiseret af os, og bruges ikke til at træne AI-"
-"modeller."
+"Dine chats er private, anonymiseret af os, og bruges ikke til at træne "
+"AI-modeller."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
@@ -26070,8 +26023,8 @@ msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Dine chats er private, anonymiseret af os, og bruges ikke til at træne AI-"
-"modeller."
+"Dine chats er private, anonymiseret af os, og bruges ikke til at træne "
+"AI-modeller."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -26189,8 +26142,8 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"Dit adgangsudtryk genererer en 512-bit-nøgle ved hjælp af Secure Hash-"
-"algoritmen kendt som %1$sSHA-2%2$s. Kun nøglen og den tilhørende "
+"Dit adgangsudtryk genererer en 512-bit-nøgle ved hjælp af Secure "
+"Hash-algoritmen kendt som %1$sSHA-2%2$s. Kun nøglen og den tilhørende "
 "indstillingsfil forlader din browser. Vi gemmer indstillingsfilen ved at "
 "bruge nøglen som navnet. DuckDuckGo får aldrig dit adgangsudtryk at vide."
 
@@ -26572,7 +26525,7 @@ msgstr "m"
 #. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the chat options menu button"
 msgid "menu"
-msgstr ""
+msgstr "Menu"
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/da_DK/LC_MESSAGES/duckduckgo.po
+++ b/locales/da_DK/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: da_DK\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1211,6 +1211,12 @@ msgid "About our ads"
 msgstr "Om vores annoncer"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1340,6 +1346,20 @@ msgid "Ad is suspicious"
 msgstr "Annoncen er mistænkelig"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Tilføj DuckDuckGo"
@@ -1366,6 +1386,27 @@ msgstr "Tilføj DuckDuckGo som søgemaskine"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Føj DuckDuckGo til %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1411,6 +1452,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Tilføj sideindhold"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1496,6 +1553,12 @@ msgstr "Tilføjelser"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Vi lægger sidste hånd på værket"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1799,6 +1862,12 @@ msgstr "Alle farver"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Helt færdig!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3507,6 +3576,14 @@ msgid "Cancel"
 msgstr "Annuller"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4002,10 +4079,22 @@ msgid "Chat response is offensive"
 msgstr "Chat-svaret er stødende"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Chat med %1$s"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4024,6 +4113,14 @@ msgstr "Chats"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Chats"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5616,6 +5713,12 @@ msgid "Current Streak"
 msgstr "Nuværende resultatliste"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5962,6 +6065,12 @@ msgstr "Slet chat"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Slet chats, der er ældre end 30 dage"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6375,6 +6484,12 @@ msgstr "Afvis for altid"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Afvis kampagne"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7544,6 +7659,12 @@ msgid "Edit Prompt"
 msgstr "Rediger prompt"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7766,6 +7887,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Krypteret model"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8594,6 +8721,12 @@ msgid "Follow-up question"
 msgstr "Opfølgende spørgsmål"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9105,6 +9238,12 @@ msgstr ""
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr "Få DuckDuckGo VPN, avanceret Duck.ai og Identity Theft Restoration."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10335,6 +10474,12 @@ msgstr "Hvordan er det anonymt?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Sådan fungerer det"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11783,6 +11928,12 @@ msgstr "Lineouts vundet"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "Linket udløber om 7 dage."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13899,6 +14050,12 @@ msgstr "Okay"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "Okay, forstået!"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16022,6 +16179,12 @@ msgid "Protected"
 msgstr "Beskyttet"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Beskyttelse. Fortrolighed. Ro i sindet."
@@ -16153,6 +16316,12 @@ msgstr "Regn"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Rangering"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17385,6 +17554,12 @@ msgid "Save your chats across all your devices."
 msgstr "Gem dine chats på alle dine enheder."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17584,6 +17759,14 @@ msgstr "Søg"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Søg"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18754,6 +18937,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Shop"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20409,6 +20598,14 @@ msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr "Sync & Backup-data kan ikke gendannes efter 18 måneders inaktivitet."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20522,6 +20719,12 @@ msgstr "Synkroniser med en enhed i nærheden."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Synkroniser dine chats på tværs af alle dine enheder."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21106,6 +21309,22 @@ msgid "This Week"
 msgstr "Denne uge"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21631,6 +21850,12 @@ msgstr "I dag"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "I dag"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23450,6 +23675,14 @@ msgstr ""
 "Annonceklik administreres af TripAdvisors annoncenetværk."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Jomfruøerne"
 
@@ -24927,6 +25160,21 @@ msgstr ""
 "Slå det til eller fra når som helst i menuen '%1$s'."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26319,6 +26567,12 @@ msgstr "m"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "m"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/da_DK/LC_MESSAGES/duckduckgo.po
+++ b/locales/da_DK/LC_MESSAGES/duckduckgo.po
@@ -8757,7 +8757,7 @@ msgstr "Formateringsproblemer"
 #. Soccer match stats
 msgctxt "Sports module"
 msgid "Fouls"
-msgstr "Frispark"
+msgstr "Forseelser"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: fours full name (tooltip)

--- a/locales/de_CH/LC_MESSAGES/duckduckgo.po
+++ b/locales/de_CH/LC_MESSAGES/duckduckgo.po
@@ -982,6 +982,11 @@ msgstr "Über uns"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1085,6 +1090,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "Werbung ist verdächtig"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Füge DuckDuckGo an"
@@ -1106,6 +1123,24 @@ msgstr "Füge DuckDuckGo als Suchmaschine hinzu"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Füge DuckDuckGo zu %s hinzu"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1144,6 +1179,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1215,6 +1264,11 @@ msgstr "Erweiterungen"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1461,6 +1515,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2819,6 +2878,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3219,9 +3285,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3237,6 +3313,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4509,6 +4592,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4793,6 +4881,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5131,6 +5224,11 @@ msgstr "für immer Verbergen"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6027,6 +6125,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6204,6 +6307,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6873,6 +6981,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7291,6 +7404,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8278,6 +8396,11 @@ msgid "How is it anonymous?"
 msgstr "Wie ist es anonym?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9441,6 +9564,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11180,6 +11308,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "OK, verstanden!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12891,6 +13024,11 @@ msgstr "Schütze deine Daten auf allen Geräten"
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12997,6 +13135,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13985,6 +14128,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14144,6 +14292,13 @@ msgstr "Suche"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15074,6 +15229,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16415,6 +16575,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16495,6 +16662,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16963,6 +17135,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17369,6 +17555,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18840,6 +19031,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -20003,6 +20201,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21100,6 +21311,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/de_DE/LC_MESSAGES/duckduckgo.po
+++ b/locales/de_DE/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: de_DE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1221,6 +1221,12 @@ msgid "About our ads"
 msgstr "Über unsere Werbung"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1351,6 +1357,20 @@ msgid "Ad is suspicious"
 msgstr "Werbung is verdächtig"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "DuckDuckGo hinzufügen"
@@ -1377,6 +1397,27 @@ msgstr "DuckDuckGo als Suchmaschine hinzufügen"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "DuckDuckGo zu %1$s hinzufügen"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1422,6 +1463,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Seiteninhalt hinzufügen"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1507,6 +1564,12 @@ msgstr "Erweiterungen"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Fertigstellen der letzten Details"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1811,6 +1874,12 @@ msgstr "Alle Farben"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Alles erledigt!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3543,6 +3612,14 @@ msgid "Cancel"
 msgstr "Abbrechen"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4042,10 +4119,22 @@ msgid "Chat response is offensive"
 msgstr "Chat-Antwort ist anstößig"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Mit %1$s chatten"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4064,6 +4153,14 @@ msgstr "Chats"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Chats"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5670,6 +5767,12 @@ msgid "Current Streak"
 msgstr "Aktuelle Serie"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -6017,6 +6120,12 @@ msgstr "Chats löschen"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Chats älter als 30 Tage löschen"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6433,6 +6542,12 @@ msgstr "Für immer verwerfen"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Werbung verwerfen"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7620,6 +7735,12 @@ msgid "Edit Prompt"
 msgstr "Prompt bearbeiten"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7843,6 +7964,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Verschlüsseltes Modell"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8692,6 +8819,12 @@ msgid "Follow-up question"
 msgstr "Folgefrage"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9207,6 +9340,12 @@ msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
 "Hol dir DuckDuckGo-VPN, fortschrittliche Duck.ai-Funktionen und Identity "
 "Theft Restoration."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10449,6 +10588,12 @@ msgstr "Wieso ist es anonym?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Und so funktioniert's"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11904,6 +12049,12 @@ msgstr "Gewonnene Lineouts"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "Link läuft in 7 Tagen ab."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14029,6 +14180,12 @@ msgstr "OK"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "Verstanden!"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16167,6 +16324,12 @@ msgid "Protected"
 msgstr "Geschützt"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Schutz. Privatsphäre. Extra an Sicherheit."
@@ -16298,6 +16461,12 @@ msgstr "Regen"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Rankings"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17541,6 +17710,12 @@ msgid "Save your chats across all your devices."
 msgstr "Speichere deine Chats auf all deinen Geräten."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17745,6 +17920,14 @@ msgstr "Suche"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Suche"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18931,6 +19114,12 @@ msgstr "Umschalt+Eingabe"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Shop"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20607,6 +20796,14 @@ msgstr ""
 "wiederhergestellt werden."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20722,6 +20919,12 @@ msgstr "Mit einem Gerät in der Nähe synchronisieren."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Synchronisiere deine Chats auf all deinen Geräten."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21315,6 +21518,22 @@ msgid "This Week"
 msgstr "Diese Woche"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21857,6 +22076,12 @@ msgstr "Heute"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Heute"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23711,6 +23936,14 @@ msgstr ""
 "TripAdvisor verwaltet."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Jungferninseln"
 
@@ -25210,6 +25443,21 @@ msgstr ""
 "verwendet. Kann jederzeit im Menü „%1$s“ ein- oder ausgeschaltet werden."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26629,6 +26877,12 @@ msgstr "Min."
 msgctxt "published date for videos"
 msgid "m"
 msgstr "Min."
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/de_DE/LC_MESSAGES/duckduckgo.po
+++ b/locales/de_DE/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: de_DE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1224,7 +1224,7 @@ msgstr "Über unsere Werbung"
 #. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
 msgctxt "Modal header for chat history with sync information"
 msgid "About Chat History with Sync & Backup"
-msgstr ""
+msgstr "Über Chatverlauf mit Sync & Backup"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
@@ -1323,8 +1323,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
 msgid "Ad clicks aren’t used to profile you"
-msgstr ""
-"Werbungsklicks werden nicht verwendet, um ein Profil von dir zu erstellen"
+msgstr "Werbungsklicks werden nicht verwendet, um ein Profil von dir zu erstellen"
 
 # smartling.placeholder_format=C
 #. Category of problem a user can select on a feedback form.
@@ -1360,7 +1359,7 @@ msgstr "Werbung is verdächtig"
 #. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
 msgctxt "Button to open menu for attaching images or page context to AI chat"
 msgid "Add"
-msgstr ""
+msgstr "Hinzufügen"
 
 # smartling.placeholder_format=C
 #. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
@@ -1368,7 +1367,7 @@ msgctxt ""
 "Primary button that attaches the tabs the user checked in the tab picker "
 "dialog"
 msgid "Add"
-msgstr ""
+msgstr "Hinzufügen"
 
 # smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
@@ -1403,13 +1402,13 @@ msgstr "DuckDuckGo zu %1$s hinzufügen"
 msgctxt ""
 "Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
 msgid "Add File"
-msgstr ""
+msgstr "Datei hinzufügen"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
 msgid "Add Image"
-msgstr ""
+msgstr "Bild hinzufügen"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
@@ -1417,7 +1416,7 @@ msgctxt ""
 "Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
 "item)"
 msgid "Add Image or File"
-msgstr ""
+msgstr "Bild oder Datei hinzufügen"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1470,7 +1469,7 @@ msgctxt ""
 "Open the tab picker to attach browser tab content to the AI chat message "
 "(attach dropdown menu item)"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Tabs hinzufügen"
 
 # smartling.placeholder_format=C
 #. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
@@ -1478,7 +1477,7 @@ msgctxt ""
 "Title and accessible name of the tab-picker dialog opened from the attach "
 "dropdown menu"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Tabs hinzufügen"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1569,7 +1568,7 @@ msgstr "Fertigstellen der letzten Details"
 #. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
 msgctxt "Aria label for the additional instructions textarea"
 msgid "Additional instructions"
-msgstr ""
+msgstr "Zusätzliche Anweisungen"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1879,7 +1878,7 @@ msgstr "Alles erledigt!"
 #. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the read-only textarea listing all AI instructions"
 msgid "All instructions"
-msgstr ""
+msgstr "Alle Anweisungen"
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -1973,8 +1972,7 @@ msgstr "Anonyme Dateiüberprüfung für diesen Chat erlauben?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Lass datenschutzfreundliche Werbung in der Private Search von DuckDuckGo zu"
+msgstr "Lass datenschutzfreundliche Werbung in der Private Search von DuckDuckGo zu"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2316,8 +2314,7 @@ msgstr ""
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr ""
-"Möchtest du diese Konversation wirklich löschen und eine neue beginnen?"
+msgstr "Möchtest du diese Konversation wirklich löschen und eine neue beginnen?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2529,13 +2526,13 @@ msgid ""
 msgstr ""
 "Assist kann anonym KI-gestützte Antworten auf einige Suchanfragen "
 "generieren, die auf der Zusammenfassung relevanter Webinhalte basieren. Du "
-"kannst auswählen, wie oft Assist angezeigt werden soll: Nie (die Assist-"
-"Benutzeroberfläche wird vollständig aus den Suchergebnissen entfernt), Bei "
-"Bedarf (KI-gestützte Antworten werden nur angezeigt, wenn du auf die Assist-"
-"Schaltfläche klickst), Manchmal (KI-gestützte Antworten werden nur bei hoher "
-"Relevanz angezeigt) oder Oft (werden häufiger bei einer größeren Anzahl von "
-"Suchanfragen angezeigt). Derzeit sind KI-gestützte Antworten nur in den USA "
-"(Englisch) verfügbar."
+"kannst auswählen, wie oft Assist angezeigt werden soll: Nie (die "
+"Assist-Benutzeroberfläche wird vollständig aus den Suchergebnissen "
+"entfernt), Bei Bedarf (KI-gestützte Antworten werden nur angezeigt, wenn du "
+"auf die Assist-Schaltfläche klickst), Manchmal (KI-gestützte Antworten "
+"werden nur bei hoher Relevanz angezeigt) oder Oft (werden häufiger bei einer "
+"größeren Anzahl von Suchanfragen angezeigt). Derzeit sind KI-gestützte "
+"Antworten nur in den USA (Englisch) verfügbar."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2547,8 +2544,8 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist ist eine optionale Funktion in unseren Suchergebnissen, die anonym KI-"
-"gestützte Antworten auf Suchanfragen generieren kann. Dazu durchsucht sie "
+"Assist ist eine optionale Funktion in unseren Suchergebnissen, die anonym "
+"KI-gestützte Antworten auf Suchanfragen generieren kann. Dazu durchsucht sie "
 "das Internet nach relevanten Inhalten und verwendet dann KI-gestützte "
 "natürliche Sprachtechnologie, um eine kurze Antwort auf der Grundlage der "
 "gefundenen relevanten Informationen zu generieren. Es ist wichtig, zu "
@@ -2716,8 +2713,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
 msgid "Auto-generated from sources. May be inaccurate."
-msgstr ""
-"Automatisch generiert basierend auf Quellen. Kann Ungenauigkeiten enthalten."
+msgstr "Automatisch generiert basierend auf Quellen. Kann Ungenauigkeiten enthalten."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2791,8 +2787,7 @@ msgstr "Durchschn. Vol."
 #. Warning text shown below the chat input when the user has attached files, advising them not to upload files from untrusted sources.
 msgctxt "Disclaimer below chat input in Duck.ai when files are attached"
 msgid "Avoid uploading files from sources you don't trust."
-msgstr ""
-"Vermeide das Hochladen von Dateien aus Quellen, denen du nicht vertraust."
+msgstr "Vermeide das Hochladen von Dateien aus Quellen, denen du nicht vertraust."
 
 # smartling.placeholder_format=C
 #. Indicates the Win-Loss record of a team when playing away
@@ -3098,8 +3093,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr ""
-"Die Blockliste ist nicht vollständig und kann Ungenauigkeiten enthalten."
+msgstr "Die Blockliste ist nicht vollständig und kann Ungenauigkeiten enthalten."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3115,8 +3109,7 @@ msgstr "Diese Seite in allen Ergebnissen blockieren"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr ""
-"Blockiere Tracker und übernimm die Kontrolle über deine persönlichen Daten"
+msgstr "Blockiere Tracker und übernimm die Kontrolle über deine persönlichen Daten"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3374,9 +3367,9 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"Surfe wie immer und wir kümmern uns um den Rest: Private Suche, Tracker-"
-"Blockade, und Website-Verschlüsselung – alles in einem Download, für %1$sdie "
-"wichtigsten Browser%2$s."
+"Surfe wie immer und wir kümmern uns um den Rest: Private Suche, "
+"Tracker-Blockade, und Website-Verschlüsselung – alles in einem Download, für "
+"%1$sdie wichtigsten Browser%2$s."
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3462,8 +3455,7 @@ msgstr "Indem du auf „%1$s“ klickst, akzeptierst du unsere %2$s."
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr ""
-"Indem du auf „%1$s“ klickst, akzeptierst du die %2$s und %3$s von Duck.ai."
+msgstr "Indem du auf „%1$s“ klickst, akzeptierst du die %2$s und %3$s von Duck.ai."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3484,11 +3476,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"Normalerweise werden die Einstellungen in nicht personenbezogenen Browser-"
-"Cookies gespeichert (im eigenen Browser). Im anonymen Cloud Save lassen sich "
-"Einstellungen dauerhafter sichern (auf einem Remote-Server in der Cloud). Es "
-"werden dabei keine personenbezogenen Daten in der Cloud gespeichert und die "
-"Passphrase verlässt nie den eigenen Browser."
+"Normalerweise werden die Einstellungen in nicht personenbezogenen "
+"Browser-Cookies gespeichert (im eigenen Browser). Im anonymen Cloud Save "
+"lassen sich Einstellungen dauerhafter sichern (auf einem Remote-Server in "
+"der Cloud). Es werden dabei keine personenbezogenen Daten in der Cloud "
+"gespeichert und die Passphrase verlässt nie den eigenen Browser."
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
@@ -3544,8 +3536,7 @@ msgstr "Kamerun"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr ""
-"Kannst du ein paar einfache Rezepte mit Hühnchen, Brokkoli und Reis kreieren?"
+msgstr "Kannst du ein paar einfache Rezepte mit Hühnchen, Brokkoli und Reis kreieren?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3617,7 +3608,7 @@ msgctxt ""
 "Secondary button that dismisses the tab picker dialog without attaching "
 "anything"
 msgid "Cancel"
-msgstr ""
+msgstr "Abbrechen"
 
 # smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
@@ -3881,8 +3872,7 @@ msgstr ""
 #. http://i.imgur.com/NdpkbY0.png
 msgctxt "settings"
 msgid "Changes the background color when hovering over a result"
-msgstr ""
-"Ändert die Hintergrundfarbe, wenn du den Mauszeiger über ein Ergebnis bewegst"
+msgstr "Ändert die Hintergrundfarbe, wenn du den Mauszeiger über ein Ergebnis bewegst"
 
 # smartling.placeholder_format=C
 #. Description of a setting managing the color of search result snippet text.
@@ -4013,8 +4003,8 @@ msgstr ""
 "KI-Chatmodellen von Drittanbietern zu führen, etwa OpenAI oder Anthropic. "
 "Wenn du diese Einstellung deaktivierst, werden Chat-Schaltflächen und -Links "
 "in DuckDuckGo Search ausgeblendet. Du kannst jedoch auch dann auf den Chat "
-"zugreifen, wenn diese Einstellung deaktiviert ist, indem du %1$shttps://duck."
-"ai%2$s direkt besuchst."
+"zugreifen, wenn diese Einstellung deaktiviert ist, indem du "
+"%1$shttps://duck.ai%2$s direkt besuchst."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4122,7 +4112,7 @@ msgstr "Chat-Antwort ist anstößig"
 #. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
 msgctxt "Chat history about modal list item headline"
 msgid "Chat storage varies by browser"
-msgstr ""
+msgstr "Der Speicher für Chats variiert je nach Browser"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4134,7 +4124,7 @@ msgstr "Mit %1$s chatten"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Chat with popular AI models, anonymized by us."
-msgstr ""
+msgstr "Mit beliebten KI-Modellen chatten, von uns anonymisiert."
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4161,6 +4151,9 @@ msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
 msgstr ""
+"Chats werden mit Ende-zu-Ende-Verschlüsselung sicher auf dem Server von "
+"DuckDuckGo gespeichert. Niemand außer dir kann deine Daten sehen, nicht "
+"einmal wir."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4169,9 +4162,9 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"Chats werden lokal auf deinem Gerät gespeichert, anstatt auf DuckDuckGo-"
-"Servern oder Remote-Servern. Wenn du den Chatverlauf deaktivierst, werden "
-"angeheftete Chats gelöscht."
+"Chats werden lokal auf deinem Gerät gespeichert, anstatt auf "
+"DuckDuckGo-Servern oder Remote-Servern. Wenn du den Chatverlauf "
+"deaktivierst, werden angeheftete Chats gelöscht."
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -4184,11 +4177,11 @@ msgid ""
 "prompts and responses."
 msgstr ""
 "Chats werden lokal auf deinem Gerät gespeichert. Neue Prompts und Antworten "
-"werden verschlüsselt und nach dem Senden vorübergehend auf einem DuckDuckGo-"
-"Server gespeichert, damit du einen Chat wiederherstellen kannst, falls deine "
-"Internetverbindung unterbrochen wird. Wenn du den Chatverlauf deaktivierst, "
-"werden angeheftete Chats gelöscht und die vorübergehende Speicherung neuer "
-"Aufforderungen und Antworten deaktiviert."
+"werden verschlüsselt und nach dem Senden vorübergehend auf einem "
+"DuckDuckGo-Server gespeichert, damit du einen Chat wiederherstellen kannst, "
+"falls deine Internetverbindung unterbrochen wird. Wenn du den Chatverlauf "
+"deaktivierst, werden angeheftete Chats gelöscht und die vorübergehende "
+"Speicherung neuer Aufforderungen und Antworten deaktiviert."
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -4211,8 +4204,8 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"Chats mit %1$s haben keine Sichtbarkeit auf Anbieterseite, aber alle in Duck."
-"ai hochgeladenen Dateien werden anonym von einem Anbieter für "
+"Chats mit %1$s haben keine Sichtbarkeit auf Anbieterseite, aber alle in "
+"Duck.ai hochgeladenen Dateien werden anonym von einem Anbieter für "
 "Inhaltsmoderation auf %2$s überprüft."
 
 # smartling.placeholder_format=C
@@ -4346,8 +4339,7 @@ msgstr "Auswahl von KI-Modellen, darunter %1$s und %2$s"
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr ""
-"Wähle %1$sBeibehalten%2$s aus, um weiterhin deine Privatsphäre zu schützen."
+msgstr "Wähle %1$sBeibehalten%2$s aus, um weiterhin deine Privatsphäre zu schützen."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -5770,7 +5762,7 @@ msgstr "Aktuelle Serie"
 #. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
 msgctxt "Suffix label indicating a tab is the currently active browser tab"
 msgid "Current Tab"
-msgstr ""
+msgstr "Aktueller Tab"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
@@ -5925,8 +5917,7 @@ msgstr "Tageslimit erreicht"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Tägliches Nutzungslimit erreicht. Du kannst diesen Chat nach %1$s fortsetzen."
+msgstr "Tägliches Nutzungslimit erreicht. Du kannst diesen Chat nach %1$s fortsetzen."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -6125,7 +6116,7 @@ msgstr "Chats älter als 30 Tage löschen"
 #. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
 msgctxt "Button text in the modal for deleting all recent chats"
 msgid "Delete Chats and Shared Links"
-msgstr ""
+msgstr "Chats und geteilte Links löschen"
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6260,8 +6251,7 @@ msgstr ""
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
 msgctxt "settings"
 msgid "Deleting cookies will reset these settings."
-msgstr ""
-"Durch das Löschen der Cookies werden diese Einstellungen zurückgesetzt."
+msgstr "Durch das Löschen der Cookies werden diese Einstellungen zurückgesetzt."
 
 # smartling.placeholder_format=C
 msgid "Democratic People's Republic of Korea"
@@ -6283,8 +6273,7 @@ msgstr "Beschreibe die Änderungen basierend auf dem Bild"
 #. Placeholder text displayed in the input field when the user can make follow-up edits to a generated image.
 msgctxt "Placeholder text for the image generation input field for follow-ups"
 msgid "Describe changes to continue editing this image"
-msgstr ""
-"Beschreibe die Änderungen, um mit der Bearbeitung dieses Bildes fortzufahren."
+msgstr "Beschreibe die Änderungen, um mit der Bearbeitung dieses Bildes fortzufahren."
 
 # smartling.placeholder_format=C
 #. Title shown when the user first enters Image Generation mode, prompting them to describe the image they want to create.
@@ -6353,8 +6342,8 @@ msgstr "Diktierfunktion in Duck.ai"
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
 msgstr ""
-"Die Diktate werden von uns anonymisiert und niemals zum Trainieren von KI-"
-"Modellen verwendet."
+"Die Diktate werden von uns anonymisiert und niemals zum Trainieren von "
+"KI-Modellen verwendet."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6547,7 +6536,7 @@ msgstr "Werbung verwerfen"
 #. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the close button on the survey banner"
 msgid "Dismiss survey"
-msgstr ""
+msgstr "Umfrage verwerfen"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6710,8 +6699,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"Du möchtest keine KI? Besuche %1$snoai.duckduckgo.com%2$s um ohne KI-"
-"Funktionen und mit herausgefilterten KI-Bildern zu suchen. %3$sMehr "
+"Du möchtest keine KI? Besuche %1$snoai.duckduckgo.com%2$s um ohne "
+"KI-Funktionen und mit herausgefilterten KI-Bildern zu suchen. %3$sMehr "
 "erfahren%4$s"
 
 # smartling.placeholder_format=C
@@ -7119,10 +7108,10 @@ msgid ""
 msgstr ""
 "Mit Duck.ai kannst du anonyme Unterhaltungen mit KI-Chatmodellen von "
 "Drittanbietern führen, darunter Modelle von OpenAI, Anthropic und anderen. "
-"Wenn du diese Einstellung deaktivierst, werden Duck.ai-Schaltflächen und -"
-"Links in DuckDuckGo Search ausgeblendet. Du kannst jedoch weiterhin auf Duck."
-"ai zugreifen, wenn diese Einstellung deaktiviert ist, indem du %1$shttps://"
-"duck.ai%2$s direkt besuchst."
+"Wenn du diese Einstellung deaktivierst, werden Duck.ai-Schaltflächen und "
+"-Links in DuckDuckGo Search ausgeblendet. Du kannst jedoch weiterhin auf "
+"Duck.ai zugreifen, wenn diese Einstellung deaktiviert ist, indem du "
+"%1$shttps://duck.ai%2$s direkt besuchst."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -7316,8 +7305,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat ist ein privater KI-gestützter Chat-Dienst, der die Chat-"
-"Modelle %2$s von %1$s und %4$s von %3$s nutzt."
+"DuckDuckGo AI Chat ist ein privater KI-gestützter Chat-Dienst, der die "
+"Chat-Modelle %2$s von %1$s und %4$s von %3$s nutzt."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7326,8 +7315,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat ist ein privater, KI-gestützter Chat-Dienst, der die Chat-"
-"Modelle %2$s von %1$s und %4$s von %3$s nutzt."
+"DuckDuckGo AI Chat ist ein privater, KI-gestützter Chat-Dienst, der die "
+"Chat-Modelle %2$s von %1$s und %4$s von %3$s nutzt."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -7738,7 +7727,7 @@ msgstr "Prompt bearbeiten"
 #. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the message-editing text area"
 msgid "Edit message"
-msgstr ""
+msgstr "Nachricht bearbeiten"
 
 # smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
@@ -7969,7 +7958,7 @@ msgstr "Verschlüsseltes Modell"
 #. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
 msgctxt "Share modal info bullet about encryption"
 msgid "Encrypted so DuckDuckGo can't read your chat."
-msgstr ""
+msgstr "Verschlüsselt, sodass DuckDuckGo deinen Chat nicht lesen kann."
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8065,8 +8054,7 @@ msgstr "Stelle sicher, dass der Zugriff auf den Standort %1$saktiviert%2$s ist"
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure location access is %sallowed%s."
-msgstr ""
-"Stelle sicher, dass der Zugriff auf den Standort %1$saktiviert%2$s ist."
+msgstr "Stelle sicher, dass der Zugriff auf den Standort %1$saktiviert%2$s ist."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
@@ -8192,8 +8180,7 @@ msgstr "Äquatorialguinea"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"Lösche deine Browserdaten im Handumdrehen mit unserem %1$sFire Button%2$s"
+msgstr "Lösche deine Browserdaten im Handumdrehen mit unserem %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -8301,8 +8288,7 @@ msgstr "Erkläre die akzeptierte Antwort in einfachen Worten."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr ""
-"Erkläre mir die grundlegenden Konzepte von Schwarzen Löchern auf Schulniveau."
+msgstr "Erkläre mir die grundlegenden Konzepte von Schwarzen Löchern auf Schulniveau."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -8810,8 +8796,7 @@ msgstr ""
 #. Privacy reassurance and instructions intro.
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
-msgstr ""
-"Folge diesen Schritten, um deine Chats auf das neue Duck.ai zu übertragen."
+msgstr "Folge diesen Schritten, um deine Chats auf das neue Duck.ai zu übertragen."
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8822,7 +8807,7 @@ msgstr "Folgefrage"
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
-msgstr ""
+msgstr "Folgemitteilungen bleiben privat."
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8928,8 +8913,7 @@ msgstr "Kostenlose und private Chats, von uns anonymisiert"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Kostenlose und private Chats, von uns anonymisiert. Kein Konto erforderlich."
+msgstr "Kostenlose und private Chats, von uns anonymisiert. Kein Konto erforderlich."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9042,9 +9026,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Wähle in der Menüleiste der Anwendung auf dem Mac <strong>DuckDuckGo</"
-"strong> &gt; <strong>Nach Updates suchen ...</strong> und dann "
-"<strong>Update installieren</strong>."
+"Wähle in der Menüleiste der Anwendung auf dem Mac "
+"<strong>DuckDuckGo</strong> &gt; <strong>Nach Updates suchen ...</strong> "
+"und dann <strong>Update installieren</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9345,7 +9329,7 @@ msgstr ""
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
 msgctxt "Tooltip on the header logo for sunglasses searches"
 msgid "Get DuckDuckGo sunglasses and other gear."
-msgstr ""
+msgstr "Hol dir DuckDuckGo-Sonnenbrillen und andere Fanartikel."
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9412,8 +9396,7 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Get a VPN + two more protections. Try it for free!"
-msgstr ""
-"Hol dir ein VPN + zwei weitere Schutzmaßnahmen. Probiere es kostenlos aus!"
+msgstr "Hol dir ein VPN + zwei weitere Schutzmaßnahmen. Probiere es kostenlos aus!"
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; shown in every market.
@@ -9449,8 +9432,8 @@ msgid ""
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
 "Erhalte Zugang zu den fortschrittlichen KI-Modellen in Duck.ai, indem du "
-"DuckDuckGo abonnierst, was auch unser VPN und andere Premium-"
-"Datenschutzmaßnahmen beinhaltet."
+"DuckDuckGo abonnierst, was auch unser VPN und andere "
+"Premium-Datenschutzmaßnahmen beinhaltet."
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -9461,9 +9444,9 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Mit einem DuckDuckGo-Abo erhältst du Zugang zu den fortschrittlichen KI-"
-"Modellen in Duck.ai, das auch unser VPN und andere Premium-"
-"Datenschutzmaßnahmen beinhaltet."
+"Mit einem DuckDuckGo-Abo erhältst du Zugang zu den fortschrittlichen "
+"KI-Modellen in Duck.ai, das auch unser VPN und andere "
+"Premium-Datenschutzmaßnahmen beinhaltet."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9666,9 +9649,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"Gehe in deinem anderen Browser oder in der DuckDuckGo-App zu %1$sDuck.ai-"
-"Einstellungen%2$s und dann zu %3$sChats › Sync & Backup › Mit einem anderen "
-"Gerät synchronisieren%4$s. Oder scanne den QR-Code auf deinem "
+"Gehe in deinem anderen Browser oder in der DuckDuckGo-App zu "
+"%1$sDuck.ai-Einstellungen%2$s und dann zu %3$sChats › Sync & Backup › Mit "
+"einem anderen Gerät synchronisieren%4$s. Oder scanne den QR-Code auf deinem "
 "Wiederherstellungs-PDF."
 
 # smartling.placeholder_format=C
@@ -10215,15 +10198,13 @@ msgstr "Hilf uns zu verstehen, was wir falsch gemacht haben"
 #. A subtitle of a page that encourages users to share DuckDuckGo with their friends.
 msgctxt "showcase_spread"
 msgid "Help your friends and family join the Duck Side!"
-msgstr ""
-"Hilf deinen Freunden und Verwandten, sich unserer Entenfamilie anzuschließen!"
+msgstr "Hilf deinen Freunden und Verwandten, sich unserer Entenfamilie anzuschließen!"
 
 # smartling.placeholder_format=C
 #. Text description for the Spread card in the SERP footer
 msgctxt "footer_card"
 msgid "Help your friends and family take back their privacy!"
-msgstr ""
-"Hilf deinen Freunden und Verwandten, ihre Privatsphäre zurückzugewinnen!"
+msgstr "Hilf deinen Freunden und Verwandten, ihre Privatsphäre zurückzugewinnen!"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -10235,8 +10216,7 @@ msgstr "Hilfreich"
 #. The title of a menu that shows other applications DuckDuckGo has made.
 msgctxt "showcase_aria_dropdown"
 msgid "Here are some things that we made that you might like."
-msgstr ""
-"Hier sind einige Dinge, die wir gemacht haben, die dir gefallen könnten."
+msgstr "Hier sind einige Dinge, die wir gemacht haben, die dir gefallen könnten."
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -10442,8 +10422,8 @@ msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
 msgstr ""
-"Achtung! Wenn du die Einstellung zurücksetzt, wird die DuckDuckGo-"
-"Erweiterung deaktiviert und du verlierst unseren Datenschutz."
+"Achtung! Wenn du die Einstellung zurücksetzt, wird die "
+"DuckDuckGo-Erweiterung deaktiviert und du verlierst unseren Datenschutz."
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -10593,7 +10573,7 @@ msgstr "Und so funktioniert's"
 #. Headline in chat history about modals for the temporary encrypted server storage explanation.
 msgctxt "Chat history about modal list item headline"
 msgid "How it works"
-msgstr ""
+msgstr "Und so funktioniert's"
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -10769,8 +10749,8 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"Ich mag das Buch „Der Name des Windes“. Welche anderen guten Bücher/"
-"Buchreihen ähneln diesem am meisten und warum?"
+"Ich mag das Buch „Der Name des Windes“. Welche anderen guten "
+"Bücher/Buchreihen ähneln diesem am meisten und warum?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -10845,9 +10825,9 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"Wenn du Bedenken bezüglich unserer Chat-Anbieter oder einer bestimmten Chat-"
-"Antwort hast, kannst du dich auch direkt über ihre Support-Seiten an %1$s "
-"und %2$s wenden."
+"Wenn du Bedenken bezüglich unserer Chat-Anbieter oder einer bestimmten "
+"Chat-Antwort hast, kannst du dich auch direkt über ihre Support-Seiten an "
+"%1$s und %2$s wenden."
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10885,8 +10865,8 @@ msgstr ""
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
 msgstr ""
-"Wenn du willst, wähle »Startseite« neben »Neues Fenster« und »Neue "
-"Tabs« (öffnen mit) aus."
+"Wenn du willst, wähle »Startseite« neben »Neues Fenster« und »Neue Tabs« "
+"(öffnen mit) aus."
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -11415,8 +11395,7 @@ msgstr "Lohnt es sich, das anzuschauen?"
 #. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Is this worth watching? Give me a spoiler-free take."
-msgstr ""
-"Lohnt es sich, das anzuschauen? Gib mir eine spoilerfreie Einschätzung."
+msgstr "Lohnt es sich, das anzuschauen? Gib mir eine spoilerfreie Einschätzung."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -12054,7 +12033,7 @@ msgstr "Link läuft in 7 Tagen ab."
 #. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days. People can save a chat copy."
-msgstr ""
+msgstr "Link läuft in 7 Tagen ab. Personen können eine Chat-Kopie speichern."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13432,8 +13411,7 @@ msgstr "Niederlande"
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a network error occurs during dictation upload.
 msgid "Network error. Please check your connection and try again."
-msgstr ""
-"Netzwerkfehler. Bitte überprüfe deine Verbindung und versuche es erneut."
+msgstr "Netzwerkfehler. Bitte überprüfe deine Verbindung und versuche es erneut."
 
 # smartling.placeholder_format=C
 #. The title of the 'Never' option in the assist settings modal.
@@ -13839,8 +13817,7 @@ msgstr "Keine Ergebnisse gefunden."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr ""
-"Keine Sprache erkannt. Bitte versuche es erneut und sprich in dein Mikrofon."
+msgstr "Keine Sprache erkannt. Bitte versuche es erneut und sprich in dein Mikrofon."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -14185,7 +14162,7 @@ msgstr "Verstanden!"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "OPTIONAL"
-msgstr ""
+msgstr "OPTIONAL"
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -14534,8 +14511,7 @@ msgstr "%1$sEinstellungen%2$s öffnen"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open 'Location', and ensure location is %senabled%s."
-msgstr ""
-"Öffne „Standort“ und stelle sicher, dass der Standort %1$saktiviert%2$s ist."
+msgstr "Öffne „Standort“ und stelle sicher, dass der Standort %1$saktiviert%2$s ist."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -14684,8 +14660,7 @@ msgstr "Öffne das Bedienfeld „So funktioniert Duck.ai“"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Öffne das Safari-Menü und wähle %1$sEinstellungen für DuckDuckGo ...%2$s"
+msgstr "Öffne das Safari-Menü und wähle %1$sEinstellungen für DuckDuckGo ...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -15307,8 +15282,8 @@ msgid ""
 msgstr ""
 "Wenn du deine Suche als vollständigen Fragesatz formulierst, ist es "
 "wahrscheinlicher, dass KI-gestützte Antworten automatisch erscheinen, und du "
-"erhältst oft bessere Antworten. Um sie auszuschalten und die Assist-"
-"Schaltfläche auszublenden, besuche die %1$s-Sucheinstellungen%2$s."
+"erhältst oft bessere Antworten. Um sie auszuschalten und die "
+"Assist-Schaltfläche auszublenden, besuche die %1$s-Sucheinstellungen%2$s."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15332,8 +15307,8 @@ msgid ""
 msgstr ""
 "Wenn du deine Suche als Frage und in einem vollständigen Satz formulierst, "
 "ist es wahrscheinlicher, dass DuckAssist automatisch erscheint, und du "
-"erhältst oft bessere Antworten. Um die Funktion auszuschalten und die Assist-"
-"Taste auszublenden, besuche die %1$sDuckAssist-Einstellungen%2$s."
+"erhältst oft bessere Antworten. Um die Funktion auszuschalten und die "
+"Assist-Taste auszublenden, besuche die %1$sDuckAssist-Einstellungen%2$s."
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -16327,7 +16302,7 @@ msgstr "Geschützt"
 #. Headline in sync-enabled chat history about modals explaining encrypted server storage.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Protected with end-to-end encryption"
-msgstr ""
+msgstr "Geschützt mit Ende-zu-Ende-Verschlüsselung"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -16466,7 +16441,7 @@ msgstr "Rankings"
 #. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
 msgctxt "star rating on a product"
 msgid "Rated %s out of %s"
-msgstr ""
+msgstr "Bewertet mit %1$s von %2$s"
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -16944,8 +16919,7 @@ msgstr "Meine Auswahl merken"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Auswahl merken (kann in den %1$s%2$s%3$sEinstellungen%4$s geändert werden)"
+msgstr "Auswahl merken (kann in den %1$s%2$s%3$sEinstellungen%4$s geändert werden)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -17700,8 +17674,8 @@ msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
 msgstr ""
-"Speichere deine Duck.ai-Chats zwischen deinen Geräten mit Ende-zu-Ende-"
-"Verschlüsselung."
+"Speichere deine Duck.ai-Chats zwischen deinen Geräten mit "
+"Ende-zu-Ende-Verschlüsselung."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17713,7 +17687,7 @@ msgstr "Speichere deine Chats auf all deinen Geräten."
 #. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
 msgctxt "Chat history about modal list item headline"
 msgid "Save your chats on this device"
-msgstr ""
+msgstr "Speichere deine Chats auf diesem Gerät"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
@@ -17743,8 +17717,7 @@ msgstr "Sag Hallo zu Duck.ai!"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr ""
-"Sag Hallo zu Duck.ai – dem kostenlosen, privaten KI-Chat von DuckDuckGo."
+msgstr "Sag Hallo zu Duck.ai – dem kostenlosen, privaten KI-Chat von DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17854,8 +17827,7 @@ msgstr "Scrolle herunter und wähle %1$sErweiterte Einstellungen%2$s aus"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr ""
-"Scrolle herunter und klicke auf %1$sErweiterte Einstellungen anzeigen%2$s."
+msgstr "Scrolle herunter und klicke auf %1$sErweiterte Einstellungen anzeigen%2$s."
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -17927,7 +17899,7 @@ msgctxt ""
 "Placeholder and accessibility label for the search input in the tab picker "
 "dialog"
 msgid "Search"
-msgstr ""
+msgstr "Suche"
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18140,8 +18112,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"Suchanfragen sind Teil der Adresse (wenn ausgeschaltet, wird die POST-"
-"Methode verwendet)"
+"Suchanfragen sind Teil der Adresse (wenn ausgeschaltet, wird die "
+"POST-Methode verwendet)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -18251,8 +18223,7 @@ msgstr "Zweite Meinung"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr ""
-"Speichere und synchronisiere deine Chats sicher auf all deinen Geräten."
+msgstr "Speichere und synchronisiere deine Chats sicher auf all deinen Geräten."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18261,8 +18232,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit Ende-"
-"zu-Ende-Verschlüsselung und greife von all deinen Geräten darauf zu."
+"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit "
+"Ende-zu-Ende-Verschlüsselung und greife von all deinen Geräten darauf zu."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -18271,8 +18242,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit Ende-"
-"zu-Ende-Verschlüsselung und greife von all deinen Geräten darauf zu."
+"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit "
+"Ende-zu-Ende-Verschlüsselung und greife von all deinen Geräten darauf zu."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18281,9 +18252,9 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit Ende-"
-"zu-Ende-Verschlüsselung und greife von all deinen synchronisierten Geräten "
-"darauf zu."
+"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit "
+"Ende-zu-Ende-Verschlüsselung und greife von all deinen synchronisierten "
+"Geräten darauf zu."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18292,16 +18263,16 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"Speichere deine Chats sicher auf unserem Server mit Ende-zu-Ende-"
-"Verschlüsselung und greife von all deinen Geräten darauf zu."
+"Speichere deine Chats sicher auf unserem Server mit "
+"Ende-zu-Ende-Verschlüsselung und greife von all deinen Geräten darauf zu."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
 msgstr ""
-"Sicher gespeichert auf dem Server von DuckDuckGo mit End-to-End-"
-"Verschlüsselung."
+"Sicher gespeichert auf dem Server von DuckDuckGo mit "
+"End-to-End-Verschlüsselung."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -18310,8 +18281,9 @@ msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
 msgstr ""
-"Sicher gespeichert auf dem Server von DuckDuckGo mit End-to-End-"
-"Verschlüsselung. Niemand außer dir kann deine Daten sehen, nicht einmal wir."
+"Sicher gespeichert auf dem Server von DuckDuckGo mit "
+"End-to-End-Verschlüsselung. Niemand außer dir kann deine Daten sehen, nicht "
+"einmal wir."
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
@@ -18428,8 +18400,7 @@ msgstr "Entdecke einige unserer neuesten Updates"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr ""
-"Mehr Informationen findest du in der %1$sÜbersicht über URL-Parameter%2$s."
+msgstr "Mehr Informationen findest du in der %1$sÜbersicht über URL-Parameter%2$s."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -18456,8 +18427,7 @@ msgstr "%1$s%2$s%3$s auswählen, dann %4$sSuchmaschine%5$s"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
-msgstr ""
-"Wähle %1$s„Einstellung für diese Website …“%2$s aus dem Safari-Menü aus."
+msgstr "Wähle %1$s„Einstellung für diese Website …“%2$s aus dem Safari-Menü aus."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -18483,15 +18453,13 @@ msgstr "Wähle %1$sDuckDuckGo%2$s und klicke auf %3$sAls Standard festlegen%4$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"Wähle %1$sDuckDuckGo%2$s und klicke auf %3$sAls Standard festlegen%4$s."
+msgstr "Wähle %1$sDuckDuckGo%2$s und klicke auf %3$sAls Standard festlegen%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr ""
-"Im Dropdown-Menü für die Standardsuchmaschine %1$sDuckDuckGo%2$s auswählen"
+msgstr "Im Dropdown-Menü für die Standardsuchmaschine %1$sDuckDuckGo%2$s auswählen"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
@@ -18946,8 +18914,7 @@ msgstr "Teilen"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Teile DuckDuckGo und hilf deinen Freunden, ihre Privatsphäre zurück zu holen!"
+msgstr "Teile DuckDuckGo und hilf deinen Freunden, ihre Privatsphäre zurück zu holen!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -18975,8 +18942,8 @@ msgid ""
 "never reveals your precise location to us or AI models."
 msgstr ""
 "Teile den Standort in Form der Stadt mit KI-Modellen, um die Relevanz zu "
-"verbessern. Duck.ai gibt niemals deinen genauen Standort an uns oder KI-"
-"Modelle weiter."
+"verbessern. Duck.ai gibt niemals deinen genauen Standort an uns oder "
+"KI-Modelle weiter."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -19119,7 +19086,7 @@ msgstr "Shop"
 #. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
 msgctxt "Button in the merchandise logo modal (mobile)"
 msgid "Shop Now"
-msgstr ""
+msgstr "Jetzt shoppen"
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -19227,8 +19194,7 @@ msgstr "DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"DuckAssist öfter anzeigen. (Du kannst es auch %1$skomplett ausschalten%2$s.)"
+msgstr "DuckAssist öfter anzeigen. (Du kannst es auch %1$skomplett ausschalten%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -19413,8 +19379,7 @@ msgstr "Seitenleiste anzeigen"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
-"Schritt-für-Schritt-Tipps anzeigen, um das Beste aus Duck.ai herauszuholen."
+msgstr "Schritt-für-Schritt-Tipps anzeigen, um das Beste aus Duck.ai herauszuholen."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -19562,8 +19527,7 @@ msgstr "Begrüßung oben auf der Suchergebnisseite anzeigen"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Begrüßung für Benutzer des Android-Einstellungsmenüs in der EU wird angezeigt"
+msgstr "Begrüßung für Benutzer des Android-Einstellungsmenüs in der EU wird angezeigt"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -19642,8 +19606,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"Von dir blockierte Websites werden in all deinen Suchergebnissen ausgeblendet"
+msgstr "Von dir blockierte Websites werden in all deinen Suchergebnissen ausgeblendet"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19863,8 +19826,7 @@ msgstr "Entschuldigung, ein unerwarteter Fehler ist aufgetreten."
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid "Sorry, no relevant information was found in our search."
-msgstr ""
-"Leider wurden bei unserer Suche keine relevanten Informationen gefunden."
+msgstr "Leider wurden bei unserer Suche keine relevanten Informationen gefunden."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search.
@@ -20140,8 +20102,7 @@ msgstr "Beginne mit einem Bild"
 #. Warning that starting fresh deletes conversations.
 msgctxt "duckai_migration"
 msgid "Starting fresh will delete all your past conversations."
-msgstr ""
-"Wenn du neu anfängst, werden alle deine bisherigen Unterhaltungen gelöscht."
+msgstr "Wenn du neu anfängst, werden alle deine bisherigen Unterhaltungen gelöscht."
 
 # smartling.placeholder_format=C
 #. Footnote warning that starting fresh deletes conversations.
@@ -20178,8 +20139,8 @@ msgstr "Bleib auf DuckDuckGo"
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
 msgstr ""
-"Bleibe gut geschützt und gut informiert – mit unseren Privatsphäre-"
-"Newslettern."
+"Bleibe gut geschützt und gut informiert – mit unseren "
+"Privatsphäre-Newslettern."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -20234,8 +20195,7 @@ msgstr "Versteckte Tracker stoppen, die auf anderen Websites lauern."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Stoppe die meisten versteckten Tracker, die auf anderen Websites lauern."
+msgstr "Stoppe die meisten versteckten Tracker, die auf anderen Websites lauern."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20457,8 +20417,7 @@ msgstr "Q&As zusammenfassen"
 #. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the background and notable work of this person."
-msgstr ""
-"Fasse den Hintergrund und die bemerkenswerte Arbeit dieser Person zusammen."
+msgstr "Fasse den Hintergrund und die bemerkenswerte Arbeit dieser Person zusammen."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
@@ -20802,6 +20761,8 @@ msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
 msgstr ""
+"Sync & Backup speichert mehr deiner Chats und synchronisiert sie auf all "
+"deinen Geräten."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20924,7 +20885,7 @@ msgstr "Synchronisiere deine Chats auf all deinen Geräten."
 #. Headline in sync-enabled chat history about modals explaining cross-device sync.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Sync your chats across all your devices"
-msgstr ""
+msgstr "Synchronisiere deine Chats auf all deinen Geräten"
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21295,8 +21256,7 @@ msgstr "Die angehängten Dateien überschreiten die Größenbegrenzung von %1$s 
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB."
-msgstr ""
-"Die angehängten Dateien überschreiten die Größenbegrenzung von %1$s MB."
+msgstr "Die angehängten Dateien überschreiten die Größenbegrenzung von %1$s MB."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
@@ -21328,8 +21288,7 @@ msgstr ""
 #. Description explaining that the AI model provider does not store any chat data on their servers.
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid "The model provider does not save this chat on their servers."
-msgstr ""
-"Der Anbieter des Modells speichert diesen Chat nicht auf seinen Servern."
+msgstr "Der Anbieter des Modells speichert diesen Chat nicht auf seinen Servern."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -21496,8 +21455,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Diese Sofort-Antwort wurde von der %1$sDuckDuckHack%2$s-Community erstellt."
+msgstr "Diese Sofort-Antwort wurde von der %1$sDuckDuckHack%2$s-Community erstellt."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -21526,12 +21484,14 @@ msgid ""
 "This chat and its generated images become public when you create and copy "
 "the link."
 msgstr ""
+"Dieser Chat und die darin generierten Bilder werden öffentlich, wenn du den "
+"Link erstellst und kopierst."
 
 # smartling.placeholder_format=C
 #. Explains that creating and copying a share link makes the selected chat content public.
 msgctxt "Share modal info bullet about public access"
 msgid "This chat becomes public when you create and copy the link."
-msgstr ""
+msgstr "Dieser Chat wird öffentlich, wenn du den Link erstellst und kopierst."
 
 # smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
@@ -21546,8 +21506,8 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"Diese Konversation wurde mit Duck.ai (%1$s) unter Verwendung des %3$s-"
-"Modells von %2$s generiert. KI-Chats zeigen möglicherweise falsche oder "
+"Diese Konversation wurde mit Duck.ai (%1$s) unter Verwendung des "
+"%3$s-Modells von %2$s generiert. KI-Chats zeigen möglicherweise falsche oder "
 "anstößige Informationen an (weitere Informationen siehe %4$s)."
 
 # smartling.placeholder_format=C
@@ -21796,8 +21756,8 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
 "Diese Einstellung wird in deinem Browser gespeichert. Das heißt, wenn du die "
-"Browserdaten von duckduckgo.com löschst, siehst du möglicherweise wieder KI-"
-"gestützte Antworten."
+"Browserdaten von duckduckgo.com löschst, siehst du möglicherweise wieder "
+"KI-gestützte Antworten."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21808,9 +21768,9 @@ msgid ""
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
 "Diese Einstellung wird in deinem Browser gespeichert. Das heißt, wenn du die "
-"Browserdaten von duckduckgo.com löschst, siehst du möglicherweise wieder KI-"
-"gestützte Antworten. Allerdings haben wir auch eine Startseite unter %1$s, "
-"auf der niemals KI-gestützte Antworten angezeigt werden."
+"Browserdaten von duckduckgo.com löschst, siehst du möglicherweise wieder "
+"KI-gestützte Antworten. Allerdings haben wir auch eine Startseite unter "
+"%1$s, auf der niemals KI-gestützte Antworten angezeigt werden."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
@@ -21855,8 +21815,7 @@ msgstr ""
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Diese Webseite verwendet keine sichere, verschlüsselte Verbindung (HTTPS)."
+msgstr "Diese Webseite verwendet keine sichere, verschlüsselte Verbindung (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21974,8 +21933,7 @@ msgstr "Tipps"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr ""
-"Du bist es leid, online getrackt zu werden? %1$sWir schaffen Abhilfe.%2$s"
+msgstr "Du bist es leid, online getrackt zu werden? %1$sWir schaffen Abhilfe.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -22082,6 +22040,8 @@ msgstr "Heute"
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
+"Wechsle zum privaten KI-Chat oder wähle %1$sIn den Einstellungen "
+"deaktivieren%2$s."
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -22437,8 +22397,7 @@ msgstr "Versuche, %1$s, um solche Nachrichten nicht mehr zu sehen."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Probiere %1$s, unser erstes Modell ohne Sichtbarkeit auf Anbieterseite."
+msgstr "Probiere %1$s, unser erstes Modell ohne Sichtbarkeit auf Anbieterseite."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -22640,8 +22599,7 @@ msgstr "Gratis testen"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr ""
-"Kostenlos testen! Ein sicheres VPN, fortschrittliche und private KI und mehr."
+msgstr "Kostenlos testen! Ein sicheres VPN, fortschrittliche und private KI und mehr."
 
 # smartling.placeholder_format=C
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
@@ -22715,8 +22673,7 @@ msgstr "Versuche deinen Standort manuell einzustellen."
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Try the %sDuckDuckGo Browser.%s Fast. Free. Private."
-msgstr ""
-"Probiere den %1$sDuckDuckGo-Browser aus.%2$s Schnell. Kostenlos. Privat."
+msgstr "Probiere den %1$sDuckDuckGo-Browser aus.%2$s Schnell. Kostenlos. Privat."
 
 # smartling.placeholder_format=C
 #. Link to a page where users can download the DuckDuckGo Browser for iOS or Android.
@@ -22762,8 +22719,7 @@ msgstr "Probiere den neuen privaten Echtzeit-Sprachchat aus!"
 #. Text for a promotional card that encourages users to try the recently added open-source AI models. The placeholders are the names of AI models like 'Try the recently added open-source Llama 3.1 and Mistral.'
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source %s and %s"
-msgstr ""
-"Probier die kürzlich hinzugefügten Open-Source-Versionen %1$s und %2$s aus"
+msgstr "Probier die kürzlich hinzugefügten Open-Source-Versionen %1$s und %2$s aus"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the recently added open-source AI models Llama 3.1 and Mixtral.
@@ -22787,8 +22743,7 @@ msgctxt ""
 "Description shown when a chat search in Duck.ai returns no matching chats, "
 "suggesting the user rephrase their query"
 msgid "Try using a different search term or phrase."
-msgstr ""
-"Versuche, einen anderen Suchbegriff oder eine andere Suchphrase zu verwenden."
+msgstr "Versuche, einen anderen Suchbegriff oder eine andere Suchphrase zu verwenden."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, text prompting the user to try their prompt with a different AI model.
@@ -22825,9 +22780,9 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"Möchtest du KI-Funktionen deaktivieren? Wechsle zur %1$sDuckDuckGo No AI%2$s-"
-"Sucherweiterung, damit deine Einstellungen gespeichert bleiben. %3$sMehr "
-"erfahren%4$s"
+"Möchtest du KI-Funktionen deaktivieren? Wechsle zur %1$sDuckDuckGo No "
+"AI%2$s-Sucherweiterung, damit deine Einstellungen gespeichert bleiben. "
+"%3$sMehr erfahren%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -22953,8 +22908,7 @@ msgstr "Abschalten:"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on %sPrecise Location%s for more accurate results"
-msgstr ""
-"Aktiviere %1$sPräziser Standort%2$s, um genauere Ergebnisse zu erhalten"
+msgstr "Aktiviere %1$sPräziser Standort%2$s, um genauere Ergebnisse zu erhalten"
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -22977,8 +22931,7 @@ msgstr "Aktiviere „Präziser Standort“, um genauere Ergebnisse zu erhalten."
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr ""
-"Aktiviere „Präzisen Standort verwenden“, um genauere Ergebnisse zu erhalten."
+msgstr "Aktiviere „Präzisen Standort verwenden“, um genauere Ergebnisse zu erhalten."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -23175,8 +23128,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Unter %1$sEinstellungen%2$s > Allgemein > %3$sStartseite%4$s https://"
-"duckduckgo.com eingeben"
+"Unter %1$sEinstellungen%2$s > Allgemein > %3$sStartseite%4$s "
+"https://duckduckgo.com eingeben"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -23208,8 +23161,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr ""
-"Im Bereich %1$sSuchen%2$s bitte %3$sSuchmaschinen verwalten …%4$s anklicken"
+msgstr "Im Bereich %1$sSuchen%2$s bitte %3$sSuchmaschinen verwalten …%4$s anklicken"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -23326,8 +23278,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Schalte fortschrittliche KI-Modelle und höhere Limits mit einem DuckDuckGo-"
-"Abo frei"
+"Schalte fortschrittliche KI-Modelle und höhere Limits mit einem "
+"DuckDuckGo-Abo frei"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -23366,8 +23318,7 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr ""
-"Schalte leistungsfähigere KI-Modelle mit einem DuckDuckGo-Abo frei. %1$s"
+msgstr "Schalte leistungsfähigere KI-Modelle mit einem DuckDuckGo-Abo frei. %1$s"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -23773,8 +23724,7 @@ msgstr ""
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
 msgctxt "DuckChat location prompt"
 msgid "Use your approximate location for more accurate results?"
-msgstr ""
-"Verwende deinen ungefähren Standort, um genauere Ergebnisse zu erhalten?"
+msgstr "Verwende deinen ungefähren Standort, um genauere Ergebnisse zu erhalten?"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes before every user message in the downloaded file, indicating which message it is out of the total number of messages. Example: 'User prompt 3 of 5'
@@ -23942,6 +23892,9 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Yelp's ad network."
 msgstr ""
+"Die Privatsphäre wird beim Aufrufen von Werbung durch DuckDuckGo "
+"gewährleistet. Die Werbungsklicks werden durch das Werbenetzwerk von Yelp "
+"verwaltet."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -24083,8 +24036,8 @@ msgstr "Sprachchat beendet"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"Der Sprachchat wird von uns anonymisiert und niemals zum Trainieren von KI-"
-"Modellen verwendet."
+"Der Sprachchat wird von uns anonymisiert und niemals zum Trainieren von "
+"KI-Modellen verwendet."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -24229,8 +24182,8 @@ msgid ""
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
 "Benutze den Duck Player, um personalisierte Werbung auf YouTube zu "
-"blockieren und zu verhindern, dass deine Aktivitäten die YouTube-"
-"Empfehlungen beeinflussen."
+"blockieren und zu verhindern, dass deine Aktivitäten die "
+"YouTube-Empfehlungen beeinflussen."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -24377,8 +24330,7 @@ msgstr "Wir tracken dich nicht. Niemals."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr ""
-"Wir tracken dich nicht. Das ist unsere Datenschutzerklärung in Kurzform."
+msgstr "Wir tracken dich nicht. Das ist unsere Datenschutzerklärung in Kurzform."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -24419,8 +24371,7 @@ msgstr "Wir tracken dich nicht, ob im privaten oder normalen Modus."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr ""
-"Wir tracken dich nicht. Das ist unsere Datenschutzerklärung in Kurzform …"
+msgstr "Wir tracken dich nicht. Das ist unsere Datenschutzerklärung in Kurzform …"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -24437,8 +24388,8 @@ msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
 msgstr ""
-"Wir finden und entfernen deine personenbezogenen Daten von Datenbroker-"
-"Websites. Hol dir zusätzlich ein VPN und mehr."
+"Wir finden und entfernen deine personenbezogenen Daten von "
+"Datenbroker-Websites. Hol dir zusätzlich ein VPN und mehr."
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -24460,8 +24411,7 @@ msgstr "Wir halten deinen Suchverlauf privat"
 #. Displayed when the voice chat connection is lost and the session ends.
 msgctxt "voice chat error"
 msgid "We lost the connection, please try again later."
-msgstr ""
-"Die Verbindung wurde unterbrochen. Bitte versuche es später noch einmal."
+msgstr "Die Verbindung wurde unterbrochen. Bitte versuche es später noch einmal."
 
 # smartling.placeholder_format=C
 #. We store chats for 15 minutes in the BE. If the user tries to fetch it after the 15 minutes elapsed or if we had an issue saving it we show them this error message so they can re-submit their prompt.
@@ -24513,8 +24463,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr ""
-"Wir verhindern, dass jemand deinen Suchverlauf erhält, einschließlich uns."
+msgstr "Wir verhindern, dass jemand deinen Suchverlauf erhält, einschließlich uns."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -24886,11 +24835,11 @@ msgid ""
 "experience."
 msgstr ""
 "Welche Vorteile bietet das Herunterladen des DuckDuckGo-Browsers für "
-"jemanden, der Duck.ai nutzen möchte? Beziehe nur offizielle DuckDuckGo-"
-"Quellen ein. Teile die Antwort in übersichtliche Abschnitte mit Titeln auf, "
-"wobei der Schwerpunkt auf den Integrationen von Duck.ai und dem Datenschutz "
-"liegt. Halte es sehr kurz, einfach und leicht verständlich für Menschen mit "
-"oder ohne viel KI- oder technische Erfahrung."
+"jemanden, der Duck.ai nutzen möchte? Beziehe nur offizielle "
+"DuckDuckGo-Quellen ein. Teile die Antwort in übersichtliche Abschnitte mit "
+"Titeln auf, wobei der Schwerpunkt auf den Integrationen von Duck.ai und dem "
+"Datenschutz liegt. Halte es sehr kurz, einfach und leicht verständlich für "
+"Menschen mit oder ohne viel KI- oder technische Erfahrung."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24975,8 +24924,7 @@ msgstr "Was muss man hier unbedingt probieren?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
-"Wie sind die Öffnungszeiten, der Standort und die Kontaktdaten dieses Ortes?"
+msgstr "Wie sind die Öffnungszeiten, der Standort und die Kontaktdaten dieses Ortes?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -25449,6 +25397,8 @@ msgid ""
 "With chat history on, up to %s of your most recent chats will be saved on "
 "this device."
 msgstr ""
+"Wenn der Chatverlauf aktiviert ist, werden bis zu %1$s deiner aktuellsten "
+"Chats auf diesem Gerät gespeichert."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline in the About Chat History modal.
@@ -25456,6 +25406,8 @@ msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, your most recent chats will be saved on this device."
 msgstr ""
+"Wenn der Chatverlauf aktiviert ist, werden deine aktuellsten Chats auf "
+"diesem Gerät gespeichert."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -25818,8 +25770,7 @@ msgstr "Du kannst dies jederzeit in den %1$sSucheinstellungen%2$s ändern"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr ""
-"Du kannst diesen Chat fortsetzen, wenn dein Limit am %1$s zurückgesetzt wird."
+msgstr "Du kannst diesen Chat fortsetzen, wenn dein Limit am %1$s zurückgesetzt wird."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -26130,8 +26081,7 @@ msgstr "Du hast das Limit für die Erstellung von Bildern erreicht."
 #. Title shown when a user has reached their image generation edit limit.
 msgctxt "Title for image generation edit limit reached message"
 msgid "You've reached the maximum number of edits for this image"
-msgstr ""
-"Du hast die maximale Anzahl von Bearbeitungen für dieses Bild erreicht."
+msgstr "Du hast die maximale Anzahl von Bearbeitungen für dieses Bild erreicht."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum number of messages for a given moment, and should try again later when they might be able to send more messages again.
@@ -26224,16 +26174,14 @@ msgctxt ""
 msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
-msgstr ""
-"Deine %1$s letzten Chats sind im lokalen Speicher dieser Browser verfügbar:"
+msgstr "Deine %1$s letzten Chats sind im lokalen Speicher dieser Browser verfügbar:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr ""
-"Deine Duck.ai-Chats werden mit Ende-zu-Ende-Verschlüsselung synchronisiert."
+msgstr "Deine Duck.ai-Chats werden mit Ende-zu-Ende-Verschlüsselung synchronisiert."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -26467,8 +26415,7 @@ msgctxt ""
 "Subtitle of the one-time popover shown above the thumbs up/down buttons on "
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
-msgstr ""
-"Dein Feedback wird anonymisiert und nicht zum Training der KI verwendet."
+msgstr "Dein Feedback wird anonymisiert und nicht zum Training der KI verwendet."
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -26566,8 +26513,8 @@ msgid ""
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 "Deine Einstellungen sind gespeichert, aber durch das Löschen der Cookies "
-"werden sie zurückgesetzt. Aktiviere die %1$sDuckDuckGo No AI%2$s-"
-"Erweiterung, um sie dauerhaft zu aktivieren."
+"werden sie zurückgesetzt. Aktiviere die %1$sDuckDuckGo No "
+"AI%2$s-Erweiterung, um sie dauerhaft zu aktivieren."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -26577,15 +26524,14 @@ msgid ""
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
 "Deine Einstellungen sind gespeichert, aber durch das Löschen der Cookies "
-"werden sie zurückgesetzt. Installiere die %1$sDuckDuckGo No AI%2$s-"
-"Erweiterung, um sie dauerhaft zu aktivieren. %3$sMehr erfahren%4$s"
+"werden sie zurückgesetzt. Installiere die %1$sDuckDuckGo No "
+"AI%2$s-Erweiterung, um sie dauerhaft zu aktivieren. %3$sMehr erfahren%4$s"
 
 # smartling.placeholder_format=C
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
 msgctxt "Body copy on the recover-data success sheet"
 msgid "Your synced chats are being restored to this device."
-msgstr ""
-"Deine synchronisierten Chats werden auf diesem Gerät wiederhergestellt."
+msgstr "Deine synchronisierten Chats werden auf diesem Gerät wiederhergestellt."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -26882,7 +26828,7 @@ msgstr "Min."
 #. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the chat options menu button"
 msgid "menu"
-msgstr ""
+msgstr "Menü"
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/el_GR/LC_MESSAGES/duckduckgo.po
+++ b/locales/el_GR/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: el_GR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1237,6 +1237,12 @@ msgid "About our ads"
 msgstr "Σχετικά με τις διαφημίσεις μας"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1368,6 +1374,20 @@ msgid "Ad is suspicious"
 msgstr "Η διαφήμιση είναι ύποπτη"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Προσθήκη του DuckDuckGo"
@@ -1394,6 +1414,27 @@ msgstr "Προσθήκη του DuckDuckGo ως μηχανή αναζήτηση�
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Προσθήκη του DuckDuckGo στο %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1439,6 +1480,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Προσθήκη περιεχομένου σελίδας"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1526,6 +1583,12 @@ msgstr "Πρόσθετα"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Προσθέτοντας τις τελικές πινελιές"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1831,6 +1894,12 @@ msgstr "Όλα τα χρώματα"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Όλα έτοιμα!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3577,6 +3646,14 @@ msgid "Cancel"
 msgstr "Ακύρωση"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4077,10 +4154,22 @@ msgid "Chat response is offensive"
 msgstr "Η απάντηση στη συνομιλία είναι προσβλητική"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Συνομιλία με %1$s"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4099,6 +4188,14 @@ msgstr "Συνομιλίες"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Συνομιλίες"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5728,6 +5825,12 @@ msgid "Current Streak"
 msgstr "Τρέχον σερί"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -6076,6 +6179,12 @@ msgstr "Διαγραφή συνομιλιών"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Διαγραφή συνομιλιών παλαιότερων των 30 ημερών"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6495,6 +6604,12 @@ msgstr "Παράβλεψη για πάντα"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Κλείσιμο προσφοράς"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7703,6 +7818,12 @@ msgid "Edit Prompt"
 msgstr "Επεξεργασία προτροπής"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7928,6 +8049,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Κρυπτογραφημένο μοντέλο"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8784,6 +8911,12 @@ msgid "Follow-up question"
 msgstr "Συμπληρωματική ερώτηση"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9300,6 +9433,12 @@ msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
 "Αποκτήστε το DuckDuckGo VPN, το προηγμένο Duck.ai και το Identity Theft "
 "Restoration."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10548,6 +10687,12 @@ msgstr "Πώς διατηρεί την ανωνυμία του χρήστη;"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Πώς λειτουργεί"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -12016,6 +12161,12 @@ msgstr "Κερδισμένα λαϊνάουτ"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "Ο σύνδεσμος λήγει σε 7 ημέρες."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14144,6 +14295,12 @@ msgstr "Εντάξει"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "Εντάξει, κατάλαβα!"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16291,6 +16448,12 @@ msgid "Protected"
 msgstr "Προστατευμένο"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Προστασία. Ιδιωτικότητα. Ηρεμία."
@@ -16422,6 +16585,12 @@ msgstr "Βροχή"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Κατατάξεις"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17675,6 +17844,12 @@ msgid "Save your chats across all your devices."
 msgstr "Αποθηκεύστε τις συνομιλίες σας σε όλες τις συσκευές σας."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17886,6 +18061,14 @@ msgstr "Αναζήτηση"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Αναζήτηση"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -19097,6 +19280,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Αγοράστε"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20785,6 +20974,14 @@ msgstr ""
 "αδράνειας."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20902,6 +21099,12 @@ msgstr "Συγχρονισμός με κοντινή συσκευή."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Συγχρονίστε τις συνομιλίες σας σε όλες τις συσκευές σας."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21497,6 +21700,22 @@ msgid "This Week"
 msgstr "Αυτή την εβδομάδα"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -22050,6 +22269,12 @@ msgstr "Σήμερα"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Σήμερα"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23923,6 +24148,14 @@ msgstr ""
 "TripAdvisor."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Παρθένοι Νήσοι"
 
@@ -25435,6 +25668,21 @@ msgstr ""
 "το ή απενεργοποίησέ το οποιαδήποτε στιγμή στο μενού '%1$s'."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26869,6 +27117,12 @@ msgstr "λ."
 msgctxt "published date for videos"
 msgid "m"
 msgstr "λ."
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/el_GR/LC_MESSAGES/duckduckgo.po
+++ b/locales/el_GR/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: el_GR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -110,8 +110,7 @@ msgstr "%1$s απόπειρες"
 # smartling.placeholder_format=C
 #. A summary description of how many tracking attempts where blocked, when there was more than 1. Eg: '1,028 attempts blocked by DuckDuckGo in the last 24 hours'
 msgid "%s attempts blocked by DuckDuckGo in the last 24 hours"
-msgstr ""
-"Αποκλείστηκαν %1$s προσπάθειες από το DuckDuckGo κατά τις τελευταίες 24 ώρες"
+msgstr "Αποκλείστηκαν %1$s προσπάθειες από το DuckDuckGo κατά τις τελευταίες 24 ώρες"
 
 # smartling.placeholder_format=C
 #. A label that indicates a specific search result has been blocked by the safe search filter. The placeholder value is the name of the search result that was blocked.
@@ -313,8 +312,7 @@ msgstr "Οι κατατάξεις %1$s δεν είναι ακόμη διαθέσ
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits 2-5x faster than other models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
-msgstr ""
-"Το %1$s φτάνει στα όρια χρήσης 2-5x νωρίτερα από τα βασικά μοντέλα. %2$s"
+msgstr "Το %1$s φτάνει στα όρια χρήσης 2-5x νωρίτερα από τα βασικά μοντέλα. %2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -385,8 +383,7 @@ msgstr "%1$s χρησιμοποιήθηκε"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
-"Το %1$s χρησιμοποιεί τα όρια έως και 2-5x ταχύτερα από τα βασικά μοντέλα %2$s"
+msgstr "Το %1$s χρησιμοποιεί τα όρια έως και 2-5x ταχύτερα από τα βασικά μοντέλα %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -541,8 +538,7 @@ msgstr ""
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr ""
-"%1$sΚρίμα!%2$s%3$sΚάτι πήγε λάθος. %4$sΑνανεώστε%5$s και προσπαθήστε ξανά."
+msgstr "%1$sΚρίμα!%2$s%3$sΚάτι πήγε λάθος. %4$sΑνανεώστε%5$s και προσπαθήστε ξανά."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -642,8 +638,7 @@ msgstr "1 προσπάθεια"
 # smartling.placeholder_format=C
 #. A summary description of how many tracking attempts where blocked, when only one exists.
 msgid "1 attempt blocked by DuckDuckGo in the last 24 hours"
-msgstr ""
-"Αποκλείστηκε 1 προσπάθεια από το DuckDuckGo κατά τις τελευταίες 24 ώρες"
+msgstr "Αποκλείστηκε 1 προσπάθεια από το DuckDuckGo κατά τις τελευταίες 24 ώρες"
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1061,8 +1056,7 @@ msgstr ""
 #. Disclaimer text displayed at the bottom of the voice chat dialog informing the user that the AI (Artificial Intelligence) may provide inaccurate or offensive information.
 msgctxt "voice chat"
 msgid "AI may provide inaccurate or offensive information."
-msgstr ""
-"Η τεχνητή νοημοσύνη μπορεί να παρέχει ανακριβείς ή προσβλητικές πληροφορίες."
+msgstr "Η τεχνητή νοημοσύνη μπορεί να παρέχει ανακριβείς ή προσβλητικές πληροφορίες."
 
 # smartling.placeholder_format=C
 #. Label for the input field where user can specify how the AI assistant should refer to itself. Example: 'AI nickname (is): Fred'
@@ -1240,7 +1234,7 @@ msgstr "Σχετικά με τις διαφημίσεις μας"
 #. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
 msgctxt "Modal header for chat history with sync information"
 msgid "About Chat History with Sync & Backup"
-msgstr ""
+msgstr "Σχετικά με το ιστορικό συνομιλιών με το Sync & Backup"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
@@ -1377,7 +1371,7 @@ msgstr "Η διαφήμιση είναι ύποπτη"
 #. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
 msgctxt "Button to open menu for attaching images or page context to AI chat"
 msgid "Add"
-msgstr ""
+msgstr "Προσθήκη"
 
 # smartling.placeholder_format=C
 #. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
@@ -1385,7 +1379,7 @@ msgctxt ""
 "Primary button that attaches the tabs the user checked in the tab picker "
 "dialog"
 msgid "Add"
-msgstr ""
+msgstr "Προσθήκη"
 
 # smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
@@ -1420,13 +1414,13 @@ msgstr "Προσθήκη του DuckDuckGo στο %1$s"
 msgctxt ""
 "Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
 msgid "Add File"
-msgstr ""
+msgstr "Προσθήκη αρχείου"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
 msgid "Add Image"
-msgstr ""
+msgstr "Προσθήκη εικόνας"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
@@ -1434,7 +1428,7 @@ msgctxt ""
 "Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
 "item)"
 msgid "Add Image or File"
-msgstr ""
+msgstr "Προσθήκη εικόνας ή αρχείου"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1487,7 +1481,7 @@ msgctxt ""
 "Open the tab picker to attach browser tab content to the AI chat message "
 "(attach dropdown menu item)"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Προσθήκη καρτελών"
 
 # smartling.placeholder_format=C
 #. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
@@ -1495,7 +1489,7 @@ msgctxt ""
 "Title and accessible name of the tab-picker dialog opened from the attach "
 "dropdown menu"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Προσθήκη καρτελών"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1588,7 +1582,7 @@ msgstr "Προσθέτοντας τις τελικές πινελιές"
 #. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
 msgctxt "Aria label for the additional instructions textarea"
 msgid "Additional instructions"
-msgstr ""
+msgstr "Πρόσθετες οδηγίες"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1857,8 +1851,7 @@ msgstr "Όλες οι συνομιλίες είναι %1$s"
 #. Disclaimer text shown below chat input. %s is replaced with a clickable underlined 'private' link that opens the privacy protection modal.
 msgctxt "Disclaimer below chat input in Duck.ai"
 msgid "All chats are %s. AI can make mistakes."
-msgstr ""
-"Όλες οι συνομιλίες είναι %1$s. Η τεχνητή νοημοσύνη μπορεί να κάνει λάθη."
+msgstr "Όλες οι συνομιλίες είναι %1$s. Η τεχνητή νοημοσύνη μπορεί να κάνει λάθη."
 
 # smartling.placeholder_format=C
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
@@ -1899,7 +1892,7 @@ msgstr "Όλα έτοιμα!"
 #. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the read-only textarea listing all AI instructions"
 msgid "All instructions"
-msgstr ""
+msgstr "Όλες οι οδηγίες"
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2338,8 +2331,7 @@ msgstr ""
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr ""
-"Θέλετε σίγουρα να διαγράψετε τη συνομιλία αυτή και να αρχίσετε μια νέα;"
+msgstr "Θέλετε σίγουρα να διαγράψετε τη συνομιλία αυτή και να αρχίσετε μια νέα;"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2935,8 +2927,7 @@ msgstr "Γραμμοκώδικας"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr ""
-"Με βάση αυτήν τη σελίδα, αξίζει να παρακολουθήσω αυτήν τη σειρά μαθημάτων;"
+msgstr "Με βάση αυτήν τη σελίδα, αξίζει να παρακολουθήσω αυτήν τη σειρά μαθημάτων;"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -3108,8 +3099,7 @@ msgstr "Αποκλεισμός ενοχλητικών αναδυόμενων π�
 #. DuckDuckGo Email Protection offers the ability to generate random email addresses to protect your personal email address
 msgctxt "SERP footer content"
 msgid "Block email trackers and hide your address."
-msgstr ""
-"Αποκλείστε εφαρμογές παρακολούθησης email και αποκρύψτε τη διεύθυνσή σας."
+msgstr "Αποκλείστε εφαρμογές παρακολούθησης email και αποκρύψτε τη διεύθυνσή σας."
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -3124,8 +3114,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr ""
-"Η λίστα αποκλεισμού δεν είναι πλήρης και ενδέχεται να περιέχει ανακρίβειες."
+msgstr "Η λίστα αποκλεισμού δεν είναι πλήρης και ενδέχεται να περιέχει ανακρίβειες."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3208,8 +3197,7 @@ msgstr "Αποκλεισμένα:"
 #. shown after the DuckDuckGo extension is installed
 msgctxt "welcome message"
 msgid "Blocks trackers on websites you visit"
-msgstr ""
-"Μπλοκάρει τα προγράμματα παρακολούθησης στους ιστοτόπους που επισκέπτεστε"
+msgstr "Μπλοκάρει τα προγράμματα παρακολούθησης στους ιστοτόπους που επισκέπτεστε"
 
 # smartling.placeholder_format=C
 msgid "Blog"
@@ -3493,8 +3481,7 @@ msgstr "Κάνοντας κλικ στο «%1$s» συμφωνείτε με το
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr ""
-"Κάνοντας κλικ στο «%1$s», αποδέχεστε την %2$s και τους %3$s του Duck.ai."
+msgstr "Κάνοντας κλικ στο «%1$s», αποδέχεστε την %2$s και τους %3$s του Duck.ai."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3651,7 +3638,7 @@ msgctxt ""
 "Secondary button that dismisses the tab picker dialog without attaching "
 "anything"
 msgid "Cancel"
-msgstr ""
+msgstr "Ακύρωση"
 
 # smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
@@ -3888,8 +3875,7 @@ msgstr "Αλλάζει την εμφάνιση των διευθύνσεων URL
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr ""
-"Αλλάζει την εμφάνιση της κεφαλίδας και τη συμπεριφορά της κατά την κύλιση"
+msgstr "Αλλάζει την εμφάνιση της κεφαλίδας και τη συμπεριφορά της κατά την κύλιση"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -4157,7 +4143,7 @@ msgstr "Η απάντηση στη συνομιλία είναι προσβλη�
 #. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
 msgctxt "Chat history about modal list item headline"
 msgid "Chat storage varies by browser"
-msgstr ""
+msgstr "Η αποθήκευση συνομιλιών διαφέρει ανά πρόγραμμα περιήγησης"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4169,7 +4155,7 @@ msgstr "Συνομιλία με %1$s"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Chat with popular AI models, anonymized by us."
-msgstr ""
+msgstr "Συνομιλία με δημοφιλή μοντέλα τεχνητής νοημοσύνης, ανωνυμοποιημένη από εμάς."
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4196,6 +4182,9 @@ msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
 msgstr ""
+"Οι συνομιλίες αποθηκεύονται με ασφάλεια στον διακομιστή του DuckDuckGo με "
+"κρυπτογράφηση από άκρο σε άκρο. Κανείς άλλος εκτός από εσάς δεν μπορεί να "
+"βλέπει τα δεδομένα σας, ούτε καν εμείς."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4635,8 +4624,8 @@ msgid ""
 msgstr ""
 "Η εκκαθάριση των δεδομένων του προγράμματος περιήγησης διαγράφει τις "
 "πρόσφατες συνομιλίες. Οι πρόσφατες συνομιλίες μπορεί να αποθηκευτούν επ' "
-"αόριστον ή να διαγραφούν αυτόματα μετά από 7 ημέρες χωρίς χρήση του Duck."
-"ai., ανάλογα με το πρόγραμμα περιήγησής σας."
+"αόριστον ή να διαγραφούν αυτόματα μετά από 7 ημέρες χωρίς χρήση του "
+"Duck.ai., ανάλογα με το πρόγραμμα περιήγησής σας."
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4756,8 +4745,7 @@ msgstr "Κάνε κλικ στις %1$sΡυθμίσεις%2$s στο αναπτ�
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Κάνε κλικ στο %1$sΧρήση τρεχουσών σελίδων%2$s και έπειτα στο %3$sΟΚ%4$s"
+msgstr "Κάνε κλικ στο %1$sΧρήση τρεχουσών σελίδων%2$s και έπειτα στο %3$sΟΚ%4$s"
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4795,8 +4783,7 @@ msgstr "Κάνε κλικ στο %1$sΠρόγραμμα περιήγησης%2$s
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on %sChange Search Settings%s in the dropdown menu"
-msgstr ""
-"Κάνε κλικ στο %1$sΑλλαγή ρυθμίσεων αναζήτησης%2$s στο αναπτυσσόμενο μενού"
+msgstr "Κάνε κλικ στο %1$sΑλλαγή ρυθμίσεων αναζήτησης%2$s στο αναπτυσσόμενο μενού"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -4876,15 +4863,13 @@ msgstr "Κάνε κλικ στην καρτέλα %1$sΓενικά%2$s."
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click the %sellipsis icon%s in the toolbar."
-msgstr ""
-"Κάνε κλικ στο %1$sεικονίδιο με τα αποσιωπητικά%2$s στη γραμμή εργαλείων."
+msgstr "Κάνε κλικ στο %1$sεικονίδιο με τα αποσιωπητικά%2$s στη γραμμή εργαλείων."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Click the %slock icon%s on the address bar."
-msgstr ""
-"Κάνε κλικ στο %1$sεικονίδιο με την κλειδαριά%2$s στη γραμμή διευθύνσεων."
+msgstr "Κάνε κλικ στο %1$sεικονίδιο με την κλειδαριά%2$s στη γραμμή διευθύνσεων."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to enable location service. Part of a list of instructions on how to enable location service.
@@ -5413,8 +5398,7 @@ msgstr "Συνεχίστε να μπλοκάρετε διαφημίσεις"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
-"Συνέχισε τις πρόσφατες συνομιλίες εδώ. Ή διάγραψέ τες με το Fire Button."
+msgstr "Συνέχισε τις πρόσφατες συνομιλίες εδώ. Ή διάγραψέ τες με το Fire Button."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5828,7 +5812,7 @@ msgstr "Τρέχον σερί"
 #. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
 msgctxt "Suffix label indicating a tab is the currently active browser tab"
 msgid "Current Tab"
-msgstr ""
+msgstr "Τρέχουσα καρτέλα"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
@@ -6184,7 +6168,7 @@ msgstr "Διαγραφή συνομιλιών παλαιότερων των 30 �
 #. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
 msgctxt "Button text in the modal for deleting all recent chats"
 msgid "Delete Chats and Shared Links"
-msgstr ""
+msgstr "Διαγραφή συνομιλιών και κοινόχρηστων συνδέσμων"
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6343,8 +6327,7 @@ msgstr "Περιγράψτε τις αλλαγές με βάση την εικό
 #. Placeholder text displayed in the input field when the user can make follow-up edits to a generated image.
 msgctxt "Placeholder text for the image generation input field for follow-ups"
 msgid "Describe changes to continue editing this image"
-msgstr ""
-"Περιγράψτε τις αλλαγές για να συνεχίσετε την επεξεργασία αυτής της εικόνας"
+msgstr "Περιγράψτε τις αλλαγές για να συνεχίσετε την επεξεργασία αυτής της εικόνας"
 
 # smartling.placeholder_format=C
 #. Title shown when the user first enters Image Generation mode, prompting them to describe the image they want to create.
@@ -6514,8 +6497,7 @@ msgstr "Απενεργοποίηση και αποσύνδεση"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr ""
-"Απενεργοποίηση ιστορικού συνομιλιών και αποσύνδεση από το Sync & Backup;"
+msgstr "Απενεργοποίηση ιστορικού συνομιλιών και αποσύνδεση από το Sync & Backup;"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6609,7 +6591,7 @@ msgstr "Κλείσιμο προσφοράς"
 #. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the close button on the survey banner"
 msgid "Dismiss survey"
-msgstr ""
+msgstr "Απόρριψη έρευνας"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6639,8 +6621,7 @@ msgstr "Γλώσσα οθόνης"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Displays a checkmark to the left of results you've visited"
-msgstr ""
-"Εμφανίζει ένα σημάδι στα αριστερά των αποτελεσμάτων που έχεις επισκεφθεί"
+msgstr "Εμφανίζει ένα σημάδι στα αριστερά των αποτελεσμάτων που έχεις επισκεφθεί"
 
 # smartling.placeholder_format=C
 #. This is the description of a user setting
@@ -6723,8 +6704,7 @@ msgstr "Δεν βλέπεις το DuckDuckGo στη λίστα;"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr ""
-"Δεν το βλέπεις; %1$s%2$s%3$sΚάνε κλικ εδώ για να το ξανακατεβάσεις.%4$s"
+msgstr "Δεν το βλέπεις; %1$s%2$s%3$sΚάνε κλικ εδώ για να το ξανακατεβάσεις.%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6773,9 +6753,10 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"Δεν επιθυμείτε τεχνητή νοημοσύνη; Επισκεφθείτε το %1$snoai.duckduckgo."
-"com%2$s για αναζήτηση χωρίς λειτουργίες τεχνητής νοημοσύνης και με "
-"φιλτραρισμένες εικόνες τεχνητής νοημοσύνης. %3$sΜάθετε περισσότερα%4$s"
+"Δεν επιθυμείτε τεχνητή νοημοσύνη; Επισκεφθείτε το "
+"%1$snoai.duckduckgo.com%2$s για αναζήτηση χωρίς λειτουργίες τεχνητής "
+"νοημοσύνης και με φιλτραρισμένες εικόνες τεχνητής νοημοσύνης. %3$sΜάθετε "
+"περισσότερα%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -7052,8 +7033,7 @@ msgstr "Όρους χρήσης υπηρεσίας του Duck.ai"
 #. The HTML <title> for Duck.ai.
 msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
-msgstr ""
-"Duck.ai από το DuckDuckGo. Ιδιωτική συνομιλία με τεχνητή νοημοσύνη. Δωρεάν."
+msgstr "Duck.ai από το DuckDuckGo. Ιδιωτική συνομιλία με τεχνητή νοημοσύνη. Δωρεάν."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -7131,8 +7111,8 @@ msgid ""
 "remember home on the web: https://duck.ai"
 msgstr ""
 "Το Duck.ai εξακολουθεί να αποτελεί προϊόν της DuckDuckGo, ωστόσο πλέον θα "
-"έχει μια πιο εύκολη στην απομνημόνευση διεύθυνση στο διαδίκτυο: https://duck."
-"ai"
+"έχει μια πιο εύκολη στην απομνημόνευση διεύθυνση στο διαδίκτυο: "
+"https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -7173,8 +7153,8 @@ msgid ""
 msgstr ""
 "Το Duck.ai σάς επιτρέπει να συνομιλείτε ιδιωτικά με δημοφιλή μοντέλα "
 "τεχνητής νοημοσύνης. Η απενεργοποίησή του αποκρύπτει τα κουμπιά και τους "
-"συνδέσμους του Duck.ai, ωστόσο μπορείτε ακόμα να επισκεφθείτε το %1$sduck."
-"ai%2$s απευθείας."
+"συνδέσμους του Duck.ai, ωστόσο μπορείτε ακόμα να επισκεφθείτε το "
+"%1$sduck.ai%2$s απευθείας."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7197,8 +7177,7 @@ msgstr ""
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
 msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid "Duck.ai may display inaccurate or offensive information."
-msgstr ""
-"Το Duck.ai ενδέχεται να εμφανίζει ανακριβείς ή προσβλητικές πληροφορίες."
+msgstr "Το Duck.ai ενδέχεται να εμφανίζει ανακριβείς ή προσβλητικές πληροφορίες."
 
 # smartling.placeholder_format=C
 #. Error modal body line 2.
@@ -7214,8 +7193,7 @@ msgstr ""
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai now can read and analyze PDFs. Give it a try!"
-msgstr ""
-"Το Duck.ai μπορεί πλέον να διαβάζει και να αναλύει αρχεία PDF. Δοκιμάστε το!"
+msgstr "Το Duck.ai μπορεί πλέον να διαβάζει και να αναλύει αρχεία PDF. Δοκιμάστε το!"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown above the chat input only when coming from a DuckAssist grounded response into ungrounded models.
@@ -7248,8 +7226,7 @@ msgstr "Το Duck.ai αναβαθμίστηκε!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Το Duck.ai λειτουργεί καλύτερα στην ιδιωτική και δωρεάν εφαρμογή DuckDuckGo!"
+msgstr "Το Duck.ai λειτουργεί καλύτερα στην ιδιωτική και δωρεάν εφαρμογή DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7443,8 +7420,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"Το DuckDuckGo AI Chat δεν είναι διαθέσιμο προσωρινά. Ξαναδοκιμάστε αργότερα."
+msgstr "Το DuckDuckGo AI Chat δεν είναι διαθέσιμο προσωρινά. Ξαναδοκιμάστε αργότερα."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7706,8 +7682,7 @@ msgctxt ""
 "Description of the DuckDuckGo subscription setting when it is not available "
 "in the user region"
 msgid "DuckDuckGo subscriptions are not available to purchase in this region."
-msgstr ""
-"Οι συνδρομές DuckDuckGo δεν είναι διαθέσιμες για αγορά στην περιοχή αυτή."
+msgstr "Οι συνδρομές DuckDuckGo δεν είναι διαθέσιμες για αγορά στην περιοχή αυτή."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use 'ducky' tone in its responses. When this option is selected, the AI assistant speaks like a duck.
@@ -7821,7 +7796,7 @@ msgstr "Επεξεργασία προτροπής"
 #. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the message-editing text area"
 msgid "Edit message"
-msgstr ""
+msgstr "Επεξεργασία μηνύματος"
 
 # smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
@@ -7891,8 +7866,7 @@ msgstr "Δώστε έμφαση σε σημαντικές πληροφορίες
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Enable 'Sites can ask for my location.'"
-msgstr ""
-"Ενεργοποίησε την επιλογή «Οι ιστότοποι μπορούν να ζητούν την τοποθεσία μου»."
+msgstr "Ενεργοποίησε την επιλογή «Οι ιστότοποι μπορούν να ζητούν την τοποθεσία μου»."
 
 # smartling.placeholder_format=C
 #. Button shown during outages to enable AI features
@@ -7904,8 +7878,7 @@ msgstr "Ενεργοποίηση λειτουργιών τεχνητής νοη�
 #. Text explaining how to enable the cloud save feature.
 msgctxt "cloudsave"
 msgid "Enable Cloud Save by entering your existing passphrase."
-msgstr ""
-"Ενεργοποίησε το Cloud Save, πληκτρολογώντας την υπάρχουσα φράση πρόσβασης."
+msgstr "Ενεργοποίησε το Cloud Save, πληκτρολογώντας την υπάρχουσα φράση πρόσβασης."
 
 # smartling.placeholder_format=C
 #. Primary button text in the dictation privacy consent modal to enable dictation.
@@ -8055,6 +8028,8 @@ msgstr "Κρυπτογραφημένο μοντέλο"
 msgctxt "Share modal info bullet about encryption"
 msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
+"Κρυπτογραφημένο, επομένως το DuckDuckGo δεν μπορεί να διαβάσει τη συνομιλία "
+"σας."
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8118,22 +8093,19 @@ msgstr "Βεβαιώσου ότι έχεις επιλέξει %1$sΑποδοχή
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr ""
-"Βεβαιώσου ότι η επιλογή «Υπηρεσίες τοποθεσίας» είναι %1$sενεργοποιημένη%2$s."
+msgstr "Βεβαιώσου ότι η επιλογή «Υπηρεσίες τοποθεσίας» είναι %1$sενεργοποιημένη%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr ""
-"Βεβαιωθείτε ότι η επιλογή «Τοποθεσία» έχει οριστεί σε %1$sΝα επιτρέπεται%2$s"
+msgstr "Βεβαιωθείτε ότι η επιλογή «Τοποθεσία» έχει οριστεί σε %1$sΝα επιτρέπεται%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s."
-msgstr ""
-"Βεβαιώσου ότι η επιλογή «Τοποθεσία» έχει οριστεί σε %1$sΝα επιτρέπεται%2$s."
+msgstr "Βεβαιώσου ότι η επιλογή «Τοποθεσία» έχει οριστεί σε %1$sΝα επιτρέπεται%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -8256,8 +8228,7 @@ msgstr "Καταχώρισε τη διεύθυνση email σου."
 #. A prompt asking users to enter their passphrase.
 msgctxt "cloudsave"
 msgid "Enter your passphrase to load your settings."
-msgstr ""
-"Πληκτρολόγησε τη φράση πρόσβασής σου για να φορτωθούν οι ρυθμίσεις σου."
+msgstr "Πληκτρολόγησε τη φράση πρόσβασής σου για να φορτωθούν οι ρυθμίσεις σου."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an entertainment guide in its responses.
@@ -8341,8 +8312,7 @@ msgstr "Ανάπτυξη χάρτη"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr ""
-"Εξειδικευμένα προϊόντα για άτομα που ενδιαφέρονται για την ιδιωτικότητα."
+msgstr "Εξειδικευμένα προϊόντα για άτομα που ενδιαφέρονται για την ιδιωτικότητα."
 
 # smartling.placeholder_format=C
 #. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
@@ -8775,8 +8745,7 @@ msgstr "Οικονομικός σύμβουλος"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr ""
-"Βρες το %1$sDuckDuckGo%2$s και κάνε κλικ στο%3$sΟρισμός ως προεπιλογής%4$s"
+msgstr "Βρες το %1$sDuckDuckGo%2$s και κάνε κλικ στο%3$sΟρισμός ως προεπιλογής%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8914,7 +8883,7 @@ msgstr "Συμπληρωματική ερώτηση"
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
-msgstr ""
+msgstr "Τα συμπληρωματικά μηνύματα παραμένουν ιδιωτικά."
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -9438,7 +9407,7 @@ msgstr ""
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
 msgctxt "Tooltip on the header logo for sunglasses searches"
 msgid "Get DuckDuckGo sunglasses and other gear."
-msgstr ""
+msgstr "Απόκτησε γυαλιά ηλίου DuckDuckGo και άλλα είδη."
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9780,8 +9749,7 @@ msgstr ""
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr ""
-"Μεταβείτε στις επιλογές %1$sΑπόρρητο και ασφάλεια > Υπηρεσίες τοποθεσίας%2$s"
+msgstr "Μεταβείτε στις επιλογές %1$sΑπόρρητο και ασφάλεια > Υπηρεσίες τοποθεσίας%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -10246,8 +10214,7 @@ msgstr "Βοηθήστε με να προετοιμαστώ για τη συνέ
 #. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Help me tailor my resume for this job."
-msgstr ""
-"Βοηθήστε με να προσαρμόσω το βιογραφικό μου γι' αυτήν τη θέση εργασίας."
+msgstr "Βοηθήστε με να προσαρμόσω το βιογραφικό μου γι' αυτήν τη θέση εργασίας."
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -10259,8 +10226,7 @@ msgstr "Βοηθήστε μας να βελτιώσουμε το DuckDuckGo"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr ""
-"Βοηθήστε μας να βελτιώσουμε τις αναζητήσεις DuckDuckGo με τα σχόλιά σας"
+msgstr "Βοηθήστε μας να βελτιώσουμε τις αναζητήσεις DuckDuckGo με τα σχόλιά σας"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -10312,8 +10278,7 @@ msgstr "Βοηθήστε μας να καταλάβουμε πώς δεν πετ
 #. A subtitle of a page that encourages users to share DuckDuckGo with their friends.
 msgctxt "showcase_spread"
 msgid "Help your friends and family join the Duck Side!"
-msgstr ""
-"Βοήθησε τους φίλους και την οικογένειά σου να μάθουν τον κόσμο του Παπιού!"
+msgstr "Βοήθησε τους φίλους και την οικογένειά σου να μάθουν τον κόσμο του Παπιού!"
 
 # smartling.placeholder_format=C
 #. Text description for the Spread card in the SERP footer
@@ -10618,8 +10583,7 @@ msgstr "Οι ώρες λείπουν"
 #. This is the name of a user setting
 msgctxt "settings"
 msgid "Hover, Module, and Dropdown Background Color"
-msgstr ""
-"Χρώμα δείκτη αποτελεσμάτων, λειτουργικής μονάδας και αναπτυσσόμενου μενού"
+msgstr "Χρώμα δείκτη αποτελεσμάτων, λειτουργικής μονάδας και αναπτυσσόμενου μενού"
 
 # smartling.placeholder_format=C
 #. Label for a pill-shaped tab below the empty-state Duck.ai chat input. Clicking it opens a panel that explains how Duck.ai protects user privacy.
@@ -10692,7 +10656,7 @@ msgstr "Πώς λειτουργεί"
 #. Headline in chat history about modals for the temporary encrypted server storage explanation.
 msgctxt "Chat history about modal list item headline"
 msgid "How it works"
-msgstr ""
+msgstr "Πώς λειτουργεί"
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -10732,8 +10696,7 @@ msgstr "Πόσο συχνά θέλετε να βλέπετε τις απαντή
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How often do you want to see AI-assisted answers?"
-msgstr ""
-"Πόσο συχνά θέλετε να βλέπετε απαντήσεις με τη βοήθεια τεχνητής νοημοσύνης;"
+msgstr "Πόσο συχνά θέλετε να βλέπετε απαντήσεις με τη βοήθεια τεχνητής νοημοσύνης;"
 
 # smartling.placeholder_format=C
 #. Section title above the frequency radio options in the Search Assist settings modal.
@@ -10968,8 +10931,7 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"Αν θες παρ' όλα αυτά να μας υποστηρίξεις, %1$sδιάδωσε το DuckDuckGo%2$s"
+msgstr "Αν θες παρ' όλα αυτά να μας υποστηρίξεις, %1$sδιάδωσε το DuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -11554,8 +11516,7 @@ msgstr ""
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Δέχομαι να με ρωτάτε (πολύ σποραδικά) για την εμπειρία μου με το DuckDuckGo"
+msgstr "Δέχομαι να με ρωτάτε (πολύ σποραδικά) για την εμπειρία μου με το DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -12167,6 +12128,8 @@ msgstr "Ο σύνδεσμος λήγει σε 7 ημέρες."
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
+"Ο σύνδεσμος λήγει σε 7 ημέρες. Οι χρήστες μπορούν να αποθηκεύσουν ένα "
+"αντίγραφο της συνομιλίας."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13952,8 +13915,7 @@ msgstr "Δεν βρέθηκαν αποτελέσματα."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr ""
-"Δεν εντοπίστηκε ομιλία. Προσπαθήστε ξανά και μιλήστε στο μικρόφωνό σας."
+msgstr "Δεν εντοπίστηκε ομιλία. Προσπαθήστε ξανά και μιλήστε στο μικρόφωνό σας."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -13977,15 +13939,13 @@ msgstr "Δεν αποκλείστηκαν εφαρμογές παρακολού�
 #. Refers to how web searches on DuckDuckGo aren't tracked.
 msgctxt "homepage onboarding"
 msgid "No tracking, no ad targeting, just searching!"
-msgstr ""
-"Χωρίς παρακολούθηση, χωρίς στοχευμένες διαφημίσεις, μόνο καθαρή αναζήτηση!"
+msgstr "Χωρίς παρακολούθηση, χωρίς στοχευμένες διαφημίσεις, μόνο καθαρή αναζήτηση!"
 
 # smartling.placeholder_format=C
 #. Refers to how web searches on DuckDuckGo aren't tracked.
 msgctxt "homepage onboarding"
 msgid "No tracking, no ad targeting, just searching."
-msgstr ""
-"Χωρίς παρακολούθηση, χωρίς στοχευμένες διαφημίσεις, μόνο καθαρή αναζήτηση."
+msgstr "Χωρίς παρακολούθηση, χωρίς στοχευμένες διαφημίσεις, μόνο καθαρή αναζήτηση."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search. The placeholder is the user's search term. For example: 'No videos found for 'bad dogs''
@@ -14300,7 +14260,7 @@ msgstr "Εντάξει, κατάλαβα!"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "OPTIONAL"
-msgstr ""
+msgstr "ΠΡΟΑΙΡΕΤΙΚΟ"
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -14801,8 +14761,8 @@ msgstr "Άνοιγμα του πίνακα «Πώς λειτουργεί το Du
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
 msgstr ""
-"Ανοίξτε το μενού του Safari και επιλέξτε %1$sΡυθμίσεις για το DuckDuckGo..."
-"%2$s"
+"Ανοίξτε το μενού του Safari και επιλέξτε %1$sΡυθμίσεις για το "
+"DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -16425,8 +16385,7 @@ msgstr "Προστατέψτε τα εισερχόμενά σας"
 #. DuckDuckGo's browser app has features to protect your data by keeping it private
 msgctxt "SERP footer content"
 msgid "Protect your data as you search and browse."
-msgstr ""
-"Προστατέψτε τα δεδομένα σας καθώς πραγματοποιείτε αναζήτηση και περιήγηση."
+msgstr "Προστατέψτε τα δεδομένα σας καθώς πραγματοποιείτε αναζήτηση και περιήγηση."
 
 # smartling.placeholder_format=C
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
@@ -16451,7 +16410,7 @@ msgstr "Προστατευμένο"
 #. Headline in sync-enabled chat history about modals explaining encrypted server storage.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Protected with end-to-end encryption"
-msgstr ""
+msgstr "Προστατεύεται με κρυπτογράφηση από άκρο σε άκρο"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -16590,7 +16549,7 @@ msgstr "Κατατάξεις"
 #. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
 msgctxt "star rating on a product"
 msgid "Rated %s out of %s"
-msgstr ""
+msgstr "Αξιολογήθηκε με %1$s στα %2$s"
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -16683,8 +16642,7 @@ msgstr "Συλλογιστική τεχνητή νοημοσύνη με μέτρ
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr ""
-"Η συλλογιστική μπορεί να δώσει καλύτερες απαντήσεις σε σύνθετες ερωτήσεις."
+msgstr "Η συλλογιστική μπορεί να δώσει καλύτερες απαντήσεις σε σύνθετες ερωτήσεις."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
@@ -17076,8 +17034,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
 msgid "Remember my choice (this can be changed in %sSettings%s)"
-msgstr ""
-"Να θυμάσαι την επιλογή μου (αυτό μπορεί να αλλαχθεί στις %1$sΡυθμίσεις%2$s)"
+msgstr "Να θυμάσαι την επιλογή μου (αυτό μπορεί να αλλαχθεί στις %1$sΡυθμίσεις%2$s)"
 
 # smartling.placeholder_format=C
 #. Button to be reminded later to update, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
@@ -17534,8 +17491,7 @@ msgstr "Κριτικές"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
-"Ξαναγράψτε αυτή τη συνταγή προσαρμοσμένη για διαφορετικό αριθμό μερίδων."
+msgstr "Ξαναγράψτε αυτή τη συνταγή προσαρμοσμένη για διαφορετικό αριθμό μερίδων."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -17612,8 +17568,7 @@ msgstr "ΝΑ"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "SERP promotion for desktop browsers has been dismissed"
-msgstr ""
-"Η προώθηση SERP για τα προγράμματα περιήγησης υπολογιστών έχει απορριφθεί"
+msgstr "Η προώθηση SERP για τα προγράμματα περιήγησης υπολογιστών έχει απορριφθεί"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating that a game is in shootouts, e.g. in NHL (hockey)
@@ -17847,7 +17802,7 @@ msgstr "Αποθηκεύστε τις συνομιλίες σας σε όλες 
 #. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
 msgctxt "Chat history about modal list item headline"
 msgid "Save your chats on this device"
-msgstr ""
+msgstr "Αποθηκεύστε τις συνομιλίες σας σε αυτήν τη συσκευή"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
@@ -17983,15 +17938,13 @@ msgstr "Σκωτία"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Scroll down and click %sView advanced settings%s"
-msgstr ""
-"Κάνε κύλιση προς τα κάτω και κλικ στην %1$sΠροβολή σύνθετων ρυθμίσεων%2$s"
+msgstr "Κάνε κύλιση προς τα κάτω και κλικ στην %1$sΠροβολή σύνθετων ρυθμίσεων%2$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr ""
-"Κάνε κύλιση προς τα κάτω και κλικ στην %1$sΠροβολή σύνθετων ρυθμίσεων%2$s"
+msgstr "Κάνε κύλιση προς τα κάτω και κλικ στην %1$sΠροβολή σύνθετων ρυθμίσεων%2$s"
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -18068,7 +18021,7 @@ msgctxt ""
 "Placeholder and accessibility label for the search input in the tab picker "
 "dialog"
 msgid "Search"
-msgstr ""
+msgstr "Αναζήτηση"
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18211,8 +18164,7 @@ msgstr "Ορατότητα αναζήτησης"
 # smartling.placeholder_format=C
 #. Message prompting users to download the DuckDuckGo app.
 msgid "Search and browse privately with the DuckDuckGo app."
-msgstr ""
-"Απόλαυσε ιδιωτική αναζήτηση και περιήγηση με την εφαρμογή του DuckDuckGo."
+msgstr "Απόλαυσε ιδιωτική αναζήτηση και περιήγηση με την εφαρμογή του DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Category a user can select on a feedback form.
@@ -18620,8 +18572,8 @@ msgstr "Επιλέξτε %1$sΡύθμιση για αυτόν τον ιστότ�
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Διάλεξε %1$sΠροσαρμοσμένη%2$s και πληκτρολόγησε %3$shttps://duckduckgo."
-"com%4$s στο πεδίο εισαγωγής"
+"Διάλεξε %1$sΠροσαρμοσμένη%2$s και πληκτρολόγησε "
+"%3$shttps://duckduckgo.com%4$s στο πεδίο εισαγωγής"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -18633,15 +18585,13 @@ msgstr ""
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"Διάλεξε %1$sDuckDuckGo%2$s και κάνε κλικ στο %3$sΟρισμός ως προεπιλογής%4$s"
+msgstr "Διάλεξε %1$sDuckDuckGo%2$s και κάνε κλικ στο %3$sΟρισμός ως προεπιλογής%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"Διάλεξε %1$sDuckDuckGo%2$s και κάνε κλικ στο %3$sΟρισμός ως προεπιλογής%4$s."
+msgstr "Διάλεξε %1$sDuckDuckGo%2$s και κάνε κλικ στο %3$sΟρισμός ως προεπιλογής%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -18682,8 +18632,7 @@ msgstr "Διάλεξε %1$sDuckDuckGo%2$s!"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr ""
-"Επιλέξτε %1$sΕπεξεργασία μηχανών αναζήτησης…%2$sστο αναπτυσσόμενη μενού"
+msgstr "Επιλέξτε %1$sΕπεξεργασία μηχανών αναζήτησης…%2$sστο αναπτυσσόμενη μενού"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18757,8 +18706,7 @@ msgstr "Διάλεξε %1$sΡυθμίσεις%2$s και έπειτα %3$sΣύν
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr ""
-"Επιλέξτε %1$sΡυθμίσεις%2$s και έπειτα %3$sΠροεπιλεγμένη μηχανή αναζήτησης%4$s"
+msgstr "Επιλέξτε %1$sΡυθμίσεις%2$s και έπειτα %3$sΠροεπιλεγμένη μηχανή αναζήτησης%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -18819,8 +18767,7 @@ msgstr "Διάλεξε όλα τα τετράγωνα που περιέχουν 
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select an option to %sallow%s location access"
-msgstr ""
-"Ορίστε μια επιλογή για να %1$sεπιτρέπεται%2$s η πρόσβαση στην τοποθεσία"
+msgstr "Ορίστε μια επιλογή για να %1$sεπιτρέπεται%2$s η πρόσβαση στην τοποθεσία"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -19225,8 +19172,7 @@ msgstr "Κοινοποίησε αυτή τη συνομιλία στο DuckDuckG
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share your prompt and chat response with DuckDuckGo"
-msgstr ""
-"Μοιραστείτε την απάντηση στην προτροπή και στη συνομιλία σας με το DuckDuckGo"
+msgstr "Μοιραστείτε την απάντηση στην προτροπή και στη συνομιλία σας με το DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Variant of the share toggle label that makes sharing mandatory when reporting harmful or illegal content.
@@ -19285,7 +19231,7 @@ msgstr "Αγοράστε"
 #. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
 msgctxt "Button in the merchandise logo modal (mobile)"
 msgid "Shop Now"
-msgstr ""
+msgstr "Αγοράστε τώρα"
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -19580,8 +19526,7 @@ msgstr "Εμφάνιση πλαϊνής γραμμής"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
-"Εμφάνιση συμβουλών βήμα προς βήμα για να αξιοποιήσεις στο έπακρο το Duck.ai."
+msgstr "Εμφάνιση συμβουλών βήμα προς βήμα για να αξιοποιήσεις στο έπακρο το Duck.ai."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -19979,8 +19924,7 @@ msgstr "Κάτι πήγε στραβά κατά την αποθήκευση στ
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr ""
-"Κάτι πήγε λάθος κατά την ενεργοποίηση του Sync & Backup. Προσπαθήστε ξανά."
+msgstr "Κάτι πήγε λάθος κατά την ενεργοποίηση του Sync & Backup. Προσπαθήστε ξανά."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -20313,8 +20257,7 @@ msgstr "Αρχίστε με μια εικόνα"
 #. Warning that starting fresh deletes conversations.
 msgctxt "duckai_migration"
 msgid "Starting fresh will delete all your past conversations."
-msgstr ""
-"Ξεκινώντας από την αρχή θα διαγραφούν όλες οι προηγούμενες συνομιλίες σας."
+msgstr "Ξεκινώντας από την αρχή θα διαγραφούν όλες οι προηγούμενες συνομιλίες σας."
 
 # smartling.placeholder_format=C
 #. Footnote warning that starting fresh deletes conversations.
@@ -20588,8 +20531,7 @@ msgstr "Πρότεινε έναν τίτλο για μια ανάρτηση σε
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
-"Προτείνετε σχετικά άρθρα ή θέματα που αξίζει να εξερευνήσετε στη συνέχεια."
+msgstr "Προτείνετε σχετικά άρθρα ή θέματα που αξίζει να εξερευνήσετε στη συνέχεια."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -20980,6 +20922,8 @@ msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
 msgstr ""
+"Το Sync & Backup αποθηκεύει περισσότερες από τις συνομιλίες σας και τις "
+"συγχρονίζει σε όλες τις συσκευές σας."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -21104,7 +21048,7 @@ msgstr "Συγχρονίστε τις συνομιλίες σας σε όλες 
 #. Headline in sync-enabled chat history about modals explaining cross-device sync.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Sync your chats across all your devices"
-msgstr ""
+msgstr "Συγχρονίστε τις συνομιλίες σας σε όλες τις συσκευές σας"
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21430,15 +21374,13 @@ msgstr "Ευχαριστούμε για τα σχόλιά σας!"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row!"
-msgstr ""
-"Ευχαριστούμε για την υπομονή σας ενώ θα βάλουμε τα παπάκια μας στη σειρά!"
+msgstr "Ευχαριστούμε για την υπομονή σας ενώ θα βάλουμε τα παπάκια μας στη σειρά!"
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row."
-msgstr ""
-"Ευχαριστούμε για την υπομονή σας ενώ θα βάλουμε τα παπάκια μας στη σειρά."
+msgstr "Ευχαριστούμε για την υπομονή σας ενώ θα βάλουμε τα παπάκια μας στη σειρά."
 
 # smartling.placeholder_format=C
 #. Message indicating that the open lock icon in the address bar means that a website is not secure.
@@ -21603,8 +21545,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
 msgid "There's been an issue loading this answer. Please try again."
-msgstr ""
-"Παρουσιάστηκε πρόβλημα κατά τη φόρτωση αυτής της απάντησης. Δοκιμάστε ξανά."
+msgstr "Παρουσιάστηκε πρόβλημα κατά τη φόρτωση αυτής της απάντησης. Δοκιμάστε ξανά."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -21678,8 +21619,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Αυτή η άμεση απάντηση δημιουργήθηκε από την κοινότητα %1$sDuckDuckHack%2$s."
+msgstr "Αυτή η άμεση απάντηση δημιουργήθηκε από την κοινότητα %1$sDuckDuckHack%2$s."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -21708,19 +21648,22 @@ msgid ""
 "This chat and its generated images become public when you create and copy "
 "the link."
 msgstr ""
+"Αυτή η συνομιλία και οι εικόνες που δημιουργούνται γίνονται δημόσιες όταν "
+"δημιουργείτε και αντιγράφετε τον σύνδεσμο."
 
 # smartling.placeholder_format=C
 #. Explains that creating and copying a share link makes the selected chat content public.
 msgctxt "Share modal info bullet about public access"
 msgid "This chat becomes public when you create and copy the link."
 msgstr ""
+"Αυτή η συνομιλία γίνεται δημόσια όταν δημιουργήσετε και αντιγράψετε τον "
+"σύνδεσμο."
 
 # smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
-msgstr ""
-"Αυτή η συνομιλία παραμένει στο Duck.ai και παραμένει ιδιωτική για σένα."
+msgstr "Αυτή η συνομιλία παραμένει στο Duck.ai και παραμένει ιδιωτική για σένα."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21794,15 +21737,13 @@ msgstr ""
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
-msgstr ""
-"Αυτό το αρχείο είναι πολύ μεγάλο. Το μέγιστο μέγεθος αρχείου είναι %1$s MB"
+msgstr "Αυτό το αρχείο είναι πολύ μεγάλο. Το μέγιστο μέγεθος αρχείου είναι %1$s MB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB."
-msgstr ""
-"Αυτό το αρχείο είναι πολύ μεγάλο. Το μέγιστο μέγεθος αρχείου είναι %1$s MB."
+msgstr "Αυτό το αρχείο είναι πολύ μεγάλο. Το μέγιστο μέγεθος αρχείου είναι %1$s MB."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -21861,16 +21802,14 @@ msgstr "Δεν ήταν δυνατή η δημιουργία αυτής της �
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr ""
-"Αυτός ο τύπος εικόνας δεν υποστηρίζεται. Επισύναψε JPG, PNG, WebP ή GIF"
+msgstr "Αυτός ο τύπος εικόνας δεν υποστηρίζεται. Επισύναψε JPG, PNG, WebP ή GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr ""
-"Αυτός ο τύπος εικόνας δεν υποστηρίζεται, επισύναψε JPG, PNG, WebP ή GIF."
+msgstr "Αυτός ο τύπος εικόνας δεν υποστηρίζεται, επισύναψε JPG, PNG, WebP ή GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -21952,8 +21891,7 @@ msgstr "Αυτή η σελίδα απαιτεί Javascript για να λειτ�
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Το περιεχόμενο της σελίδας αυτής θα σταλεί μαζί με το μήνυμά σας στο Duck.ai"
+msgstr "Το περιεχόμενο της σελίδας αυτής θα σταλεί μαζί με το μήνυμά σας στο Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -22046,8 +21984,7 @@ msgstr ""
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Η ιστοσελίδα αυτή δεν χρησιμοποιεί ασφαλή, κρυπτογραφημένη σύνδεση (HTTPS)."
+msgstr "Η ιστοσελίδα αυτή δεν χρησιμοποιεί ασφαλή, κρυπτογραφημένη σύνδεση (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -22076,8 +22013,7 @@ msgstr ""
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
-msgstr ""
-"Αυτό θα διαγράψει την επιλεγμένη εικόνα σας. Αυτό δεν μπορεί να αναιρεθεί."
+msgstr "Αυτό θα διαγράψει την επιλεγμένη εικόνα σας. Αυτό δεν μπορεί να αναιρεθεί."
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -22165,8 +22101,7 @@ msgstr "Συμβουλές"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr ""
-"Έχεις βαρεθεί να σε παρακολουθούν στο διαδίκτυο; %1$sΆσ' το πάνω μας.%2$s"
+msgstr "Έχεις βαρεθεί να σε παρακολουθούν στο διαδίκτυο; %1$sΆσ' το πάνω μας.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -22199,8 +22134,8 @@ msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to Duck.ai’s %s and %s"
 msgstr ""
-"Για να συνεχίσετε, πρέπει να συμφωνήσετε με την %1$s και τους %2$s του Duck."
-"ai"
+"Για να συνεχίσετε, πρέπει να συμφωνήσετε με την %1$s και τους %2$s του "
+"Duck.ai"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to AI Chat Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to DuckDuckGo AI Chat’s Privacy Policy and Terms of Service'
@@ -22275,6 +22210,8 @@ msgstr "Σήμερα"
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
+"Εναλλαγή σε ιδιωτική συνομιλία με τεχνητή νοημοσύνη ή %1$sαπενεργοποίηση από "
+"τις ρυθμίσεις%2$s."
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -22447,8 +22384,7 @@ msgstr "Εφαρμογές παρακολούθησης που αποκλείσ�
 #. Placeholder for when we cannot report any blocked trackers yet
 msgctxt "tracker_stats"
 msgid "Trackers that DuckDuckGo blocks will appear here"
-msgstr ""
-"Οι εφαρμογές παρακολούθησης που αποκλείει το DuckDuckGo θα εμφανίζονται εδώ"
+msgstr "Οι εφαρμογές παρακολούθησης που αποκλείει το DuckDuckGo θα εμφανίζονται εδώ"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -22634,8 +22570,7 @@ msgstr "Δοκιμάστε το %1$s για να σταματήσετε να β�
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Δοκίμασε το %1$s, το πρώτο μας μοντέλο με μηδενική ορατότητα από τον πάροχο."
+msgstr "Δοκίμασε το %1$s, το πρώτο μας μοντέλο με μηδενική ορατότητα από τον πάροχο."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -22761,8 +22696,7 @@ msgstr ""
 #. A message suggesting that the user clears their filters and tries their search again when they get no results
 msgctxt "noresults"
 msgid "Try clearing your filters and searching again."
-msgstr ""
-"Δοκιμάστε να καθαρίσετε τα φίλτρα σας και να πραγματοποιήσετε αναζήτηση ξανά."
+msgstr "Δοκιμάστε να καθαρίσετε τα φίλτρα σας και να πραγματοποιήσετε αναζήτηση ξανά."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words.
@@ -22781,8 +22715,7 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Δοκίμασε να ενεργοποιήσεις την ανώνυμη τοποθεσία για πιο ακριβή αποτελέσματα."
+msgstr "Δοκίμασε να ενεργοποιήσεις την ανώνυμη τοποθεσία για πιο ακριβή αποτελέσματα."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
@@ -22856,8 +22789,7 @@ msgstr "Δοκίμασε δωρεάν για 7 ημέρες"
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
 msgid "Try generating an AI-assisted answer"
-msgstr ""
-"Δοκιμάστε να δημιουργήσετε μια απάντηση με τη βοήθεια τεχνητής νοημοσύνης"
+msgstr "Δοκιμάστε να δημιουργήσετε μια απάντηση με τη βοήθεια τεχνητής νοημοσύνης"
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask duckassist (an instant answer based on generative AI) for an answer
@@ -22885,8 +22817,7 @@ msgstr "Δοκιμάστε το πρόγραμμα περιήγησής μας"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr ""
-"Δοκίμασε την αρχική μας σελίδα που ποτέ δεν εμφανίζει αυτά τα μηνύματα:"
+msgstr "Δοκίμασε την αρχική μας σελίδα που ποτέ δεν εμφανίζει αυτά τα μηνύματα:"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time; shown in the US. Invites the user to start a free trial of the paid subscription.
@@ -23092,8 +23023,7 @@ msgstr "Απενεργοποίηση Sync & Backup"
 #. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
 msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Turn Off Sync & Backup and Delete Server Data?"
-msgstr ""
-"Απενεργοποίηση του Sync & Backup και διαγραφή των δεδομένων διακομιστή;"
+msgstr "Απενεργοποίηση του Sync & Backup και διαγραφή των δεδομένων διακομιστή;"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -23186,8 +23116,7 @@ msgstr "Ενεργοποιήστε την «Ακριβή τοποθεσία» γ
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr ""
-"Ενεργοποιήστε τη «Χρήση ακριβούς τοποθεσίας» για πιο ακριβή αποτελέσματα."
+msgstr "Ενεργοποιήστε τη «Χρήση ακριβούς τοποθεσίας» για πιο ακριβή αποτελέσματα."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -23339,8 +23268,7 @@ msgstr "Δεν είναι δυνατή η αποστολή σχολίων"
 #. Message shown to the user when the voice chat failed to establish a connection, and they should try again later.
 msgctxt "voice chat"
 msgid "Unable to connect to voice chat, please try again later."
-msgstr ""
-"Δεν είναι δυνατή η σύνδεση στη φωνητική συνομιλία. Προσπαθήστε πάλι αργότερα."
+msgstr "Δεν είναι δυνατή η σύνδεση στη φωνητική συνομιλία. Προσπαθήστε πάλι αργότερα."
 
 # smartling.placeholder_format=C
 #. Message shown to the user when there was an issue connecting to their microphone.
@@ -23394,8 +23322,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"Στο %1$sΕΚΚΙΝΗΣΗ > Αρχική σελίδα%2$s, πληκτρολόγησε: https://duckduckgo.com"
+msgstr "Στο %1$sΕΚΚΙΝΗΣΗ > Αρχική σελίδα%2$s, πληκτρολόγησε: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23414,8 +23341,8 @@ msgstr ""
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"Στην ενότητα %1$sΑναζήτηση%2$s, διάλεξε %3$sΔιαχείριση μηχανών αναζήτησης…"
-"%4$s"
+"Στην ενότητα %1$sΑναζήτηση%2$s, διάλεξε %3$sΔιαχείριση μηχανών "
+"αναζήτησης…%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -23516,8 +23443,7 @@ msgstr ""
 #. Title for the subscription promo shown in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Unlock VPN + Advanced AI"
-msgstr ""
-"Αποκτήστε πρόσβαση σε δίκτυο VPN + προηγμένες δυνατότητες τεχνητής νοημοσύνης"
+msgstr "Αποκτήστε πρόσβαση σε δίκτυο VPN + προηγμένες δυνατότητες τεχνητής νοημοσύνης"
 
 # smartling.placeholder_format=C
 #. Text for the button that allows the user to unlock an AI model with a DuckDuckGo subscription when clicked.
@@ -23547,8 +23473,7 @@ msgstr "Ξεκλειδώστε προηγμένα μοντέλα τεχνητή�
 #. Tooltip text shown when the user hovers over the free badge telling the user that they can unlock advanced AI (Artificial Intelligence) models with a DuckDuckGo subscription.
 msgctxt "Tooltip for the free badge"
 msgid "Unlock advanced AI models with a DuckDuckGo subscription"
-msgstr ""
-"Ξεκλείδωσε προηγμένα μοντέλα τεχνητής νοημοσύνης με συνδρομή στο DuckDuckGo"
+msgstr "Ξεκλείδωσε προηγμένα μοντέλα τεχνητής νοημοσύνης με συνδρομή στο DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
@@ -23923,8 +23848,7 @@ msgstr "Χρήση της ιδιωτικής αναζήτησης του DuckDuc
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"Χρησιμοποίησε την ιδιωτική αναζήτηση DuckDuckGo σε iPad, iPhone ή Android!"
+msgstr "Χρησιμοποίησε την ιδιωτική αναζήτηση DuckDuckGo σε iPad, iPhone ή Android!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -23958,8 +23882,7 @@ msgstr "Χρησιμοποιείτε δημόσιο Wi-Fi; Χρησιμοποι�
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr ""
-"Χρησιμοποίησε το Fire Button για να διαγράψεις μια συνομιλία από το ιστορικό."
+msgstr "Χρησιμοποίησε το Fire Button για να διαγράψεις μια συνομιλία από το ιστορικό."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -24123,8 +24046,7 @@ msgstr "Δείτε τιμές για τη διαμονή σας"
 # smartling.placeholder_format=C
 #. A description for the ads tooltip that explains that viewing ads is privacy protected by DuckDuckGo.
 msgid "Viewing ads is privacy protected by DuckDuckGo."
-msgstr ""
-"Στην προβολή διαφημίσεων υπάρχει προστασία απορρήτου από την DuckDuckGo."
+msgstr "Στην προβολή διαφημίσεων υπάρχει προστασία απορρήτου από την DuckDuckGo."
 
 # smartling.placeholder_format=C
 msgctxt "Ads GDPR, internal use only. Do not change"
@@ -24154,6 +24076,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Yelp's ad network."
 msgstr ""
+"Στην προβολή διαφημίσεων υπάρχει προστασία απορρήτου από την DuckDuckGo. Η "
+"διαχείριση των κλικ διαφήμισης γίνεται από το δίκτυο διαφημίσεων της Yelp."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -24592,8 +24516,7 @@ msgstr "Δεν σε παρακολουθούμε, ποτέ μα ποτέ."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr ""
-"Δεν σας παρακολουθούμε. Αυτή είναι η Πολιτική απορρήτου μας με λίγα λόγια."
+msgstr "Δεν σας παρακολουθούμε. Αυτή είναι η Πολιτική απορρήτου μας με λίγα λόγια."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -24636,8 +24559,7 @@ msgstr ""
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr ""
-"Δεν σας παρακολουθούμε. Αυτή είναι η Πολιτική απορρήτου μας με λίγα λόγια…"
+msgstr "Δεν σας παρακολουθούμε. Αυτή είναι η Πολιτική απορρήτου μας με λίγα λόγια…"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -24976,8 +24898,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai, it's time to import your chats"
-msgstr ""
-"Καλώς ορίσατε στο νέο Duck.ai, ήρθε η ώρα να εισαγάγετε τις συνομιλίες σας"
+msgstr "Καλώς ορίσατε στο νέο Duck.ai, ήρθε η ώρα να εισαγάγετε τις συνομιλίες σας"
 
 # smartling.placeholder_format=C
 #. Welcome message for new DuckDuckGo users.
@@ -25039,15 +24960,14 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"Λυπούμαστε πολύ, αλλά φαίνεται ότι υπήρξε πρόβλημα κατά τη φόρτωση του Duck."
-"ai. Προσπαθήστε να επαναλάβετε τη φόρτωση της σελίδας."
+"Λυπούμαστε πολύ, αλλά φαίνεται ότι υπήρξε πρόβλημα κατά τη φόρτωση του "
+"Duck.ai. Προσπαθήστε να επαναλάβετε τη φόρτωση της σελίδας."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What AI model would you like us to add? (optional)"
-msgstr ""
-"Ποιο μοντέλο τεχνητής νοημοσύνης θα θέλατε να προσθέσουμε; (προαιρετικό)"
+msgstr "Ποιο μοντέλο τεχνητής νοημοσύνης θα θέλατε να προσθέσουμε; (προαιρετικό)"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for providing arguments, counter-arguments, and rebuttals to the concept of a plant-based diet.
@@ -25674,6 +25594,8 @@ msgid ""
 "With chat history on, up to %s of your most recent chats will be saved on "
 "this device."
 msgstr ""
+"Με το ιστορικό συνομιλιών ενεργοποιημένο, έως και %1$s από τις πιο πρόσφατες "
+"συνομιλίες σας θα αποθηκευτούν σε αυτήν τη συσκευή."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline in the About Chat History modal.
@@ -25681,6 +25603,8 @@ msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, your most recent chats will be saved on this device."
 msgstr ""
+"Με ενεργοποιημένο το ιστορικό συνομιλιών, οι πιο πρόσφατες συνομιλίες σας θα "
+"αποθηκεύονται σε αυτήν τη συσκευή."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -25983,8 +25907,7 @@ msgstr ""
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
 msgctxt "Information about direct access to DuckDuckGo AI Chat"
 msgid "You can access DuckDuckGo AI Chat directly at %s."
-msgstr ""
-"Μπορείτε να αποκτήσετε πρόσβαση στο DuckDuckGo AI Chat απευθείας από το %1$s."
+msgstr "Μπορείτε να αποκτήσετε πρόσβαση στο DuckDuckGo AI Chat απευθείας από το %1$s."
 
 # smartling.placeholder_format=C
 #. Search Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Search Assist.
@@ -26046,8 +25969,7 @@ msgstr ""
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr ""
-"Μπορείς να συνεχίσεις αυτή τη συνομιλία όταν ανανεωθεί το όριό σου: %1$s."
+msgstr "Μπορείς να συνεχίσεις αυτή τη συνομιλία όταν ανανεωθεί το όριό σου: %1$s."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -26084,8 +26006,7 @@ msgstr ""
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can keep chatting by using your monthly limit."
-msgstr ""
-"Μπορείς να συνεχίσεις να συνομιλείς χρησιμοποιώντας το μηνιαίο όριό σου."
+msgstr "Μπορείς να συνεχίσεις να συνομιλείς χρησιμοποιώντας το μηνιαίο όριό σου."
 
 # smartling.placeholder_format=C
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
@@ -26196,8 +26117,7 @@ msgstr "Μπορείς να ξεκινήσεις από την αρχή σε α�
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can store several sets of settings for different purposes."
-msgstr ""
-"Μπορείς να αποθηκεύσεις διάφορα σύνολα ρυθμίσεων για διαφορετικούς σκοπούς."
+msgstr "Μπορείς να αποθηκεύσεις διάφορα σύνολα ρυθμίσεων για διαφορετικούς σκοπούς."
 
 # smartling.placeholder_format=C
 #. Instructions for user once they've failed the bot challenge
@@ -26380,16 +26300,14 @@ msgstr ""
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr ""
-"Έχετε φτάσει τη μέγιστη διάρκεια φωνητικής συνομιλίας για μία συνεδρία."
+msgstr "Έχετε φτάσει τη μέγιστη διάρκεια φωνητικής συνομιλίας για μία συνεδρία."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"Έχετε φτάσει το όριο φωνητικής συνομιλίας για σήμερα. Δοκιμάστε ξανά αύριο."
+msgstr "Έχετε φτάσει το όριο φωνητικής συνομιλίας για σήμερα. Δοκιμάστε ξανά αύριο."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -26415,9 +26333,9 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"Έχει εξαντληθεί ο χώρος αποθήκευσης του Sync & Backup για συνομιλίες Duck."
-"ai. Διαγράψτε τις %1$s παλαιότερες συνομιλίες με συνημμένα για να συνεχίσετε "
-"τον συγχρονισμό. Οι καρφιτσωμένες συνομιλίες δεν θα διαγραφούν."
+"Έχει εξαντληθεί ο χώρος αποθήκευσης του Sync & Backup για συνομιλίες "
+"Duck.ai. Διαγράψτε τις %1$s παλαιότερες συνομιλίες με συνημμένα για να "
+"συνεχίσετε τον συγχρονισμό. Οι καρφιτσωμένες συνομιλίες δεν θα διαγραφούν."
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -27122,7 +27040,7 @@ msgstr "λ."
 #. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the chat options menu button"
 msgid "menu"
-msgstr ""
+msgstr "Μενού"
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/en_AU/LC_MESSAGES/duckduckgo.po
+++ b/locales/en_AU/LC_MESSAGES/duckduckgo.po
@@ -980,6 +980,11 @@ msgstr "About Us"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1083,6 +1088,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "Ad is suspicious"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Add DuckDuckGo"
@@ -1102,6 +1119,24 @@ msgstr "Add DuckDuckGo as a search engine"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Add DuckDuckGo to %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1140,6 +1175,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1211,6 +1260,11 @@ msgstr "Add-ons"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1456,6 +1510,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2805,6 +2864,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3205,9 +3271,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3223,6 +3299,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4487,6 +4570,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4771,6 +4859,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5109,6 +5202,11 @@ msgstr "Dismiss forever"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6005,6 +6103,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6182,6 +6285,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6850,6 +6958,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7268,6 +7381,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8252,6 +8370,11 @@ msgid "How is it anonymous?"
 msgstr "How is it anonymous?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9411,6 +9534,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11148,6 +11276,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "OK, got it!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12856,6 +12989,11 @@ msgstr "Protect your data on every device."
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12962,6 +13100,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13950,6 +14093,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14107,6 +14255,13 @@ msgstr "Search"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15028,6 +15183,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16367,6 +16527,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16447,6 +16614,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16910,6 +17082,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17312,6 +17498,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18777,6 +18968,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19934,6 +20132,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21024,6 +21235,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/en_CA/LC_MESSAGES/duckduckgo.po
+++ b/locales/en_CA/LC_MESSAGES/duckduckgo.po
@@ -980,6 +980,11 @@ msgstr "About Us"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1083,6 +1088,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "Ad is suspicious"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Add DuckDuckGo"
@@ -1102,6 +1119,24 @@ msgstr "Add DuckDuckGo as a search engine"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Add DuckDuckGo to %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1140,6 +1175,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1211,6 +1260,11 @@ msgstr "Add-ons"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1456,6 +1510,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2805,6 +2864,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3205,9 +3271,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3223,6 +3299,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4487,6 +4570,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4771,6 +4859,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5109,6 +5202,11 @@ msgstr "Dismiss forever"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6005,6 +6103,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6182,6 +6285,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6850,6 +6958,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7268,6 +7381,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8252,6 +8370,11 @@ msgid "How is it anonymous?"
 msgstr "How is it anonymous?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9411,6 +9534,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11148,6 +11276,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "OK, got it!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12856,6 +12989,11 @@ msgstr "Protect your data on every device."
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12962,6 +13100,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13950,6 +14093,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14107,6 +14255,13 @@ msgstr "Search"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15028,6 +15183,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16367,6 +16527,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16447,6 +16614,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16910,6 +17082,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17312,6 +17498,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18777,6 +18968,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19934,6 +20132,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21024,6 +21235,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/en_GB/LC_MESSAGES/duckduckgo.po
+++ b/locales/en_GB/LC_MESSAGES/duckduckgo.po
@@ -980,6 +980,11 @@ msgstr "About Us"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1083,6 +1088,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "Ad is suspicious"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Add DuckDuckGo"
@@ -1102,6 +1119,24 @@ msgstr "Add DuckDuckGo as a search engine"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Add DuckDuckGo to %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1140,6 +1175,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1211,6 +1260,11 @@ msgstr "Add-ons"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1456,6 +1510,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2805,6 +2864,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3205,9 +3271,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3223,6 +3299,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4487,6 +4570,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4771,6 +4859,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5109,6 +5202,11 @@ msgstr "Dismiss forever"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6005,6 +6103,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6182,6 +6285,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6850,6 +6958,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7268,6 +7381,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8252,6 +8370,11 @@ msgid "How is it anonymous?"
 msgstr "How is it anonymous?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9411,6 +9534,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11148,6 +11276,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "OK, got it!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12856,6 +12989,11 @@ msgstr "Protect your data on every device."
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12962,6 +13100,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13950,6 +14093,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14107,6 +14255,13 @@ msgstr "Search"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15028,6 +15183,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16367,6 +16527,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16447,6 +16614,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16910,6 +17082,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17312,6 +17498,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18777,6 +18968,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19934,6 +20132,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21024,6 +21235,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/en_US/LC_MESSAGES/duckduckgo.po
+++ b/locales/en_US/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr ""
@@ -1099,6 +1116,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr ""
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1453,6 +1507,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2800,6 +2859,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3200,9 +3266,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3218,6 +3294,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4475,6 +4558,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4759,6 +4847,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5097,6 +5190,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -5993,6 +6091,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6170,6 +6273,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6835,6 +6943,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7253,6 +7366,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8235,6 +8353,11 @@ msgid "How is it anonymous?"
 msgstr ""
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9388,6 +9511,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11125,6 +11253,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12825,6 +12958,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12931,6 +13069,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13919,6 +14062,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14074,6 +14222,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -14989,6 +15144,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16328,6 +16488,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16408,6 +16575,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16868,6 +17040,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17270,6 +17456,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18732,6 +18923,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19881,6 +20079,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20963,6 +21174,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/eo_XX/LC_MESSAGES/duckduckgo.po
+++ b/locales/eo_XX/LC_MESSAGES/duckduckgo.po
@@ -984,6 +984,11 @@ msgstr "Pri Ni"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1087,6 +1092,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "Reklamo estas suspektata"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Aldonu DuckDuckGo"
@@ -1106,6 +1123,24 @@ msgstr "Aldonu DuckDuckGo kiel serĉilon"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Aldonu DuckDuckGo al %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1144,6 +1179,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1215,6 +1264,11 @@ msgstr "Aldonaĵoj"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1461,6 +1515,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2811,6 +2870,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3211,9 +3277,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3229,6 +3305,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4496,6 +4579,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4780,6 +4868,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5118,6 +5211,11 @@ msgstr "Rezignu porĉiame"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6014,6 +6112,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6191,6 +6294,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6859,6 +6967,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7277,6 +7390,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8261,6 +8379,11 @@ msgid "How is it anonymous?"
 msgstr "Kiel estas sennome?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9420,6 +9543,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11157,6 +11285,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "Bone, mi komprenas!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12865,6 +12998,11 @@ msgstr "Protekti viajn datumojn sur ĉiu aparato."
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12971,6 +13109,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13959,6 +14102,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14116,6 +14264,13 @@ msgstr "Serĉu"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15038,6 +15193,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16379,6 +16539,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16459,6 +16626,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16925,6 +17097,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17329,6 +17515,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18794,6 +18985,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19951,6 +20149,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21045,6 +21256,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/es_AR/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_AR/LC_MESSAGES/duckduckgo.po
@@ -980,6 +980,11 @@ msgstr "Acerca de nosotros"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1083,6 +1088,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "El anuncio es sospechoso"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Agregá DuckDuckGo"
@@ -1102,6 +1119,24 @@ msgstr "Agregá DuckDuckGo como motor de búsqueda"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Agregá DuckDuckGo a %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1140,6 +1175,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1211,6 +1260,11 @@ msgstr "Complementos"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1457,6 +1511,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2807,6 +2866,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3207,9 +3273,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3225,6 +3301,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4504,6 +4587,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4788,6 +4876,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5126,6 +5219,11 @@ msgstr "Omitir para siempre"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6022,6 +6120,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6199,6 +6302,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6870,6 +6978,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7288,6 +7401,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8274,6 +8392,11 @@ msgid "How is it anonymous?"
 msgstr "Por qué es anónimo?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9440,6 +9563,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11179,6 +11307,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "¡Ok, entendido!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12887,6 +13020,11 @@ msgstr "Protegé tus datos en cada dispositivo."
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12993,6 +13131,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13981,6 +14124,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14138,6 +14286,13 @@ msgstr "Buscar"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15070,6 +15225,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16410,6 +16570,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16490,6 +16657,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16954,6 +17126,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17358,6 +17544,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18831,6 +19022,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19991,6 +20189,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21086,6 +21297,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/es_CL/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_CL/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Agrega DuckDuckGo"
@@ -1100,6 +1117,24 @@ msgstr "Agrega DuckDuckGo como motor de búsqueda"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Añade DuckDuckGo a %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr "Complementos"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1455,6 +1509,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2802,6 +2861,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3202,9 +3268,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3220,6 +3296,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4491,6 +4574,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4775,6 +4863,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5113,6 +5206,11 @@ msgstr "Descartar para siempre"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6009,6 +6107,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6186,6 +6289,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6856,6 +6964,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7274,6 +7387,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8256,6 +8374,11 @@ msgid "How is it anonymous?"
 msgstr "¿Cómo es eso de anónimo?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9415,6 +9538,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11154,6 +11282,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12862,6 +12995,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12968,6 +13106,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13957,6 +14100,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14114,6 +14262,13 @@ msgstr "Buscar"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15046,6 +15201,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16385,6 +16545,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16465,6 +16632,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16925,6 +17097,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17329,6 +17515,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18801,6 +18992,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19952,6 +20150,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21040,6 +21251,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/es_CO/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_CO/LC_MESSAGES/duckduckgo.po
@@ -980,6 +980,11 @@ msgstr "Sobre nosotros"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1083,6 +1088,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "El anuncio es sospechoso"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Y DuckDuckGo"
@@ -1102,6 +1119,24 @@ msgstr "Agregue DuckDuckGo como un motor de búsqueda"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Añadir DuckDuckGo a %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1140,6 +1175,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1211,6 +1260,11 @@ msgstr "Complementos"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1457,6 +1511,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2806,6 +2865,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3206,9 +3272,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3224,6 +3300,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4499,6 +4582,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4783,6 +4871,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5121,6 +5214,11 @@ msgstr "Descartar por siempre"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6017,6 +6115,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6194,6 +6297,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6865,6 +6973,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7283,6 +7396,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8265,6 +8383,11 @@ msgid "How is it anonymous?"
 msgstr "¿Cómo se mantiene anónimo?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9425,6 +9548,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11164,6 +11292,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12872,6 +13005,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12978,6 +13116,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13966,6 +14109,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14124,6 +14272,13 @@ msgstr "Buscar"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15055,6 +15210,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16394,6 +16554,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16474,6 +16641,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16934,6 +17106,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17338,6 +17524,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18809,6 +19000,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19967,6 +20165,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21058,6 +21269,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/es_CR/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_CR/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Agregar DuckDuckGo"
@@ -1099,6 +1116,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr "Extensiones"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1453,6 +1507,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2800,6 +2859,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3201,9 +3267,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3219,6 +3295,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4478,6 +4561,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4762,6 +4850,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5100,6 +5193,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -5996,6 +6094,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6173,6 +6276,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6840,6 +6948,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7258,6 +7371,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8240,6 +8358,11 @@ msgid "How is it anonymous?"
 msgstr "¿Cómo es que es anónimo?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9397,6 +9520,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11134,6 +11262,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12834,6 +12967,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12940,6 +13078,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13928,6 +14071,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14083,6 +14231,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15002,6 +15157,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16341,6 +16501,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16421,6 +16588,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16881,6 +17053,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17283,6 +17469,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18746,6 +18937,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19895,6 +20093,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20985,6 +21196,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/es_EC/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_EC/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Añadir DuckDuckGo"
@@ -1099,6 +1116,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr "Complementarios"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1453,6 +1507,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2800,6 +2859,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3200,9 +3266,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3218,6 +3294,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4482,6 +4565,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4766,6 +4854,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5104,6 +5197,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6000,6 +6098,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6177,6 +6280,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6847,6 +6955,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7265,6 +7378,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8247,6 +8365,11 @@ msgid "How is it anonymous?"
 msgstr "¿Cómo es el anonimato?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9404,6 +9527,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11141,6 +11269,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12843,6 +12976,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12949,6 +13087,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13938,6 +14081,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14093,6 +14241,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15016,6 +15171,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16355,6 +16515,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16435,6 +16602,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16895,6 +17067,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17299,6 +17485,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18765,6 +18956,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19921,6 +20119,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21012,6 +21223,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/es_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_ES/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: es_ES\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -446,8 +446,7 @@ msgstr "%1$s palabras"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr ""
-"%1$sPulsa %2$sAñadir%3$sMarcar %4$sPermitir%5$s y luego %6$sAceptar%7$s"
+msgstr "%1$sPulsa %2$sAñadir%3$sMarcar %4$sPermitir%5$s y luego %6$sAceptar%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -1226,7 +1225,7 @@ msgstr "Acerca de nuestros anuncios"
 #. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
 msgctxt "Modal header for chat history with sync information"
 msgid "About Chat History with Sync & Backup"
-msgstr ""
+msgstr "Acerca del historial de chat con Sync & Backup"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
@@ -1361,7 +1360,7 @@ msgstr "Anuncio sospechoso"
 #. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
 msgctxt "Button to open menu for attaching images or page context to AI chat"
 msgid "Add"
-msgstr ""
+msgstr "Añadir"
 
 # smartling.placeholder_format=C
 #. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
@@ -1369,7 +1368,7 @@ msgctxt ""
 "Primary button that attaches the tabs the user checked in the tab picker "
 "dialog"
 msgid "Add"
-msgstr ""
+msgstr "Añadir"
 
 # smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
@@ -1404,13 +1403,13 @@ msgstr "Añadir DuckDuckGo a %1$s"
 msgctxt ""
 "Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
 msgid "Add File"
-msgstr ""
+msgstr "Añadir archivo"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
 msgid "Add Image"
-msgstr ""
+msgstr "Añadir imagen"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
@@ -1418,7 +1417,7 @@ msgctxt ""
 "Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
 "item)"
 msgid "Add Image or File"
-msgstr ""
+msgstr "Añadir imagen o archivo"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1471,7 +1470,7 @@ msgctxt ""
 "Open the tab picker to attach browser tab content to the AI chat message "
 "(attach dropdown menu item)"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Añadir pestañas"
 
 # smartling.placeholder_format=C
 #. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
@@ -1479,7 +1478,7 @@ msgctxt ""
 "Title and accessible name of the tab-picker dialog opened from the attach "
 "dropdown menu"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Añadir pestañas"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1570,7 +1569,7 @@ msgstr "Añadiendo los toques finales"
 #. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
 msgctxt "Aria label for the additional instructions textarea"
 msgid "Additional instructions"
-msgstr ""
+msgstr "Instrucciones adicionales"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1880,7 +1879,7 @@ msgstr "¡Todo listo!"
 #. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the read-only textarea listing all AI instructions"
 msgid "All instructions"
-msgstr ""
+msgstr "Todas las instrucciones"
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2310,22 +2309,19 @@ msgstr "¿Sigues ahí?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"¿Seguro que quieres borrar todos tus chats? Esta acción no se puede deshacer."
+msgstr "¿Seguro que quieres borrar todos tus chats? Esta acción no se puede deshacer."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr ""
-"¿Estás seguro de que quieres eliminar esta conversación y empezar una nueva?"
+msgstr "¿Estás seguro de que quieres eliminar esta conversación y empezar una nueva?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
 msgctxt "Body text for delete chat confirmation modal"
 msgid "Are you sure you want to delete this chat? This cannot be undone."
-msgstr ""
-"¿Seguro que quieres borrar este chat? Esta acción no se puede deshacer."
+msgstr "¿Seguro que quieres borrar este chat? Esta acción no se puede deshacer."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable chat history, with a warning that it will also delete currently saved chats including pinned chats.
@@ -3604,7 +3600,7 @@ msgctxt ""
 "Secondary button that dismisses the tab picker dialog without attaching "
 "anything"
 msgid "Cancel"
-msgstr ""
+msgstr "Cancelar"
 
 # smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
@@ -4106,7 +4102,7 @@ msgstr "La respuesta del chat es ofensiva"
 #. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
 msgctxt "Chat history about modal list item headline"
 msgid "Chat storage varies by browser"
-msgstr ""
+msgstr "El almacenamiento de chats varía según el navegador"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4118,7 +4114,7 @@ msgstr "Chatea con %1$s"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Chat with popular AI models, anonymized by us."
-msgstr ""
+msgstr "Chatea con modelos de IA populares, anonimizados por nosotros."
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4145,6 +4141,9 @@ msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
 msgstr ""
+"Los chats se almacenan de forma segura en el servidor de DuckDuckGo con "
+"encriptación de extremo a extremo. Nadie más que tú puede ver tus datos, ni "
+"siquiera nosotros."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4671,8 +4670,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr ""
-"Pulsa %1$sPrivacidad y servicios%2$s en la barra lateral de la izquierda."
+msgstr "Pulsa %1$sPrivacidad y servicios%2$s en la barra lateral de la izquierda."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -4699,8 +4697,7 @@ msgstr "Haz clic en %1$sAjustes%2$s en el menú desplegable."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Pulsa %1$sUse las actuales páginas%2$s y, a continuación, %3$sAceptar%4$s."
+msgstr "Pulsa %1$sUse las actuales páginas%2$s y, a continuación, %3$sAceptar%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4833,8 +4830,7 @@ msgstr "Haz clic en el %1$sicono de permisos%2$s en la barra de direcciones"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr ""
-"¡Pulsa el icono del pato en la parte superior del navegador para buscar!"
+msgstr "¡Pulsa el icono del pato en la parte superior del navegador para buscar!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -5464,8 +5460,7 @@ msgstr "Copiar"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"Copia y pega %1$sabout:preferences#search%2$s en la barra de direcciones"
+msgstr "Copia y pega %1$sabout:preferences#search%2$s en la barra de direcciones"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5758,7 +5753,7 @@ msgstr "Racha actual"
 #. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
 msgctxt "Suffix label indicating a tab is the currently active browser tab"
 msgid "Current Tab"
-msgstr ""
+msgstr "Pestaña actual"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
@@ -6114,7 +6109,7 @@ msgstr "Borrar chats con una antigüedad superior a 30 días"
 #. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
 msgctxt "Button text in the modal for deleting all recent chats"
 msgid "Delete Chats and Shared Links"
-msgstr ""
+msgstr "Borrar chats y enlaces compartidos"
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6206,8 +6201,7 @@ msgstr "¿Borrar los chats más antiguos para liberar espacio de almacenamiento?
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr ""
-"¿Eliminar los chats más antiguos con archivos adjuntos para liberar espacio?"
+msgstr "¿Eliminar los chats más antiguos con archivos adjuntos para liberar espacio?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
@@ -6339,8 +6333,7 @@ msgstr "Dictado en Duck.ai"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr ""
-"Anonimizamos el dictado y nunca lo utilizamos para entrenar modelos de IA."
+msgstr "Anonimizamos el dictado y nunca lo utilizamos para entrenar modelos de IA."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6533,7 +6526,7 @@ msgstr "Descartar promoción"
 #. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the close button on the survey banner"
 msgid "Dismiss survey"
-msgstr ""
+msgstr "Omitir encuesta"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7020,8 +7013,7 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"¡Duck.ai es mejor en nuestro navegador privado y gratuito de DuckDuckGo!"
+msgstr "¡Duck.ai es mejor en nuestro navegador privado y gratuito de DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -7080,8 +7072,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
-msgstr ""
-"Duck.ai no está disponible temporalmente. Inténtalo de nuevo más tarde."
+msgstr "Duck.ai no está disponible temporalmente. Inténtalo de nuevo más tarde."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7726,7 +7717,7 @@ msgstr "Editar instrucción"
 #. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the message-editing text area"
 msgid "Edit message"
-msgstr ""
+msgstr "Editar mensaje"
 
 # smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
@@ -7956,7 +7947,7 @@ msgstr "Modelo cifrado"
 #. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
 msgctxt "Share modal info bullet about encryption"
 msgid "Encrypted so DuckDuckGo can't read your chat."
-msgstr ""
+msgstr "Cifrado, por lo que DuckDuckGo no puede leer tu chat."
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8080,8 +8071,7 @@ msgstr "Asegúrate de que tu navegador tenga permitido el acceso a la ubicación
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr ""
-"Asegúrate de que tu navegador tenga permitido el acceso a la ubicación."
+msgstr "Asegúrate de que tu navegador tenga permitido el acceso a la ubicación."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -8175,8 +8165,7 @@ msgstr "Guinea Ecuatorial"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"Borra tus datos de navegación en un instante con nuestro %1$sFire Button%2$s"
+msgstr "Borra tus datos de navegación en un instante con nuestro %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -8364,8 +8353,7 @@ msgstr "Explora Duck.ai"
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
-msgstr ""
-"Explora las últimas actualizaciones de productos y funciones de DuckDuckGo."
+msgstr "Explora las últimas actualizaciones de productos y funciones de DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8670,8 +8658,7 @@ msgstr "Asesor financiero"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr ""
-"Busca %1$sDuckDuckGo%2$s y haz clic en %3$sEstablecer como predeterminado%4$s"
+msgstr "Busca %1$sDuckDuckGo%2$s y haz clic en %3$sEstablecer como predeterminado%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8807,7 +8794,7 @@ msgstr "Pregunta de seguimiento"
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
-msgstr ""
+msgstr "Los mensajes de seguimiento siguen siendo privados."
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8913,8 +8900,7 @@ msgstr "Chats gratuitos y privados, anonimizados por nosotros"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Chats gratuitos y privados, anonimizados por nosotros. No se requiere cuenta."
+msgstr "Chats gratuitos y privados, anonimizados por nosotros. No se requiere cuenta."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8944,8 +8930,7 @@ msgstr "Libre de compartir y usar comercialmente"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr ""
-"Libera espacio eliminando tus chats. Los chats anclados no se eliminarán."
+msgstr "Libera espacio eliminando tus chats. Los chats anclados no se eliminarán."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -9026,9 +9011,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"En la barra de menú de la aplicación en Mac, selecciona <strong>DuckDuckGo</"
-"strong> &gt; <strong>Buscar actualizaciones...</strong> y, a continuación, "
-"selecciona <strong>Instalar actualización</strong>."
+"En la barra de menú de la aplicación en Mac, selecciona "
+"<strong>DuckDuckGo</strong> &gt; <strong>Buscar actualizaciones...</strong> "
+"y, a continuación, selecciona <strong>Instalar actualización</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9327,7 +9312,7 @@ msgstr "Obtén DuckDuckGo VPN, Duck.ai avanzado e Identity Theft Restoration."
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
 msgctxt "Tooltip on the header logo for sunglasses searches"
 msgid "Get DuckDuckGo sunglasses and other gear."
-msgstr ""
+msgstr "Consigue gafas de sol de DuckDuckGo y otros artículos."
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9550,8 +9535,8 @@ msgstr "Obtén la app"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"Obtén el navegador gratuito DuckDuckGo %1$spara bloquear anuncios en YouTube."
-"%2$s"
+"Obtén el navegador gratuito DuckDuckGo %1$spara bloquear anuncios en "
+"YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -10493,8 +10478,7 @@ msgstr "Falta el horario"
 #. This is the name of a user setting
 msgctxt "settings"
 msgid "Hover, Module, and Dropdown Background Color"
-msgstr ""
-"Color de fondo al pasar el cursor, de los módulos y de los desplegables"
+msgstr "Color de fondo al pasar el cursor, de los módulos y de los desplegables"
 
 # smartling.placeholder_format=C
 #. Label for a pill-shaped tab below the empty-state Duck.ai chat input. Clicking it opens a panel that explains how Duck.ai protects user privacy.
@@ -10567,7 +10551,7 @@ msgstr "Cómo funciona"
 #. Headline in chat history about modals for the temporary encrypted server storage explanation.
 msgctxt "Chat history about modal list item headline"
 msgid "How it works"
-msgstr ""
+msgstr "Cómo funciona"
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -10585,15 +10569,13 @@ msgstr "Cómo funciona"
 #. Header for the assist settings modal where the user can choose how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How much do you want AI-assisted answers to appear?"
-msgstr ""
-"¿Con qué frecuencia quieres que aparezcan las respuestas asistidas por IA?"
+msgstr "¿Con qué frecuencia quieres que aparezcan las respuestas asistidas por IA?"
 
 # smartling.placeholder_format=C
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr ""
-"Qué parte de tus límites diarios y semanales has utilizado hasta ahora."
+msgstr "Qué parte de tus límites diarios y semanales has utilizado hasta ahora."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10848,8 +10830,7 @@ msgstr ""
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr ""
-"Si quieres usar DuckDuckGo sin JavaScript, usa nuestra versión %1$s o %2$s."
+msgstr "Si quieres usar DuckDuckGo sin JavaScript, usa nuestra versión %1$s o %2$s."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10896,8 +10877,8 @@ msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
 msgstr ""
-"Las indicaciones para las imágenes deben cumplir con las directrices de Duck."
-"ai %1$s."
+"Las indicaciones para las imágenes deben cumplir con las directrices de "
+"Duck.ai %1$s."
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11828,8 +11809,7 @@ msgstr "Obtén más información sobre la protección de privacidad activa"
 # smartling.placeholder_format=C
 msgctxt "showcase_newsletter"
 msgid "Learn about online privacy right in your inbox."
-msgstr ""
-"Más información sobre la privacidad en Internet en tu bandeja de entrada."
+msgstr "Más información sobre la privacidad en Internet en tu bandeja de entrada."
 
 # smartling.placeholder_format=C
 #. Link to a page with more information about how DuckDuckGo settings are managed.
@@ -11946,8 +11926,8 @@ msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
 msgstr ""
-"Te permite alternar entre enviar consultas de búsqueda y sugerencias a Duck."
-"ai"
+"Te permite alternar entre enviar consultas de búsqueda y sugerencias a "
+"Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -12031,7 +12011,7 @@ msgstr "El enlace caduca en 7 días."
 #. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days. People can save a chat copy."
-msgstr ""
+msgstr "El enlace caduca en 7 días. Las personas pueden guardar una copia del chat."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14161,7 +14141,7 @@ msgstr "Vale, ¡entendido!"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "OPTIONAL"
-msgstr ""
+msgstr "Opcional"
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -15420,8 +15400,7 @@ msgstr "Anclados"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
-"Los chats anclados aparecerán en la parte superior de tus chats recientes."
+msgstr "Los chats anclados aparecerán en la parte superior de tus chats recientes."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -15480,15 +15459,13 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr ""
-"Describe por qué la respuesta del chat es perjudicial o ilegal. (opcional)"
+msgstr "Describe por qué la respuesta del chat es perjudicial o ilegal. (opcional)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr ""
-"Describe por qué la respuesta del chat es ilegal o perjudicial. (Opcional)"
+msgstr "Describe por qué la respuesta del chat es ilegal o perjudicial. (Opcional)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -16257,8 +16234,7 @@ msgstr "Pedir confirmación"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"Pedirme utilizar mi ubicación aproximada para obtener mejores resultados."
+msgstr "Pedirme utilizar mi ubicación aproximada para obtener mejores resultados."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -16293,7 +16269,7 @@ msgstr "Protegido"
 #. Headline in sync-enabled chat history about modals explaining encrypted server storage.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Protected with end-to-end encryption"
-msgstr ""
+msgstr "Protegido con encriptación de extremo a extremo"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -16432,7 +16408,7 @@ msgstr "Clasificaciones"
 #. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
 msgctxt "star rating on a product"
 msgid "Rated %s out of %s"
-msgstr ""
+msgstr "Valoración: %1$s de %2$s"
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -16525,8 +16501,7 @@ msgstr "IA de razonamiento con moderación media integrada"
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr ""
-"El razonamiento puede ofrecer mejores respuestas a preguntas complejas."
+msgstr "El razonamiento puede ofrecer mejores respuestas a preguntas complejas."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
@@ -17369,8 +17344,7 @@ msgstr "Reseñas"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
-"Reescribe esta receta ajustándola para un número diferente de raciones."
+msgstr "Reescribe esta receta ajustándola para un número diferente de raciones."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -17655,8 +17629,7 @@ msgstr ""
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
 msgctxt "Short description for Chat History feature on native DDG browsers"
 msgid "Save up to 30 of your most recent chats locally on your device."
-msgstr ""
-"Guarda hasta 30 de tus chats más recientes localmente en tu dispositivo."
+msgstr "Guarda hasta 30 de tus chats más recientes localmente en tu dispositivo."
 
 # smartling.placeholder_format=C
 #. Desktop/mobile intro modal body under the title per Sync Chats Figma (choose step).
@@ -17677,7 +17650,7 @@ msgstr "Guarda tus chats en todos tus dispositivos."
 #. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
 msgctxt "Chat history about modal list item headline"
 msgid "Save your chats on this device"
-msgstr ""
+msgstr "Guarda tus chats en este dispositivo"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
@@ -17889,7 +17862,7 @@ msgctxt ""
 "Placeholder and accessibility label for the search input in the tab picker "
 "dialog"
 msgid "Search"
-msgstr ""
+msgstr "Buscar"
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18214,8 +18187,7 @@ msgstr "Segunda opinión"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr ""
-"Guarda y sincroniza tus chats de forma segura en todos tus dispositivos."
+msgstr "Guarda y sincroniza tus chats de forma segura en todos tus dispositivos."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18438,8 +18410,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Selecciona %1$sDuckDuckGo%2$s y pulsa %3$sAgregar como predeterminado%4$s."
+msgstr "Selecciona %1$sDuckDuckGo%2$s y pulsa %3$sAgregar como predeterminado%4$s."
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -18538,8 +18509,7 @@ msgstr "Selecciona %1$sMotor de búsqueda%2$s"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"
-msgstr ""
-"Selecciona %1$sMotor de búsqueda%2$s y, a continuación, %3$sOtros...%4$s"
+msgstr "Selecciona %1$sMotor de búsqueda%2$s y, a continuación, %3$sOtros...%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -18564,8 +18534,7 @@ msgstr "Selecciona %1$sAjustes%2$s en el menú desplegable."
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sAdvanced settings%s"
-msgstr ""
-"Selecciona %1$sAjustes%2$s y, a continuación, %3$sAjustes avanzados%4$s"
+msgstr "Selecciona %1$sAjustes%2$s y, a continuación, %3$sAjustes avanzados%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -18580,8 +18549,7 @@ msgstr ""
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sSearch Engine%s"
-msgstr ""
-"Selecciona %1$sAjustes%2$s y, a continuación, %3$sMotor de búsqueda%4$s"
+msgstr "Selecciona %1$sAjustes%2$s y, a continuación, %3$sMotor de búsqueda%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -19096,7 +19064,7 @@ msgstr "Tienda"
 #. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
 msgctxt "Button in the merchandise logo modal (mobile)"
 msgid "Shop Now"
-msgstr ""
+msgstr "Comprar ahora"
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -19323,8 +19291,7 @@ msgstr "Mostrar todos los resultados"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show answers more often. (You can also %sturn them off%s.)"
-msgstr ""
-"Mostrar respuestas con más frecuencia. (También puedes %1$sapagarlas%2$s.)"
+msgstr "Mostrar respuestas con más frecuencia. (También puedes %1$sapagarlas%2$s.)"
 
 # smartling.placeholder_format=C
 #. Accessible label for the button that reveals a popover listing multiple citation sources in Duck.ai chat responses.
@@ -19488,8 +19455,7 @@ msgstr "Muestra recordatorios ocasionales para añadir DuckDuckGo al navegador"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Muestra recordatorios ocasionales para añadir DuckDuckGo a tus dispositivos"
+msgstr "Muestra recordatorios ocasionales para añadir DuckDuckGo a tus dispositivos"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19502,8 +19468,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows page numbers at result page breaks"
-msgstr ""
-"Muestra los números de página en los saltos de página de los resultados"
+msgstr "Muestra los números de página en los saltos de página de los resultados"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19516,8 +19481,7 @@ msgstr ""
 #. http://i.imgur.com/94erFcS.png
 msgctxt "settings"
 msgid "Shows suggestions under the search box as you type"
-msgstr ""
-"Muestra sugerencias debajo del cuadro de búsqueda a medida que escribes"
+msgstr "Muestra sugerencias debajo del cuadro de búsqueda a medida que escribes"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19622,8 +19586,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"Los sitios que bloquees se ocultarán de todos tus resultados de búsqueda"
+msgstr "Los sitios que bloquees se ocultarán de todos tus resultados de búsqueda"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19837,8 +19800,7 @@ msgstr "Lo sentimos, se ha producido un error inesperado."
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid "Sorry, no relevant information was found in our search."
-msgstr ""
-"Lo sentimos, no se ha encontrado información relevante en nuestra búsqueda."
+msgstr "Lo sentimos, no se ha encontrado información relevante en nuestra búsqueda."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search.
@@ -20205,8 +20167,7 @@ msgstr "Detén a los rastreadores ocultos que acechan en otros sitios web."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Detén a la mayoría de rastreadores ocultos que acechan en otros sitios web."
+msgstr "Detén a la mayoría de rastreadores ocultos que acechan en otros sitios web."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20769,7 +20730,7 @@ msgctxt "Chat history with sync modal list item description"
 msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
-msgstr ""
+msgstr "Sync & Backup guarda más chats y los sincroniza en todos tus dispositivos."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20854,8 +20815,7 @@ msgstr "Sincronizar con otro dispositivo"
 #. Title shown when sync service is temporarily unavailable.
 msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
-msgstr ""
-"La sincronización y la copia de seguridad no están disponibles temporalmente"
+msgstr "La sincronización y la copia de seguridad no están disponibles temporalmente"
 
 # smartling.placeholder_format=C
 #. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
@@ -20891,7 +20851,7 @@ msgstr "Sincroniza tus chats en todos tus dispositivos."
 #. Headline in sync-enabled chat history about modals explaining cross-device sync.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Sync your chats across all your devices"
-msgstr ""
+msgstr "Sincroniza tus chats en todos tus dispositivos"
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21010,8 +20970,7 @@ msgstr "Toma el control de tus datos personales"
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr ""
-"Responde a esta encuesta anónima para decirnos cómo podemos mejorar Duck.ai."
+msgstr "Responde a esta encuesta anónima para decirnos cómo podemos mejorar Duck.ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -21382,8 +21341,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
 msgid "There's been an issue loading this answer. Please try again."
-msgstr ""
-"Se ha producido un problema al cargar esta respuesta. Inténtalo de nuevo."
+msgstr "Se ha producido un problema al cargar esta respuesta. Inténtalo de nuevo."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -21486,12 +21444,14 @@ msgid ""
 "This chat and its generated images become public when you create and copy "
 "the link."
 msgstr ""
+"Este chat y las imágenes que genera se hacen públicos cuando creas y copias "
+"el enlace."
 
 # smartling.placeholder_format=C
 #. Explains that creating and copying a share link makes the selected chat content public.
 msgctxt "Share modal info bullet about public access"
 msgid "This chat becomes public when you create and copy the link."
-msgstr ""
+msgstr "Este chat se hace público cuando creas y copias el enlace."
 
 # smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
@@ -21568,15 +21528,13 @@ msgstr ""
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
-msgstr ""
-"Este archivo es demasiado grande. El tamaño máximo del archivo es de %1$s MB"
+msgstr "Este archivo es demasiado grande. El tamaño máximo del archivo es de %1$s MB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB."
-msgstr ""
-"Este archivo es demasiado grande. El tamaño máximo del archivo es de %1$s MB."
+msgstr "Este archivo es demasiado grande. El tamaño máximo del archivo es de %1$s MB."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -21596,8 +21554,7 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s"
-msgstr ""
-"Este tipo de archivo no es compatible, por favor adjunta un %1$s o %2$s"
+msgstr "Este tipo de archivo no es compatible, por favor adjunta un %1$s o %2$s"
 
 # smartling.placeholder_format=C
 #. Error message for unsupported file type when multiple types are accepted. First placeholder is a comma-separated list of all accepted types except the last (e.g. PNG, JPG, WebP, GIF). Second placeholder is the last accepted type (e.g. PDF). Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF
@@ -21605,8 +21562,7 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s."
-msgstr ""
-"Este tipo de archivo no es compatible, por favor adjunta un %1$s o %2$s."
+msgstr "Este tipo de archivo no es compatible, por favor adjunta un %1$s o %2$s."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to upload an unsupported file type and we know which types are accepted. Placeholder is a single accepted type. E.g. This file type is not supported, please attach a PDF
@@ -21842,8 +21798,7 @@ msgstr ""
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
-msgstr ""
-"Esto eliminará tu imagen seleccionada. Esta acción no se puede deshacer."
+msgstr "Esto eliminará tu imagen seleccionada. Esta acción no se puede deshacer."
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -22034,15 +21989,15 @@ msgstr "Hoy"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
-msgstr ""
+msgstr "Cambia al chat privado de IA o %1$sdesactívalo en los ajustes%2$s."
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
-"Cambia para probar el chat privado de IA o %1$sdesactívalo en el menú %2$s."
-"%3$s"
+"Cambia para probar el chat privado de IA o %1$sdesactívalo en el menú "
+"%2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -22264,8 +22219,7 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"Traduce esta frase del español al francés: «¿Cómo ir al cine más cercano?»"
+msgstr "Traduce esta frase del español al francés: «¿Cómo ir al cine más cercano?»"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -22273,8 +22227,7 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"Traduce esta frase del español al inglés: «¿Cómo ir al cine más cercano?»"
+msgstr "Traduce esta frase del español al inglés: «¿Cómo ir al cine más cercano?»"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -22529,16 +22482,14 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Prueba a activar la ubicación anónima para obtener resultados más precisos."
+msgstr "Prueba a activar la ubicación anónima para obtener resultados más precisos."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Intenta experimentar con cada modelo, ya que ofrecerán diferentes respuestas."
+msgstr "Intenta experimentar con cada modelo, ya que ofrecerán diferentes respuestas."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -22716,15 +22667,13 @@ msgstr "Prueba %1$s y %2$s de código abierto recientemente añadidos"
 #. Text for a promotional card that encourages users to try the recently added open-source AI models Llama 3.1 and Mixtral.
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source Llama 3.1 and Mixtral"
-msgstr ""
-"Prueba los recientemente añadidos de código abierto Llama 3.1 y Mixtral"
+msgstr "Prueba los recientemente añadidos de código abierto Llama 3.1 y Mixtral"
 
 # smartling.placeholder_format=C
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
-msgstr ""
-"Prueba uno de estos mensajes o introduce tu propio mensaje a continuación"
+msgstr "Prueba uno de estos mensajes o introduce tu propio mensaje a continuación"
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -23118,8 +23067,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"En %1$sAbrir con%2$s, selecciona %3$sUna o varias páginas específicas%4$s"
+msgstr "En %1$sAbrir con%2$s, selecciona %3$sUna o varias páginas específicas%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -23299,8 +23247,7 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr ""
-"Desbloquea modelos de IA más capaces con una suscripción a DuckDuckGo. %1$s"
+msgstr "Desbloquea modelos de IA más capaces con una suscripción a DuckDuckGo. %1$s"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -23866,6 +23813,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Yelp's ad network."
 msgstr ""
+"DuckDuckGo protege la privacidad de la visualización de anuncios. La red de "
+"anuncios de Yelp gestiona los clics en los anuncios."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -23896,8 +23845,7 @@ msgctxt "mobile promotion on desktop"
 msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
-msgstr ""
-"Visita %1$sDuckDuckGo.com%2$s en tu móvil o tablet y sigue las instrucciones."
+msgstr "Visita %1$sDuckDuckGo.com%2$s en tu móvil o tablet y sigue las instrucciones."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -24244,8 +24192,7 @@ msgstr "No te perseguimos con anuncios."
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr ""
-"No almacenamos nombres de usuario ni información personal identificable."
+msgstr "No almacenamos nombres de usuario ni información personal identificable."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -24425,14 +24372,12 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr ""
-"Confiamos en tus comentarios anónimos para mejorar DuckDuckGo para todos."
+msgstr "Confiamos en tus comentarios anónimos para mejorar DuckDuckGo para todos."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr ""
-"Impedimos que nadie acceda a tu historial de búsquedas, ni siquiera nosotros."
+msgstr "Impedimos que nadie acceda a tu historial de búsquedas, ni siquiera nosotros."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -24677,8 +24622,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai, it's time to import your chats"
-msgstr ""
-"¡Te damos la bienvenida al nuevo Duck.ai! Es hora de importar tus chats."
+msgstr "¡Te damos la bienvenida al nuevo Duck.ai! Es hora de importar tus chats."
 
 # smartling.placeholder_format=C
 #. Welcome message for new DuckDuckGo users.
@@ -24719,8 +24663,7 @@ msgstr "Conferencia Oeste"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "We’re currently experiencing an issue with DuckDuckGo Search."
-msgstr ""
-"En estos momentos, estamos experimentando un problema con DuckDuckGo Search."
+msgstr "En estos momentos, estamos experimentando un problema con DuckDuckGo Search."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong even though we were able to show some organic results.
@@ -25128,8 +25071,7 @@ msgstr "¿Sobre qué te gustaría dar tu opinión?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"Lo que veas en DuckDuckGo no influirá en tus recomendaciones en YouTube."
+msgstr "Lo que veas en DuckDuckGo no influirá en tus recomendaciones en YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -25161,8 +25103,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"Cuando esté activado, Duck.ai mostrará respuestas instantáneas en el chat."
+msgstr "Cuando esté activado, Duck.ai mostrará respuestas instantáneas en el chat."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -25180,8 +25121,7 @@ msgstr "Dónde ver <strong>%1$s</strong>"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr ""
-"Donde pone Página de inicio pulsa en %1$sEstablecer como página actual%2$s."
+msgstr "Donde pone Página de inicio pulsa en %1$sEstablecer como página actual%2$s."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -25371,6 +25311,8 @@ msgid ""
 "With chat history on, up to %s of your most recent chats will be saved on "
 "this device."
 msgstr ""
+"Con el historial de chats activado, se guardarán hasta %1$s de tus chats más "
+"recientes en este dispositivo."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline in the About Chat History modal.
@@ -25378,6 +25320,8 @@ msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, your most recent chats will be saved on this device."
 msgstr ""
+"Con el historial de chats activado, tus chats más recientes se guardarán en "
+"este dispositivo."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -25883,8 +25827,7 @@ msgstr "Puedes empezar de cero en este nuevo dominio (duck.ai)."
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can store several sets of settings for different purposes."
-msgstr ""
-"Puedes almacenar varios conjuntos de ajustes para diferentes propósitos."
+msgstr "Puedes almacenar varios conjuntos de ajustes para diferentes propósitos."
 
 # smartling.placeholder_format=C
 #. Instructions for user once they've failed the bot challenge
@@ -25964,8 +25907,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr ""
-"No volverás a ver este mensaje a menos que borres los datos de tu navegador."
+msgstr "No volverás a ver este mensaje a menos que borres los datos de tu navegador."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -26070,14 +26012,12 @@ msgstr "Has alcanzado la duración máxima del chat de voz para una sola sesión
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"Has alcanzado el límite de chat de voz para hoy. Inténtalo de nuevo mañana."
+msgstr "Has alcanzado el límite de chat de voz para hoy. Inténtalo de nuevo mañana."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"Has alcanzado tu límite de uso de dictado. Inténtalo de nuevo más tarde."
+msgstr "Has alcanzado tu límite de uso de dictado. Inténtalo de nuevo más tarde."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -26792,7 +26732,7 @@ msgstr "min"
 #. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the chat options menu button"
 msgid "menu"
-msgstr ""
+msgstr "menú"
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/es_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_ES/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: es_ES\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1223,6 +1223,12 @@ msgid "About our ads"
 msgstr "Acerca de nuestros anuncios"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1352,6 +1358,20 @@ msgid "Ad is suspicious"
 msgstr "Anuncio sospechoso"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Añadir DuckDuckGo"
@@ -1378,6 +1398,27 @@ msgstr "Añadir DuckDuckGo como motor de búsqueda"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Añadir DuckDuckGo a %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1423,6 +1464,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Añadir contenido a la página"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1508,6 +1565,12 @@ msgstr "Addons"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Añadiendo los toques finales"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1812,6 +1875,12 @@ msgstr "Todos los colores"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "¡Todo listo!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3530,6 +3599,14 @@ msgid "Cancel"
 msgstr "Cancelar"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4026,10 +4103,22 @@ msgid "Chat response is offensive"
 msgstr "La respuesta del chat es ofensiva"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Chatea con %1$s"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4048,6 +4137,14 @@ msgstr "Chats"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Chats"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5658,6 +5755,12 @@ msgid "Current Streak"
 msgstr "Racha actual"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -6006,6 +6109,12 @@ msgstr "Borrar chats"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Borrar chats con una antigüedad superior a 30 días"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6419,6 +6528,12 @@ msgstr "Descartar para siempre"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Descartar promoción"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7608,6 +7723,12 @@ msgid "Edit Prompt"
 msgstr "Editar instrucción"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7830,6 +7951,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Modelo cifrado"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8677,6 +8804,12 @@ msgid "Follow-up question"
 msgstr "Pregunta de seguimiento"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9189,6 +9322,12 @@ msgstr ""
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr "Obtén DuckDuckGo VPN, Duck.ai avanzado e Identity Theft Restoration."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10423,6 +10562,12 @@ msgstr "¿Cómo se mantienen anónimos?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Cómo funciona"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11881,6 +12026,12 @@ msgstr "Touches ganadas"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "El enlace caduca en 7 días."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14005,6 +14156,12 @@ msgstr "Aceptar"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "Vale, ¡entendido!"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16133,6 +16290,12 @@ msgid "Protected"
 msgstr "Protegido"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Protección. Privacidad. Tranquilidad."
@@ -16264,6 +16427,12 @@ msgstr "Lluvia"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Clasificaciones"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17505,6 +17674,12 @@ msgid "Save your chats across all your devices."
 msgstr "Guarda tus chats en todos tus dispositivos."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17707,6 +17882,14 @@ msgstr "Buscar"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Buscar"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18908,6 +19091,12 @@ msgstr "Mayús+Intro"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Tienda"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20575,6 +20764,14 @@ msgstr ""
 "inactividad."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20689,6 +20886,12 @@ msgstr "Sincronizar con un dispositivo cercano."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Sincroniza tus chats en todos tus dispositivos."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21275,6 +21478,22 @@ msgid "This Week"
 msgstr "Esta semana"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21810,6 +22029,12 @@ msgstr "Hoy"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Hoy"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23635,6 +23860,14 @@ msgstr ""
 "anuncios de Microsoft gestiona los clics en los anuncios."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Islas Vírgenes"
 
@@ -25132,6 +25365,21 @@ msgstr ""
 "IA. Actívalo o desactívalo en cualquier momento en el menú «%1$s»."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26539,6 +26787,12 @@ msgstr "min"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "min"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/es_MX/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_MX/LC_MESSAGES/duckduckgo.po
@@ -982,6 +982,11 @@ msgstr "Acerca de nosotros"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1085,6 +1090,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "El anuncio es sospechoso"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Añade DuckDuckGo"
@@ -1104,6 +1121,24 @@ msgstr "Agrega DuckDuckGo como motor de búsqueda"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Agrega DuckDuckGo en %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1142,6 +1177,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1213,6 +1262,11 @@ msgstr "Complementos"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1458,6 +1512,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2815,6 +2874,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3216,9 +3282,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3234,6 +3310,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4508,6 +4591,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4792,6 +4880,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5130,6 +5223,11 @@ msgstr "Descartar para siempre"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6026,6 +6124,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6203,6 +6306,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6874,6 +6982,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7292,6 +7405,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8280,6 +8398,11 @@ msgid "How is it anonymous?"
 msgstr "¿Cómo es eso anónimo?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9444,6 +9567,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11185,6 +11313,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "¡Entendido!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12898,6 +13031,11 @@ msgstr "Protege tu información en cada dispositivo."
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -13004,6 +13142,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13992,6 +14135,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14149,6 +14297,13 @@ msgstr "Buscar"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15083,6 +15238,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16423,6 +16583,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16503,6 +16670,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16969,6 +17141,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17373,6 +17559,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18851,6 +19042,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -20011,6 +20209,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21107,6 +21318,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/es_PE/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_PE/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Añade DuckDuckGo"
@@ -1099,6 +1116,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr "Componentes adicionales "
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1455,6 +1509,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2802,6 +2861,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3202,9 +3268,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3220,6 +3296,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4487,6 +4570,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4771,6 +4859,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5109,6 +5202,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6005,6 +6103,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6182,6 +6285,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6849,6 +6957,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7267,6 +7380,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8249,6 +8367,11 @@ msgid "How is it anonymous?"
 msgstr "Como es esto anonimo?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9407,6 +9530,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11144,6 +11272,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12846,6 +12979,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12952,6 +13090,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13940,6 +14083,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14095,6 +14243,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15022,6 +15177,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16362,6 +16522,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16442,6 +16609,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16902,6 +17074,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17306,6 +17492,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18773,6 +18964,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19922,6 +20120,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21010,6 +21221,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/es_UY/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_UY/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Agregar DuckDuckGo"
@@ -1099,6 +1116,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr "Complementos"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1453,6 +1507,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2800,6 +2859,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3200,9 +3266,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3218,6 +3294,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4477,6 +4560,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4761,6 +4849,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5099,6 +5192,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -5995,6 +6093,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6172,6 +6275,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6839,6 +6947,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7257,6 +7370,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8239,6 +8357,11 @@ msgid "How is it anonymous?"
 msgstr "¿Cómo es anónimo?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9394,6 +9517,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11131,6 +11259,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12831,6 +12964,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12937,6 +13075,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13925,6 +14068,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14080,6 +14228,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -14997,6 +15152,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16336,6 +16496,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16416,6 +16583,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16876,6 +17048,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17278,6 +17464,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18741,6 +18932,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19890,6 +20088,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20977,6 +21188,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/es_VE/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_VE/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Agregar DuckDuckGo"
@@ -1099,6 +1116,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr "Complementos"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1455,6 +1509,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2802,6 +2861,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3204,9 +3270,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3222,6 +3298,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4484,6 +4567,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4768,6 +4856,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5106,6 +5199,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6002,6 +6100,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6179,6 +6282,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6848,6 +6956,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7266,6 +7379,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8248,6 +8366,11 @@ msgid "How is it anonymous?"
 msgstr "¿Cómo es anónimo?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9405,6 +9528,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11142,6 +11270,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12844,6 +12977,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12950,6 +13088,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13938,6 +14081,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14093,6 +14241,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15014,6 +15169,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16355,6 +16515,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16435,6 +16602,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16895,6 +17067,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17297,6 +17483,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18762,6 +18953,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19911,6 +20109,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20999,6 +21210,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/et_EE/LC_MESSAGES/duckduckgo.po
+++ b/locales/et_EE/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: et_EE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1212,6 +1212,12 @@ msgid "About our ads"
 msgstr "Meie reklaamide kohta"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1341,6 +1347,20 @@ msgid "Ad is suspicious"
 msgstr "Reklaam on kahtlane"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Lisa DuckDuckGo"
@@ -1367,6 +1387,27 @@ msgstr "Lisa DuckDuckGo otsingumootorina"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Lisa DuckDuckGo brauserisse %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1412,6 +1453,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Lisa lehe sisu"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1497,6 +1554,12 @@ msgstr "Lisandid"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Viimistlusdetailide lisamine"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1800,6 +1863,12 @@ msgstr "Kõik värvid"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Kõik valmis!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3516,6 +3585,14 @@ msgid "Cancel"
 msgstr "Tühista"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4008,10 +4085,22 @@ msgid "Chat response is offensive"
 msgstr "Vestluse vastus on solvav"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Vestle %1$s-ga"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4030,6 +4119,14 @@ msgstr "Vestlused"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Vestlused"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5624,6 +5721,12 @@ msgid "Current Streak"
 msgstr "Praegune seeria"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5971,6 +6074,12 @@ msgstr "Kustuta vestlused"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Kustuta vestlused, mis on vanemad kui 30 päeva"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6386,6 +6495,12 @@ msgstr "Tühista igaveseks"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Loobu reklaamist"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7555,6 +7670,12 @@ msgid "Edit Prompt"
 msgstr "Muuda käsklust"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7773,6 +7894,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Krüptitud mudel"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8599,6 +8726,12 @@ msgid "Follow-up question"
 msgstr "Lisaküsimus"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9113,6 +9246,12 @@ msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
 "Hangi DuckDuckGo VPN, täiustatud Duck.ai ja Identity Theft Restoration "
 "teenus."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10344,6 +10483,12 @@ msgstr "Mis moodi see on anonüümne?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Kuidas see töötab"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11785,6 +11930,12 @@ msgstr "Võidetud lahtimängud"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "Link aegub seitsme päeva pärast."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13906,6 +14057,12 @@ msgid "OK, got it!"
 msgstr "OK, sain aru!"
 
 # smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -16023,6 +16180,12 @@ msgid "Protected"
 msgstr "Kaitstud"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Kaitse Privaatsus Meelerahu."
@@ -16154,6 +16317,12 @@ msgstr "Vihm"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Paremusjärjestus"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17391,6 +17560,12 @@ msgid "Save your chats across all your devices."
 msgstr "Salvesta oma vestlused kõigis seadmetes."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17590,6 +17765,14 @@ msgstr "Otsing"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Otsing"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18758,6 +18941,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Pood"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20404,6 +20593,14 @@ msgstr ""
 "mitteaktiivsust."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20518,6 +20715,12 @@ msgstr "Sünkrooni lähedalasuva seadmega."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Sünkrooni oma vestlused kõigis oma seadmetes."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21098,6 +21301,22 @@ msgid "This Week"
 msgstr "Sel nädalal"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21619,6 +21838,12 @@ msgstr "Täna"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Täna"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23436,6 +23661,14 @@ msgstr ""
 "haldab TripAdvisori reklaamivõrgustik."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Neitsisaared"
 
@@ -24911,6 +25144,21 @@ msgstr ""
 "„%1$s“ menüüs."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26313,6 +26561,12 @@ msgstr "k"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "k"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/et_EE/LC_MESSAGES/duckduckgo.po
+++ b/locales/et_EE/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: et_EE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -442,8 +442,7 @@ msgstr "%1$s sõna"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr ""
-"%1$sKlõpsa %2$sLisa%3$sKontrolli %4$sLuba%5$s, seejärel klõpsa %6$sOK%7$s"
+msgstr "%1$sKlõpsa %2$sLisa%3$sKontrolli %4$sLuba%5$s, seejärel klõpsa %6$sOK%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -1215,7 +1214,7 @@ msgstr "Meie reklaamide kohta"
 #. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
 msgctxt "Modal header for chat history with sync information"
 msgid "About Chat History with Sync & Backup"
-msgstr ""
+msgstr "Vestluse ajaloo kohta koos funktsiooniga Sync & Backup"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
@@ -1350,7 +1349,7 @@ msgstr "Reklaam on kahtlane"
 #. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
 msgctxt "Button to open menu for attaching images or page context to AI chat"
 msgid "Add"
-msgstr ""
+msgstr "Lisa"
 
 # smartling.placeholder_format=C
 #. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
@@ -1358,7 +1357,7 @@ msgctxt ""
 "Primary button that attaches the tabs the user checked in the tab picker "
 "dialog"
 msgid "Add"
-msgstr ""
+msgstr "Lisa"
 
 # smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
@@ -1393,13 +1392,13 @@ msgstr "Lisa DuckDuckGo brauserisse %1$s"
 msgctxt ""
 "Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
 msgid "Add File"
-msgstr ""
+msgstr "Lisa fail"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
 msgid "Add Image"
-msgstr ""
+msgstr "Lisa pilt"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
@@ -1407,7 +1406,7 @@ msgctxt ""
 "Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
 "item)"
 msgid "Add Image or File"
-msgstr ""
+msgstr "Lisa pilt või fail"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1460,7 +1459,7 @@ msgctxt ""
 "Open the tab picker to attach browser tab content to the AI chat message "
 "(attach dropdown menu item)"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Lisa vahekaardid"
 
 # smartling.placeholder_format=C
 #. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
@@ -1468,7 +1467,7 @@ msgctxt ""
 "Title and accessible name of the tab-picker dialog opened from the attach "
 "dropdown menu"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Lisa vahekaardid"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1559,7 +1558,7 @@ msgstr "Viimistlusdetailide lisamine"
 #. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
 msgctxt "Aria label for the additional instructions textarea"
 msgid "Additional instructions"
-msgstr ""
+msgstr "Täiendavad juhised"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1868,7 +1867,7 @@ msgstr "Kõik valmis!"
 #. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the read-only textarea listing all AI instructions"
 msgid "All instructions"
-msgstr ""
+msgstr "Kõik juhised"
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2517,8 +2516,8 @@ msgstr ""
 "mõnedele otsingutele, tuginedes asjakohase veebisisu kokkuvõttele. Saate "
 "valida, kui tihti soovite Assisti kuvada: mitte kunagi (eemaldab "
 "otsingutulemustest täielikult Assisti kasutajaliidese), nõudmisel (AI-toega "
-"vastuseid kuvatakse ainult siis, kui klõpsate nuppu Assist), mõnikord (AI-"
-"toega vastuseid kuvatakse ainult siis, kui need on väga asjakohased) või "
+"vastuseid kuvatakse ainult siis, kui klõpsate nuppu Assist), mõnikord "
+"(AI-toega vastuseid kuvatakse ainult siis, kui need on väga asjakohased) või "
 "sageli (kuvatakse sagedamini laiema otsingute valiku puhul). Praegu on AI "
 "abil genereeritud vastused saadaval ainult USA (ingliskeelses) piirkonnas."
 
@@ -2639,8 +2638,7 @@ msgstr "Heli ei salvestata meie ega OpenAI poolt pärast vestluse lõppu."
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"Heli ei salvestata meie ega OpenAI poolt pärast vestluse transkribeerimist."
+msgstr "Heli ei salvestata meie ega OpenAI poolt pärast vestluse transkribeerimist."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -3590,7 +3588,7 @@ msgctxt ""
 "Secondary button that dismisses the tab picker dialog without attaching "
 "anything"
 msgid "Cancel"
-msgstr ""
+msgstr "Tühista"
 
 # smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
@@ -4088,7 +4086,7 @@ msgstr "Vestluse vastus on solvav"
 #. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
 msgctxt "Chat history about modal list item headline"
 msgid "Chat storage varies by browser"
-msgstr ""
+msgstr "Vestluste salvestamine sõltub brauserist"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4100,7 +4098,7 @@ msgstr "Vestle %1$s-ga"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Chat with popular AI models, anonymized by us."
-msgstr ""
+msgstr "Vestle populaarsete tehisintellekti mudelitega, meie poolt anonüümistatud."
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4127,6 +4125,9 @@ msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
 msgstr ""
+"Vestlused salvestatakse turvaliselt DuckDuckGo serverisse "
+"otspunktkrüpteerimisega. Keegi peale sinu ei näe sinu andmeid, isegi mitte "
+"meie."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4577,9 +4578,9 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"Teema süvenemiseks klõpsake nuppu \"Veel\" ja esitage lisaküsimusi %1$sDuck."
-"ai%2$skaudu, meie privaatne AI-vestlusteenus, mis toetab vestlusmudeleid "
-"OpenAI, Anthropic ja teised."
+"Teema süvenemiseks klõpsake nuppu \"Veel\" ja esitage lisaküsimusi "
+"%1$sDuck.ai%2$skaudu, meie privaatne AI-vestlusteenus, mis toetab "
+"vestlusmudeleid OpenAI, Anthropic ja teised."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4638,8 +4639,7 @@ msgstr "Klõpsa %1$sSiia%2$s, et laadida alla DuckDuckGo laiend"
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr ""
-"Klõpsa %1$sAva%2$s, et laadida alla ja avada DuckDuckGo Safari laiendus"
+msgstr "Klõpsa %1$sAva%2$s, et laadida alla ja avada DuckDuckGo Safari laiendus"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -5724,7 +5724,7 @@ msgstr "Praegune seeria"
 #. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
 msgctxt "Suffix label indicating a tab is the currently active browser tab"
 msgid "Current Tab"
-msgstr ""
+msgstr "Praegune vahekaart"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
@@ -5879,8 +5879,7 @@ msgstr "Päevane piirang on saavutatud"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Päevane kasutuspiirang on saavutatud. Saad seda vestlust jätkata pärast %1$s."
+msgstr "Päevane kasutuspiirang on saavutatud. Saad seda vestlust jätkata pärast %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -6079,7 +6078,7 @@ msgstr "Kustuta vestlused, mis on vanemad kui 30 päeva"
 #. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
 msgctxt "Button text in the modal for deleting all recent chats"
 msgid "Delete Chats and Shared Links"
-msgstr ""
+msgstr "Kustuta vestlused ja jagatud lingid"
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6306,8 +6305,8 @@ msgstr "Dikteerimine Duck.ai-s"
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
 msgstr ""
-"Dikteerimine on meie poolt anonümiseeritud ja seda ei kasutata kunagi AI-"
-"mudelite koolitamiseks."
+"Dikteerimine on meie poolt anonümiseeritud ja seda ei kasutata kunagi "
+"AI-mudelite koolitamiseks."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6500,7 +6499,7 @@ msgstr "Loobu reklaamist"
 #. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the close button on the survey banner"
 msgid "Dismiss survey"
-msgstr ""
+msgstr "Loobu küsitlusest"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7179,9 +7178,9 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist ei saa järelküsimustele vastata, kuid pakume ka privaatset AI-"
-"põhist vestlusteenust %1$sDuckDuckGo AI Chat%2$s, mis toetab vestlusmudeleid "
-"OpenAI, Anthropic ja teisi."
+"DuckAssist ei saa järelküsimustele vastata, kuid pakume ka privaatset "
+"AI-põhist vestlusteenust %1$sDuckDuckGo AI Chat%2$s, mis toetab "
+"vestlusmudeleid OpenAI, Anthropic ja teisi."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7190,8 +7189,8 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist ei saa järelküsimustele vastata, kuid pakume ka privaatset AI-"
-"põhist vestlusteenust DuckDuckGo %1$sAI Chat%2$s, mis toetab OpenAI ja "
+"DuckAssist ei saa järelküsimustele vastata, kuid pakume ka privaatset "
+"AI-põhist vestlusteenust DuckDuckGo %1$sAI Chat%2$s, mis toetab OpenAI ja "
 "Anthropicu vestlusmudeleid."
 
 # smartling.placeholder_format=C
@@ -7297,8 +7296,7 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr ""
-"DuckDuckGo AI Chat pole ajutiselt saadaval. Värskenda lehte ja proovi uuesti."
+msgstr "DuckDuckGo AI Chat pole ajutiselt saadaval. Värskenda lehte ja proovi uuesti."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7673,7 +7671,7 @@ msgstr "Muuda käsklust"
 #. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the message-editing text area"
 msgid "Edit message"
-msgstr ""
+msgstr "Muuda sõnumit"
 
 # smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
@@ -7899,7 +7897,7 @@ msgstr "Krüptitud mudel"
 #. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
 msgctxt "Share modal info bullet about encryption"
 msgid "Encrypted so DuckDuckGo can't read your chat."
-msgstr ""
+msgstr "Krüpteeritud, nii et DuckDuckGo ei saa sinu vestlust lugeda."
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8171,8 +8169,7 @@ msgstr "Laienda kaarti"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr ""
-"Asjatundlikult loodud tooted inimestele, kes tõesti hoolivad privaatsusest."
+msgstr "Asjatundlikult loodud tooted inimestele, kes tõesti hoolivad privaatsusest."
 
 # smartling.placeholder_format=C
 #. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
@@ -8729,7 +8726,7 @@ msgstr "Lisaküsimus"
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
-msgstr ""
+msgstr "Järgnevad sõnumid jäävad privaatseks."
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8835,8 +8832,7 @@ msgstr "Meie poolt anonüümistatud tasuta ja privaatsed vestlused"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Meie poolt anonüümistatud tasuta ja privaatsed vestlused. Konto pole vajalik."
+msgstr "Meie poolt anonüümistatud tasuta ja privaatsed vestlused. Konto pole vajalik."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8866,8 +8862,7 @@ msgstr "Tasuta jagatavad ja kaubanduslikult kasutatavad"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr ""
-"Vabasta ruumi oma vestluste kustutamisega. Kinnitatud vestlusi ei kustutata."
+msgstr "Vabasta ruumi oma vestluste kustutamisega. Kinnitatud vestlusi ei kustutata."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -9251,7 +9246,7 @@ msgstr ""
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
 msgctxt "Tooltip on the header logo for sunglasses searches"
 msgid "Get DuckDuckGo sunglasses and other gear."
-msgstr ""
+msgstr "Hangi DuckDuckGo päikeseprillid ja muu varustus."
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9422,8 +9417,8 @@ msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, Personal Information Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"Hangi meie turvaline, kasutajate andmeid salvestamatu VPN, täiustatud Duck."
-"ai, Personal Information Removal ja Identity Theft Restoration teenus."
+"Hangi meie turvaline, kasutajate andmeid salvestamatu VPN, täiustatud "
+"Duck.ai, Personal Information Removal ja Identity Theft Restoration teenus."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
@@ -9475,8 +9470,7 @@ msgstr "Hangi rakendus"
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
-msgstr ""
-"Hangi tasuta DuckDuckGo brauser %1$sreklaamide blokeerimiseks YouTube'is.%2$s"
+msgstr "Hangi tasuta DuckDuckGo brauser %1$sreklaamide blokeerimiseks YouTube'is.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -10488,7 +10482,7 @@ msgstr "Kuidas see töötab"
 #. Headline in chat history about modals for the temporary encrypted server storage explanation.
 msgctxt "Chat history about modal list item headline"
 msgid "How it works"
-msgstr ""
+msgstr "Kuidas see töötab"
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -10512,8 +10506,7 @@ msgstr "Kui tihti soovid, et ilmuksid AI-toega vastused?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr ""
-"Kui suurt osa oma päevastest ja nädalapiirangutest sa seni kasutanud oled."
+msgstr "Kui suurt osa oma päevastest ja nädalapiirangutest sa seni kasutanud oled."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -11333,8 +11326,7 @@ msgstr "See on kiire, tasuta ja pakub sulle veelgi suuremat võrgukaitset."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Mulle sobib, kui küsite (väga harva) minu DuckDuckGo kasutuskogemuse kohta"
+msgstr "Mulle sobib, kui küsite (väga harva) minu DuckDuckGo kasutuskogemuse kohta"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11852,8 +11844,7 @@ msgstr "Võimaldab sul DuckDuckGo abil anonüümselt otsida"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr ""
-"Võimaldab vahetada Duck.ai-le otsingupäringute ja käskluste saatmise vahel"
+msgstr "Võimaldab vahetada Duck.ai-le otsingupäringute ja käskluste saatmise vahel"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11935,7 +11926,7 @@ msgstr "Link aegub seitsme päeva pärast."
 #. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days. People can save a chat copy."
-msgstr ""
+msgstr "Link aegub seitsme päeva pärast. Inimesed saavad vestluse koopia salvestada."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11951,8 +11942,7 @@ msgstr "Lingid:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
-"Loetle tööriistad, materjalid või eeltingimused, mida ma selleks vajan."
+msgstr "Loetle tööriistad, materjalid või eeltingimused, mida ma selleks vajan."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12249,8 +12239,7 @@ msgstr "Veendu, et kõik sõnad on korrektselt kirjutatud."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr ""
-"Veendu, et märkisid %1$s„Muuda see minu vaikimisi otsingupakkujaks“%2$s"
+msgstr "Veendu, et märkisid %1$s„Muuda see minu vaikimisi otsingupakkujaks“%2$s"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -14060,7 +14049,7 @@ msgstr "OK, sain aru!"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "OPTIONAL"
-msgstr ""
+msgstr "VALIKULINE"
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -14330,8 +14319,7 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr ""
-"Oih! Selle teksti tõlkimisel tekkis ootamatu viga. Proovi hiljem uuesti."
+msgstr "Oih! Selle teksti tõlkimisel tekkis ootamatu viga. Proovi hiljem uuesti."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -14670,8 +14658,8 @@ msgid ""
 "more premium protections. All in one subscription."
 msgstr ""
 "Meie kiire ja kasutajate andmeid salvestamatu VPN sisaldab nutikamaid "
-"tehisintellekti vestlusi kõrgemate piirangutega ning lisaks muid premium-"
-"kaitseid. Kõik ühes tellimuses."
+"tehisintellekti vestlusi kõrgemate piirangutega ning lisaks muid "
+"premium-kaitseid. Kõik ühes tellimuses."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -15265,8 +15253,7 @@ msgstr "Vali konkreetne probleem"
 #. Header instructing the user to follow the instructions for their ad blocker
 msgid ""
 "Pick your ad blocker and follow the instructions to allow ads on DuckDuckGo."
-msgstr ""
-"Vali oma reklaamiblokeerija ja järgi juhiseid, et lubada DuckDuckGo reklaame."
+msgstr "Vali oma reklaamiblokeerija ja järgi juhiseid, et lubada DuckDuckGo reklaame."
 
 # smartling.placeholder_format=C
 #. Text for a button that pins a chat, as in it will it will add the chat to the pinned chats list.
@@ -15362,22 +15349,19 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr ""
-"Soorita järgmine ülesanne, et kinnitada, et selle otsingu tegi inimene."
+msgstr "Soorita järgmine ülesanne, et kinnitada, et selle otsingu tegi inimene."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr ""
-"Kirjelda, miks vestluse vastus on kahjulik või ebaseaduslik. (valikuline)"
+msgstr "Kirjelda, miks vestluse vastus on kahjulik või ebaseaduslik. (valikuline)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr ""
-"Kirjeldage, miks vestluse vastus on ebaseaduslik või kahjulik. (Valikuline)"
+msgstr "Kirjeldage, miks vestluse vastus on ebaseaduslik või kahjulik. (Valikuline)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -16183,7 +16167,7 @@ msgstr "Kaitstud"
 #. Headline in sync-enabled chat history about modals explaining encrypted server storage.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Protected with end-to-end encryption"
-msgstr ""
+msgstr "Kaitstud otspunktkrüptimisega"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -16322,7 +16306,7 @@ msgstr "Paremusjärjestus"
 #. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
 msgctxt "star rating on a product"
 msgid "Rated %s out of %s"
-msgstr ""
+msgstr "Hinnang: %1$s/%2$s"
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -16421,15 +16405,13 @@ msgstr "Arutlus võib anda paremaid vastuseid keerulistele küsimustele."
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
-msgstr ""
-"Arutlus on põhjalikum, kuid jõuab kasutuspiiranguteni 2–5 korda varem. %1$s"
+msgstr "Arutlus on põhjalikum, kuid jõuab kasutuspiiranguteni 2–5 korda varem. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr ""
-"Arutlus on põhjalikum, kuid ammendab piiranguid 2–5 korda kiiremini. %1$s"
+msgstr "Arutlus on põhjalikum, kuid ammendab piiranguid 2–5 korda kiiremini. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -17185,8 +17167,7 @@ msgstr "Tulemused ei sisalda blokeeritud saitide teavet."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr ""
-"Tulemused välistavad sinu blokeeritud saidid, mida saad hallata oma %1$s-s."
+msgstr "Tulemused välistavad sinu blokeeritud saidid, mida saad hallata oma %1$s-s."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -17257,8 +17238,7 @@ msgstr "Arvustused"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
-"Kirjuta see retsept ümber, kohandades seda teistsugusele portsjonite arvule."
+msgstr "Kirjuta see retsept ümber, kohandades seda teistsugusele portsjonite arvule."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -17550,8 +17530,7 @@ msgstr "Salvesta oma seadmesse kuni 30 viimast vestlust."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Salvesta oma Duck.ai vestlused seadmete vahel otsast lõpuni krüptimisega."
+msgstr "Salvesta oma Duck.ai vestlused seadmete vahel otsast lõpuni krüptimisega."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17563,7 +17542,7 @@ msgstr "Salvesta oma vestlused kõigis seadmetes."
 #. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
 msgctxt "Chat history about modal list item headline"
 msgid "Save your chats on this device"
-msgstr ""
+msgstr "Salvesta oma vestlused sellesse seadmesse"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
@@ -17740,8 +17719,7 @@ msgstr "Keri alla ja leia loendist %1$soma brauser%2$s."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr ""
-"Keri alla suvandini %1$sDuckDuckGo%2$s ja luba sellel oma asukohta kasutada."
+msgstr "Keri alla suvandini %1$sDuckDuckGo%2$s ja luba sellel oma asukohta kasutada."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -17772,7 +17750,7 @@ msgctxt ""
 "Placeholder and accessibility label for the search input in the tab picker "
 "dialog"
 msgid "Search"
-msgstr ""
+msgstr "Otsi"
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18143,8 +18121,7 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr ""
-"Turvaliselt salvestatud DuckDuckGo serverisse otspunktide krüptimisega."
+msgstr "Turvaliselt salvestatud DuckDuckGo serverisse otspunktide krüptimisega."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -18304,8 +18281,7 @@ msgstr "Vali Safari menüüst %1$sSelle veebisaidi seadistamine...%2$s."
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
-msgstr ""
-"Vali %1$sKohanda%2$s ja sisesta %3$shttps://duckduckgo.com%4$s sisendväljale"
+msgstr "Vali %1$sKohanda%2$s ja sisesta %3$shttps://duckduckgo.com%4$s sisendväljale"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -18699,8 +18675,7 @@ msgstr ""
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr ""
-"Määra oma asukoht käsitsi või veendu, et asukohateenused oleksid lubatud."
+msgstr "Määra oma asukoht käsitsi või veendu, et asukohateenused oleksid lubatud."
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -18774,8 +18749,7 @@ msgstr "Jaga"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Jaga rakendust DuckDuckGo ja aita sõpradel oma privaatsus tagasi saada!"
+msgstr "Jaga rakendust DuckDuckGo ja aita sõpradel oma privaatsus tagasi saada!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -18802,8 +18776,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"Jaga linna tasemel asukohta TI-mudelitega, et parandada asjakohasust. Duck."
-"ai ei avalda meile ega TI-mudelitele kunagi teie täpset asukohta."
+"Jaga linna tasemel asukohta TI-mudelitega, et parandada asjakohasust. "
+"Duck.ai ei avalda meile ega TI-mudelitele kunagi teie täpset asukohta."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -18927,8 +18901,8 @@ msgid ""
 "Shield your online activity with our no-log, fast VPN. Simple to set up and "
 "easy to turn on and off anytime."
 msgstr ""
-"Kaitse oma veebitegevust meie kasutajate andmeid salvestamatu ja kiire VPN-"
-"iga. Lihtne seadistada ning igal ajal hõlpsasti sisse ja välja lülitada."
+"Kaitse oma veebitegevust meie kasutajate andmeid salvestamatu ja kiire "
+"VPN-iga. Lihtne seadistada ning igal ajal hõlpsasti sisse ja välja lülitada."
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -18946,7 +18920,7 @@ msgstr "Pood"
 #. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
 msgctxt "Button in the merchandise logo modal (mobile)"
 msgid "Shop Now"
-msgstr ""
+msgstr "Osta kohe"
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -19774,8 +19748,7 @@ msgstr "Algtekst kustutatud"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr ""
-"Algtekst on liiga pikk, et seda kokku võtta. Proovi uuesti lühema valikuga."
+msgstr "Algtekst on liiga pikk, et seda kokku võtta. Proovi uuesti lühema valikuga."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -20599,6 +20572,8 @@ msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
 msgstr ""
+"Sync & Backup salvestab rohkem sinu vestlusi ja sünkroonib need kõigis sinu "
+"seadmetes."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20720,7 +20695,7 @@ msgstr "Sünkrooni oma vestlused kõigis oma seadmetes."
 #. Headline in sync-enabled chat history about modals explaining cross-device sync.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Sync your chats across all your devices"
-msgstr ""
+msgstr "Sünkrooni oma vestlused kõigis oma seadmetes"
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21112,8 +21087,7 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr ""
-"Mudelipakkuja kustutab kõik selle vestlusega seotud andmed 30 päeva jooksul."
+msgstr "Mudelipakkuja kustutab kõik selle vestlusega seotud andmed 30 päeva jooksul."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -21263,8 +21237,7 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr ""
-"See AI mudel pole enam saadaval. Proovi alustada uut vestlust teise mudeliga."
+msgstr "See AI mudel pole enam saadaval. Proovi alustada uut vestlust teise mudeliga."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -21309,12 +21282,14 @@ msgid ""
 "This chat and its generated images become public when you create and copy "
 "the link."
 msgstr ""
+"See vestlus ja selle loodud pildid muutuvad avalikuks, kui lood ja kopeerid "
+"lingi."
 
 # smartling.placeholder_format=C
 #. Explains that creating and copying a share link makes the selected chat content public.
 msgctxt "Share modal info bullet about public access"
 msgid "This chat becomes public when you create and copy the link."
-msgstr ""
+msgstr "Lingi loomisel ja kopeerimisel muutub see vestlus avalikuks."
 
 # smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
@@ -21621,8 +21596,7 @@ msgstr "See tõlge on vale"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Seda videot ei saa veel siin vaadata. Sa saad seda vaadata saidil %1$s."
+msgstr "Seda videot ei saa veel siin vaadata. Sa saad seda vaadata saidil %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -21742,8 +21716,7 @@ msgstr "Soovitused"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr ""
-"Oled väsinud sellest, et sind võrgus jälitatakse? %1$sMeie saame aidata.%2$s"
+msgstr "Oled väsinud sellest, et sind võrgus jälitatakse? %1$sMeie saame aidata.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -21801,8 +21774,8 @@ msgid ""
 "you originally used to set up Sync."
 msgstr ""
 "Sünkroonitud andmete taastamiseks vajad taastamiskoodi, mille salvestasid "
-"sünkroonimise esmakordsel seadistamisel. See kood võis olla salvestatud PDF-"
-"vormingus seadmesse, milles sa sünkroonimise algselt seadistasid."
+"sünkroonimise esmakordsel seadistamisel. See kood võis olla salvestatud "
+"PDF-vormingus seadmesse, milles sa sünkroonimise algselt seadistasid."
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -21843,7 +21816,7 @@ msgstr "Täna"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
-msgstr ""
+msgstr "Lülita sisse privaatne AI-vestlus või %1$skeela see seadetes%2$s."
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -22199,8 +22172,7 @@ msgstr "Proovi %1$s, et selliseid sõnumeid enam ei näeks."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Proovi mudelit %1$s, meie esimest mudelit null teenusepakkuja nähtavusega."
+msgstr "Proovi mudelit %1$s, meie esimest mudelit null teenusepakkuja nähtavusega."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -22333,8 +22305,7 @@ msgstr "Proovi teisi märksõnu."
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr ""
-"Rohkemate tulemuste nägemiseks proovi DuckDuckGo reklaamiblokeerija keelata."
+msgstr "Rohkemate tulemuste nägemiseks proovi DuckDuckGo reklaamiblokeerija keelata."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
@@ -22727,8 +22698,7 @@ msgstr "Täpsemate tulemuste saamiseks lülita sisse suvand „Täpne asukoht“
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr ""
-"Täpsemate tulemuste saamiseks lülita sisse suvand „Kasuta täpset asukohta“."
+msgstr "Täpsemate tulemuste saamiseks lülita sisse suvand „Kasuta täpset asukohta“."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -22920,8 +22890,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Jaotisest %1$sKäivitamisel%2$s vali %3$sAvaleht%4$s ja sisesta: https://"
-"duckduckgo.com"
+"Jaotisest %1$sKäivitamisel%2$s vali %3$sAvaleht%4$s ja sisesta: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -23443,8 +23413,7 @@ msgstr "Kasuta DuckDuckGo privaatset otsingut"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"Kasuta DuckDuckGo privaatsest otsingut oma iPadis, iPhone'is või Androidis!"
+msgstr "Kasuta DuckDuckGo privaatsest otsingut oma iPadis, iPhone'is või Androidis!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -23667,6 +23636,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Yelp's ad network."
 msgstr ""
+"DuckDuckGo kaitseb reklaamide vaatamisel sinu privaatsust. Reklaamiklõpse "
+"haldab Yelpi reklaamivõrgustik."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -24041,8 +24012,7 @@ msgstr "Me ei jälita sind reklaamidega."
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr ""
-"Me ei salvesta kasutajanimesid ega isikut tuvastada võimaldavat teavet."
+msgstr "Me ei salvesta kasutajanimesid ega isikut tuvastada võimaldavat teavet."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -24222,8 +24192,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr ""
-"Me ei lase kellelgi, sealhulgas meil endil, sinu otsinguajalugu vaadata."
+msgstr "Me ei lase kellelgi, sealhulgas meil endil, sinu otsinguajalugu vaadata."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -24402,8 +24371,7 @@ msgstr "Nädala kasutuspiirang on saavutatud"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Nädala kasutuspiirang on saavutatud. Saad seda vestlust jätkata pärast %1$s."
+msgstr "Nädala kasutuspiirang on saavutatud. Saad seda vestlust jätkata pärast %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -25150,6 +25118,8 @@ msgid ""
 "With chat history on, up to %s of your most recent chats will be saved on "
 "this device."
 msgstr ""
+"Kui vestluste ajalugu on sisse lülitatud, salvestatakse sellesse seadmesse "
+"kuni %1$s sinu viimast vestlust."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline in the About Chat History modal.
@@ -25157,6 +25127,8 @@ msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, your most recent chats will be saved on this device."
 msgstr ""
+"Kui vestluste ajalugu on sisse lülitatud, salvestatakse sinu viimased "
+"vestlused sellesse seadmesse."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -25171,8 +25143,8 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
-"Töötab otse teie seadmest, et eemaldada andmevahendajate saitidelt teie e-"
-"posti aadress, nimi, aadress ja muu."
+"Töötab otse teie seadmest, et eemaldada andmevahendajate saitidelt teie "
+"e-posti aadress, nimi, aadress ja muu."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25441,8 +25413,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"Vestled %1$s-ga. AI-vestlused võivad kuvada ebatäpset või solvavat teavet."
+msgstr "Vestled %1$s-ga. AI-vestlused võivad kuvada ebatäpset või solvavat teavet."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -25482,8 +25453,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
 msgstr ""
-"Küsimustele vastamiseks või teksti kokkuvõtmiseks võite kasutada ka %1$sDuck."
-"ai%2$s."
+"Küsimustele vastamiseks või teksti kokkuvõtmiseks võite kasutada ka "
+"%1$sDuck.ai%2$s."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -25557,8 +25528,7 @@ msgstr "Saad vestlust jätkata, kasutades oma igakuist piirangut."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Nüüd saad sellesse seadmesse salvestada kuni 100 vestlust. Vestle edasi!"
+msgstr "Nüüd saad sellesse seadmesse salvestada kuni 100 vestlust. Vestle edasi!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -25739,8 +25709,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr ""
-"Sa ei näe seda sõnumit enam, kui sa ei kustuta oma veebilehitseja andmeid."
+msgstr "Sa ei näe seda sõnumit enam, kui sa ei kustuta oma veebilehitseja andmeid."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -25830,8 +25799,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr ""
-"Oled hetkel saavutanud maksimaalse sõnumite arvu. Proovi hiljem uuesti."
+msgstr "Oled hetkel saavutanud maksimaalse sõnumite arvu. Proovi hiljem uuesti."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -25844,8 +25812,7 @@ msgstr "Oled saavutanud ühe seansi maksimaalse häälvestluse kestuse."
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"Oled jõudnud tänase päeva häälvestluse limiidini. Palun proovi homme uuesti."
+msgstr "Oled jõudnud tänase päeva häälvestluse limiidini. Palun proovi homme uuesti."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -25992,8 +25959,7 @@ msgstr "Sinu brauser näitab, kui oled seda linki külastanud"
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid "Your browser provides a list of your most-visited sites."
-msgstr ""
-"Sinu brauser esitab sinu kõige sagedamini külastatavate saitide loetelu."
+msgstr "Sinu brauser esitab sinu kõige sagedamini külastatavate saitide loetelu."
 
 # smartling.placeholder_format=C
 #. Used as a description in a menu
@@ -26035,8 +26001,8 @@ msgstr "Sinu vestlused salvestatakse nüüd."
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"Sinu vestlused on privaatsed ja neid ei salvestata ega kasutata kunagi AI-"
-"mudelite treenimiseks"
+"Sinu vestlused on privaatsed ja neid ei salvestata ega kasutata kunagi "
+"AI-mudelite treenimiseks"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
@@ -26566,7 +26532,7 @@ msgstr "k"
 #. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the chat options menu button"
 msgid "menu"
-msgstr ""
+msgstr "menüü"
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/eu_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/eu_ES/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Gehitu DuckDuckGo"
@@ -1099,6 +1116,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr "Gehigarriak"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1453,6 +1507,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2800,6 +2859,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3200,9 +3266,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3218,6 +3294,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4477,6 +4560,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4761,6 +4849,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5099,6 +5192,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -5995,6 +6093,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6172,6 +6275,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6839,6 +6947,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7257,6 +7370,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8239,6 +8357,11 @@ msgid "How is it anonymous?"
 msgstr "Zer da izengabea?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9394,6 +9517,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11131,6 +11259,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12831,6 +12964,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12937,6 +13075,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13925,6 +14068,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14080,6 +14228,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -14997,6 +15152,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16336,6 +16496,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16416,6 +16583,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16876,6 +17048,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17278,6 +17464,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18740,6 +18931,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19889,6 +20087,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20977,6 +21188,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/fa_IR/LC_MESSAGES/duckduckgo.po
+++ b/locales/fa_IR/LC_MESSAGES/duckduckgo.po
@@ -983,6 +983,11 @@ msgstr "درباره ما"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1086,6 +1091,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "فرم انتقاد و پیشنهادات"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "افزودن DuckDuckGo"
@@ -1109,6 +1126,24 @@ msgstr "داک‌داک‌گو را به موتورهای جستجو اضافه 
 #, fuzzy
 msgid "Add DuckDuckGo to %s"
 msgstr "‫افزودن داک‌داک‌گو به %s‬"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1147,6 +1182,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1218,6 +1267,11 @@ msgstr "افزونه ها"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1463,6 +1517,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2817,6 +2876,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3217,9 +3283,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3235,6 +3311,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4505,6 +4588,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4789,6 +4877,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5127,6 +5220,11 @@ msgstr "دیگر نشان نده"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6037,6 +6135,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6214,6 +6317,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6889,6 +6997,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7307,6 +7420,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8299,6 +8417,11 @@ msgid "How is it anonymous?"
 msgstr "آیا تنظیمات من قابل ردگیری است؟"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9469,6 +9592,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11210,6 +11338,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "باشه فهمیدم!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12918,6 +13051,11 @@ msgstr "از داده‌های خود در هر دستگاهی محافظت کن
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -13024,6 +13162,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -14013,6 +14156,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14170,6 +14318,13 @@ msgstr "جستجو"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15108,6 +15263,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16451,6 +16611,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16531,6 +16698,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16997,6 +17169,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17399,6 +17585,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18874,6 +19065,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -20035,6 +20233,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21127,6 +21338,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/fi_FI/LC_MESSAGES/duckduckgo.po
+++ b/locales/fi_FI/LC_MESSAGES/duckduckgo.po
@@ -1211,6 +1211,12 @@ msgid "About our ads"
 msgstr "Tietoa mainoksistamme"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1340,6 +1346,20 @@ msgid "Ad is suspicious"
 msgstr "Mainos on epäilyttävä"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Lisää DuckDuckGo"
@@ -1365,6 +1385,27 @@ msgstr "Lisää DuckDuckGo hakukoneeksi"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Lisää DuckDuckGo selaimeen %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1410,6 +1451,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Lisää sivun sisältö"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1495,6 +1552,12 @@ msgstr "Laajennukset"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Tehdään viimeistelyjä"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1792,6 +1855,12 @@ msgstr "Kaikki värit"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Valmista!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3496,6 +3565,14 @@ msgid "Cancel"
 msgstr "Peruuta"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3989,10 +4066,22 @@ msgid "Chat response is offensive"
 msgstr "Chat-vastaus on loukkaava."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Keskustele %1$s:n kanssa"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4011,6 +4100,14 @@ msgstr "Keskustelut"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Keskustelut"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5599,6 +5696,12 @@ msgid "Current Streak"
 msgstr "Nykyinen putki"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5947,6 +6050,12 @@ msgstr "Poista keskustelut"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Poista yli 30 päivää vanhemmat keskustelut"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6362,6 +6471,12 @@ msgstr "Hylkää pysyvästi"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Kampanjan hylkääminen"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7525,6 +7640,12 @@ msgid "Edit Prompt"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7744,6 +7865,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Salattu malli"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8567,6 +8694,12 @@ msgid "Follow-up question"
 msgstr "Jatkokysymys"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9079,6 +9212,12 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -10285,6 +10424,12 @@ msgstr "Kuinka se voi olla anonyymiä?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Näin se toimii"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11725,6 +11870,12 @@ msgstr "Voitettujen linjapallojen määrä"
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -13847,6 +13998,12 @@ msgid "OK, got it!"
 msgstr "OK, selvä!"
 
 # smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -15948,6 +16105,12 @@ msgid "Protected"
 msgstr "Suojattu"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Suojausta. Tietosuojaa. takaavat mielenrauhan."
@@ -16079,6 +16242,12 @@ msgstr "Sadetta"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Sijoitukset"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17315,6 +17484,12 @@ msgid "Save your chats across all your devices."
 msgstr "Tallenna keskustelusi kaikkiin laitteisiisi."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17514,6 +17689,14 @@ msgstr "Etsi"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Etsi"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18688,6 +18871,12 @@ msgstr "Vaihtonäppäin + Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Osta"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20338,6 +20527,14 @@ msgstr ""
 "toimettomuuden jälkeen."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20451,6 +20648,12 @@ msgstr ""
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Synkronoi keskustelusi kaikkien laitteidesi välillä."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21031,6 +21234,22 @@ msgid "This Week"
 msgstr "Tämä viikko"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21552,6 +21771,12 @@ msgstr "Tänään"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Tänään"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23375,6 +23600,14 @@ msgstr ""
 "hallinnoi TripAdvisorin mainosverkosto."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Neitsytsaaret"
 
@@ -24828,6 +25061,21 @@ msgid ""
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26212,6 +26460,12 @@ msgstr "min"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "min"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/fr_BE/LC_MESSAGES/duckduckgo.po
+++ b/locales/fr_BE/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "Publicité suspecte"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Ajouter DuckDuckGo"
@@ -1100,6 +1117,24 @@ msgstr "Ajouter DuckDuckGo comme une moteur de recherche"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Ajouter DuckDuckGo à %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr "Extensions"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1455,6 +1509,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2802,6 +2861,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3202,9 +3268,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3220,6 +3296,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4493,6 +4576,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4777,6 +4865,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5115,6 +5208,11 @@ msgstr "Rejeter pour toujours"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6013,6 +6111,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6190,6 +6293,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6859,6 +6967,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7277,6 +7390,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8261,6 +8379,11 @@ msgid "How is it anonymous?"
 msgstr "Anonyme, c'est-à-dire ?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9422,6 +9545,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11162,6 +11290,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "C'est bon, je l'ai !"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12871,6 +13004,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12977,6 +13115,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13966,6 +14109,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14124,6 +14272,13 @@ msgstr "Recherche"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15058,6 +15213,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16399,6 +16559,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16479,6 +16646,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16939,6 +17111,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17342,6 +17528,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18815,6 +19006,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19973,6 +20171,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21068,6 +21279,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/fr_CA/LC_MESSAGES/duckduckgo.po
+++ b/locales/fr_CA/LC_MESSAGES/duckduckgo.po
@@ -979,6 +979,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1082,6 +1087,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "Cette pub est suspicieuse"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Ajouter DuckDuckGo"
@@ -1101,6 +1118,24 @@ msgstr "Ajouter DuckDuckGo comme moteur de recherche"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Ajoutez DuckDuckGo à %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1139,6 +1174,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1210,6 +1259,11 @@ msgstr "Extensions"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1456,6 +1510,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2805,6 +2864,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3205,9 +3271,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3223,6 +3299,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4497,6 +4580,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4781,6 +4869,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5119,6 +5212,11 @@ msgstr "Passer (pour toujours)"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6015,6 +6113,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6192,6 +6295,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6860,6 +6968,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7278,6 +7391,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8262,6 +8380,11 @@ msgid "How is it anonymous?"
 msgstr "Comment ça peut être anonyme?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9425,6 +9548,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11166,6 +11294,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "OK, j'ai compris!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12874,6 +13007,11 @@ msgstr "Protégez vos informations sur tous vos appareils."
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12980,6 +13118,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13969,6 +14112,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14126,6 +14274,13 @@ msgstr "Rechercher"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15059,6 +15214,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16398,6 +16558,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16478,6 +16645,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16938,6 +17110,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17342,6 +17528,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18817,6 +19008,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19979,6 +20177,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21077,6 +21288,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/fr_CH/LC_MESSAGES/duckduckgo.po
+++ b/locales/fr_CH/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Ajouter DuckDuckGo"
@@ -1100,6 +1117,24 @@ msgstr "Ajouter DuckDuckGo comme moteur de recherche"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Ajouter DuckDuckGo à %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr "Extensions"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1455,6 +1509,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2802,6 +2861,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3202,9 +3268,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3220,6 +3296,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4493,6 +4576,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4777,6 +4865,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5115,6 +5208,11 @@ msgstr "Ne plus jamais prendre en compte"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6011,6 +6109,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6188,6 +6291,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6857,6 +6965,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7275,6 +7388,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8257,6 +8375,11 @@ msgid "How is it anonymous?"
 msgstr "Anonyme, c'est-à-dire ?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9417,6 +9540,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11157,6 +11285,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12865,6 +12998,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12971,6 +13109,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13960,6 +14103,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14117,6 +14265,13 @@ msgstr "Recherche"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15049,6 +15204,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16390,6 +16550,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16470,6 +16637,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16930,6 +17102,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17334,6 +17520,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18806,6 +18997,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19960,6 +20158,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21050,6 +21261,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/fr_FR/LC_MESSAGES/duckduckgo.po
+++ b/locales/fr_FR/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: fr_FR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1225,6 +1225,12 @@ msgid "About our ads"
 msgstr "À propos de nos publicités"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1354,6 +1360,20 @@ msgid "Ad is suspicious"
 msgstr "Publicité suspecte"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Ajouter DuckDuckGo"
@@ -1380,6 +1400,27 @@ msgstr "Ajouter DuckDuckGo en tant que moteur de recherche"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Ajoutez DuckDuckGo à %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1425,6 +1466,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Ajouter le contenu de la page"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1511,6 +1568,12 @@ msgstr "Extensions"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Ajout des touches finales"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1817,6 +1880,12 @@ msgstr "Toutes les couleurs"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "C'est fait !"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3555,6 +3624,14 @@ msgid "Cancel"
 msgstr "Annuler"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4052,10 +4129,22 @@ msgid "Chat response is offensive"
 msgstr "La réponse du chat est offensante"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Discuter avec %1$s"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4074,6 +4163,14 @@ msgstr "Discussions"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Discussions"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5698,6 +5795,12 @@ msgid "Current Streak"
 msgstr "Série actuelle"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -6046,6 +6149,12 @@ msgstr "Supprimer les discussions"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Supprimer les discussions datant de plus de 30 jours"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6467,6 +6576,12 @@ msgstr "Ne plus afficher"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Ignorer la promotion"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7660,6 +7775,12 @@ msgid "Edit Prompt"
 msgstr "Modifier le prompt"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7884,6 +8005,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Modèle chiffré"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8729,6 +8856,12 @@ msgid "Follow-up question"
 msgstr "Question de suivi"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9245,6 +9378,12 @@ msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
 "Bénéficiez du VPN DuckDuckGo, du chat avancé Duck.ai et d'Identity Theft "
 "Restoration."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10490,6 +10629,12 @@ msgstr "Anonyme, c'est-à-dire ?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Comment ça fonctionne"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11949,6 +12094,12 @@ msgstr "Touches gagnées"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "Le lien expire dans 7 jours."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14075,6 +14226,12 @@ msgstr "Ok"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "C'est bon, je l'ai !"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16218,6 +16375,12 @@ msgid "Protected"
 msgstr "Protégé"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Protection. Confidentialité. Tranquillité d'esprit."
@@ -16349,6 +16512,12 @@ msgstr "Pluie"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Classements"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17597,6 +17766,12 @@ msgid "Save your chats across all your devices."
 msgstr "Enregistrez vos discussions sur tous vos appareils."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17807,6 +17982,14 @@ msgstr "Rechercher"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Rechercher"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -19010,6 +19193,12 @@ msgstr "Maj+Entrée"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Acheter"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20693,6 +20882,14 @@ msgstr ""
 "d'inactivité."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20809,6 +21006,12 @@ msgstr "Synchroniser avec un appareil à proximité."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Synchronisez vos discussions sur tous vos appareils."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21405,6 +21608,22 @@ msgid "This Week"
 msgstr "Cette semaine"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21956,6 +22175,12 @@ msgstr "Auj."
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Auj."
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23803,6 +24028,14 @@ msgstr ""
 "publicitaire de TripAdvisor."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Îles Vierges"
 
@@ -25310,6 +25543,21 @@ msgstr ""
 "à tout moment dans le menu « %1$s »."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26736,6 +26984,12 @@ msgstr "min"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "min"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/fr_FR/LC_MESSAGES/duckduckgo.po
+++ b/locales/fr_FR/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: fr_FR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1018,8 +1018,8 @@ msgstr ""
 "AI Chat vous permet d'avoir des conversations anonymes avec des modèles de "
 "chat IA tiers. La désactivation de cette option masquera la fonctionnalité "
 "AI Chat sur DuckDuckGo Search. Vous pouvez toujours accéder à l'AI Chat "
-"lorsque ce paramètre est désactivé en consultant %1$sduckduckgo.com/"
-"aichat%2$s."
+"lorsque ce paramètre est désactivé en consultant "
+"%1$sduckduckgo.com/aichat%2$s."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1228,7 +1228,7 @@ msgstr "À propos de nos publicités"
 #. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
 msgctxt "Modal header for chat history with sync information"
 msgid "About Chat History with Sync & Backup"
-msgstr ""
+msgstr "À propos de l'historique des discussions avec Sync & Backup"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
@@ -1363,7 +1363,7 @@ msgstr "Publicité suspecte"
 #. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
 msgctxt "Button to open menu for attaching images or page context to AI chat"
 msgid "Add"
-msgstr ""
+msgstr "Ajouter"
 
 # smartling.placeholder_format=C
 #. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
@@ -1371,7 +1371,7 @@ msgctxt ""
 "Primary button that attaches the tabs the user checked in the tab picker "
 "dialog"
 msgid "Add"
-msgstr ""
+msgstr "Ajouter"
 
 # smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
@@ -1406,13 +1406,13 @@ msgstr "Ajoutez DuckDuckGo à %1$s"
 msgctxt ""
 "Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
 msgid "Add File"
-msgstr ""
+msgstr "Ajouter un fichier"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
 msgid "Add Image"
-msgstr ""
+msgstr "Ajouter une image"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
@@ -1420,7 +1420,7 @@ msgctxt ""
 "Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
 "item)"
 msgid "Add Image or File"
-msgstr ""
+msgstr "Ajouter une image ou un fichier"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1473,7 +1473,7 @@ msgctxt ""
 "Open the tab picker to attach browser tab content to the AI chat message "
 "(attach dropdown menu item)"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Ajouter des onglets"
 
 # smartling.placeholder_format=C
 #. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
@@ -1481,7 +1481,7 @@ msgctxt ""
 "Title and accessible name of the tab-picker dialog opened from the attach "
 "dropdown menu"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Ajouter des onglets"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1493,8 +1493,7 @@ msgstr "Ajouter un champ de recherche %1$s à votre site !"
 #. Prompt to add locations on a map in order to get directions.
 msgctxt "directions"
 msgid "Add a starting point and destination to find a route."
-msgstr ""
-"Ajoutez un lieu de départ et une destination pour trouver un itinéraire."
+msgstr "Ajoutez un lieu de départ et une destination pour trouver un itinéraire."
 
 # smartling.placeholder_format=C
 #. Label on the AI model card indicating the model supports file uploads.
@@ -1573,7 +1572,7 @@ msgstr "Ajout des touches finales"
 #. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
 msgctxt "Aria label for the additional instructions textarea"
 msgid "Additional instructions"
-msgstr ""
+msgstr "Instructions supplémentaires"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1885,7 +1884,7 @@ msgstr "C'est fait !"
 #. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the read-only textarea listing all AI instructions"
 msgid "All instructions"
-msgstr ""
+msgstr "Toutes les instructions"
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2324,8 +2323,7 @@ msgstr ""
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr ""
-"Voulez-vous vraiment effacer cette conversation et en commencer une autre ?"
+msgstr "Voulez-vous vraiment effacer cette conversation et en commencer une autre ?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2653,21 +2651,18 @@ msgstr "Audio"
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"Une fois le chat terminé, le son n'est conservé ni par nous ni par OpenAI."
+msgstr "Une fois le chat terminé, le son n'est conservé ni par nous ni par OpenAI."
 
 # smartling.placeholder_format=C
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"Une fois le chat terminé, le son n'est conservé ni par nous ni par OpenAI."
+msgstr "Une fois le chat terminé, le son n'est conservé ni par nous ni par OpenAI."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"Une fois le chat transcrit, le son n'est conservé ni par nous ni par OpenAI."
+msgstr "Une fois le chat transcrit, le son n'est conservé ni par nous ni par OpenAI."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2969,8 +2964,8 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 "Avant de stocker ce rapport, DuckDuckGo anonymisera votre conversation en "
-"supprimant les données à caractère personnel comme les noms, les adresses e-"
-"mail et les métadonnées d'identification."
+"supprimant les données à caractère personnel comme les noms, les adresses "
+"e-mail et les métadonnées d'identification."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3106,8 +3101,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr ""
-"La liste de blocage n'est pas exhaustive et peut contenir des inexactitudes."
+msgstr "La liste de blocage n'est pas exhaustive et peut contenir des inexactitudes."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3123,8 +3117,7 @@ msgstr "Bloquer ce site dans tous les résultats"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr ""
-"Bloquez les traqueurs et prenez le contrôle de vos données personnelles"
+msgstr "Bloquez les traqueurs et prenez le contrôle de vos données personnelles"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3472,8 +3465,7 @@ msgstr "En cliquant sur « %1$s », vous acceptez nos %2$s."
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr ""
-"En cliquant sur « %1$s », vous acceptez la %2$s et les %3$s de Duck.ai."
+msgstr "En cliquant sur « %1$s », vous acceptez la %2$s et les %3$s de Duck.ai."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3629,7 +3621,7 @@ msgctxt ""
 "Secondary button that dismisses the tab picker dialog without attaching "
 "anything"
 msgid "Cancel"
-msgstr ""
+msgstr "Annuler"
 
 # smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
@@ -3866,8 +3858,7 @@ msgstr "Change l'affichage de l'URL des résultats"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr ""
-"Change l'affichage de l'en-tête ainsi que son comportement lors du défilement"
+msgstr "Change l'affichage de l'en-tête ainsi que son comportement lors du défilement"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -4132,7 +4123,7 @@ msgstr "La réponse du chat est offensante"
 #. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
 msgctxt "Chat history about modal list item headline"
 msgid "Chat storage varies by browser"
-msgstr ""
+msgstr "Le stockage des discussions varie selon le navigateur"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4144,7 +4135,7 @@ msgstr "Discuter avec %1$s"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Chat with popular AI models, anonymized by us."
-msgstr ""
+msgstr "Discutez avec des modèles d'IA populaires, anonymisés par nos soins."
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4171,6 +4162,9 @@ msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
 msgstr ""
+"Les discussions sont stockées en toute sécurité sur le serveur de DuckDuckGo "
+"grâce à un cryptage de bout en bout. Personne d'autre que vous ne peut voir "
+"vos données, pas même nous."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4361,8 +4355,7 @@ msgstr "Choix de modèles d'IA, y compris %1$s et %2$s"
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr ""
-"Choisissez %1$sConserver%2$s pour continuer à protéger votre confidentialité."
+msgstr "Choisissez %1$sConserver%2$s pour continuer à protéger votre confidentialité."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -4730,8 +4723,7 @@ msgstr "Cliquez sur %1$sParamètres%2$s dans le menu déroulant."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Cliquez sur %1$sUtiliser les pages Web actuelles%2$s puis sur %3$sOK%4$s."
+msgstr "Cliquez sur %1$sUtiliser les pages Web actuelles%2$s puis sur %3$sOK%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -5798,7 +5790,7 @@ msgstr "Série actuelle"
 #. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
 msgctxt "Suffix label indicating a tab is the currently active browser tab"
 msgid "Current Tab"
-msgstr ""
+msgstr "Onglet actuel"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
@@ -6154,7 +6146,7 @@ msgstr "Supprimer les discussions datant de plus de 30 jours"
 #. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
 msgctxt "Button text in the modal for deleting all recent chats"
 msgid "Delete Chats and Shared Links"
-msgstr ""
+msgstr "Supprimer les discussions et les liens partagés"
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6293,8 +6285,7 @@ msgstr ""
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
 msgctxt "settings"
 msgid "Deleting cookies will reset these settings."
-msgstr ""
-"La suppression des cookies aura pour effet de réinitialiser ces paramètres."
+msgstr "La suppression des cookies aura pour effet de réinitialiser ces paramètres."
 
 # smartling.placeholder_format=C
 msgid "Democratic People's Republic of Korea"
@@ -6316,8 +6307,7 @@ msgstr "Décrivez les modifications en fonction de l'image"
 #. Placeholder text displayed in the input field when the user can make follow-up edits to a generated image.
 msgctxt "Placeholder text for the image generation input field for follow-ups"
 msgid "Describe changes to continue editing this image"
-msgstr ""
-"Décrivez les modifications souhaitées pour continuer à modifier cette image"
+msgstr "Décrivez les modifications souhaitées pour continuer à modifier cette image"
 
 # smartling.placeholder_format=C
 #. Title shown when the user first enters Image Generation mode, prompting them to describe the image they want to create.
@@ -6486,8 +6476,7 @@ msgstr "Désactiver et déconnecter"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr ""
-"Désactiver l'historique des discussions et se déconnecter de Sync & Backup ?"
+msgstr "Désactiver l'historique des discussions et se déconnecter de Sync & Backup ?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6581,7 +6570,7 @@ msgstr "Ignorer la promotion"
 #. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the close button on the survey banner"
 msgid "Dismiss survey"
-msgstr ""
+msgstr "Ignorer l'enquête"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7067,8 +7056,7 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"Duck.ai fonctionne mieux dans notre navigateur DuckDuckGo privé et gratuit !"
+msgstr "Duck.ai fonctionne mieux dans notre navigateur DuckDuckGo privé et gratuit !"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -7159,8 +7147,7 @@ msgstr ""
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
 msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid "Duck.ai may display inaccurate or offensive information."
-msgstr ""
-"Duck.ai est susceptible d'afficher des informations inexactes ou offensantes."
+msgstr "Duck.ai est susceptible d'afficher des informations inexactes ou offensantes."
 
 # smartling.placeholder_format=C
 #. Error modal body line 2.
@@ -7176,8 +7163,7 @@ msgstr ""
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai now can read and analyze PDFs. Give it a try!"
-msgstr ""
-"Duck.ai peut désormais lire et analyser des PDF. Essayez par vous-même !"
+msgstr "Duck.ai peut désormais lire et analyser des PDF. Essayez par vous-même !"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown above the chat input only when coming from a DuckAssist grounded response into ungrounded models.
@@ -7778,7 +7764,7 @@ msgstr "Modifier le prompt"
 #. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the message-editing text area"
 msgid "Edit message"
-msgstr ""
+msgstr "Modifier le message"
 
 # smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
@@ -7860,8 +7846,7 @@ msgstr "Activer les fonctionnalités d'IA"
 #. Text explaining how to enable the cloud save feature.
 msgctxt "cloudsave"
 msgid "Enable Cloud Save by entering your existing passphrase."
-msgstr ""
-"Activez la sauvegarde dans le cloud en saisissant votre phrase de passe."
+msgstr "Activez la sauvegarde dans le cloud en saisissant votre phrase de passe."
 
 # smartling.placeholder_format=C
 #. Primary button text in the dictation privacy consent modal to enable dictation.
@@ -8010,7 +7995,7 @@ msgstr "Modèle chiffré"
 #. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
 msgctxt "Share modal info bullet about encryption"
 msgid "Encrypted so DuckDuckGo can't read your chat."
-msgstr ""
+msgstr "C'est crypté, donc DuckDuckGo ne peut pas lire votre discussion."
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8128,15 +8113,13 @@ msgstr ""
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access"
-msgstr ""
-"Assurez-vous que votre navigateur est autorisé à accéder à la localisation"
+msgstr "Assurez-vous que votre navigateur est autorisé à accéder à la localisation"
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr ""
-"Vérifiez que votre navigateur est autorisé à accéder à la localisation."
+msgstr "Vérifiez que votre navigateur est autorisé à accéder à la localisation."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -8599,8 +8582,8 @@ msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
 msgstr ""
-"Ajustez les paramètres ci-dessous comme bon vous semble. Ensuite, copiez-"
-"collez le code dans votre site."
+"Ajustez les paramètres ci-dessous comme bon vous semble. Ensuite, "
+"copiez-collez le code dans votre site."
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8677,8 +8660,7 @@ msgstr "Filtres inefficaces"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Filters out AI-generated images from image search results"
-msgstr ""
-"Filtre les images générées par l'IA des résultats de recherche d'images"
+msgstr "Filtre les images générées par l'IA des résultats de recherche d'images"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8735,8 +8717,7 @@ msgstr "Vous trouverez <b>%1$s</b> dans votre dossier de téléchargements"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr ""
-"Cherchez DuckDuckGo dans la liste et cliquez sur %1$sDéfinir par défaut%2$s"
+msgstr "Cherchez DuckDuckGo dans la liste et cliquez sur %1$sDéfinir par défaut%2$s"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8847,8 +8828,7 @@ msgstr ""
 #. Privacy reassurance and instructions intro.
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
-msgstr ""
-"Suivez ces étapes pour déplacer vos discussions vers le nouveau Duck.ai"
+msgstr "Suivez ces étapes pour déplacer vos discussions vers le nouveau Duck.ai"
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8859,7 +8839,7 @@ msgstr "Question de suivi"
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
-msgstr ""
+msgstr "Les messages complémentaires restent privés."
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -9081,8 +9061,8 @@ msgid ""
 "strong>."
 msgstr ""
 "Dans la barre de menu de l'application sur Mac, sélectionnez "
-"<strong>DuckDuckGo</strong> &gt; <strong>Rechercher des mises à jour…</"
-"strong>, puis sélectionnez <strong>Installer la mise à jour</strong>."
+"<strong>DuckDuckGo</strong> &gt; <strong>Rechercher des mises à "
+"jour…</strong>, puis sélectionnez <strong>Installer la mise à jour</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9383,7 +9363,7 @@ msgstr ""
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
 msgctxt "Tooltip on the header logo for sunglasses searches"
 msgid "Get DuckDuckGo sunglasses and other gear."
-msgstr ""
+msgstr "Procurez-vous des lunettes de soleil DuckDuckGo et d'autres articles."
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9559,8 +9539,8 @@ msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, Personal Information Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"Bénéficiez de notre VPN sécurisé sans journalisation, du chat avancé Duck."
-"ai, de Personal Information Removal et d'Identity Theft Restoration."
+"Bénéficiez de notre VPN sécurisé sans journalisation, du chat avancé "
+"Duck.ai, de Personal Information Removal et d'Identity Theft Restoration."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
@@ -9727,8 +9707,7 @@ msgstr ""
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr ""
-"Accédez à %1$sConfidentialité et sécurité > Services de localisation%2$s"
+msgstr "Accédez à %1$sConfidentialité et sécurité > Services de localisation%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -10005,8 +9984,7 @@ msgstr "Guatemala"
 #. Text for a prompt suggestion for guiding through the basic steps of replacing a window wiper.
 msgctxt "Full sentence for learning a new skill"
 msgid "Guide me through the basic steps of replacing a window wiper."
-msgstr ""
-"Explique-moi les principales étapes à suivre pour remplacer un essuie-glace."
+msgstr "Explique-moi les principales étapes à suivre pour remplacer un essuie-glace."
 
 # smartling.placeholder_format=C
 msgid "Guinea"
@@ -10206,8 +10184,7 @@ msgstr "Aide-nous à améliorer DuckDuckGo"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr ""
-"Aidez-nous à améliorer les recherches DuckDuckGo grâce à vos commentaires"
+msgstr "Aidez-nous à améliorer les recherches DuckDuckGo grâce à vos commentaires"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -10265,8 +10242,7 @@ msgstr "Aidez votre famille et vos ami(e)s à rejoindre le côté Duck !"
 #. Text description for the Spread card in the SERP footer
 msgctxt "footer_card"
 msgid "Help your friends and family take back their privacy!"
-msgstr ""
-"Aidez vos amis et votre famille à reprendre le contrôle de leur vie privée !"
+msgstr "Aidez vos amis et votre famille à reprendre le contrôle de leur vie privée !"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -10634,7 +10610,7 @@ msgstr "Comment ça fonctionne"
 #. Headline in chat history about modals for the temporary encrypted server storage explanation.
 msgctxt "Chat history about modal list item headline"
 msgid "How it works"
-msgstr ""
+msgstr "Comment ça fonctionne"
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -10674,8 +10650,7 @@ msgstr "À quelle fréquence souhaitez-vous voir des réponses %1$s ?"
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How often do you want to see AI-assisted answers?"
-msgstr ""
-"À quelle fréquence souhaitez-vous voir des réponses assistées par l’IA ?"
+msgstr "À quelle fréquence souhaitez-vous voir des réponses assistées par l’IA ?"
 
 # smartling.placeholder_format=C
 #. Section title above the frequency radio options in the Search Assist settings modal.
@@ -10964,8 +10939,7 @@ msgstr "Les prompts d’image doivent respecter les %1$s"
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
-msgstr ""
-"Les prompts relatifs aux images doivent être conformes aux %1$s de Duck.ai."
+msgstr "Les prompts relatifs aux images doivent être conformes aux %1$s de Duck.ai."
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11485,8 +11459,7 @@ msgstr "Cela peut prendre quelques minutes."
 #. Body text of a card that promotes installing the DuckDuckGo desktop browser.
 msgctxt "new tab page"
 msgid "It's fast, free, and gives you even more online protection."
-msgstr ""
-"Il est rapide, gratuit et vous offre encore plus de protection en ligne."
+msgstr "Il est rapide, gratuit et vous offre encore plus de protection en ligne."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -12100,6 +12073,8 @@ msgstr "Le lien expire dans 7 jours."
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
+"Le lien expire dans 7 jours. Les personnes peuvent enregistrer une copie de "
+"la discussion."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -12115,8 +12090,7 @@ msgstr "Liens :"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
-"Liste les outils, le matériel ou les prérequis dont j'ai besoin pour cela."
+msgstr "Liste les outils, le matériel ou les prérequis dont j'ai besoin pour cela."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -14231,7 +14205,7 @@ msgstr "C'est bon, je l'ai !"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "OPTIONAL"
-msgstr ""
+msgstr "FACULTATIF"
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -14361,8 +14335,7 @@ msgstr "Oman"
 #. http://i.imgur.com/zQWKLIm.png
 msgctxt "settings"
 msgid "Omits objectionable (mostly adult) material"
-msgstr ""
-"Omet le contenu à caractère sensible (principalement du contenu pour adulte)"
+msgstr "Omet le contenu à caractère sensible (principalement du contenu pour adulte)"
 
 # smartling.placeholder_format=C
 msgid "On"
@@ -14581,8 +14554,7 @@ msgstr "Ouvrir %1$sParamètres%2$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open 'Location', and ensure location is %senabled%s."
-msgstr ""
-"Ouvrez « Localisation » et vérifiez que la localisation est %1$sactivée%2$s."
+msgstr "Ouvrez « Localisation » et vérifiez que la localisation est %1$sactivée%2$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -14731,8 +14703,7 @@ msgstr "Ouvrir le volet « Comment fonctionne Duck.ai »"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Ouvrez le menu Safari et sélectionnez %1$sRéglages pour DuckDuckGo...%2$s"
+msgstr "Ouvrez le menu Safari et sélectionnez %1$sRéglages pour DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -15498,8 +15469,7 @@ msgstr "Épinglé"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
-"Les discussions épinglées apparaîtront en haut de vos discussions récentes."
+msgstr "Les discussions épinglées apparaîtront en haut de vos discussions récentes."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -16378,7 +16348,7 @@ msgstr "Protégé"
 #. Headline in sync-enabled chat history about modals explaining encrypted server storage.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Protected with end-to-end encryption"
-msgstr ""
+msgstr "Protection par un cryptage de bout en bout"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -16517,7 +16487,7 @@ msgstr "Classements"
 #. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
 msgctxt "star rating on a product"
 msgid "Rated %s out of %s"
-msgstr ""
+msgstr "Note de %1$s sur %2$s"
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -16610,8 +16580,7 @@ msgstr "IA de raisonnement avec modération intégrée moyenne"
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr ""
-"Le raisonnement peut donner de meilleures réponses aux questions complexes."
+msgstr "Le raisonnement peut donner de meilleures réponses aux questions complexes."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
@@ -16996,8 +16965,7 @@ msgstr "Mémoriser mon choix"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Se souvenir de mon choix (peut être changé dans %1$s%2$s%3$sParamètres%4$s)"
+msgstr "Se souvenir de mon choix (peut être changé dans %1$s%2$s%3$sParamètres%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -17459,8 +17427,7 @@ msgstr "Avis"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
-"Réécris cette recette pour l'adapter à un nombre de portions différent."
+msgstr "Réécris cette recette pour l'adapter à un nombre de portions différent."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -17769,7 +17736,7 @@ msgstr "Enregistrez vos discussions sur tous vos appareils."
 #. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
 msgctxt "Chat history about modal list item headline"
 msgid "Save your chats on this device"
-msgstr ""
+msgstr "Enregistrez vos discussions sur cet appareil"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
@@ -17947,8 +17914,7 @@ msgstr ""
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down and locate %syour browser%s in the list."
-msgstr ""
-"Faites défiler la liste vers le bas et localisez %1$svotre navigateur%2$s."
+msgstr "Faites défiler la liste vers le bas et localisez %1$svotre navigateur%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -17989,7 +17955,7 @@ msgctxt ""
 "Placeholder and accessibility label for the search input in the tab picker "
 "dialog"
 msgid "Search"
-msgstr ""
+msgstr "Rechercher"
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18531,35 +18497,31 @@ msgstr "Sélectionner %1$s%2$s%3$s, puis %4$sMoteur de recherche%5$s"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
-msgstr ""
-"Sélectionnez %1$s« Réglages pour ce site Web... »%2$s dans le menu Safari."
+msgstr "Sélectionnez %1$s« Réglages pour ce site Web... »%2$s dans le menu Safari."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Selectionnez %1$sPersonnaliser%2$s et saisissez %3$shttps://duckduckgo."
-"com%4$s dans le champ de saisie"
+"Selectionnez %1$sPersonnaliser%2$s et saisissez "
+"%3$shttps://duckduckgo.com%4$s dans le champ de saisie"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Sélectionnez %1$sDuckDuckGo%2$s, puis cliquez sur %3$sAjouter par défaut%4$s!"
+msgstr "Sélectionnez %1$sDuckDuckGo%2$s, puis cliquez sur %3$sAjouter par défaut%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"Sélectionnez %1$sDuckDuckGo%2$s et cliquez sur %3$sDéfinir par défaut%4$s"
+msgstr "Sélectionnez %1$sDuckDuckGo%2$s et cliquez sur %3$sDéfinir par défaut%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"Sélectionnez %1$sDuckDuckGo%2$s et cliquez sur %3$sDéfinir par défaut%4$s."
+msgstr "Sélectionnez %1$sDuckDuckGo%2$s et cliquez sur %3$sDéfinir par défaut%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -18600,8 +18562,7 @@ msgstr "Sélectionnez %1$sDuckDuckGo%2$s!"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr ""
-"Sélectionnez %1$sModifier les moteurs de recherche…%2$sdans le menu déroulant"
+msgstr "Sélectionnez %1$sModifier les moteurs de recherche…%2$sdans le menu déroulant"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18675,8 +18636,7 @@ msgstr "Sélectionnez %1$sRéglages%2$s, puis %3$sRéglages avancés%4$s"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr ""
-"Sélectionnez %1$sRéglages%2$s, puis %3$sMoteur de recherche par défaut%4$s"
+msgstr "Sélectionnez %1$sRéglages%2$s, puis %3$sMoteur de recherche par défaut%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -18737,8 +18697,7 @@ msgstr "Sélectionnez tous les carrés contenant un canard :"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select an option to %sallow%s location access"
-msgstr ""
-"Sélectionnez une option pour %1$sautoriser%2$s l'accès à la localisation"
+msgstr "Sélectionnez une option pour %1$sautoriser%2$s l'accès à la localisation"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -18773,8 +18732,7 @@ msgstr "Texte sélectionné de %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr ""
-"Le texte sélectionné est trop long. Réessayez avec une sélection plus courte."
+msgstr "Le texte sélectionné est trop long. Réessayez avec une sélection plus courte."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -19198,7 +19156,7 @@ msgstr "Acheter"
 #. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
 msgctxt "Button in the merchandise logo modal (mobile)"
 msgid "Shop Now"
-msgstr ""
+msgstr "Acheter"
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -19494,8 +19452,8 @@ msgstr "Afficher la barre latérale"
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
-"Découvrez des conseils étape par étape pour tirer le meilleur parti de Duck."
-"ai."
+"Découvrez des conseils étape par étape pour tirer le meilleur parti de "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -19642,8 +19600,7 @@ msgstr "Montre l'arrière-plan du bouton de recherche"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message on top of the search results page"
-msgstr ""
-"Affiche un message de bienvenue en haut de la page des résultats de recherche"
+msgstr "Affiche un message de bienvenue en haut de la page des résultats de recherche"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19850,8 +19807,7 @@ msgstr "Résolvez des problèmes complexes grâce au mode de raisonnement !"
 #. Text for a promotional card that encourages users to try the reasoning mode on complex problems which thinks longer to hopefully provide a more accurate answer.
 msgctxt "Promotional text for reasoning mode"
 msgid "Solve complex problems with the new reasoning mode!"
-msgstr ""
-"Résolvez des problèmes complexes grâce au nouveau mode de raisonnement !"
+msgstr "Résolvez des problèmes complexes grâce au nouveau mode de raisonnement !"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the reasoning mode on complex problems which thinks longer to hopefully provide a more accurate answer.
@@ -19879,8 +19835,7 @@ msgstr "Une erreur s'est produite"
 #. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
 msgctxt "Generic toast for share view load failures"
 msgid "Something went wrong loading this shared chat."
-msgstr ""
-"Une erreur s'est produite lors du chargement de cette discussion partagée."
+msgstr "Une erreur s'est produite lors du chargement de cette discussion partagée."
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -19924,8 +19879,7 @@ msgstr "Parfois"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr ""
-"Désolé, je ne peux pas vous aider, veuillez décrire votre image différemment."
+msgstr "Désolé, je ne peux pas vous aider, veuillez décrire votre image différemment."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -20264,8 +20218,7 @@ msgstr "Reste sur DuckDuckGo"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr ""
-"Restez protégé(e) et informé(e) avec notre newsletter sur la confidentialité."
+msgstr "Restez protégé(e) et informé(e) avec notre newsletter sur la confidentialité."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -20320,8 +20273,7 @@ msgstr "Arrêtez les traqueurs qui se cachent sur d'autres sites Web."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Arrêtez la plupart des traqueurs qui se cachent sur d'autres sites Web."
+msgstr "Arrêtez la plupart des traqueurs qui se cachent sur d'autres sites Web."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20411,8 +20363,8 @@ msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
 msgstr ""
-"Abonnez-vous à DuckDuckGo pour débloquer des limites plus élevées dans Duck."
-"ai, ou revenez plus tard pour créer plus d'images."
+"Abonnez-vous à DuckDuckGo pour débloquer des limites plus élevées dans "
+"Duck.ai, ou revenez plus tard pour créer plus d'images."
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -20747,8 +20699,7 @@ msgstr "Changer de modèle"
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
-msgstr ""
-"Passez cette conversation à un modèle gratuit ou attendez jusqu’au %1$s."
+msgstr "Passez cette conversation à un modèle gratuit ou attendez jusqu’au %1$s."
 
 # smartling.placeholder_format=C
 #. Button that switches the conversation to the second-opinion model. %s is the model name.
@@ -20888,6 +20839,8 @@ msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
 msgstr ""
+"Sync & Backup enregistre davantage de vos discussions et les synchronise sur "
+"tous vos appareils."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20948,8 +20901,8 @@ msgstr ""
 "%1$s\n"
 "\n"
 "Comment fonctionne ce code ?\n"
-"1. Accédez à Duck.ai dans votre navigateur et ouvrez les paramètres de Duck."
-"ai.\n"
+"1. Accédez à Duck.ai dans votre navigateur et ouvrez les paramètres de "
+"Duck.ai.\n"
 "2. Sélectionnez « Activer Sync & Backup », puis « Récupérer les données "
 "synchronisées »\n"
 "3. Copiez le code de récupération ci-dessus et collez-le là où il est écrit "
@@ -21011,7 +20964,7 @@ msgstr "Synchronisez vos discussions sur tous vos appareils."
 #. Headline in sync-enabled chat history about modals explaining cross-device sync.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Sync your chats across all your devices"
-msgstr ""
+msgstr "Synchronisez vos discussions sur tous vos appareils"
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21337,15 +21290,13 @@ msgstr "Merci pour vos commentaires !"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row!"
-msgstr ""
-"Merci pour votre patience pendant que nous mettons les choses en ordre !"
+msgstr "Merci pour votre patience pendant que nous mettons les choses en ordre !"
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row."
-msgstr ""
-"Merci pour votre patience pendant que nous mettons les choses en ordre."
+msgstr "Merci pour votre patience pendant que nous mettons les choses en ordre."
 
 # smartling.placeholder_format=C
 #. Message indicating that the open lock icon in the address bar means that a website is not secure.
@@ -21390,8 +21341,7 @@ msgstr "Les fichiers joints dépassent la limite totale de taille de %1$s Mo."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
 msgid "The audio could not be processed. Please try recording again."
-msgstr ""
-"L'audio n'a pas pu être traité. Veuillez essayer d'enregistrer à nouveau."
+msgstr "L'audio n'a pas pu être traité. Veuillez essayer d'enregistrer à nouveau."
 
 # smartling.placeholder_format=C
 #. Second paragraph explaining where the encryption key is stored on the entry screen.
@@ -21416,8 +21366,7 @@ msgstr ""
 #. Description explaining that the AI model provider does not store any chat data on their servers.
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid "The model provider does not save this chat on their servers."
-msgstr ""
-"Le fournisseur de modèles n'enregistre pas cette discussion sur ses serveurs."
+msgstr "Le fournisseur de modèles n'enregistre pas cette discussion sur ses serveurs."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -21477,8 +21426,7 @@ msgstr "Thèmes"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "There was an error displaying the search results."
-msgstr ""
-"Une erreur s'est produite lors de l'affichage des résultats de recherche."
+msgstr "Une erreur s'est produite lors de l'affichage des résultats de recherche."
 
 # smartling.placeholder_format=C
 #. Error message displayed when there was an issue in saving the chat locally to the browser's storage
@@ -21616,12 +21564,14 @@ msgid ""
 "This chat and its generated images become public when you create and copy "
 "the link."
 msgstr ""
+"Cette discussion et les images qu'elle génère deviennent publiques lorsque "
+"vous créez et copiez le lien."
 
 # smartling.placeholder_format=C
 #. Explains that creating and copying a share link makes the selected chat content public.
 msgctxt "Share modal info bullet about public access"
 msgid "This chat becomes public when you create and copy the link."
-msgstr ""
+msgstr "Cette discussion devient publique lorsque vous créez et copiez le lien."
 
 # smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
@@ -21698,15 +21648,13 @@ msgstr ""
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
-msgstr ""
-"Ce fichier est trop volumineux. La taille maximale du fichier est de %1$s Mo"
+msgstr "Ce fichier est trop volumineux. La taille maximale du fichier est de %1$s Mo"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB."
-msgstr ""
-"Ce fichier est trop volumineux. La taille maximale du fichier est de %1$s Mo."
+msgstr "Ce fichier est trop volumineux. La taille maximale du fichier est de %1$s Mo."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -21744,8 +21692,7 @@ msgstr ""
 #. Error message displayed when the user tries to upload an unsupported file type and we know which types are accepted. Placeholder is a single accepted type. E.g. This file type is not supported, please attach a PDF
 msgctxt "Error message when an uploaded file type is not supported"
 msgid "This file type is not supported, please attach a %s."
-msgstr ""
-"Ce type de fichier n’est pas pris en charge ; veuillez joindre un %1$s."
+msgstr "Ce type de fichier n’est pas pris en charge ; veuillez joindre un %1$s."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -21835,8 +21782,8 @@ msgid ""
 "Other model providers follow a zero data retention model."
 msgstr ""
 "Ce fournisseur de modèles supprime les données associées à cette discussion "
-"dans les 30 jours. D'autres fournisseurs de modèles suivent un modèle de non-"
-"conservation des données."
+"dans les 30 jours. D'autres fournisseurs de modèles suivent un modèle de "
+"non-conservation des données."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -21956,8 +21903,7 @@ msgstr ""
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Cette page web n'utilise pas de connexion sécurisée et cryptée (HTTPS)."
+msgstr "Cette page web n'utilise pas de connexion sécurisée et cryptée (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -22098,8 +22044,7 @@ msgstr "Souligner le titre"
 # smartling.placeholder_format=C
 #. Informative header on a list of steps for the user to take to disable their adblocker
 msgid "To allowlist DuckDuckGo in other ad blocker extensions:"
-msgstr ""
-"Pour autoriser DuckDuckGo dans d'autres extensions de blocage de publicités :"
+msgstr "Pour autoriser DuckDuckGo dans d'autres extensions de blocage de publicités :"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to Duck.ai’s Privacy Policy and Terms of Service'
@@ -22113,8 +22058,7 @@ msgstr "Pour continuer, vous devez accepter la %1$s et les %2$s de Duck.ai"
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr ""
-"Pour continuer, vous devez accepter la %1$s et les %2$s de DuckDuckGo AI Chat"
+msgstr "Pour continuer, vous devez accepter la %1$s et les %2$s de DuckDuckGo AI Chat"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -22180,15 +22124,15 @@ msgstr "Auj."
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
-msgstr ""
+msgstr "Passez au chat IA privé ou %1$sdésactivez dans les paramètres%2$s."
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
-"Activez cette option pour essayer le chat privé avec l’IA ou %1$sdésactivez-"
-"la dans le menu %2$s.%3$s"
+"Activez cette option pour essayer le chat privé avec l’IA ou "
+"%1$sdésactivez-la dans le menu %2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -22536,8 +22480,7 @@ msgstr "Essayez %1$s pour ne plus voir de messages comme celui-ci."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Essayez %1$s, notre premier modèle sans aucune visibilité du fournisseur."
+msgstr "Essayez %1$s, notre premier modèle sans aucune visibilité du fournisseur."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -22678,16 +22621,14 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Essayez d'activer la géolocalisation anonyme pour des résultats plus précis."
+msgstr "Essayez d'activer la géolocalisation anonyme pour des résultats plus précis."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"N’hésitez pas à essayer chaque modèle pour obtenir des réponses différentes."
+msgstr "N’hésitez pas à essayer chaque modèle pour obtenir des réponses différentes."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -22867,15 +22808,13 @@ msgstr "Essayez les logiciels open source %1$s et %2$s récemment ajoutés"
 #. Text for a promotional card that encourages users to try the recently added open-source AI models Llama 3.1 and Mixtral.
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source Llama 3.1 and Mixtral"
-msgstr ""
-"Essayez les logiciels open source Llama 3.1 et Mixtral récemment ajoutés"
+msgstr "Essayez les logiciels open source Llama 3.1 et Mixtral récemment ajoutés"
 
 # smartling.placeholder_format=C
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
-msgstr ""
-"Essayez ces prompts pour commencer ou saisissez les vôtres ci-dessous :"
+msgstr "Essayez ces prompts pour commencer ou saisissez les vôtres ci-dessous :"
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -22883,8 +22822,7 @@ msgctxt ""
 "Description shown when a chat search in Duck.ai returns no matching chats, "
 "suggesting the user rephrase their query"
 msgid "Try using a different search term or phrase."
-msgstr ""
-"Essayez d'utiliser un autre terme ou une autre expression de recherche."
+msgstr "Essayez d'utiliser un autre terme ou une autre expression de recherche."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, text prompting the user to try their prompt with a different AI model.
@@ -23072,8 +23010,7 @@ msgstr "Activez la « position exacte » pour des résultats plus précis."
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr ""
-"Activez « Utiliser la position exacte » pour des résultats plus précis."
+msgstr "Activez « Utiliser la position exacte » pour des résultats plus précis."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -23266,20 +23203,18 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Sous %1$sAu démarrage%2$s, séléctionnez %3$sPage d'accueil%4$s et "
-"saisissez : https://duckduckgo.com"
+"Sous %1$sAu démarrage%2$s, séléctionnez %3$sPage d'accueil%4$s et saisissez "
+": https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"Sous %1$sOuvrir avec%2$s, sélectionnez %3$sUne ou des pages spécifiques%4$s"
+msgstr "Sous %1$sOuvrir avec%2$s, sélectionnez %3$sUne ou des pages spécifiques%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"Sous %1$sDÉMARRAGE > Page d'accueil%2$s saisissez : https://duckduckgo.com"
+msgstr "Sous %1$sDÉMARRAGE > Page d'accueil%2$s saisissez : https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23840,8 +23775,7 @@ msgstr "Vous utilisez le Wi-Fi public ? Utilisez notre VPN."
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr ""
-"Utilisez le Fire Button pour supprimer une conversation de l’historique."
+msgstr "Utilisez le Fire Button pour supprimer une conversation de l’historique."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -24004,8 +23938,7 @@ msgstr "Voir les prix de votre séjour"
 # smartling.placeholder_format=C
 #. A description for the ads tooltip that explains that viewing ads is privacy protected by DuckDuckGo.
 msgid "Viewing ads is privacy protected by DuckDuckGo."
-msgstr ""
-"DuckDuckGo protège la confidentialité lors de la consultation des publicités."
+msgstr "DuckDuckGo protège la confidentialité lors de la consultation des publicités."
 
 # smartling.placeholder_format=C
 msgctxt "Ads GDPR, internal use only. Do not change"
@@ -24034,6 +23967,9 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Yelp's ad network."
 msgstr ""
+"DuckDuckGo protège la confidentialité lors de la consultation des "
+"publicités. Les clics sur les publicités sont gérés par le réseau "
+"publicitaire de Yelp."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -24093,9 +24029,9 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"Visitez Duck.ai dans votre autre navigateur et ouvrez les paramètres de Duck."
-"ai. Sélectionnez « Activer » sous Sync & Backup, puis « Synchroniser avec un "
-"autre appareil ». Ou scannez le code QR figurant sur votre PDF de "
+"Visitez Duck.ai dans votre autre navigateur et ouvrez les paramètres de "
+"Duck.ai. Sélectionnez « Activer » sous Sync & Backup, puis « Synchroniser "
+"avec un autre appareil ». Ou scannez le code QR figurant sur votre PDF de "
 "récupération."
 
 # smartling.placeholder_format=C
@@ -24560,8 +24496,7 @@ msgstr "Nous avons perdu la connexion ; veuillez réessayer plus tard."
 #. We store chats for 15 minutes in the BE. If the user tries to fetch it after the 15 minutes elapsed or if we had an issue saving it we show them this error message so they can re-submit their prompt.
 msgctxt "AI Chat: Error message for unsaved or expired chats saved in sync"
 msgid "We lost the connection. Please try sending your message again."
-msgstr ""
-"Nous avons perdu la connexion. Veuillez réessayer d'envoyer votre message."
+msgstr "Nous avons perdu la connexion. Veuillez réessayer d'envoyer votre message."
 
 # smartling.placeholder_format=C
 #. Message asking the user to disable their ad blocker, with a link to how our ads don't track you. The placeholders are for the start and end tags of that link (e.g. <a href="%">, </a>)
@@ -24852,8 +24787,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai, it's time to import your chats"
-msgstr ""
-"Bienvenue sur le nouveau Duck.ai ; il est temps d'importer vos discussions."
+msgstr "Bienvenue sur le nouveau Duck.ai ; il est temps d'importer vos discussions."
 
 # smartling.placeholder_format=C
 #. Welcome message for new DuckDuckGo users.
@@ -25205,8 +25139,7 @@ msgstr "À quoi cela répond-il ?"
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
-msgstr ""
-"Quelle fonctionnalité souhaiteriez-vous que nous ajoutions ? (facultatif)"
+msgstr "Quelle fonctionnalité souhaiteriez-vous que nous ajoutions ? (facultatif)"
 
 # smartling.placeholder_format=C
 #. Header above a list of types of information that gets saved by the cloud save feature.
@@ -25218,8 +25151,7 @@ msgstr "Quelles informations sont sauvegardées ?"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr ""
-"Quelles questions pourraient être posées lors de l'entretien pour ce poste ?"
+msgstr "Quelles questions pourraient être posées lors de l'entretien pour ce poste ?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -25228,8 +25160,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"À quoi sert le bookmarklet de sauvegarde dans le Cloud Save et en quoi est-"
-"il différent du bookmarklet avec URL de paramétrage ?"
+"À quoi sert le bookmarklet de sauvegarde dans le Cloud Save et en quoi "
+"est-il différent du bookmarklet avec URL de paramétrage ?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -25549,6 +25481,8 @@ msgid ""
 "With chat history on, up to %s of your most recent chats will be saved on "
 "this device."
 msgstr ""
+"Lorsque l'historique des discussions est activé, jusqu'à %1$s de vos "
+"discussions les plus récentes sont enregistrées sur cet appareil."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline in the About Chat History modal.
@@ -25556,6 +25490,8 @@ msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, your most recent chats will be saved on this device."
 msgstr ""
+"Lorsque l'historique des discussions est activé, vos discussions les plus "
+"récentes sont enregistrées sur cet appareil."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -25570,8 +25506,8 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
-"Fonctionne directement depuis votre appareil pour supprimer votre adresse e-"
-"mail, votre nom, votre adresse et plus encore des sites de courtiers en "
+"Fonctionne directement depuis votre appareil pour supprimer votre adresse "
+"e-mail, votre nom, votre adresse et plus encore des sites de courtiers en "
 "données."
 
 # smartling.placeholder_format=C
@@ -25914,8 +25850,7 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr ""
-"Vous pouvez modifier cela à tout moment dans %1$sParamètres de recherche%2$s"
+msgstr "Vous pouvez modifier cela à tout moment dans %1$sParamètres de recherche%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
@@ -25945,8 +25880,7 @@ msgstr "Vous pouvez trouver le"
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
 msgctxt "duckai_migration"
 msgid "You can find the <b>%s</b> file in your downloads folder."
-msgstr ""
-"Vous trouverez le fichier <b>%1$s</b> dans votre dossier de téléchargements."
+msgstr "Vous trouverez le fichier <b>%1$s</b> dans votre dossier de téléchargements."
 
 # smartling.placeholder_format=C
 #. A link to the settings to where the user can hide the private search reminder from the filter bar of search results
@@ -26251,8 +26185,7 @@ msgstr ""
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr ""
-"Vous avez atteint la durée maximale de chat vocal lors d'une seule session."
+msgstr "Vous avez atteint la durée maximale de chat vocal lors d'une seule session."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
@@ -26266,8 +26199,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"Vous avez atteint votre limite d'utilisation de dictée. Réessayez plus tard."
+msgstr "Vous avez atteint votre limite d'utilisation de dictée. Réessayez plus tard."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -26422,8 +26354,8 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"Votre navigateur fournit une liste des sites que vous visitez le plus."
-"DuckDuckGo n'a jamais accès à ces données."
+"Votre navigateur fournit une liste des sites que vous visitez le "
+"plus.DuckDuckGo n'a jamais accès à ces données."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -26689,8 +26621,7 @@ msgstr ""
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
 msgctxt "Body copy on the recover-data success sheet"
 msgid "Your synced chats are being restored to this device."
-msgstr ""
-"Vos discussions synchronisées sont en cours de restauration sur cet appareil."
+msgstr "Vos discussions synchronisées sont en cours de restauration sur cet appareil."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -26758,8 +26689,7 @@ msgstr ""
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr ""
-"Vous avez atteint la limite de chat vocal. Veuillez réessayer plus tard."
+msgstr "Vous avez atteint la limite de chat vocal. Veuillez réessayer plus tard."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -26989,7 +26919,7 @@ msgstr "min"
 #. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the chat options menu button"
 msgid "menu"
-msgstr ""
+msgstr "menu"
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/ga_IE/LC_MESSAGES/duckduckgo.po
+++ b/locales/ga_IE/LC_MESSAGES/duckduckgo.po
@@ -988,6 +988,11 @@ msgstr "Maidir Linn"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1091,6 +1096,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "Tá an fógra amhrasach"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Cuir DuckDuckGo leis"
@@ -1110,6 +1127,24 @@ msgstr "Abair DuckDuckGo agus an cuardach éagsúla"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Cuir DuckDuckGo le %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1148,6 +1183,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1219,6 +1268,11 @@ msgstr "Breiseáin"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1465,6 +1519,11 @@ msgstr "Gach dath"
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2815,6 +2874,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3218,9 +3284,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3236,6 +3312,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4513,6 +4596,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4797,6 +4885,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5135,6 +5228,11 @@ msgstr "Ruaig go deo é"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6032,6 +6130,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6209,6 +6312,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6882,6 +6990,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7300,6 +7413,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8285,6 +8403,11 @@ msgid "How is it anonymous?"
 msgstr "Conas mar atá sé anaithnid?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9452,6 +9575,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11196,6 +11324,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "Tuigim é!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12905,6 +13038,11 @@ msgstr "Cosain do chuid sonraí ar gach gléas."
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -13011,6 +13149,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13999,6 +14142,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14156,6 +14304,13 @@ msgstr "Cuardaigh"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15089,6 +15244,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16441,6 +16601,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16521,6 +16688,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16990,6 +17162,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17404,6 +17590,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18880,6 +19071,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -20043,6 +20241,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21143,6 +21354,11 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "m"
 msgstr "n"
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.
 msgctxt "Aria label for the menu button"

--- a/locales/gd_GB/LC_MESSAGES/duckduckgo.po
+++ b/locales/gd_GB/LC_MESSAGES/duckduckgo.po
@@ -980,6 +980,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1083,6 +1088,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Cuir DuckDuckGo ris"
@@ -1102,6 +1119,24 @@ msgstr "Cuir DuckDuckGo ris mar einnsean-luirg"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Cuir DuckDuckGo ri %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1140,6 +1175,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1211,6 +1260,11 @@ msgstr "Tuilleadain"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1458,6 +1512,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2805,6 +2864,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3206,9 +3272,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3224,6 +3300,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4499,6 +4582,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4783,6 +4871,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5121,6 +5214,11 @@ msgstr "Na seall seo a-rithist"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6019,6 +6117,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6196,6 +6299,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6868,6 +6976,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7286,6 +7399,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8268,6 +8386,11 @@ msgid "How is it anonymous?"
 msgstr "Gun urra? Ciamar?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9430,6 +9553,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11169,6 +11297,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12877,6 +13010,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12983,6 +13121,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13972,6 +14115,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14129,6 +14277,13 @@ msgstr "Lorg"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15057,6 +15212,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16398,6 +16558,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16478,6 +16645,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16938,6 +17110,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17343,6 +17529,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18813,6 +19004,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19975,6 +20173,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21073,6 +21284,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/gl_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/gl_ES/LC_MESSAGES/duckduckgo.po
@@ -985,6 +985,11 @@ msgstr "Sobre nós"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1088,6 +1093,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "Este anuncio é sospeitoso"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Engadir DuckDuckGo"
@@ -1109,6 +1126,24 @@ msgstr "Engadir DuckDuckGo como buscador"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Engadir DuckDuckGo a %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1147,6 +1182,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1218,6 +1267,11 @@ msgstr "Complementos"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1464,6 +1518,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2823,6 +2882,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3223,9 +3289,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3241,6 +3317,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4508,6 +4591,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4792,6 +4880,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5130,6 +5223,11 @@ msgstr "Rexeitar para sempre"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6026,6 +6124,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6203,6 +6306,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6873,6 +6981,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7291,6 +7404,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8278,6 +8396,11 @@ msgid "How is it anonymous?"
 msgstr "Como é anónimo?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9440,6 +9563,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11177,6 +11305,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "De acordo, comprendo!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12888,6 +13021,11 @@ msgstr "Protexa a súa información en calquera dispositivo."
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12994,6 +13132,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13982,6 +14125,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14139,6 +14287,13 @@ msgstr "Buscar"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15070,6 +15225,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16409,6 +16569,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16489,6 +16656,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16956,6 +17128,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17359,6 +17545,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18826,6 +19017,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19985,6 +20183,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21078,6 +21289,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/gu_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/gu_IN/LC_MESSAGES/duckduckgo.po
@@ -980,6 +980,11 @@ msgstr "અમારા વિષે"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1083,6 +1088,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "જાહેરાત શંકાસ્પદ છે"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "DuckDuckGo ઉમેરો"
@@ -1102,6 +1119,24 @@ msgstr ""
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "DuckDuckGo ને %s માં ઉમેરો"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1140,6 +1175,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1211,6 +1260,11 @@ msgstr "ઍડૉનો"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1455,6 +1509,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2802,6 +2861,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3202,9 +3268,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3220,6 +3296,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4477,6 +4560,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4761,6 +4849,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5099,6 +5192,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6003,6 +6101,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6180,6 +6283,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6845,6 +6953,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7263,6 +7376,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8245,6 +8363,11 @@ msgid "How is it anonymous?"
 msgstr "તે કેવી રીતે અનામિક છે?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9398,6 +9521,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11135,6 +11263,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12835,6 +12968,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12941,6 +13079,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13929,6 +14072,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14084,6 +14232,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15001,6 +15156,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16340,6 +16500,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16420,6 +16587,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16880,6 +17052,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17282,6 +17468,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18744,6 +18935,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19893,6 +20091,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20975,6 +21186,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/he_IL/LC_MESSAGES/duckduckgo.po
+++ b/locales/he_IL/LC_MESSAGES/duckduckgo.po
@@ -980,6 +980,11 @@ msgstr "אודותנו"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1083,6 +1088,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "הפרסומת זדונית"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "הוסף את DuckDuckGo"
@@ -1102,6 +1119,24 @@ msgstr "הוסף את DuckDuckGo כמנוע החיפוש"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "הוסף את DuckDuckGo ל%s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1140,6 +1175,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1211,6 +1260,11 @@ msgstr "תוספים"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1455,6 +1509,11 @@ msgstr "כל הצבעים"
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2805,6 +2864,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3205,9 +3271,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3223,6 +3299,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4487,6 +4570,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4771,6 +4859,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5109,6 +5202,11 @@ msgstr "התעלם לתמיד"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6005,6 +6103,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6182,6 +6285,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6848,6 +6956,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7266,6 +7379,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8248,6 +8366,11 @@ msgid "How is it anonymous?"
 msgstr "איך זה אנונימי, בדיוק?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9405,6 +9528,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11143,6 +11271,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "טוב, הבנתי!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12848,6 +12981,11 @@ msgstr "הגן על הנתונים שלך בכל מכשיר."
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12954,6 +13092,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13942,6 +14085,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14100,6 +14248,13 @@ msgstr "חפש"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15017,6 +15172,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16356,6 +16516,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16436,6 +16603,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16896,6 +17068,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17298,6 +17484,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18763,6 +18954,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19914,6 +20112,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21000,6 +21211,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/hi_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/hi_IN/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: hi_IN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -190,8 +190,9 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"%1$s सिर्फ़ Pro प्लान में उपलब्ध है। चैट जारी रखने के लिए इस ब्राउज़र में अपना DuckDuckGo "
-"सब्सक्रिप्शन फिर से अपग्रेड करें, या Plus या मुफ़्त मॉडल पर स्विच करें।"
+"%1$s सिर्फ़ Pro प्लान में उपलब्ध है। चैट जारी रखने के लिए इस ब्राउज़र में "
+"अपना DuckDuckGo सब्सक्रिप्शन फिर से अपग्रेड करें, या Plus या मुफ़्त मॉडल पर "
+"स्विच करें।"
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -201,8 +202,9 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"%1$s सिर्फ़ Pro प्लान में उपलब्ध है। चैट जारी रखने के लिए इस ब्राउज़र में अपना DuckDuckGo "
-"सब्सक्रिप्शन फिर से अपग्रेड करें, या Plus या मुफ़्त मॉडल पर स्विच करें।"
+"%1$s सिर्फ़ Pro प्लान में उपलब्ध है। चैट जारी रखने के लिए इस ब्राउज़र में "
+"अपना DuckDuckGo सब्सक्रिप्शन फिर से अपग्रेड करें, या Plus या मुफ़्त मॉडल पर "
+"स्विच करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -218,8 +220,9 @@ msgid ""
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
 msgstr ""
-"%1$s केवल DuckDuckGo सब्सक्रिप्शन के साथ उपलब्ध है। चैट जारी रखने के लिए इस ब्राउज़र में "
-"अपने सब्सक्रिप्शन को फिर से एक्टिवेट करें, या किसी मुफ़्त मॉडल पर स्विच करें।"
+"%1$s केवल DuckDuckGo सब्सक्रिप्शन के साथ उपलब्ध है। चैट जारी रखने के लिए इस "
+"ब्राउज़र में अपने सब्सक्रिप्शन को फिर से एक्टिवेट करें, या किसी मुफ़्त मॉडल "
+"पर स्विच करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -228,8 +231,8 @@ msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
 msgstr ""
-"%1$s फिलहाल उपलब्ध नहीं है। कृपया किसी अन्य मॉडल पर स्विच करें या बाद में फिर से कोशिश "
-"करें।"
+"%1$s फिलहाल उपलब्ध नहीं है। कृपया किसी अन्य मॉडल पर स्विच करें या बाद में "
+"फिर से कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -305,7 +308,9 @@ msgstr "%1$s रैंकिंग अभी तक उपलब्ध नही
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits 2-5x faster than other models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
-msgstr "%1$s बेसिक मॉडलों की तुलना में 2-5 गुना जल्दी उपयोग सीमा तक पहुंच जाता है। %2$s"
+msgstr ""
+"%1$s बेसिक मॉडलों की तुलना में 2-5 गुना जल्दी उपयोग सीमा तक पहुंच जाता है। "
+"%2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -326,9 +331,9 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$s एक भरोसेमंद एक्ज़ीक्यूशन एनवायरमेंट में चलता है। इसका मतलब है कि मॉडल प्रोवाइडर भी "
-"आपके प्रॉम्प्ट्स या मॉडल के जवाबों को नहीं देख सकता, और न ही इस चैट को अपने सर्वर पर सेव "
-"कर सकता है।"
+"%1$s एक भरोसेमंद एक्ज़ीक्यूशन एनवायरमेंट में चलता है। इसका मतलब है कि मॉडल "
+"प्रोवाइडर भी आपके प्रॉम्प्ट्स या मॉडल के जवाबों को नहीं देख सकता, और न ही इस "
+"चैट को अपने सर्वर पर सेव कर सकता है।"
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -376,7 +381,8 @@ msgstr "%1$s उपयोग किया गया"
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
-"%1$s बेसिक मॉडलों की तुलना में 2-5 गुना तक तेज़ी से लिमिट्स का इस्तेमाल करता है %2$s"
+"%1$s बेसिक मॉडलों की तुलना में 2-5 गुना तक तेज़ी से लिमिट्स का इस्तेमाल करता "
+"है %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -415,8 +421,8 @@ msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
 msgstr ""
-"%1$s %2$s दिन में (%3$s को) Duck.ai से हट जाएगा। उसके बाद, आप इस चैट को जारी रखने "
-"के लिए मॉडल बदल सकते हैं।"
+"%1$s %2$s दिन में (%3$s को) Duck.ai से हट जाएगा। उसके बाद, आप इस चैट को जारी "
+"रखने के लिए मॉडल बदल सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -427,8 +433,8 @@ msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
 msgstr ""
-"%1$s 1 दिन में (%2$s को) Duck.ai से हटने वाला है। उसके बाद, आप इस चैट को जारी रखने के "
-"लिए मॉडल बदल सकते हैं।"
+"%1$s 1 दिन में (%2$s को) Duck.ai से हटने वाला है। उसके बाद, आप इस चैट को "
+"जारी रखने के लिए मॉडल बदल सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -441,8 +447,8 @@ msgstr "%1$s शब्द"
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$sजोड़ें%2$sपर%3$s क्लिक करें %4$sअनुमति दें%5$s पर सही का निशान लगाएं, फिर %6$sठीक "
-"हैं%7$s पर क्लिक करें"
+"%1$sजोड़ें%2$sपर%3$s क्लिक करें %4$sअनुमति दें%5$s पर सही का निशान लगाएं, "
+"फिर %6$sठीक हैं%7$s पर क्लिक करें"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -450,8 +456,8 @@ msgstr ""
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$sअनुमति दें%2$s %3$sपर क्लिक करें %4$sजोड़ें%5$s पर क्लिक करें %6$sअनुमति दें%7$s पर "
-"निशान लगाएं, फिर %8$sओके%9$s पर क्लिक करें"
+"%1$sअनुमति दें%2$s %3$sपर क्लिक करें %4$sजोड़ें%5$s पर क्लिक करें %6$sअनुमति "
+"दें%7$s पर निशान लगाएं, फिर %8$sओके%9$s पर क्लिक करें"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -461,8 +467,8 @@ msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
 msgstr ""
-"%1$s%2$sइंस्टॉलेशन जारी रखें%3$s पर क्लिक करें %4$sजोड़ें%5$s पर क्लिक करें %6$sअनुमति "
-"दें%7$s पर निशान लगाएं, फिर %8$sओके%9$s पर क्लिक करें"
+"%1$s%2$sइंस्टॉलेशन जारी रखें%3$s पर क्लिक करें %4$sजोड़ें%5$s पर क्लिक करें "
+"%6$sअनुमति दें%7$s पर निशान लगाएं, फिर %8$sओके%9$s पर क्लिक करें"
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -503,14 +509,16 @@ msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
 msgstr ""
-"%1$sऔर जानें%2$s कि चैट को DuckDuckGo के सर्वर पर गोपनीय ढंग से कैसे स्टोर किया जाता है।"
+"%1$sऔर जानें%2$s कि चैट को DuckDuckGo के सर्वर पर गोपनीय ढंग से कैसे स्टोर "
+"किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
 msgstr ""
-"आपके डिवाइस पर चैट निजी तौर पर कैसे स्टोर किए जाते हैं, इस बारे में %1$sऔर जानें।%2$s"
+"आपके डिवाइस पर चैट निजी तौर पर कैसे स्टोर किए जाते हैं, इस बारे में %1$sऔर "
+"जानें।%2$s"
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -522,7 +530,9 @@ msgstr "होम स्क्रीन पर DuckDuckGo ऐप आइकन �
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr "%1$sउफ़!%2$s%3$sकुछ गड़बड़ हुई है। कृपया %4$sरीफ्रेश%5$s करें और फिर से कोशिश करें।"
+msgstr ""
+"%1$sउफ़!%2$s%3$sकुछ गड़बड़ हुई है। कृपया %4$sरीफ्रेश%5$s करें और फिर से "
+"कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -873,7 +883,9 @@ msgstr "6 घंटे की उपयोग सीमा पूरी हो �
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr "6 घंटे की उपयोग सीमा पूरी हो गई है। आप %1$s के बाद इस चैट को जारी रख सकते हैं।"
+msgstr ""
+"6 घंटे की उपयोग सीमा पूरी हो गई है। आप %1$s के बाद इस चैट को जारी रख सकते "
+"हैं।"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -881,8 +893,8 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "6-hour usage limit reached. You can keep chatting by using your daily limit."
 msgstr ""
-"6 घंटे की उपयोग सीमा पूरी हो गई है। आप अपनी दैनिक सीमा का इस्तेमाल करके चैटिंग जारी रख "
-"सकते हैं।"
+"6 घंटे की उपयोग सीमा पूरी हो गई है। आप अपनी दैनिक सीमा का इस्तेमाल करके "
+"चैटिंग जारी रख सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes abbreviation
@@ -936,22 +948,26 @@ msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
 msgstr ""
-"नेटवर्क की समस्या की वजह से Search Assist जवाब नहीं दे पा रहा है। कृपया अपना कनेक्शन "
-"जांचें और फिर से कोशिश करें।"
+"नेटवर्क की समस्या की वजह से Search Assist जवाब नहीं दे पा रहा है। कृपया अपना "
+"कनेक्शन जांचें और फिर से कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr "AI Chat का नया वर्ज़न उपलब्ध है! कृपया जारी रखने के लिए इस पेज को रीफ्रेश करें।"
+msgstr ""
+"AI Chat का नया वर्ज़न उपलब्ध है! कृपया जारी रखने के लिए इस पेज को रीफ्रेश "
+"करें।"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr "Duck.ai का नया वर्ज़न उपलब्ध है! कृपया जारी रखने के लिए इस पेज को रीफ्रेश करें।"
+msgstr ""
+"Duck.ai का नया वर्ज़न उपलब्ध है! कृपया जारी रखने के लिए इस पेज को रीफ्रेश "
+"करें।"
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -995,9 +1011,10 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"AI Chat आपको थर्ड-पार्टी AI चैट मॉडल के साथ गुमनाम ढंग से बातचीत करने की सुविधा देता "
-"है। इसे बंद करने से DuckDuckGo Search पर AI Chat फ़ीचर छिप जाएगा। जब यह सेटिंग बंद हो "
-"तब भी आप %1$sduckduckgo.com/aichat%2$s पर जाकर AI Chat का उपयोग कर सकते हैं।"
+"AI Chat आपको थर्ड-पार्टी AI चैट मॉडल के साथ गुमनाम ढंग से बातचीत करने की "
+"सुविधा देता है। इसे बंद करने से DuckDuckGo Search पर AI Chat फ़ीचर छिप "
+"जाएगा। जब यह सेटिंग बंद हो तब भी आप %1$sduckduckgo.com/aichat%2$s पर जाकर AI "
+"Chat का उपयोग कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1058,10 +1075,10 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"AI की सहायता से दिए गए जवाब फिलहाल फ़ॉलोअप सवालों को सीधे सपोर्ट नहीं करते हैं। "
-"हालांकि, हम फ़ॉलोअप सवालों के लिए %1$sDuck.ai%2$s भी ऑफ़र करते हैं और अक्सर उससे लिंक "
-"करते हैं, जो हमारी निजी AI-संचालित चैट सेवा है जो OpenAI, और Anthropic, और अन्य के चैट "
-"मॉडलों को सपोर्ट करती है।"
+"AI की सहायता से दिए गए जवाब फिलहाल फ़ॉलोअप सवालों को सीधे सपोर्ट नहीं करते "
+"हैं। हालांकि, हम फ़ॉलोअप सवालों के लिए %1$sDuck.ai%2$s भी ऑफ़र करते हैं और "
+"अक्सर उससे लिंक करते हैं, जो हमारी निजी AI-संचालित चैट सेवा है जो OpenAI, और "
+"Anthropic, और अन्य के चैट मॉडलों को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1205,7 +1222,7 @@ msgstr "हमारे विज्ञापनों के बारे म�
 #. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
 msgctxt "Modal header for chat history with sync information"
 msgid "About Chat History with Sync & Backup"
-msgstr ""
+msgstr "Sync & Backup वाली चैट हिस्ट्री के बारे में"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
@@ -1252,8 +1269,8 @@ msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
 msgstr ""
-"चैट जारी रखने के लिए इस ब्राउज़र में अपने %1$s को फिर से एक्टिवेट करें, या किसी मुफ़्त मॉडल "
-"पर स्विच करें।"
+"चैट जारी रखने के लिए इस ब्राउज़र में अपने %1$s को फिर से एक्टिवेट करें, या "
+"किसी मुफ़्त मॉडल पर स्विच करें।"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1289,8 +1306,8 @@ msgstr "विज्ञापन"
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
 msgstr ""
-"%1$s के विज्ञापन नेटवर्क द्वारा विज्ञापन क्लिक प्रबंधित किए जाते हैं और इनका उपयोग आपकी "
-"व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
+"%1$s के विज्ञापन नेटवर्क द्वारा विज्ञापन क्लिक प्रबंधित किए जाते हैं और इनका "
+"उपयोग आपकी व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
@@ -1298,8 +1315,8 @@ msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
 msgstr ""
-"Microsoft के विज्ञापन नेटवर्क द्वारा विज्ञापन क्लिक प्रबंधित किए जाते हैं और इनका उपयोग "
-"आपकी व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
+"Microsoft के विज्ञापन नेटवर्क द्वारा विज्ञापन क्लिक प्रबंधित किए जाते हैं और "
+"इनका उपयोग आपकी व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1340,7 +1357,7 @@ msgstr "विज्ञापन सन्देहजनक है"
 #. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
 msgctxt "Button to open menu for attaching images or page context to AI chat"
 msgid "Add"
-msgstr ""
+msgstr "जोड़ें"
 
 # smartling.placeholder_format=C
 #. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
@@ -1348,7 +1365,7 @@ msgctxt ""
 "Primary button that attaches the tabs the user checked in the tab picker "
 "dialog"
 msgid "Add"
-msgstr ""
+msgstr "जोड़ें"
 
 # smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
@@ -1364,7 +1381,8 @@ msgstr "DuckDuckGo एक्सटेंशन जोड़ें"
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
 msgstr ""
-"एक डाउनलोड के साथ अपने ब्राउज़र पर मुफ़्त में DuckDuckGo Privacy Essentials जोड़ें:"
+"एक डाउनलोड के साथ अपने ब्राउज़र पर मुफ़्त में DuckDuckGo Privacy Essentials "
+"जोड़ें:"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1382,13 +1400,13 @@ msgstr "DuckDuckGo को %1$s में जोड़ें"
 msgctxt ""
 "Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
 msgid "Add File"
-msgstr ""
+msgstr "फ़ाइल जोड़ें"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
 msgid "Add Image"
-msgstr ""
+msgstr "इमेज जोड़ें"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
@@ -1396,7 +1414,7 @@ msgctxt ""
 "Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
 "item)"
 msgid "Add Image or File"
-msgstr ""
+msgstr "इमेज या फ़ाइल जोड़ें"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1449,7 +1467,7 @@ msgctxt ""
 "Open the tab picker to attach browser tab content to the AI chat message "
 "(attach dropdown menu item)"
 msgid "Add Tabs"
-msgstr ""
+msgstr "टैब जोड़ें"
 
 # smartling.placeholder_format=C
 #. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
@@ -1457,7 +1475,7 @@ msgctxt ""
 "Title and accessible name of the tab-picker dialog opened from the attach "
 "dropdown menu"
 msgid "Add Tabs"
-msgstr ""
+msgstr "टैब जोड़ें"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1548,7 +1566,7 @@ msgstr "अंतिम तैयारी"
 #. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
 msgctxt "Aria label for the additional instructions textarea"
 msgid "Additional instructions"
-msgstr ""
+msgstr "अतिरिक्त निर्देश"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1641,7 +1659,8 @@ msgctxt ""
 msgid ""
 "Advanced models can reach usage limits 2–5x sooner than other models. %s"
 msgstr ""
-"एडवांस्ड मॉडल अन्य मॉडलों की तुलना में 2–5 गुना तेज़ी से उपयोग सीमा तक पहुंच सकते हैं। %1$s"
+"एडवांस्ड मॉडल अन्य मॉडलों की तुलना में 2–5 गुना तेज़ी से उपयोग सीमा तक पहुंच "
+"सकते हैं। %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
@@ -1650,7 +1669,8 @@ msgctxt ""
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
 msgstr ""
-"एडवांस्ड मॉडल अन्य मॉडलों की तुलना में 2-5 गुना तेज़ी से लिमिट का इस्तेमाल कर सकते हैं। %1$s"
+"एडवांस्ड मॉडल अन्य मॉडलों की तुलना में 2-5 गुना तेज़ी से लिमिट का इस्तेमाल "
+"कर सकते हैं। %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1692,7 +1712,9 @@ msgstr "जैसे ही वह डाउनलोड होकर खुल�
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr "डाइनलोड होने के बाद, ऐक्सटेंशन फ़ाइल को ढूंढें और इंस्टॉल करने के लिए डबल क्लिक करें"
+msgstr ""
+"डाइनलोड होने के बाद, ऐक्सटेंशन फ़ाइल को ढूंढें और इंस्टॉल करने के लिए डबल "
+"क्लिक करें"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1829,8 +1851,8 @@ msgid ""
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 "सभी चैट DuckDuckGo द्वारा अनाम कर दी जाती हैं, और आपकी बातचीत का इस्तेमाल "
-"DuckDuckGo या मॉडल प्रोवाइडर द्वारा चैट मॉडल को प्रशिक्षित करने के लिए नहीं किया "
-"जाता है"
+"DuckDuckGo या मॉडल प्रोवाइडर द्वारा चैट मॉडल को प्रशिक्षित करने के लिए नहीं "
+"किया जाता है"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1854,7 +1876,7 @@ msgstr "सब हो गया!"
 #. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the read-only textarea listing all AI instructions"
 msgid "All instructions"
-msgstr ""
+msgstr "सभी निर्देश"
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -1869,8 +1891,8 @@ msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
 msgstr ""
-"सभी मॉडल प्रदाताओं को आपकी बातचीत के आधार पर अपने AI को प्रशिक्षित करने से रोका गया "
-"है।"
+"सभी मॉडल प्रदाताओं को आपकी बातचीत के आधार पर अपने AI को प्रशिक्षित करने से "
+"रोका गया है।"
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1885,8 +1907,8 @@ msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
 msgstr ""
-"AI प्रोवाइडर को चैट भेजने से पहले सभी पर्सनल मेटाडेटा (जैसे, आपका IP एड्रेस) हटा दिया "
-"जाता है।"
+"AI प्रोवाइडर को चैट भेजने से पहले सभी पर्सनल मेटाडेटा (जैसे, आपका IP एड्रेस) "
+"हटा दिया जाता है।"
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1925,8 +1947,8 @@ msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
 msgstr ""
-"वॉयस चैट का इस्तेमाल करने के लिए सिस्टम सेटिंग में DuckDuckGo माइक्रोफ़ोन एक्सेस की अनुमति "
-"दें।"
+"वॉयस चैट का इस्तेमाल करने के लिए सिस्टम सेटिंग में DuckDuckGo माइक्रोफ़ोन "
+"एक्सेस की अनुमति दें।"
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1949,7 +1971,8 @@ msgstr "इस चैट के लिए गुमनाम फ़ाइल र
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
 msgstr ""
-"DuckDuckGo Private Search पर गोपनीयता का सम्मान करने वाले विज्ञापनों को अनुमति दें"
+"DuckDuckGo Private Search पर गोपनीयता का सम्मान करने वाले विज्ञापनों को "
+"अनुमति दें"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -1959,10 +1982,10 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"यह %1$s को वेब पर सर्च करने की सुविधा देता है, ताकि वह संबंधित प्रॉम्प्ट्स के जवाबों को "
-"बेहतर बना सके। यह सर्च इंजन पर केवल AI-जनरेटेड क्वेरीज़ ही भेजता है, जिनमें डेटा रिटेंशन की "
-"लिमिट सीमित होती है। %2$s वाले प्रॉम्प्ट्स और जवाबों पर अभी भी %3$sप्रोवाइडर की "
-"विज़िबिलिटी शून्य%4$s रहती है।"
+"यह %1$s को वेब पर सर्च करने की सुविधा देता है, ताकि वह संबंधित प्रॉम्प्ट्स "
+"के जवाबों को बेहतर बना सके। यह सर्च इंजन पर केवल AI-जनरेटेड क्वेरीज़ ही "
+"भेजता है, जिनमें डेटा रिटेंशन की लिमिट सीमित होती है। %2$s वाले प्रॉम्प्ट्स "
+"और जवाबों पर अभी भी %3$sप्रोवाइडर की विज़िबिलिटी शून्य%4$s रहती है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -1970,8 +1993,8 @@ msgid ""
 "Allows Cloud Save key to be stored locally on device (required to use Cloud "
 "Save)"
 msgstr ""
-"डिवाइस पर स्थानीय रूप से संग्रहित की जाने वाली Cloud Save की को अनुमति देता है (Cloud "
-"Save का उपयोग करने के लिए आवश्यक है)"
+"डिवाइस पर स्थानीय रूप से संग्रहित की जाने वाली Cloud Save की को अनुमति देता "
+"है (Cloud Save का उपयोग करने के लिए आवश्यक है)"
 
 # smartling.placeholder_format=C
 #. Pending title indicating near completion.
@@ -2109,8 +2132,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"लोकप्रिय AI मॉडलों तक अनाम ढंग से पहुंच, जिसमें %1$s, %2$sऔर मुक्त स्रोत %3$s और %4$s "
-"शामिल हैं।"
+"लोकप्रिय AI मॉडलों तक अनाम ढंग से पहुंच, जिसमें %1$s, %2$sऔर मुक्त स्रोत "
+"%3$s और %4$s शामिल हैं।"
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -2119,8 +2142,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"लोकप्रिय AI मॉडलों तक अनाम ढंग से पहुंच, जिसमें %1$s, %2$sऔर मुक्त स्रोत %3$s और %4$s "
-"शामिल हैं।"
+"लोकप्रिय AI मॉडलों तक अनाम ढंग से पहुंच, जिसमें %1$s, %2$sऔर मुक्त स्रोत "
+"%3$s और %4$s शामिल हैं।"
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -2134,8 +2157,8 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
-"वेब कंटेंट के आधार पर सर्च क्वेरी के लिए गुमनाम रूप से जवाब तैयार करता है। चुनें कि इसे कितनी "
-"बार दिखाया जाए, या इसे पूरी तरह से बंद कर दें।"
+"वेब कंटेंट के आधार पर सर्च क्वेरी के लिए गुमनाम रूप से जवाब तैयार करता है। "
+"चुनें कि इसे कितनी बार दिखाया जाए, या इसे पूरी तरह से बंद कर दें।"
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2182,8 +2205,8 @@ msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
 msgstr ""
-"कोई अतिरिक्त निर्देश जो आप चाहते हैं कि Duck.ai पालन करे। जैसे कि हमेशा मुझे बतख संबंधी "
-"तथ्य बताएं"
+"कोई अतिरिक्त निर्देश जो आप चाहते हैं कि Duck.ai पालन करे। जैसे कि हमेशा मुझे "
+"बतख संबंधी तथ्य बताएं"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2283,8 +2306,8 @@ msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
 msgstr ""
-"क्या आपको पक्का पता है कि आप अपनी सभी चैट साफ़ करना चाहते हैं? इसे पहले जैसा नहीं किया "
-"जा सकता।"
+"क्या आपको पक्का पता है कि आप अपनी सभी चैट साफ़ करना चाहते हैं? इसे पहले जैसा "
+"नहीं किया जा सकता।"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2305,8 +2328,8 @@ msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
 msgstr ""
-"क्या आप वाकई हिस्ट्री को बंद करना चाहते हैं? इससे सभी चैट्स डिलीट हो जाएंगी, जिनमें पिन "
-"की गई चैट्स भी शामिल हैं।"
+"क्या आप वाकई हिस्ट्री को बंद करना चाहते हैं? इससे सभी चैट्स डिलीट हो जाएंगी, "
+"जिनमें पिन की गई चैट्स भी शामिल हैं।"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2315,8 +2338,8 @@ msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
 msgstr ""
-"क्या आप वाकई हालिया चैट को बंद करना चाहते हैं? यह हाल ही में सेव की गई सभी चैट को भी "
-"डिलीट कर देगा।"
+"क्या आप वाकई हालिया चैट को बंद करना चाहते हैं? यह हाल ही में सेव की गई सभी "
+"चैट को भी डिलीट कर देगा।"
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2354,8 +2377,8 @@ msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
 msgstr ""
-"हमारी गोपनीयता नीति के अनुसार, हम खुद से कोई निजी जानकारी एकत्रित या साझा नहीं करते "
-"हैं। यह सभी गोपनीयता संरक्षण आपके डिवाइस पर होती है।"
+"हमारी गोपनीयता नीति के अनुसार, हम खुद से कोई निजी जानकारी एकत्रित या साझा "
+"नहीं करते हैं। यह सभी गोपनीयता संरक्षण आपके डिवाइस पर होती है।"
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2497,12 +2520,13 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assist प्रासंगिक वेब सामग्री को संक्षेप में प्रस्तुत करने के आधार पर कुछ खोजों के लिए गुमनाम "
-"रूप से AI की सहायता से जवाब जनरेट कर सकता है। आप चुन सकते हैं कि Assist को कितनी बार "
-"दिखाना है: कभी नहीं (यह खोज परिणामों से Assist के UI को पूरी तरह हटा देता है), ऑन-"
-"डिमांड (सिर्फ़ तभी दिखाता है जब आप 'सहायता' बटन पर क्लिक करते हैं), कभी-कभी (सिर्फ़ "
-"तभी दिखाता है, जब नतीजे बहुत काम के हों), या अक्सर (कई तरह की खोजों पर अक्सर दिखाता "
-"है)। फिलहाल, AI की सहायता से दिए गए जवाब केवल अमेरिका (अंग्रेज़ी) क्षेत्र में उपलब्ध हैं।"
+"Assist प्रासंगिक वेब सामग्री को संक्षेप में प्रस्तुत करने के आधार पर कुछ "
+"खोजों के लिए गुमनाम रूप से AI की सहायता से जवाब जनरेट कर सकता है। आप चुन "
+"सकते हैं कि Assist को कितनी बार दिखाना है: कभी नहीं (यह खोज परिणामों से "
+"Assist के UI को पूरी तरह हटा देता है), ऑन-डिमांड (सिर्फ़ तभी दिखाता है जब आप "
+"'सहायता' बटन पर क्लिक करते हैं), कभी-कभी (सिर्फ़ तभी दिखाता है, जब नतीजे "
+"बहुत काम के हों), या अक्सर (कई तरह की खोजों पर अक्सर दिखाता है)। फिलहाल, AI "
+"की सहायता से दिए गए जवाब केवल अमेरिका (अंग्रेज़ी) क्षेत्र में उपलब्ध हैं।"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2514,11 +2538,12 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist, खोज परिणाम दिखाने से जुड़ा एक नया वैकल्पिक फ़ीचर है। यह गुमनाम रहकर, खोज संबंधी "
-"क्वेरी के जवाब AI की सहायता से जनरेट कर सकता है। ऐसा करने के लिए, यह वेब को स्कैन करके "
-"क्वेरी से जुड़ी सामग्री जुटाता है। इसके बाद, उस सामग्री से जुड़ी जानकारी के आधार पर कम "
-"शब्दों में जवाब देने के लिए, AI-संचालित नेचुरल लैंग्वेज टेक्नोलॉजी का इस्तेमाल करता है। यह याद "
-"रखना ज़रूरी है कि जवाब, दूसरे स्रोतों से अपने-आप जनरेट होते हैं और %1$sवेब क्रॉलिंग%2$s पर "
+"Assist, खोज परिणाम दिखाने से जुड़ा एक नया वैकल्पिक फ़ीचर है। यह गुमनाम रहकर, "
+"खोज संबंधी क्वेरी के जवाब AI की सहायता से जनरेट कर सकता है। ऐसा करने के लिए, "
+"यह वेब को स्कैन करके क्वेरी से जुड़ी सामग्री जुटाता है। इसके बाद, उस सामग्री "
+"से जुड़ी जानकारी के आधार पर कम शब्दों में जवाब देने के लिए, AI-संचालित "
+"नेचुरल लैंग्वेज टेक्नोलॉजी का इस्तेमाल करता है। यह याद रखना ज़रूरी है कि "
+"जवाब, दूसरे स्रोतों से अपने-आप जनरेट होते हैं और %1$sवेब क्रॉलिंग%2$s पर "
 "आधारित होते हैं।"
 
 # smartling.placeholder_format=C
@@ -2545,8 +2570,8 @@ msgid ""
 "At the café, airport, or hotel, DuckDuckGo VPN encrypts your connection and "
 "hides your IP address on Wi-Fi."
 msgstr ""
-"कैफ़े, एयरपोर्ट या होटल में, DuckDuckGo VPN आपके कनेक्शन को एन्क्रिप्ट करता है और वाई-फ़ाई "
-"पर आपके IP एड्रेस को छिपाता है।"
+"कैफ़े, एयरपोर्ट या होटल में, DuckDuckGo VPN आपके कनेक्शन को एन्क्रिप्ट करता "
+"है और वाई-फ़ाई पर आपके IP एड्रेस को छिपाता है।"
 
 # smartling.placeholder_format=C
 #. In the context of the National Hockey League (NHL), label for teams belonging to the Atlantic division
@@ -2621,8 +2646,8 @@ msgstr "चैट खत्म होने के बाद ऑडियो ह
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
 msgstr ""
-"चैट ट्रांसक्रिप्ट होने के बाद, ऑडियो हमारे द्वारा या OpenAI द्वारा स्टोर नहीं किया जाता "
-"है।"
+"चैट ट्रांसक्रिप्ट होने के बाद, ऑडियो हमारे द्वारा या OpenAI द्वारा स्टोर "
+"नहीं किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2664,14 +2689,16 @@ msgstr "स्वत: उत्तर"
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
 msgstr ""
-"सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट किया गया। इसमें अशुद्धियां हो सकती हैं।"
+"सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट किया गया। इसमें अशुद्धियां "
+"हो सकती हैं।"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
 msgstr ""
-"सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट किया गया। जवाबों में अशुद्धियां हो सकती हैं।"
+"सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट किया गया। जवाबों में "
+"अशुद्धियां हो सकती हैं।"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
@@ -2696,9 +2723,9 @@ msgid ""
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
 msgstr ""
-"प्रासंगिक खोजों के लिए Assist स्वतः ही दिखाता है। कुछ खोजों के लिए Assist, जानकारी को "
-"गुमनाम रूप से खोज सकता है और उसके बारे में खास जानकारी दे सकता है। फिलहाल, Assist केवल "
-"अंग्रेज़ी क्षेत्रों में उपलब्ध है।"
+"प्रासंगिक खोजों के लिए Assist स्वतः ही दिखाता है। कुछ खोजों के लिए Assist, "
+"जानकारी को गुमनाम रूप से खोज सकता है और उसके बारे में खास जानकारी दे सकता "
+"है। फिलहाल, Assist केवल अंग्रेज़ी क्षेत्रों में उपलब्ध है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2707,15 +2734,17 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"प्रासंगिक खोजों के लिए DuckAssist स्वतः ही दिखाता है। कुछ खोजों के लिए DuckAssist "
-"जानकारी को गुमनाम रूप से खोज और संक्षिप्त कर सकता है। फिलहाल DuckAssist केवल अंग्रेज़ी "
-"क्षेत्रों में उपलब्ध है।"
+"प्रासंगिक खोजों के लिए DuckAssist स्वतः ही दिखाता है। कुछ खोजों के लिए "
+"DuckAssist जानकारी को गुमनाम रूप से खोज और संक्षिप्त कर सकता है। फिलहाल "
+"DuckAssist केवल अंग्रेज़ी क्षेत्रों में उपलब्ध है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Autoplay short, silent video previews when you hover over video results."
-msgstr "वीडियो परिणामों पर कर्सर ले जाने पर, छोटे और म्यूट वाले वीडियो प्रीव्यू ऑटोप्ले करें।"
+msgstr ""
+"वीडियो परिणामों पर कर्सर ले जाने पर, छोटे और म्यूट वाले वीडियो प्रीव्यू "
+"ऑटोप्ले करें।"
 
 # smartling.placeholder_format=C
 #. Title for the menu listing free/degraded models available after the advanced-model usage limit has been reached.
@@ -2915,8 +2944,9 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
-"इस रिपोर्ट को स्टोर करने से पहले, DuckDuckGo आपकी बातचीत से नाम, ईमेल एड्रेस और पहचान "
-"बताने वाले मेटाडेटा जैसी PII (व्यक्तिगत पहचान योग्य जानकारी) हटाकर उसे अनाम बना देगा।"
+"इस रिपोर्ट को स्टोर करने से पहले, DuckDuckGo आपकी बातचीत से नाम, ईमेल एड्रेस "
+"और पहचान बताने वाले मेटाडेटा जैसी PII (व्यक्तिगत पहचान योग्य जानकारी) हटाकर "
+"उसे अनाम बना देगा।"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3046,8 +3076,8 @@ msgid ""
 "Block harmful sites, hide your IP address, plus get more premium protections "
 "with our subscription."
 msgstr ""
-"हमारे सब्सक्रिप्शन के माध्यम से हानिकारक साइटों को ब्लॉक करें, अपना IP एड्रेस छिपाएं, और "
-"ज़्यादा प्रीमियम सुरक्षा पाएं।"
+"हमारे सब्सक्रिप्शन के माध्यम से हानिकारक साइटों को ब्लॉक करें, अपना IP "
+"एड्रेस छिपाएं, और ज़्यादा प्रीमियम सुरक्षा पाएं।"
 
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
@@ -3307,16 +3337,18 @@ msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"जब हम गोपनीयता संरक्षण जोड़ते हैं तब सामान्य रूप से ब्राउज़ करें। हमने अपने खोज इंजन, ट्रैकर "
-"ब्लॉकर और एन्क्रिप्शन एनफोर्सर को एक ही %1$s%2$s एक्सटेंशन%3$s में बंडल किया है।"
+"जब हम गोपनीयता संरक्षण जोड़ते हैं तब सामान्य रूप से ब्राउज़ करें। हमने अपने "
+"खोज इंजन, ट्रैकर ब्लॉकर और एन्क्रिप्शन एनफोर्सर को एक ही %1$s%2$s "
+"एक्सटेंशन%3$s में बंडल किया है।"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"सामान्य तौर पर ब्राउज़ करें, और बाकी सबका ध्यान हम रखेंगे। हमने अपने खोज इंजन, ट्रैकर "
-"ब्लॉकर और एनक्रिप्शन एनफोर्सर को एक ही %1$s%2$s एक्सटेंशन%3$s में बंडल कर दिया है।"
+"सामान्य तौर पर ब्राउज़ करें, और बाकी सबका ध्यान हम रखेंगे। हमने अपने खोज "
+"इंजन, ट्रैकर ब्लॉकर और एनक्रिप्शन एनफोर्सर को एक ही %1$s%2$s एक्सटेंशन%3$s "
+"में बंडल कर दिया है।"
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3324,8 +3356,9 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"सामान्य तौर पर ब्राउज़ करें, और बाकी सबका ध्यान हम रखेंगे। %1$sप्रमुख ब्राउज़र्स%2$s के लिए "
-"गोपनीय खोज, ट्रैकर ब्लॉकिंग और साइट एनक्रिप्शन पाएं, सब कुछ एक ही डाउनलोड में।"
+"सामान्य तौर पर ब्राउज़ करें, और बाकी सबका ध्यान हम रखेंगे। %1$sप्रमुख "
+"ब्राउज़र्स%2$s के लिए गोपनीय खोज, ट्रैकर ब्लॉकिंग और साइट एनक्रिप्शन पाएं, "
+"सब कुछ एक ही डाउनलोड में।"
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3432,11 +3465,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"डिफ़ॉल्ट रूप से, सेटिंग्स को गैर-व्यक्तिगत ब्राउज़र कुकीज़ (आपके ब्राउज़र में) में संग्रहित किया "
-"जाता है। आप अपनी सेटिंग्स को अधिक स्थायी तरीके से (क्लाउड में रिमोट सर्वर पर) संग्रहित "
-"करने के लिए अनाम क्लाउड सेव का उपयोग कर सकते हैं। व्यक्तिगत रूप से पहचान योग्य कोई भी "
-"जानकारी क्लाउड में संग्रहित नहीं की जाएगी और आपका पासफ़्रेज़ आपके ब्राउज़र से कभी अलग नहीं "
-"होगा।"
+"डिफ़ॉल्ट रूप से, सेटिंग्स को गैर-व्यक्तिगत ब्राउज़र कुकीज़ (आपके ब्राउज़र "
+"में) में संग्रहित किया जाता है। आप अपनी सेटिंग्स को अधिक स्थायी तरीके से "
+"(क्लाउड में रिमोट सर्वर पर) संग्रहित करने के लिए अनाम क्लाउड सेव का उपयोग कर "
+"सकते हैं। व्यक्तिगत रूप से पहचान योग्य कोई भी जानकारी क्लाउड में संग्रहित "
+"नहीं की जाएगी और आपका पासफ़्रेज़ आपके ब्राउज़र से कभी अलग नहीं होगा।"
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
@@ -3444,8 +3477,8 @@ msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"डिक्टेशन चालू करके, आप इस फ़ीचर के इस्तेमाल के लिए अपना वॉयस डेटा OpenAI को भेजने की "
-"सहमति देते हैं। शुरू करने से पहले हमारे %1$s को देखें।"
+"डिक्टेशन चालू करके, आप इस फ़ीचर के इस्तेमाल के लिए अपना वॉयस डेटा OpenAI को "
+"भेजने की सहमति देते हैं। शुरू करने से पहले हमारे %1$s को देखें।"
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3454,8 +3487,8 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"वॉयस चैट चालू करके, आप इस फ़ीचर के इस्तेमाल के लिए अपना वॉयस डेटा OpenAI को भेजने की "
-"सहमति देते हैं। शुरू करने से पहले हमारे %1$s को देखें।"
+"वॉयस चैट चालू करके, आप इस फ़ीचर के इस्तेमाल के लिए अपना वॉयस डेटा OpenAI को "
+"भेजने की सहमति देते हैं। शुरू करने से पहले हमारे %1$s को देखें।"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3562,7 +3595,7 @@ msgctxt ""
 "Secondary button that dismisses the tab picker dialog without attaching "
 "anything"
 msgid "Cancel"
-msgstr ""
+msgstr "कैंसिल करें"
 
 # smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
@@ -3799,7 +3832,9 @@ msgstr "यूआरएल के दिखाई देने का तरी�
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr "जब आप स्क्रॉल करते हैं तो हेडर कैसे प्रदर्शित होने और उसका ढंग परिवर्तित कर देता है"
+msgstr ""
+"जब आप स्क्रॉल करते हैं तो हेडर कैसे प्रदर्शित होने और उसका ढंग परिवर्तित कर "
+"देता है"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3947,11 +3982,11 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"Chat से (हमारी Duck.ai सेवा के माध्यम से) आपको थर्ड-पार्टी AI चैट मॉडल के साथ गुमनाम "
-"ढंग से बातचीत करने की सुविधा मिलती है, जो OpenAI, Anthropic आदि मॉडलों को सपोर्ट "
-"करती है। इस सेटिंग को बंद करने से DuckDuckGo Search पर Chat बटन और लिंक छिप जाएंगे। "
-"हालांकि, यह सेटिंग बंद होने पर भी आप %1$shttps://duck.ai%2$s पर जाकर, सीधे तौर पर "
-"Chat का इस्तेमाल कर सकते हैं।"
+"Chat से (हमारी Duck.ai सेवा के माध्यम से) आपको थर्ड-पार्टी AI चैट मॉडल के "
+"साथ गुमनाम ढंग से बातचीत करने की सुविधा मिलती है, जो OpenAI, Anthropic आदि "
+"मॉडलों को सपोर्ट करती है। इस सेटिंग को बंद करने से DuckDuckGo Search पर Chat "
+"बटन और लिंक छिप जाएंगे। हालांकि, यह सेटिंग बंद होने पर भी आप "
+"%1$shttps://duck.ai%2$s पर जाकर, सीधे तौर पर Chat का इस्तेमाल कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4007,7 +4042,8 @@ msgstr "गोपनीय ढंग से चैट करें"
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
 msgstr ""
-"हमारे मुफ़्त ब्राउज़र में मौजूद Duck.ai के ज़रिए किसी भी वेबसाइट पर गोपनीय ढंग से चैट करें।"
+"हमारे मुफ़्त ब्राउज़र में मौजूद Duck.ai के ज़रिए किसी भी वेबसाइट पर गोपनीय "
+"ढंग से चैट करें।"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
@@ -4015,7 +4051,8 @@ msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
 msgstr ""
-"हमारे मुफ़्त ब्राउज़र में Duck.ai साइडबार के ज़रिए किसी भी वेबसाइट पर गोपनीय ढंग से चैट करें।"
+"हमारे मुफ़्त ब्राउज़र में Duck.ai साइडबार के ज़रिए किसी भी वेबसाइट पर गोपनीय "
+"ढंग से चैट करें।"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4057,7 +4094,7 @@ msgstr "चैट में मिला जवाब आपत्तिजन�
 #. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
 msgctxt "Chat history about modal list item headline"
 msgid "Chat storage varies by browser"
-msgstr ""
+msgstr "चैट स्टोरेज ब्राउज़र के हिसाब से अलग-अलग होता है"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4069,7 +4106,7 @@ msgstr "%1$s से चैट करें"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Chat with popular AI models, anonymized by us."
-msgstr ""
+msgstr "पॉपुलर AI मॉडल के साथ चैट करें, जिन्हें हमने गुमनाम रखा है।"
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4096,6 +4133,8 @@ msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
 msgstr ""
+"चैट्स एंड-टू-एंड एनक्रिप्शन के साथ DuckDuckGo के सर्वर पर सुरक्षित रूप से "
+"स्टोर की जाती हैं। आपके अलावा कोई भी आपका डेटा नहीं देख सकता, हम भी नहीं।"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4104,8 +4143,8 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"चैट DuckDuckGo सर्वर या रिमोट सर्वर के बजाय आपके डिवाइस पर स्थानीय स्तर पर स्टोर की "
-"जाती हैं। चैट हिस्ट्री बंद करने से पिन की गई चैट्स डिलीट हो जाएंगी।"
+"चैट DuckDuckGo सर्वर या रिमोट सर्वर के बजाय आपके डिवाइस पर स्थानीय स्तर पर "
+"स्टोर की जाती हैं। चैट हिस्ट्री बंद करने से पिन की गई चैट्स डिलीट हो जाएंगी।"
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -4117,10 +4156,11 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"चैट्स आपके डिवाइस में स्टोर होते हैं। नए प्रॉम्प्ट और रिस्पॉन्स भेजे जाने के बाद एन्क्रिप्ट किए "
-"जाते हैं और अस्थायी रूप से DuckDuckGo सर्वर पर स्टोर रहते हैं, ताकि यदि आपका इंटरनेट "
-"कनेक्शन खो जाए तो चैट को रिकवर किया जा सके। चैट हिस्ट्री को डिसेबल करने से पिन की गई "
-"चैट डिलीट हो जाएंगी, और नए प्रॉम्प्ट और रिस्पॉन्स का टेम्पररी स्टोरेज भी बंद हो जाएगा।"
+"चैट्स आपके डिवाइस में स्टोर होते हैं। नए प्रॉम्प्ट और रिस्पॉन्स भेजे जाने के "
+"बाद एन्क्रिप्ट किए जाते हैं और अस्थायी रूप से DuckDuckGo सर्वर पर स्टोर रहते "
+"हैं, ताकि यदि आपका इंटरनेट कनेक्शन खो जाए तो चैट को रिकवर किया जा सके। चैट "
+"हिस्ट्री को डिसेबल करने से पिन की गई चैट डिलीट हो जाएंगी, और नए प्रॉम्प्ट और "
+"रिस्पॉन्स का टेम्पररी स्टोरेज भी बंद हो जाएगा।"
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -4143,9 +4183,9 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"%1$s के साथ चैट में ज़ीरो प्रोवाइडर विज़िबिलिटी रहती है, लेकिन Duck.ai पर अपलोड की गई "
-"सभी फ़ाइलों के रिव्यू को %2$s के लिए एक कंटेंट मॉडरेशन प्रोवाइडर द्वारा गुमनाम रूप से किया "
-"जाता है।"
+"%1$s के साथ चैट में ज़ीरो प्रोवाइडर विज़िबिलिटी रहती है, लेकिन Duck.ai पर "
+"अपलोड की गई सभी फ़ाइलों के रिव्यू को %2$s के लिए एक कंटेंट मॉडरेशन प्रोवाइडर "
+"द्वारा गुमनाम रूप से किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -4153,7 +4193,8 @@ msgctxt "Sync file storage inline disclaimer body"
 msgid ""
 "Chats with attachments have stopped syncing. Free up storage to resume Sync."
 msgstr ""
-"अटैचमेंट वाली चैट्स सिंक होना बंद हो गई हैं। सिंक फिर से शुरू करने के लिए स्टोरेज खाली करें।"
+"अटैचमेंट वाली चैट्स सिंक होना बंद हो गई हैं। सिंक फिर से शुरू करने के लिए "
+"स्टोरेज खाली करें।"
 
 # smartling.placeholder_format=C
 #. Message shown when we have no data from upstream to display
@@ -4309,8 +4350,8 @@ msgid ""
 "Choose from 40+ server locations worldwide to help block harmful sites and "
 "scams."
 msgstr ""
-"हानिकारक साइटों और स्कैम को ब्लॉक करने में मदद के लिए दुनिया भर में 40+ सर्वर लोकेशन में से "
-"चुनें।"
+"हानिकारक साइटों और स्कैम को ब्लॉक करने में मदद के लिए दुनिया भर में 40+ "
+"सर्वर लोकेशन में से चुनें।"
 
 # smartling.placeholder_format=C
 #. The title of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -4328,8 +4369,8 @@ msgctxt "settings"
 msgid ""
 "Choose which app to use when you need directions for a location search result"
 msgstr ""
-"किसी स्थान खोज परिणाम के लिए आपको डायरेक्शन की ज़रूरत होने पर चुनें कि किस ऐप का "
-"इस्तेमाल करना है"
+"किसी स्थान खोज परिणाम के लिए आपको डायरेक्शन की ज़रूरत होने पर चुनें कि किस "
+"ऐप का इस्तेमाल करना है"
 
 # smartling.placeholder_format=C
 #. Accessible label for the citations popover dialog in Duck.ai chat responses.
@@ -4510,8 +4551,9 @@ msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
-"ब्राउज़र डेटा साफ़ करने से चैट डिलीट हो जाती हैं। कुछ ब्राउज़र हालिया चैट को लंबे समय तक रख "
-"सकते हैं या 7 से ज़्यादा दिनों तक AI Chat का उपयोग न करने पर उन्हें ऑटो-डिलीट कर सकते हैं।"
+"ब्राउज़र डेटा साफ़ करने से चैट डिलीट हो जाती हैं। कुछ ब्राउज़र हालिया चैट को "
+"लंबे समय तक रख सकते हैं या 7 से ज़्यादा दिनों तक AI Chat का उपयोग न करने पर "
+"उन्हें ऑटो-डिलीट कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4521,9 +4563,9 @@ msgid ""
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
 msgstr ""
-"ब्राउज़र डेटा साफ़ करने से हाल की चैट हट जाती हैं। Duck.ai का इस्तेमाल किए बिना, हाल की "
-"चैट को अनिश्चित काल के लिए सेव किया जा सकता है या 7 दिनों के बाद अपने-आप हटाया जा "
-"सकता है। यह आपके ब्राउज़र पर निर्भर करता है।"
+"ब्राउज़र डेटा साफ़ करने से हाल की चैट हट जाती हैं। Duck.ai का इस्तेमाल किए "
+"बिना, हाल की चैट को अनिश्चित काल के लिए सेव किया जा सकता है या 7 दिनों के "
+"बाद अपने-आप हटाया जा सकता है। यह आपके ब्राउज़र पर निर्भर करता है।"
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4532,8 +4574,8 @@ msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
 msgstr ""
-"ब्राउज़र डेटा क्लियर करने से आपकी ब्लॉक की गई साइटें रीसेट हो जाएंगी। अपनी ब्लॉक लिस्ट को "
-"हमेशा के लिए सेव करें"
+"ब्राउज़र डेटा क्लियर करने से आपकी ब्लॉक की गई साइटें रीसेट हो जाएंगी। अपनी "
+"ब्लॉक लिस्ट को हमेशा के लिए सेव करें"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4542,9 +4584,9 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"किसी विषय पर और गहराई से जानने के लिए \"अधिक\" पर क्लिक करें, और फ़ॉलोअप प्रश्न "
-"%1$sDuck.ai%2$s के ज़रिए पूछें, यह हमारी प्राइवेट AI चैट सेवा है जो OpenAI, Anthropic "
-"और अन्य के चैट मॉडलों को सपोर्ट करती है।"
+"किसी विषय पर और गहराई से जानने के लिए \"अधिक\" पर क्लिक करें, और फ़ॉलोअप "
+"प्रश्न %1$sDuck.ai%2$s के ज़रिए पूछें, यह हमारी प्राइवेट AI चैट सेवा है जो "
+"OpenAI, Anthropic और अन्य के चैट मॉडलों को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4586,8 +4628,8 @@ msgid ""
 "Click %sEdit > Preferences%s (on Windows) %sSeaMonkey > Preferences%s (on "
 "Mac)"
 msgstr ""
-"%1$sसंपादित करें > प्राथमिकताएं%2$s (Windows पर) %3$sSeaMonkey > प्राथमिकताएं%4$s "
-"(Mac पर) क्लिक करें"
+"%1$sसंपादित करें > प्राथमिकताएं%2$s (Windows पर) %3$sSeaMonkey > "
+"प्राथमिकताएं%4$s (Mac पर) क्लिक करें"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4603,7 +4645,9 @@ msgstr "DuckDuckGo एकस्टेंशन को डाउनलोड क�
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr "DuckDuckGo Safari एकस्टेंशन को डाउनलोड करके खोलने के लिए %1$sखोलें%2$s क्लिक करें"
+msgstr ""
+"DuckDuckGo Safari एकस्टेंशन को डाउनलोड करके खोलने के लिए %1$sखोलें%2$s क्लिक "
+"करें"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4618,8 +4662,8 @@ msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
 msgstr ""
-"शीर्ष मेनू में %1$sSafari%2$s पर क्लिक करें (Windows पर, शीर्ष दाईं ओर %3$sगियर "
-"आइकन%4$s पर क्लिक करें)"
+"शीर्ष मेनू में %1$sSafari%2$s पर क्लिक करें (Windows पर, शीर्ष दाईं ओर "
+"%3$sगियर आइकन%4$s पर क्लिक करें)"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4636,7 +4680,9 @@ msgstr "ड्रॉपडाउन में %1$sसेटिंग्स%2$s �
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "%1$sमौजूदा पेज इस्तेमाल करें%2$s पर क्लिक करें, फिर %3$sओके पर क्लिक%4$s करें।"
+msgstr ""
+"%1$sमौजूदा पेज इस्तेमाल करें%2$s पर क्लिक करें, फिर %3$sओके पर क्लिक%4$s "
+"करें।"
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4649,7 +4695,8 @@ msgstr "%1$sहां%2$s पर क्लिक करें"
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
 msgstr ""
-"Chrome टूलबार (ऊपर से दाहिने) पर %1$ssettings/hamburger आइकन%2$s पर क्लिक करें"
+"Chrome टूलबार (ऊपर से दाहिने) पर %1$ssettings/hamburger आइकन%2$s पर क्लिक "
+"करें"
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4711,9 +4758,9 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
 msgstr ""
-"%1$sमेरा डेटा डिलीट करें%2$s पर क्लिक करें या टैप करें। यह क्लाउड से डेटा हटा देता है, लेकिन "
-"यह आपके ब्राउज़र में तब तक बना रहता है जब तक आप %3$sसभी खोज सेटिंग रीसेट करें%4$s पर "
-"क्लिक/टैप नहीं कर देते।"
+"%1$sमेरा डेटा डिलीट करें%2$s पर क्लिक करें या टैप करें। यह क्लाउड से डेटा "
+"हटा देता है, लेकिन यह आपके ब्राउज़र में तब तक बना रहता है जब तक आप %3$sसभी "
+"खोज सेटिंग रीसेट करें%4$s पर क्लिक/टैप नहीं कर देते।"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4724,8 +4771,9 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
 msgstr ""
-"%1$sमेरा डेटा हटाएं%2$s पर क्लिक करें या टैप करें। यह क्लाउड से डेटा हटाता है, लेकिन यह "
-"आपके ब्राउज़र में तब तक रहता है जब तक आप %3$sसभी सेटिंग्स रीसेट%4$s पर क्लिक/टैप नहीं करते।"
+"%1$sमेरा डेटा हटाएं%2$s पर क्लिक करें या टैप करें। यह क्लाउड से डेटा हटाता "
+"है, लेकिन यह आपके ब्राउज़र में तब तक रहता है जब तक आप %3$sसभी सेटिंग्स "
+"रीसेट%4$s पर क्लिक/टैप नहीं करते।"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4794,8 +4842,8 @@ msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
 msgstr ""
-"%1$sएड्रेस बार में उपयोग किए गए खोज इंजन%2$s के पास वाले ड्रॉपडाउन मेनू पर क्लिक करें और "
-"%3$sDuckDuckGo%4$s चुनें।"
+"%1$sएड्रेस बार में उपयोग किए गए खोज इंजन%2$s के पास वाले ड्रॉपडाउन मेनू पर "
+"क्लिक करें और %3$sDuckDuckGo%4$s चुनें।"
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
@@ -4803,8 +4851,8 @@ msgid ""
 "Click the icon of the ad blocker extension. It's usually in the upper right "
 "hand corner of your browser."
 msgstr ""
-"विज्ञापन ब्लॉकर एक्सटेंशन के आइकॉन पर क्लिक करें। यह आम तौर पर आपके ब्राउज़र के ऊपरी दाएं "
-"कोने में होता है।"
+"विज्ञापन ब्लॉकर एक्सटेंशन के आइकॉन पर क्लिक करें। यह आम तौर पर आपके ब्राउज़र "
+"के ऊपरी दाएं कोने में होता है।"
 
 #  Safari default search engine instruction
 # smartling.placeholder_format=C
@@ -5005,8 +5053,8 @@ msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
 msgstr ""
-"Cloud Save से आप अपनी चुनी हुई सेटिंग्स एक पासवर्ड द्वारा सर्वर पर ज़्यादा सुरक्षित रख "
-"सकते हैं। यह पूर्ण तरह से वैकल्पिक है।"
+"Cloud Save से आप अपनी चुनी हुई सेटिंग्स एक पासवर्ड द्वारा सर्वर पर ज़्यादा "
+"सुरक्षित रख सकते हैं। यह पूर्ण तरह से वैकल्पिक है।"
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -5448,8 +5496,8 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
-"दूसरे डिवाइस से कोड कॉपी करें. %1$sDuck.ai Settings › Chats › Sync & Backup › "
-"Sync With Another Device%2$s पर जाएँ और फिर से कोशिश करें."
+"दूसरे डिवाइस से कोड कॉपी करें. %1$sDuck.ai Settings › Chats › Sync & Backup "
+"› Sync With Another Device%2$s पर जाएँ और फिर से कोशिश करें."
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5684,7 +5732,7 @@ msgstr "मौजूदा स्ट्रीक"
 #. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
 msgctxt "Suffix label indicating a tab is the currently active browser tab"
 msgid "Current Tab"
-msgstr ""
+msgstr "मौजूदा टैब"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
@@ -5847,8 +5895,8 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Daily usage limit reached. You can keep chatting by using your weekly limit."
 msgstr ""
-"दैनिक उपयोग सीमा पूरी हो गई है। आप अपनी साप्ताहिक सीमा का इस्तेमाल करके चैट करना "
-"जारी रख सकते हैं।"
+"दैनिक उपयोग सीमा पूरी हो गई है। आप अपनी साप्ताहिक सीमा का इस्तेमाल करके चैट "
+"करना जारी रख सकते हैं।"
 
 # smartling.placeholder_format=C
 #. The name of the Danish language
@@ -6038,7 +6086,7 @@ msgstr "30 दिन से पुरानी चैट डिलीट कर�
 #. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
 msgctxt "Button text in the modal for deleting all recent chats"
 msgid "Delete Chats and Shared Links"
-msgstr ""
+msgstr "चैट और शेयर किए गए लिंक डिलीट करें"
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6165,8 +6213,8 @@ msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
 msgstr ""
-"लिंक को डिलीट करने से यह काम करना बंद कर देगा. जिन लोगों ने इसे खोला है और बातचीत को "
-"अपनी चैट में जोड़ा है, उनके पास इसकी अपनी कॉपी रहेगी."
+"लिंक को डिलीट करने से यह काम करना बंद कर देगा. जिन लोगों ने इसे खोला है और "
+"बातचीत को अपनी चैट में जोड़ा है, उनके पास इसकी अपनी कॉपी रहेगी."
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6263,8 +6311,8 @@ msgstr "Duck.ai में डिक्टेशन"
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
 msgstr ""
-"हम डिक्टेशन को गुमनाम रखते हैं और इसका उपयोग कभी भी AI मॉडल प्रशिक्षित करने के लिए नहीं "
-"किया जाता है।"
+"हम डिक्टेशन को गुमनाम रखते हैं और इसका उपयोग कभी भी AI मॉडल प्रशिक्षित करने "
+"के लिए नहीं किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6282,8 +6330,8 @@ msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
 msgstr ""
-"डिक्टेशन आपकी स्पीच को टेक्स्ट में बदलने के लिए OpenAI मॉडल का इस्तेमाल करता है, ताकि आप "
-"बिना टाइप किए भी Duck.ai में चैट कर सकें।"
+"डिक्टेशन आपकी स्पीच को टेक्स्ट में बदलने के लिए OpenAI मॉडल का इस्तेमाल करता "
+"है, ताकि आप बिना टाइप किए भी Duck.ai में चैट कर सकें।"
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6457,7 +6505,7 @@ msgstr "प्रमोशन हटाएं"
 #. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the close button on the survey banner"
 msgid "Dismiss survey"
-msgstr ""
+msgstr "सर्वे खारिज करें"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6608,8 +6656,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
-"क्या आपको AI नहीं चाहिए? %1$snoai.duckduckgo.com%2$s इसमें कोई AI सुविधा नहीं है और "
-"AI इमेज फ़िल्टर कर दी गई हैं। %3$sऔर जानें%4$s"
+"क्या आपको AI नहीं चाहिए? %1$snoai.duckduckgo.com%2$s इसमें कोई AI सुविधा "
+"नहीं है और AI इमेज फ़िल्टर कर दी गई हैं। %3$sऔर जानें%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6618,8 +6666,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"क्या आपको AI नहीं चाहिए? %1$snoai.duckduckgo.com%2$s पर जाएं ताकि बिना AI फ़ीचर्स "
-"और बिना AI इमेज फ़िल्टर के साथ खोज सकें। %3$sऔर जानें%4$s"
+"क्या आपको AI नहीं चाहिए? %1$snoai.duckduckgo.com%2$s पर जाएं ताकि बिना AI "
+"फ़ीचर्स और बिना AI इमेज फ़िल्टर के साथ खोज सकें। %3$sऔर जानें%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6735,8 +6783,8 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for "
 "ceiling fan repair services."
 msgstr ""
-"छत वाले पंखे की मरम्मत सेवा के लिए कोटेशन का अनुरोध करते हुए, वेंडर को कम शब्दों में ज़रूरी "
-"जानकारी के साथ ईमेल लिखें।"
+"छत वाले पंखे की मरम्मत सेवा के लिए कोटेशन का अनुरोध करते हुए, वेंडर को कम "
+"शब्दों में ज़रूरी जानकारी के साथ ईमेल लिखें।"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion asking for an email draft to a vendor requesting a quote for home refrigerator repair services.
@@ -6745,8 +6793,8 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
 msgstr ""
-"घर के रेफ़्रिजरेरट की मरम्मत के लिए कोटेशन का अनुरोध करते हुए, वेंडर को कम शब्दों में ज़रूरी "
-"जानकारी के साथ ईमेल लिखें।"
+"घर के रेफ़्रिजरेरट की मरम्मत के लिए कोटेशन का अनुरोध करते हुए, वेंडर को कम "
+"शब्दों में ज़रूरी जानकारी के साथ ईमेल लिखें।"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -6767,8 +6815,8 @@ msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
 msgstr ""
-"ऐसी एक सोशल मीडिया पोस्ट हेतु कुछ ऑप्शन ड्राफ्ट करें जो मेरी आगामी पार्टी में लोगों को "
-"आमंत्रित करने के लिए है।"
+"ऐसी एक सोशल मीडिया पोस्ट हेतु कुछ ऑप्शन ड्राफ्ट करें जो मेरी आगामी पार्टी "
+"में लोगों को आमंत्रित करने के लिए है।"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6777,8 +6825,8 @@ msgid ""
 "Draft a few options for a title of a post I’m writing about strategies to "
 "increase team collaboration."
 msgstr ""
-"ऐसी एक पोस्ट के शीर्षक के लिए कुछ ऑप्शन ड्राफ्ट करें जिसमें मुझे टीम सहयोग बढ़ाने की मेरी "
-"रणनीतियों के बारे में लिखना है।"
+"ऐसी एक पोस्ट के शीर्षक के लिए कुछ ऑप्शन ड्राफ्ट करें जिसमें मुझे टीम सहयोग "
+"बढ़ाने की मेरी रणनीतियों के बारे में लिखना है।"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for drafting a social media post.
@@ -6910,9 +6958,9 @@ msgid ""
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
 msgstr ""
-"अब Duck.ai आपके द्वारा देखे जा रहे पेज से संबंधित सवालों के जवाब दे सकता है। पेज का कंटेंट "
-"तभी शामिल होता है जब आप उसे अटैच करते हैं, बशर्ते आपने सेटिंग में पेजों को ऑटोमैटिकली अटैच "
-"करने का विकल्प न चुना हो।"
+"अब Duck.ai आपके द्वारा देखे जा रहे पेज से संबंधित सवालों के जवाब दे सकता है। "
+"पेज का कंटेंट तभी शामिल होता है जब आप उसे अटैच करते हैं, बशर्ते आपने सेटिंग "
+"में पेजों को ऑटोमैटिकली अटैच करने का विकल्प न चुना हो।"
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6922,8 +6970,9 @@ msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
 msgstr ""
-"Duck.ai आपकी चैट्स को सेव करने के लिए लोकल स्टोरेज एक्सेस नहीं कर सकता। कृपया अपनी "
-"ब्राउज़र सेटिंग्स चेक करें या कोई भी एक्सटेंशन डिसेबल (अक्षम) करें और फिर से कोशिश करें।"
+"Duck.ai आपकी चैट्स को सेव करने के लिए लोकल स्टोरेज एक्सेस नहीं कर सकता। "
+"कृपया अपनी ब्राउज़र सेटिंग्स चेक करें या कोई भी एक्सटेंशन डिसेबल (अक्षम) "
+"करें और फिर से कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6932,8 +6981,8 @@ msgid ""
 "Duck.ai has reached the maximum number of messages for one day. Please "
 "continue this chat tomorrow."
 msgstr ""
-"Duck.ai एक दिन के लिए तय संदेशों की अधिकतम संख्या तक पहुंच गया है। कृपया इस चैट को अब "
-"कल जारी रखें।"
+"Duck.ai एक दिन के लिए तय संदेशों की अधिकतम संख्या तक पहुंच गया है। कृपया इस "
+"चैट को अब कल जारी रखें।"
 
 # smartling.placeholder_format=C
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
@@ -6949,8 +6998,9 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
-"Duck.ai को DuckDuckGo द्वारा बनाया गया है। हम एक स्वतंत्र ऑनलाइन प्रोटेक्शन कंपनी हैं, "
-"जो उन सभी के लिए है जो अपनी पर्सनल जानकारी का कंट्रोल वापस अपने हाथ में लेना चाहते हैं।"
+"Duck.ai को DuckDuckGo द्वारा बनाया गया है। हम एक स्वतंत्र ऑनलाइन प्रोटेक्शन "
+"कंपनी हैं, जो उन सभी के लिए है जो अपनी पर्सनल जानकारी का कंट्रोल वापस अपने "
+"हाथ में लेना चाहते हैं।"
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6965,8 +7015,8 @@ msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
 msgstr ""
-"Duck.ai अभी भी DuckDuckGo का प्रोडक्ट है, लेकिन अब वेब पर इसे याद रखना और भी आसान "
-"होगा: https://duck.ai"
+"Duck.ai अभी भी DuckDuckGo का प्रोडक्ट है, लेकिन अब वेब पर इसे याद रखना और भी "
+"आसान होगा: https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6981,8 +7031,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai फिलहाल उपलब्ध नहीं है। अगर यह समस्या बनी रहती है, तो कृपया इस अनाम कोड "
-"%1$s को %2$s पर ईमेल करें"
+"Duck.ai फिलहाल उपलब्ध नहीं है। अगर यह समस्या बनी रहती है, तो कृपया इस अनाम "
+"कोड %1$s को %2$s पर ईमेल करें"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7003,9 +7053,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"Duck.ai आपको पॉपुलर AI मॉडल्स के साथ गोपनीय ढंग से प्राइवेट चैट करने देता है। इसे बंद करने "
-"से Duck.ai बटन और लिंक छिप जाते हैं, लेकिन आप अभी भी %1$sduck.ai%2$s पर जा सकते हैं "
-"सीधे ही।"
+"Duck.ai आपको पॉपुलर AI मॉडल्स के साथ गोपनीय ढंग से प्राइवेट चैट करने देता "
+"है। इसे बंद करने से Duck.ai बटन और लिंक छिप जाते हैं, लेकिन आप अभी भी "
+"%1$sduck.ai%2$s पर जा सकते हैं सीधे ही।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7016,10 +7066,11 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai से आपको थर्ड-पार्टी AI चैट मॉडल के साथ गुमनाम ढंग से बातचीत करने की सुविधा "
-"मिलती है, जिसमें OpenAI, Anthropic और अन्य मॉडल शामिल हैं। इस सेटिंग को बंद करने से "
-"DuckDuckGo Search पर Duck.ai बटन और लिंक छिप जाएंगे। हालांकि, यह सेटिंग बंद होने पर "
-"भी आप %1$shttps://duck.ai%2$s पर जाकर, सीधे तौर पर Duck.ai का इस्तेमाल कर सकते हैं।"
+"Duck.ai से आपको थर्ड-पार्टी AI चैट मॉडल के साथ गुमनाम ढंग से बातचीत करने की "
+"सुविधा मिलती है, जिसमें OpenAI, Anthropic और अन्य मॉडल शामिल हैं। इस सेटिंग "
+"को बंद करने से DuckDuckGo Search पर Duck.ai बटन और लिंक छिप जाएंगे। हालांकि, "
+"यह सेटिंग बंद होने पर भी आप %1$shttps://duck.ai%2$s पर जाकर, सीधे तौर पर "
+"Duck.ai का इस्तेमाल कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -7034,8 +7085,8 @@ msgid ""
 "Duck.ai might have lost your recent chats. You can still use Duck.ai as "
 "usual."
 msgstr ""
-"हो सकता है कि Duck.ai ने आपकी पिछली चैट हटा दी हों। आप Duck.ai का उपयोग जारी रख "
-"सकते हैं।"
+"हो सकता है कि Duck.ai ने आपकी पिछली चैट हटा दी हों। आप Duck.ai का उपयोग जारी "
+"रख सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -7049,8 +7100,8 @@ msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
 msgstr ""
-"Duck.ai के जवाब कुछ खास स्रोतों पर आधारित नहीं होते हैं और इनकी सटीकता संबंधी कोई जांच "
-"नहीं होती है।"
+"Duck.ai के जवाब कुछ खास स्रोतों पर आधारित नहीं होते हैं और इनकी सटीकता "
+"संबंधी कोई जांच नहीं होती है।"
 
 # smartling.placeholder_format=C
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
@@ -7084,9 +7135,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, प्राइवेट AI चैटबॉट, मुफ़्त AI चैट, गुमनाम AI चैट, बिना साइन "
-"अप AI चैट, OpenAI, Anthropic, Llama, Mistral, ओपन सोर्स AI मॉडल, गोपनीयता "
-"केंद्रित AI, बिना खाता AI चैट"
+"Duck.ai, DuckDuckGo AI, प्राइवेट AI चैटबॉट, मुफ़्त AI चैट, गुमनाम AI चैट, "
+"बिना साइन अप AI चैट, OpenAI, Anthropic, Llama, Mistral, ओपन सोर्स AI मॉडल, "
+"गोपनीयता केंद्रित AI, बिना खाता AI चैट"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7114,12 +7165,13 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"कुछ खोजों के लिए DuckAssist, जानकारी को गुमनाम रूप से खोज सकता है और उसके बारे में खास "
-"जानकारी दे सकता है। आप चुन सकते हैं कि DuckAssist को कितनी बार दिखाना है: कभी नहीं "
-"(यह खोज परिणामों से DuckAssist के यूआई को पूरी तरह हटा देता है), ऑन-डिमांड (सिर्फ़ तभी "
-"दिखाता है जब आप 'सहायता' बटन पर क्लिक करते हैं), कभी-कभी (सिर्फ़ तभी दिखाता है, जब "
-"नतीजे बहुत काम के हों), या अक्सर (कई तरह की खोजों पर अक्सर दिखाता है)। फ़िलहाल, "
-"DuckAssist सिर्फ़ अमेरिका (अंग्रेज़ी) में उपलब्ध है।"
+"कुछ खोजों के लिए DuckAssist, जानकारी को गुमनाम रूप से खोज सकता है और उसके "
+"बारे में खास जानकारी दे सकता है। आप चुन सकते हैं कि DuckAssist को कितनी बार "
+"दिखाना है: कभी नहीं (यह खोज परिणामों से DuckAssist के यूआई को पूरी तरह हटा "
+"देता है), ऑन-डिमांड (सिर्फ़ तभी दिखाता है जब आप 'सहायता' बटन पर क्लिक करते "
+"हैं), कभी-कभी (सिर्फ़ तभी दिखाता है, जब नतीजे बहुत काम के हों), या अक्सर (कई "
+"तरह की खोजों पर अक्सर दिखाता है)। फ़िलहाल, DuckAssist सिर्फ़ अमेरिका "
+"(अंग्रेज़ी) में उपलब्ध है।"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7129,8 +7181,8 @@ msgid ""
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
 "DuckAssist से फ़ॉलोअप सवालों के जवाब नहीं दिए जा सकते। हालांकि, हमारी ओर से "
-"%1$sDuckDuckGo AI Chat%2$s भी उपलब्ध है, जो एक प्राइवेट AI-संचालित चैट सेवा है जो "
-"OpenAI के चैट मॉडलों को, और Anthropic को और अन्य को सपोर्ट करती है।"
+"%1$sDuckDuckGo AI Chat%2$s भी उपलब्ध है, जो एक प्राइवेट AI-संचालित चैट सेवा "
+"है जो OpenAI के चैट मॉडलों को, और Anthropic को और अन्य को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7140,8 +7192,8 @@ msgid ""
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
 "DuckAssist से फ़ॉलोअप सवालों के जवाब नहीं दिए जा सकते। हालांकि, हमारी ओर से "
-"DuckDuckGo %1$sAI Chat%2$s भी उपलब्ध है। यह एक प्राइवेट AI-संचालित चैट सेवा है जो "
-"OpenAI और Anthropic के चैट मॉडलों को सपोर्ट करती है।"
+"DuckDuckGo %1$sAI Chat%2$s भी उपलब्ध है। यह एक प्राइवेट AI-संचालित चैट सेवा "
+"है जो OpenAI और Anthropic के चैट मॉडलों को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7153,12 +7205,12 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist, खोज परिणाम दिखाने से जुड़ा एक नया फ़ीचर है। यह गुमनाम रहकर, खोज संबंधी "
-"क्वेरी के जवाब जनरेट कर सकता है। ऐसा करने के लिए, यह Wikipedia और संबंधित साइटों को "
-"स्कैन करके उनसे काम की जानकारी जुटाता है। इसके बाद, उससे जुड़ी खास जानकारी को जनरेट करने "
-"के लिए AI-संचालित नेचुरल लैंग्वेज टेक्नोलॉजी का इस्तेमाल करता है। कृपया ध्यान दें कि फ़िलहाल "
-"इसके जवाब Wikipedia और संबंधित कॉन्टेंट पर आधारित होते हैं और इसकी सटीकता की जांच नहीं "
-"की जाती है।"
+"DuckAssist, खोज परिणाम दिखाने से जुड़ा एक नया फ़ीचर है। यह गुमनाम रहकर, खोज "
+"संबंधी क्वेरी के जवाब जनरेट कर सकता है। ऐसा करने के लिए, यह Wikipedia और "
+"संबंधित साइटों को स्कैन करके उनसे काम की जानकारी जुटाता है। इसके बाद, उससे "
+"जुड़ी खास जानकारी को जनरेट करने के लिए AI-संचालित नेचुरल लैंग्वेज टेक्नोलॉजी "
+"का इस्तेमाल करता है। कृपया ध्यान दें कि फ़िलहाल इसके जवाब Wikipedia और "
+"संबंधित कॉन्टेंट पर आधारित होते हैं और इसकी सटीकता की जांच नहीं की जाती है।"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7172,13 +7224,15 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssist, खोज परिणाम दिखाने से जुड़ा एक नया वैकल्पिक फ़ीचर है। यह गुमनाम रहकर, खोज "
-"संबंधी क्वेरी के जवाब जनरेट कर सकता है। ऐसा करने के लिए, यह वेब को स्कैन करके क्वेरी से जुड़ी "
-"सामग्री जुटाता है। इसके बाद, उस सामग्री से जुड़ी जानकारी के आधार पर कम शब्दों में जवाब देने "
-"के लिए, AI-संचालित नेचुरल लैंग्वेज टेक्नोलॉजी का इस्तेमाल करता है। DuckAssist के जवाब हमेशा "
-"एक या दो स्रोतों से सीधे लिंक होते हैं, जिसमें बताया जाता है कि जवाब कहां से आया है, ताकि "
-"आपको आसानी से वहां जाकर ज़्यादा जानकारी मिल सके। यह याद रखना ज़रूरी है कि जवाब, दूसरे "
-"स्रोतों से अपने-आप जनरेट होते हैं और %1$sवेब क्रॉलिंग%2$s पर आधारित होते हैं।"
+"DuckAssist, खोज परिणाम दिखाने से जुड़ा एक नया वैकल्पिक फ़ीचर है। यह गुमनाम "
+"रहकर, खोज संबंधी क्वेरी के जवाब जनरेट कर सकता है। ऐसा करने के लिए, यह वेब को "
+"स्कैन करके क्वेरी से जुड़ी सामग्री जुटाता है। इसके बाद, उस सामग्री से जुड़ी "
+"जानकारी के आधार पर कम शब्दों में जवाब देने के लिए, AI-संचालित नेचुरल "
+"लैंग्वेज टेक्नोलॉजी का इस्तेमाल करता है। DuckAssist के जवाब हमेशा एक या दो "
+"स्रोतों से सीधे लिंक होते हैं, जिसमें बताया जाता है कि जवाब कहां से आया है, "
+"ताकि आपको आसानी से वहां जाकर ज़्यादा जानकारी मिल सके। यह याद रखना ज़रूरी है "
+"कि जवाब, दूसरे स्रोतों से अपने-आप जनरेट होते हैं और %1$sवेब क्रॉलिंग%2$s पर "
+"आधारित होते हैं।"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -7186,8 +7240,8 @@ msgid ""
 "DuckAssist responses are auto-generated based on listed sources and not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist वाले जवाब सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट होते हैं और इनकी "
-"सटीकता की जांच नहीं की जाती है।"
+"DuckAssist वाले जवाब सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट होते "
+"हैं और इनकी सटीकता की जांच नहीं की जाती है।"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -7196,8 +7250,8 @@ msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
 msgstr ""
-"DuckDuckGo AI Chat में एक दिन के संदेशों की अधिकतम संख्या पूरी हो गई है। कृपया इस चैट को "
-"अब कल जारी रखें।"
+"DuckDuckGo AI Chat में एक दिन के संदेशों की अधिकतम संख्या पूरी हो गई है। "
+"कृपया इस चैट को अब कल जारी रखें।"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7206,8 +7260,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat एक प्राइवेट AI-संचालित चैट सेवा है जो वर्तमान में %1$s के %2$s और "
-"%3$s के %4$s चैट मॉडल को सपोर्ट करती है।"
+"DuckDuckGo AI Chat एक प्राइवेट AI-संचालित चैट सेवा है जो वर्तमान में %1$s के "
+"%2$s और %3$s के %4$s चैट मॉडल को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7216,8 +7270,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat एक प्राइवेट AI-संचालित चैट सेवा है जो वर्तमान में %1$s के %2$s और "
-"%3$s के %4$s चैट मॉडल को सपोर्ट करती है।"
+"DuckDuckGo AI Chat एक प्राइवेट AI-संचालित चैट सेवा है जो वर्तमान में %1$s के "
+"%2$s और %3$s के %4$s चैट मॉडल को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -7226,7 +7280,8 @@ msgid ""
 "DuckDuckGo AI Chat is in Beta, it may display inaccurate or offensive "
 "information."
 msgstr ""
-"DuckDuckGo AI Chat बीटा में है, इसमें गलत या आपत्तिजनक जानकारी भी दिखाई दे सकती है।"
+"DuckDuckGo AI Chat बीटा में है, इसमें गलत या आपत्तिजनक जानकारी भी दिखाई दे "
+"सकती है।"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat making it unavailable, and asking the user to send an email with a specific code if the error persists. E.g. 'DuckDuckGo AI Chat is temporarily unavailable. If this persists, please email this anonymous code abcdefg12345 to aichat-error@duckduckgo.com'
@@ -7235,8 +7290,8 @@ msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
 msgstr ""
-"DuckDuckGo AI Chat फिलहाल उपलब्ध नहीं है। अगर यह समस्या बनी रहती है, तो कृपया इस "
-"अनाम कोड %1$s को %2$s पर ईमेल करें"
+"DuckDuckGo AI Chat फिलहाल उपलब्ध नहीं है। अगर यह समस्या बनी रहती है, तो "
+"कृपया इस अनाम कोड %1$s को %2$s पर ईमेल करें"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7245,7 +7300,8 @@ msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
 msgstr ""
-"DuckDuckGo AI Chat फिलहाल उपलब्ध नहीं है। पेज को रीफ्रेश करें और फिर से कोशिश करें।"
+"DuckDuckGo AI Chat फिलहाल उपलब्ध नहीं है। पेज को रीफ्रेश करें और फिर से "
+"कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7401,8 +7457,9 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"DuckDuckGo सुरक्षा की दृष्टि से नाम, ईमेल पते, फ़ोन नंबर और पहचान संबंधी मेटाडेटा जैसी "
-"व्यक्तिगत जानकारी (PII) को ऑटोमैटिकली हटाकर इन रिपोर्टों को एनोनिमाइज़ कर देता है।"
+"DuckDuckGo सुरक्षा की दृष्टि से नाम, ईमेल पते, फ़ोन नंबर और पहचान संबंधी "
+"मेटाडेटा जैसी व्यक्तिगत जानकारी (PII) को ऑटोमैटिकली हटाकर इन रिपोर्टों को "
+"एनोनिमाइज़ कर देता है।"
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -7410,8 +7467,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo आपकी चैट को अनाम बनाता है। '%1$s' पर क्लिक करके आप Duck.ai की %2$s से "
-"सहमत होते हैं।"
+"DuckDuckGo आपकी चैट को अनाम बनाता है। '%1$s' पर क्लिक करके आप Duck.ai की "
+"%2$s से सहमत होते हैं।"
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7420,8 +7477,8 @@ msgctxt ""
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
 msgstr ""
-"DuckDuckGo आपकी चैट को अनाम बनाता है। '%1$s' पर क्लिक करके आप हमारी %2$s से सहमत "
-"होते हैं।"
+"DuckDuckGo आपकी चैट को अनाम बनाता है। '%1$s' पर क्लिक करके आप हमारी %2$s से "
+"सहमत होते हैं।"
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7430,9 +7487,9 @@ msgid ""
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
 msgstr ""
-"DuckDuckGo आपके द्वारा देखी जाने वाली वेबसाइटों पर ट्रैकरों को ब्लॉक करता है, जिसमें "
-"Google और Facebook जैसी कंपनियों के ट्रैकर शामिल हैं, जो अक्सर आपको अन्य वेबसाइटों पर "
-"ट्रैक करने की कोशिश करते हैं।"
+"DuckDuckGo आपके द्वारा देखी जाने वाली वेबसाइटों पर ट्रैकरों को ब्लॉक करता "
+"है, जिसमें Google और Facebook जैसी कंपनियों के ट्रैकर शामिल हैं, जो अक्सर "
+"आपको अन्य वेबसाइटों पर ट्रैक करने की कोशिश करते हैं।"
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7444,11 +7501,12 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo को गोपनीयता के लिए बनाया गया है। जब आप स्‍थान सक्षम करते हैं, तो यह केवल "
-"आपके स्थानीय डिवाइस में स्टोर हो जाता है। जब आप खोज करते हैं, तो आपकी डिवाइस उसे हमें "
-"भेजता है, हम उसका उपयोग उस खोज के परिणामों को बेहतर बनाने के लिए करते हैं और फिर हम "
-"तुरंत इसे फेंक देते हैं, जिससे आप गुमनाम ही रहते हैं। %1$sआपकी गोपनीयता की सुरक्षा के लिए हमने "
-"इस तकनीक को कैसे डिज़ाइन किया है, इसके बारे में और जानें%2$s।"
+"DuckDuckGo को गोपनीयता के लिए बनाया गया है। जब आप स्‍थान सक्षम करते हैं, तो "
+"यह केवल आपके स्थानीय डिवाइस में स्टोर हो जाता है। जब आप खोज करते हैं, तो "
+"आपकी डिवाइस उसे हमें भेजता है, हम उसका उपयोग उस खोज के परिणामों को बेहतर "
+"बनाने के लिए करते हैं और फिर हम तुरंत इसे फेंक देते हैं, जिससे आप गुमनाम ही "
+"रहते हैं। %1$sआपकी गोपनीयता की सुरक्षा के लिए हमने इस तकनीक को कैसे डिज़ाइन "
+"किया है, इसके बारे में और जानें%2$s।"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -7468,8 +7526,8 @@ msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
 msgstr ""
-"DuckDuckGo केवल आपके अनुमानित स्‍थान का उपयोग करता है। हम सभी को आपके नज़दीक के बेहतर "
-"परिणाम देने की जरूरत है। %1$sऔर जानें%2$s।"
+"DuckDuckGo केवल आपके अनुमानित स्‍थान का उपयोग करता है। हम सभी को आपके नज़दीक "
+"के बेहतर परिणाम देने की जरूरत है। %1$sऔर जानें%2$s।"
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7561,9 +7619,10 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"हर बार जब आप पासफ्रेज़ सुझाव मांगते हैं, तो हमें DuckDuckGo सर्वर से आकस्मिक शब्दों की लंबी "
-"सूची मिलती है। ब्राउज़र में, हम उस सूची से 4-5 आकस्मिक शब्दों का चयन करते हैं, यह सुनिश्चित "
-"करते हुए कि पासफ्रेज़ कम से कम 18-20 अक्षर लंबा है।"
+"हर बार जब आप पासफ्रेज़ सुझाव मांगते हैं, तो हमें DuckDuckGo सर्वर से आकस्मिक "
+"शब्दों की लंबी सूची मिलती है। ब्राउज़र में, हम उस सूची से 4-5 आकस्मिक शब्दों "
+"का चयन करते हैं, यह सुनिश्चित करते हुए कि पासफ्रेज़ कम से कम 18-20 अक्षर "
+"लंबा है।"
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7620,7 +7679,7 @@ msgstr "प्रॉम्प्ट एडिट करें"
 #. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the message-editing text area"
 msgid "Edit message"
-msgstr ""
+msgstr "मैसेज एडिट करें"
 
 # smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
@@ -7640,8 +7699,8 @@ msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
 msgstr ""
-"आपके संदेश को एडिट करने से नीचे दिया गया जवाब हट जाएगा और उसकी जगह नया जवाब तैयार "
-"होगा।"
+"आपके संदेश को एडिट करने से नीचे दिया गया जवाब हट जाएगा और उसकी जगह नया जवाब "
+"तैयार होगा।"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7779,8 +7838,8 @@ msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
 msgstr ""
-"अधिक सटीक परिणामों के लिए अनाम स्थान सक्षम करें। आप अक्‍सर बाद में अपना विचार बदल सकते "
-"हैं।"
+"अधिक सटीक परिणामों के लिए अनाम स्थान सक्षम करें। आप अक्‍सर बाद में अपना "
+"विचार बदल सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7823,8 +7882,9 @@ msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
 msgstr ""
-"जगह की जानकारी गुप्त रखने की सुविध चालू करने से ज़्यादा सटीक परिणाम मिलते हैं, लेकिन फिर "
-"भी DuckDuckGo के लिए आपकी खोजें और सटीक स्थान गोपनीय बने रहते हैं।"
+"जगह की जानकारी गुप्त रखने की सुविध चालू करने से ज़्यादा सटीक परिणाम मिलते "
+"हैं, लेकिन फिर भी DuckDuckGo के लिए आपकी खोजें और सटीक स्थान गोपनीय बने रहते "
+"हैं।"
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7848,7 +7908,7 @@ msgstr "एन्क्रिप्ट किया गया मॉडल"
 #. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
 msgctxt "Share modal info bullet about encryption"
 msgid "Encrypted so DuckDuckGo can't read your chat."
-msgstr ""
+msgstr "इसे एन्क्रिप्ट किया गया है ताकि DuckDuckGo आपकी चैट न पढ़ सके।"
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -7992,8 +8052,8 @@ msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
 msgstr ""
-"एक नया पासफ्रेज़ दर्ज करें और %1$sसेटिंग सहेजें%2$s पर टैप/क्लिक करें। यह आपके नए पासफ्रेज़ के "
-"तहत आपके डेटा को बचाएगा।"
+"एक नया पासफ्रेज़ दर्ज करें और %1$sसेटिंग सहेजें%2$s पर टैप/क्लिक करें। यह "
+"आपके नए पासफ्रेज़ के तहत आपके डेटा को बचाएगा।"
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -8019,8 +8079,8 @@ msgstr "टेक्स्ट डालें"
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
 msgstr ""
-"निम्नलिखित विवरण दर्ज करें: %1$sनाम%2$s: DuckDuckGo%3$s यूआरएल%4$s: %5$s उपनाम "
-"%6$s: d%7$s"
+"निम्नलिखित विवरण दर्ज करें: %1$sनाम%2$s: DuckDuckGo%3$s यूआरएल%4$s: %5$s "
+"उपनाम %6$s: d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -8121,8 +8181,8 @@ msgstr "मैप का विस्तार करें"
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
-"उन लोगों के लिए बेहतरीन ढंग से तैयार किए गए प्रोडक्ट, जिन्हें अपनी प्राइवेसी की सचमुच "
-"परवाह है।"
+"उन लोगों के लिए बेहतरीन ढंग से तैयार किए गए प्रोडक्ट, जिन्हें अपनी प्राइवेसी "
+"की सचमुच परवाह है।"
 
 # smartling.placeholder_format=C
 #. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
@@ -8406,8 +8466,8 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
 msgstr ""
-"आप लोगों से जो फीडबैक मिलती है उससे हमें हमारे प्रोडक्ट अपडेट और सुधार संंबंधी कार्यों में मदद "
-"मिलती है।"
+"आप लोगों से जो फीडबैक मिलती है उससे हमें हमारे प्रोडक्ट अपडेट और सुधार "
+"संंबंधी कार्यों में मदद मिलती है।"
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8416,8 +8476,9 @@ msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
 msgstr ""
-"आप लोगों से जो फ़ीडबैक मिलता है उससे हमारे प्रॉडक्ट अपडेट और बेहतर बनाने की कोशिश में मदद "
-"मिलती है। उम्मीद है हम जल्द ही वह समस्या भी हल कर पाएंगे जिसे आपने शेयर किया है।"
+"आप लोगों से जो फ़ीडबैक मिलता है उससे हमारे प्रॉडक्ट अपडेट और बेहतर बनाने की "
+"कोशिश में मदद मिलती है। उम्मीद है हम जल्द ही वह समस्या भी हल कर पाएंगे जिसे "
+"आपने शेयर किया है।"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -8425,8 +8486,8 @@ msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
 msgstr ""
-"नीचे दी गई सेटिंग को निस्संकोच होकर एडजस्ट करें। उसके बाद, कोड को अपनी वेबसाइट में कॉपी "
-"पेस्ट करें।"
+"नीचे दी गई सेटिंग को निस्संकोच होकर एडजस्ट करें। उसके बाद, कोड को अपनी "
+"वेबसाइट में कॉपी पेस्ट करें।"
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8515,7 +8576,9 @@ msgstr "इमेज खोज परिणामों से AI-जनरे�
 msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
-msgstr "इमेज खोज परिणामों से ज्ञात AI स्पैम साइटों को फ़िल्टर कर देता है। %1$sऔर जानें%2$s"
+msgstr ""
+"इमेज खोज परिणामों से ज्ञात AI स्पैम साइटों को फ़िल्टर कर देता है। %1$sऔर "
+"जानें%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8593,7 +8656,9 @@ msgstr "अपने नज़दीक के परिणामों को �
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr "अपने आस-पास के परिणाम खोजें। %1$sआपकी लोकेशन निजी, सुरक्षित और गुमनाम रहती है।"
+msgstr ""
+"अपने आस-पास के परिणाम खोजें। %1$sआपकी लोकेशन निजी, सुरक्षित और गुमनाम रहती "
+"है।"
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8657,8 +8722,8 @@ msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
 msgstr ""
-"DuckDuckGo के लिए विज्ञापन ब्लॉकर बंद करने के निर्देशों का पालन करें। कोई मेन्यू विकल्प चुनें "
-"या कोई बटन क्लिक करें।"
+"DuckDuckGo के लिए विज्ञापन ब्लॉकर बंद करने के निर्देशों का पालन करें। कोई "
+"मेन्यू विकल्प चुनें या कोई बटन क्लिक करें।"
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8675,7 +8740,7 @@ msgstr "फ़ॉलोअप सवाल"
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
-msgstr ""
+msgstr "फ़ॉलोअप गोपनीय रहते हैं।"
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8812,8 +8877,8 @@ msgstr "व्यावसायिक रूप से शेयर और उ�
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
 msgstr ""
-"जो चैट काम की नहीं हैं, उन्हें डिलीट कर स्पेस खाली करें। पिन की गई चैट डिलीट नहीं की "
-"जाएंगी।"
+"जो चैट काम की नहीं हैं, उन्हें डिलीट कर स्पेस खाली करें। पिन की गई चैट डिलीट "
+"नहीं की जाएंगी।"
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8894,8 +8959,8 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Mac पर ऐप के मेनू बार से, <strong>DuckDuckGo</strong> &gt; <strong>अपडेट देखें...</"
-"strong> चुनें, फिर <strong>अपडेट इंस्टॉल करें</strong> को चुनें।"
+"Mac पर ऐप के मेनू बार से, <strong>DuckDuckGo</strong> &gt; <strong>अपडेट "
+"देखें...</strong> चुनें, फिर <strong>अपडेट इंस्टॉल करें</strong> को चुनें।"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9181,21 +9246,20 @@ msgid ""
 "Get DuckDuckGo VPN, advanced Duck.ai, Personal Info Removal, and Identity "
 "Theft Restoration."
 msgstr ""
-"प्राप्त करें DuckDuckGo VPN, एडवांस्ड Duck.ai, Personal Info Removal, और Identity "
-"Theft Restoration."
+"प्राप्त करें DuckDuckGo VPN, एडवांस्ड Duck.ai, Personal Info Removal, और "
+"Identity Theft Restoration."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr ""
-"DuckDuckGo VPN, एडवांस्ड Duck.ai, और Identity Theft Restoration प्राप्त करें।"
+msgstr "DuckDuckGo VPN, एडवांस्ड Duck.ai, और Identity Theft Restoration प्राप्त करें।"
 
 # smartling.placeholder_format=C
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
 msgctxt "Tooltip on the header logo for sunglasses searches"
 msgid "Get DuckDuckGo sunglasses and other gear."
-msgstr ""
+msgstr "DuckDuckGo सनग्लासेज़ और अन्य सामान प्राप्त करें।"
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9275,8 +9339,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, Personal Info Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"तेज़, नो-लॉग VPN, ऑप्शनल एडवांस्ड AI चैट, Personal Info Removal, और Identity Theft "
-"Restoration पाएं।"
+"तेज़, नो-लॉग VPN, ऑप्शनल एडवांस्ड AI चैट, Personal Info Removal, और Identity "
+"Theft Restoration पाएं।"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; 'advanced AI chat' refers to Duck.ai; Identity Theft Restoration is a bundled feature.
@@ -9285,7 +9349,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, and Identity Theft "
 "Restoration."
 msgstr ""
-"तेज़, नो-लॉग VPN, ऑप्शनल एडवांस्ड AI चैट, और Identity Theft Restoration प्राप्त करें।"
+"तेज़, नो-लॉग VPN, ऑप्शनल एडवांस्ड AI चैट, और Identity Theft Restoration "
+"प्राप्त करें।"
 
 # smartling.placeholder_format=C
 #. Description for the subscription modal where users can update their subscription to DuckDuckGo.
@@ -9294,8 +9359,9 @@ msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"DuckDuckGo को सब्सक्राइब करके Duck.ai में एडवांस्ड AI मॉडल्स का एक्सेस प्राप्त करें, जिसमें "
-"हमारा VPN और अन्य प्रीमियम गोपनीयता संरक्षण भी शामिल हैं।"
+"DuckDuckGo को सब्सक्राइब करके Duck.ai में एडवांस्ड AI मॉडल्स का एक्सेस "
+"प्राप्त करें, जिसमें हमारा VPN और अन्य प्रीमियम गोपनीयता संरक्षण भी शामिल "
+"हैं।"
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -9306,8 +9372,9 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Duck.ai में एडवांस्ड AI मॉडल मॉडल्स का एक्सेस प्राप्त करें DuckDuckGo सब्सक्रिप्शन के साथ, "
-"जिसमें हमारा VPN और अन्य प्रीमियम गोपनीयता संरक्षण भी शामिल हैं।"
+"Duck.ai में एडवांस्ड AI मॉडल मॉडल्स का एक्सेस प्राप्त करें DuckDuckGo "
+"सब्सक्रिप्शन के साथ, जिसमें हमारा VPN और अन्य प्रीमियम गोपनीयता संरक्षण भी "
+"शामिल हैं।"
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9351,8 +9418,8 @@ msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
 msgstr ""
-"हमारा तेज़, नो-लॉग VPN पाएं, साथ ही ज़्यादा चैट लिमिट वाले एडवांस्ड AI मॉडल का ऑप्शनल "
-"एक्सेस और कई प्रीमियम प्रोटेक्शन भी पाएं।"
+"हमारा तेज़, नो-लॉग VPN पाएं, साथ ही ज़्यादा चैट लिमिट वाले एडवांस्ड AI मॉडल "
+"का ऑप्शनल एक्सेस और कई प्रीमियम प्रोटेक्शन भी पाएं।"
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9413,7 +9480,8 @@ msgstr "ऐप प्राप्त करें"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"DuckDuckGo ब्राउज़र मुफ़्त में डाउनलोड करें और %1$sYouTube पर विज्ञापन ब्लॉक करें।%2$s"
+"DuckDuckGo ब्राउज़र मुफ़्त में डाउनलोड करें और %1$sYouTube पर विज्ञापन ब्लॉक "
+"करें।%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9435,7 +9503,9 @@ msgstr "यह गाना यहां पाएंः"
 # smartling.placeholder_format=C
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
-msgstr "आपके दोस्तों को स्विच करने के लिए प्रेरित करें और हमें विकसित होने में मदद करें!"
+msgstr ""
+"आपके दोस्तों को स्विच करने के लिए प्रेरित करें और हमें विकसित होने में मदद "
+"करें!"
 
 # smartling.placeholder_format=C
 #. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
@@ -9472,9 +9542,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"अपने दूसरे ब्राउज़र में %1$sDuck.ai सेटिंग%2$s पर जाएं, या DuckDuckGo ऐप में जाएं और "
-"%3$sचैट › Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें › टेक्स्ट कोड कॉपी "
-"करें%4$sपर जाएं"
+"अपने दूसरे ब्राउज़र में %1$sDuck.ai सेटिंग%2$s पर जाएं, या DuckDuckGo ऐप में "
+"जाएं और %3$sचैट › Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें › "
+"टेक्स्ट कोड कॉपी करें%4$sपर जाएं"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9483,8 +9553,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में %1$sDuck.ai सेटिंग%2$s पर जाएं और %3$sचैट › "
-"Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएं"
+"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में %1$sDuck.ai सेटिंग%2$s पर जाएं और "
+"%3$sचैट › Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएं"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9494,8 +9564,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में %1$sDuck.ai सेटिंग%2$s पर जाएं और %3$sचैट › "
-"Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएं और इस कोड को स्कैन करें:"
+"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में %1$sDuck.ai सेटिंग%2$s पर जाएं और "
+"%3$sचैट › Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएं और "
+"इस कोड को स्कैन करें:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9505,9 +9576,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में %1$sDuck.ai सेटिंग%2$s पर जाएं और %3$sचैट › "
-"Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएं। या अपनी रिकवरी PDF "
-"पर मौजूद QR कोड स्कैन करें।"
+"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में %1$sDuck.ai सेटिंग%2$s पर जाएं और "
+"%3$sचैट › Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएं। या "
+"अपनी रिकवरी PDF पर मौजूद QR कोड स्कैन करें।"
 
 # smartling.placeholder_format=C
 #. Path to the pairing code on the other device. Bold segments are UI path labels.
@@ -9516,8 +9587,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
 msgstr ""
-"%1$sDuck.ai सेटिंग%2$s › %3$sचैट › Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक "
-"करें%4$s पर जाएँ."
+"%1$sDuck.ai सेटिंग%2$s › %3$sचैट › Sync & Backup › किसी दूसरे डिवाइस के साथ "
+"सिंक करें%4$s पर जाएँ."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9532,8 +9603,8 @@ msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
 msgstr ""
-"%1$sसेटिंग > गोपनीयता और सुरक्षा > स्थान सेवाएं%2$s पर जाएं और पक्का करें कि \"स्थान "
-"सेवाएं\" चालू है।"
+"%1$sसेटिंग > गोपनीयता और सुरक्षा > स्थान सेवाएं%2$s पर जाएं और पक्का करें कि "
+"\"स्थान सेवाएं\" चालू है।"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -9542,8 +9613,8 @@ msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
 msgstr ""
-"यहां जाएं: %1$sसेटिंग > गोपनीयता > अनुमति प्रबंधक > स्थान%2$s, और फिर नीचे स्क्रॉल करके "
-"%3$sDuckDuckGo%4$s पर जाएं।"
+"यहां जाएं: %1$sसेटिंग > गोपनीयता > अनुमति प्रबंधक > स्थान%2$s, और फिर नीचे "
+"स्क्रॉल करके %3$sDuckDuckGo%4$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -10232,8 +10303,8 @@ msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
 msgstr ""
-"महत्वपूर्ण जानकारी तेज़ी से ढूंढने में आपकी सहायता करने के लिए Search Assist उत्तरों में मुख्य "
-"तथ्यों को हाइलाइट करता है।"
+"महत्वपूर्ण जानकारी तेज़ी से ढूंढने में आपकी सहायता करने के लिए Search Assist "
+"उत्तरों में मुख्य तथ्यों को हाइलाइट करता है।"
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -10260,8 +10331,8 @@ msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
 msgstr ""
-"सूची में DuckDuckGo को सहेजने के लिए अपने कीबोर्ड पर %1$sरिटर्न%2$s दबाएं%3$s। %4$sफिर "
-"%5$sडिफ़ॉल्ट बनाएं%6$s क्लिक करें"
+"सूची में DuckDuckGo को सहेजने के लिए अपने कीबोर्ड पर %1$sरिटर्न%2$s "
+"दबाएं%3$s। %4$sफिर %5$sडिफ़ॉल्ट बनाएं%6$s क्लिक करें"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -10275,8 +10346,8 @@ msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
 msgstr ""
-"रुके रहें! इसे वापस बदलने पर DuckDuckGo एक्सटेंशन अक्षम हो जाएगा और आप हमारा गोपनीयता "
-"संरक्षण खो देंगे।"
+"रुके रहें! इसे वापस बदलने पर DuckDuckGo एक्सटेंशन अक्षम हो जाएगा और आप हमारा "
+"गोपनीयता संरक्षण खो देंगे।"
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -10326,8 +10397,8 @@ msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
 msgstr ""
-"होटल विज्ञापन क्लिक TripAdvisor के विज्ञापन नेटवर्क द्वारा प्रबंधित किए जाते हैं और इनका "
-"उपयोग आपकी व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
+"होटल विज्ञापन क्लिक TripAdvisor के विज्ञापन नेटवर्क द्वारा प्रबंधित किए जाते "
+"हैं और इनका उपयोग आपकी व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -10424,7 +10495,7 @@ msgstr "यह कैसे काम करता है"
 #. Headline in chat history about modals for the temporary encrypted server storage explanation.
 msgctxt "Chat history about modal list item headline"
 msgid "How it works"
-msgstr ""
+msgstr "यह कैसे काम करता है"
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -10475,8 +10546,8 @@ msgid ""
 "How should I tactfully approach a colleague about their constant pencil "
 "tapping and what should I say?"
 msgstr ""
-"मुझे अपने सहकर्मी से उनकी लगातार पेंसिल से खट-खट करने के बारे में किस तरह व्यवहारकुशलता से "
-"बात करनी चाहिए और क्या कहना चाहिए?"
+"मुझे अपने सहकर्मी से उनकी लगातार पेंसिल से खट-खट करने के बारे में किस तरह "
+"व्यवहारकुशलता से बात करनी चाहिए और क्या कहना चाहिए?"
 
 # smartling.placeholder_format=C
 #. The title for a feedback prompt that includes thumbs up and thumbs down buttons
@@ -10598,8 +10669,8 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"मुझे 'नेम ऑफ द विंड' पुस्तक पसंद है। इस तरह की कुछ और अच्छी किताबें/सीरीज़ कौन-सी हैं और "
-"क्यों?"
+"मुझे 'नेम ऑफ द विंड' पुस्तक पसंद है। इस तरह की कुछ और अच्छी किताबें/सीरीज़ "
+"कौन-सी हैं और क्यों?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -10634,8 +10705,8 @@ msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
 msgstr ""
-"यदि ब्राउज़र स्थान अभी भी मौजूद नहीं है, तो %1$sसेटिंग्‍स > सामान्य > रीसेट > 'स्थान और "
-"गोपनीयता रीसेट करें' पर जाएं%2$s।"
+"यदि ब्राउज़र स्थान अभी भी मौजूद नहीं है, तो %1$sसेटिंग्‍स > सामान्य > रीसेट "
+"> 'स्थान और गोपनीयता रीसेट करें' पर जाएं%2$s।"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10645,8 +10716,9 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"यदि ब्राउज़र स्थान मौजूद नहीं है, तो अपने ब्राउज़र में %1$s⋮ > मेनू > सेटिंग्‍स > साइट सेटिंग्स "
-"> स्थान%2$s पर जाएं, और सुनिश्चित करें कि DuckDuckGo को स्थान एक्सेस की अनुमति है।"
+"यदि ब्राउज़र स्थान मौजूद नहीं है, तो अपने ब्राउज़र में %1$s⋮ > मेनू > "
+"सेटिंग्‍स > साइट सेटिंग्स > स्थान%2$s पर जाएं, और सुनिश्चित करें कि "
+"DuckDuckGo को स्थान एक्सेस की अनुमति है।"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10661,8 +10733,8 @@ msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
 msgstr ""
-"अगर आपको %1$sDuckDuckGo%2$s दिखाई नहीं दे रहा है तो आपको उसे %3$sअन्य खोज इंजन%4$s "
-"की सूची में जोड़ना होगा"
+"अगर आपको %1$sDuckDuckGo%2$s दिखाई नहीं दे रहा है तो आपको उसे %3$sअन्य खोज "
+"इंजन%4$s की सूची में जोड़ना होगा"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -10671,8 +10743,8 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"अगर आपको हमारे चैट प्रदाताओं या किसी खास चैट जवाब के बारे में कोई समस्या है, तो आप सीधे "
-"%1$s और %2$s सपोर्ट पेज पर भी जा सकते हैं।"
+"अगर आपको हमारे चैट प्रदाताओं या किसी खास चैट जवाब के बारे में कोई समस्या है, "
+"तो आप सीधे %1$s और %2$s सपोर्ट पेज पर भी जा सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10681,15 +10753,17 @@ msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
 msgstr ""
-"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपनी सेव की गई चैट्स को रिकवर करने के लिए "
-"आपको इस कोड की ज़रूरत पड़ेगी। आप इस कोड को एक टेक्स्ट फ़ाइल के रूप में अपने डिवाइस पर सेव "
-"कर सकते हैं।"
+"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपनी सेव की गई चैट्स को रिकवर "
+"करने के लिए आपको इस कोड की ज़रूरत पड़ेगी। आप इस कोड को एक टेक्स्ट फ़ाइल के "
+"रूप में अपने डिवाइस पर सेव कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "अगर आप और सहायता करना चाहते हैं तो, %1$s DuckDuckGo को फेलाने में मदद करें %2$s"
+msgstr ""
+"अगर आप और सहायता करना चाहते हैं तो, %1$s DuckDuckGo को फेलाने में मदद करें "
+"%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10699,15 +10773,17 @@ msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
 msgstr ""
-"अगर​ आप जावास्क्रिप्ट के बिना DuckDuckGo का उपयोग करना चाहते, तो कृपया हमारे %1$s या "
-"%2$s संस्करणों का उपयोग करें।"
+"अगर​ आप जावास्क्रिप्ट के बिना DuckDuckGo का उपयोग करना चाहते, तो कृपया हमारे "
+"%1$s या %2$s संस्करणों का उपयोग करें।"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
-msgstr "अगर आप चाहते हैं, तो नई विंडो और नए टैब के सामने होम पेज चुनें (इसके साथ खोलें)"
+msgstr ""
+"अगर आप चाहते हैं, तो नई विंडो और नए टैब के सामने होम पेज चुनें (इसके साथ "
+"खोलें)"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -10836,7 +10912,8 @@ msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
 msgstr ""
-"अपडेट किए गए URL फ़ॉर्मैट, प्लेसमेंट और रंग के साथ नतीजे के बेहतर दिखने में सुधार करता है"
+"अपडेट किए गए URL फ़ॉर्मैट, प्लेसमेंट और रंग के साथ नतीजे के बेहतर दिखने में "
+"सुधार करता है"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -10849,8 +10926,8 @@ msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
 msgstr ""
-"कुछ पुराने ब्राउज़रों में हमारे सर्वर से खोज लीकेज रोकने के लिए आपके क्लिकों को रीडायरेक्ट करना "
-"आवश्यक है। %1$sऔर जानें%2$s।"
+"कुछ पुराने ब्राउज़रों में हमारे सर्वर से खोज लीकेज रोकने के लिए आपके क्लिकों "
+"को रीडायरेक्ट करना आवश्यक है। %1$sऔर जानें%2$s।"
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -10861,8 +10938,8 @@ msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
 msgstr ""
-"DuckDuckGo ब्राउज़र में, सेटिंग › Sync & Backup पर जाएं और फिर “किसी अन्य डिवाइस के "
-"साथ सिंक करें” चुनें।"
+"DuckDuckGo ब्राउज़र में, सेटिंग › Sync & Backup पर जाएं और फिर “किसी अन्य "
+"डिवाइस के साथ सिंक करें” चुनें।"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -10877,8 +10954,8 @@ msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
 msgstr ""
-"पारदर्शिता के हित में यह डेटा एन्क्रिप्ट नहीं किया गया है: आप वाकई देख सकते हैं कि हम क्या "
-"जानकारी संग्रहित करते हैं।"
+"पारदर्शिता के हित में यह डेटा एन्क्रिप्ट नहीं किया गया है: आप वाकई देख सकते "
+"हैं कि हम क्या जानकारी संग्रहित करते हैं।"
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -11214,7 +11291,9 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr "क्या यह जगह अच्छी है? रिव्यू और रेटिंग के आधार पर इसकी रेपुटेशन का सारांश बताएं।"
+msgstr ""
+"क्या यह जगह अच्छी है? रिव्यू और रेटिंग के आधार पर इसकी रेपुटेशन का सारांश "
+"बताएं।"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -11265,7 +11344,8 @@ msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
 msgstr ""
-"मुझसे मेरे DuckDuckGo को उपयोग करने के अनुभव के बारे में पूछना (बहुत ज़्यादा बार) ठीक है"
+"मुझसे मेरे DuckDuckGo को उपयोग करने के अनुभव के बारे में पूछना (बहुत ज़्यादा "
+"बार) ठीक है"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11284,9 +11364,10 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"आइटम आपके खोज शब्दों की प्रासंगिकता के आधार पर रैंक किए जाते हैं और Microsoft के विज्ञापन "
-"नेटवर्क के माध्यम से डिलीवर किए जाते हैं। क्लिक सीधे मर्चेंट लैंडिंग पेज पर ले जाते हैं और "
-"विज्ञापनों के विपरीत, DuckDuckGo को इन परिणामों के लिए प्रतिफल नहीं दिया जाता है।"
+"आइटम आपके खोज शब्दों की प्रासंगिकता के आधार पर रैंक किए जाते हैं और "
+"Microsoft के विज्ञापन नेटवर्क के माध्यम से डिलीवर किए जाते हैं। क्लिक सीधे "
+"मर्चेंट लैंडिंग पेज पर ले जाते हैं और विज्ञापनों के विपरीत, DuckDuckGo को इन "
+"परिणामों के लिए प्रतिफल नहीं दिया जाता है।"
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -11295,8 +11376,8 @@ msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
 msgstr ""
-"10 आकस्मिक अक्षरों और संख्याओं की तुलना में 4-5 शब्दों को याद रखना आसान और अधिक सुरक्षित "
-"भी है।"
+"10 आकस्मिक अक्षरों और संख्याओं की तुलना में 4-5 शब्दों को याद रखना आसान और "
+"अधिक सुरक्षित भी है।"
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -11781,7 +11862,8 @@ msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
 msgstr ""
-"यह आपको Duck.ai पर सर्च क्वेरी और प्रॉम्प्ट सबमिट करने के बीच स्विच करने की सुविधा देता है"
+"यह आपको Duck.ai पर सर्च क्वेरी और प्रॉम्प्ट सबमिट करने के बीच स्विच करने की "
+"सुविधा देता है"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11863,7 +11945,7 @@ msgstr "लिंक 7 दिनों में समाप्त हो ज�
 #. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days. People can save a chat copy."
-msgstr ""
+msgstr "लिंक 7 दिनों में समाप्त हो जाएगा। लोग चैट की कॉपी सेव कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11879,7 +11961,9 @@ msgstr "लिंक्स:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr "इसके लिए मुझे जिन टूल्स, सामग्रियों या ज़रूरी चीज़ों की ज़रूरत होगी, उनकी लिस्ट दें।"
+msgstr ""
+"इसके लिए मुझे जिन टूल्स, सामग्रियों या ज़रूरी चीज़ों की ज़रूरत होगी, उनकी "
+"लिस्ट दें।"
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12536,8 +12620,8 @@ msgstr "माइक्रोनेशिया"
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
 msgstr ""
-"माइक्रोफ़ोन एक्सेस की अनुमति नहीं दी गई। कृपया माइक्रोफ़ोन एक्सेस करने की अनुमति दें और फिर "
-"से प्रयास करें।"
+"माइक्रोफ़ोन एक्सेस की अनुमति नहीं दी गई। कृपया माइक्रोफ़ोन एक्सेस करने की "
+"अनुमति दें और फिर से प्रयास करें।"
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -13321,10 +13405,11 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"नए प्रॉम्प्ट और रिस्पॉन्स भेजे जाने के बाद एन्क्रिप्ट किए जाते हैं और अस्थायी रूप से "
-"DuckDuckGo सर्वर पर स्टोर रहते हैं, ताकि यदि आपका इंटरनेट कनेक्शन खो जाए तो चैट को "
-"रिकवर किया जा सके। चैट हिस्ट्री को डिसेबल करने से पिन की गई चैट डिलीट हो जाएंगी, और "
-"नए प्रॉम्प्ट और रिस्पॉन्स का टेम्पररी स्टोरेज भी बंद हो जाएगा।"
+"नए प्रॉम्प्ट और रिस्पॉन्स भेजे जाने के बाद एन्क्रिप्ट किए जाते हैं और "
+"अस्थायी रूप से DuckDuckGo सर्वर पर स्टोर रहते हैं, ताकि यदि आपका इंटरनेट "
+"कनेक्शन खो जाए तो चैट को रिकवर किया जा सके। चैट हिस्ट्री को डिसेबल करने से "
+"पिन की गई चैट डिलीट हो जाएंगी, और नए प्रॉम्प्ट और रिस्पॉन्स का टेम्पररी "
+"स्टोरेज भी बंद हो जाएगा।"
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -13984,7 +14069,7 @@ msgstr "ठीक है, समझ गए!"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "OPTIONAL"
-msgstr ""
+msgstr "वैकल्पिक"
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -14152,8 +14237,8 @@ msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
 msgstr ""
-"Mac पर, %1$sMaxthon > प्राथमिकताएं पर क्लिक करें%2$s, Windows पर, %3$s %4$s आइकन "
-"> सेटिंग्स%5$s पर क्लिक करें"
+"Mac पर, %1$sMaxthon > प्राथमिकताएं पर क्लिक करें%2$s, Windows पर, %3$s %4$s "
+"आइकन > सेटिंग्स%5$s पर क्लिक करें"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -14162,8 +14247,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
 msgstr ""
-"दूसरे डिवाइस पर %1$sDuck.ai सेटिंग%2$s › %3$sचैट › Sync & Backup › किसी दूसरे "
-"डिवाइस के साथ सिंक करें%4$s पर जाएँ"
+"दूसरे डिवाइस पर %1$sDuck.ai सेटिंग%2$s › %3$sचैट › Sync & Backup › किसी "
+"दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएँ"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14172,8 +14257,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
 msgstr ""
-"दूसरे डिवाइस पर %1$sDuck.ai सेटिंग%2$s › %3$sचैट › Sync & Backup › किसी दूसरे "
-"डिवाइस के साथ सिंक करें%4$s पर जाएँ और इस कोड को स्कैन करें:"
+"दूसरे डिवाइस पर %1$sDuck.ai सेटिंग%2$s › %3$sचैट › Sync & Backup › किसी "
+"दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएँ और इस कोड को स्कैन करें:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14182,8 +14267,9 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
-"दूसरे डिवाइस पर %1$sDuck.ai सेटिंग%2$s › %3$sचैट › Sync & Backup › किसी दूसरे "
-"डिवाइस के साथ सिंक करें%4$s पर जाएँ. या अपनी रिकवरी PDF पर मौजूद QR कोड को स्कैन करें."
+"दूसरे डिवाइस पर %1$sDuck.ai सेटिंग%2$s › %3$sचैट › Sync & Backup › किसी "
+"दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएँ. या अपनी रिकवरी PDF पर मौजूद QR "
+"कोड को स्कैन करें."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14211,8 +14297,8 @@ msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
 msgstr ""
-"अटैच की गई फ़ाइलों में से एक में हमारी सपोर्ट सीमा से ज़्यादा पेज हैं। कृपया %1$s पेज या उससे "
-"कम वाली फ़ाइलें अपलोड करें।"
+"अटैच की गई फ़ाइलों में से एक में हमारी सपोर्ट सीमा से ज़्यादा पेज हैं। कृपया "
+"%1$s पेज या उससे कम वाली फ़ाइलें अपलोड करें।"
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -14239,8 +14325,8 @@ msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
 msgstr ""
-"केवल वो सेटिंग्स जिन्हें आपने बदला है। उनकी पूरी जानकारी इस %1$sयूआरएल पैरामीटर%2$s पेज "
-"पर है।"
+"केवल वो सेटिंग्स जिन्हें आपने बदला है। उनकी पूरी जानकारी इस %1$sयूआरएल "
+"पैरामीटर%2$s पेज पर है।"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -14255,7 +14341,8 @@ msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
 msgstr ""
-"उफ़! इस टेक्स्ट का अनुवाद करते समय एक अनपेक्षित त्रुटि हुई है। कृपया बाद में फिर से प्रयास करें।"
+"उफ़! इस टेक्स्ट का अनुवाद करते समय एक अनपेक्षित त्रुटि हुई है। कृपया बाद में "
+"फिर से प्रयास करें।"
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -14578,8 +14665,8 @@ msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
 msgstr ""
-"अन्य खोज इंजन आपकी खोजों को ट्रैक करता है भले ही आप गुप्त ब्राउज़िंग मोड में हो। हम आपको — "
-"अवधि में ट्रैक नहीं करते हैं।"
+"अन्य खोज इंजन आपकी खोजों को ट्रैक करता है भले ही आप गुप्त ब्राउज़िंग मोड में "
+"हो। हम आपको — अवधि में ट्रैक नहीं करते हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -14593,8 +14680,8 @@ msgid ""
 "Our fast, no-log VPN comes with smarter AI chats with higher limits, plus "
 "more premium protections. All in one subscription."
 msgstr ""
-"हमारा तेज़, नो-लॉग VPN ज़्यादा लिमिट वाले स्मार्ट AI चैट्स और ज़्यादा प्रीमियम प्रोटेक्शन के "
-"साथ आता है। सब कुछ एक ही सब्सक्रिप्शन में।"
+"हमारा तेज़, नो-लॉग VPN ज़्यादा लिमिट वाले स्मार्ट AI चैट्स और ज़्यादा "
+"प्रीमियम प्रोटेक्शन के साथ आता है। सब कुछ एक ही सब्सक्रिप्शन में।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -14602,8 +14689,8 @@ msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
 msgstr ""
-"हमारी गोपनीयता नीति सरल है: हम आपकी किसी भी निजी जानकारी को एकत्रित या शेयर नहीं "
-"करते हैं।"
+"हमारी गोपनीयता नीति सरल है: हम आपकी किसी भी निजी जानकारी को एकत्रित या शेयर "
+"नहीं करते हैं।"
 
 # smartling.placeholder_format=C
 msgid ""
@@ -14611,8 +14698,8 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"मोबाइल के लिए हमारे गोपनीय ब्राउज़र में हमारा खोज इंजन, ट्रैकर ब्लॉकर, एनक्रिप्शन "
-"एनफोर्सर और बहुत कुछ शामिल है। %1$siOS और Android%2$s पर उपलब्ध।"
+"मोबाइल के लिए हमारे गोपनीय ब्राउज़र में हमारा खोज इंजन, ट्रैकर ब्लॉकर, "
+"एनक्रिप्शन एनफोर्सर और बहुत कुछ शामिल है। %1$siOS और Android%2$s पर उपलब्ध।"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14865,8 +14952,8 @@ msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
 msgstr ""
-"पासफ्रेज़ को दोबारा प्राप्त नहीं किया जा सकता है, क्योंकि हम आपके आईपी पते, ब्राउज़र "
-"फ़िंगरप्रिंट या किसी अन्य जानकारी को फ़ाइल के साथ नहीं जोड़ते हैं।"
+"पासफ्रेज़ को दोबारा प्राप्त नहीं किया जा सकता है, क्योंकि हम आपके आईपी पते, "
+"ब्राउज़र फ़िंगरप्रिंट या किसी अन्य जानकारी को फ़ाइल के साथ नहीं जोड़ते हैं।"
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -15022,8 +15109,8 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
-"Personal Information Removal उन डेटा ब्रोकर साइट्स पर आपकी जानकारी ढूंढता है जो उसे "
-"बेच रही हैं. फिर हम इसे आपके लिए हटवाने का काम करते हैं."
+"Personal Information Removal उन डेटा ब्रोकर साइट्स पर आपकी जानकारी ढूंढता है "
+"जो उसे बेच रही हैं. फिर हम इसे आपके लिए हटवाने का काम करते हैं."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15094,9 +15181,10 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, तो AI की मदद से "
-"दिए गए जवाब अपने-आप दिखने की संभावना बढ़ जाती है और बेहतर जवाब अक्सर मिलते हैं। उन्हें बंद "
-"करने और Assist बटन छिपाने के लिए %1$sखोज सेटिंग%2$s पर जाएं।"
+"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, "
+"तो AI की मदद से दिए गए जवाब अपने-आप दिखने की संभावना बढ़ जाती है और बेहतर "
+"जवाब अक्सर मिलते हैं। उन्हें बंद करने और Assist बटन छिपाने के लिए %1$sखोज "
+"सेटिंग%2$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15105,9 +15193,10 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, तो DuckAssist "
-"के दिखने की संभावना बढ़ जाती है और बेहतर जवाब अक्सर मिलते हैं। इस फ़ीचर के काम करने के "
-"तरीके को एडजस्ट करने के लिए या इसे बंद करने के लिए, %1$sDuckAssist सेटिंग%2$s पर जाएं।"
+"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, "
+"तो DuckAssist के दिखने की संभावना बढ़ जाती है और बेहतर जवाब अक्सर मिलते हैं। "
+"इस फ़ीचर के काम करने के तरीके को एडजस्ट करने के लिए या इसे बंद करने के लिए, "
+"%1$sDuckAssist सेटिंग%2$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15117,9 +15206,10 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, तो DuckAssist "
-"अपने-आप दिखने की संभावना बढ़ जाती है और बेहतर जवाब अक्सर मिलते हैं। इसे बंद करने और "
-"Assist यानी सहायता बटन छिपाने के लिए %1$sDuckAssist Settings%2$s पर जाएं।"
+"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, "
+"तो DuckAssist अपने-आप दिखने की संभावना बढ़ जाती है और बेहतर जवाब अक्सर मिलते "
+"हैं। इसे बंद करने और Assist यानी सहायता बटन छिपाने के लिए %1$sDuckAssist "
+"Settings%2$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -15152,8 +15242,8 @@ msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
 msgstr ""
-"चैट करने के लिए कोई लोकप्रिय AI चुनें, जैसे GPT-5 mini, Claude Haiku 4.5, Mistral, "
-"वगैरह।"
+"चैट करने के लिए कोई लोकप्रिय AI चुनें, जैसे GPT-5 mini, Claude Haiku 4.5, "
+"Mistral, वगैरह।"
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -15172,7 +15262,8 @@ msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
 msgstr ""
-"अपने गंतव्य तक जाने के लिए एक सेवा चुनें। बाहरी ऐप्स में DuckDuckGo सुरक्षा उपलब्ध नहीं होगी।"
+"अपने गंतव्य तक जाने के लिए एक सेवा चुनें। बाहरी ऐप्स में DuckDuckGo सुरक्षा "
+"उपलब्ध नहीं होगी।"
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -15185,8 +15276,8 @@ msgstr "कोई विशिष्ट समस्या चुनें"
 msgid ""
 "Pick your ad blocker and follow the instructions to allow ads on DuckDuckGo."
 msgstr ""
-"अपना विज्ञापन ब्लॉकर चुनें और DuckDuckGo पर विज्ञापनों की अनुमति देने के लिए निर्देशों का "
-"पालन करें।"
+"अपना विज्ञापन ब्लॉकर चुनें और DuckDuckGo पर विज्ञापनों की अनुमति देने के लिए "
+"निर्देशों का पालन करें।"
 
 # smartling.placeholder_format=C
 #. Text for a button that pins a chat, as in it will it will add the chat to the pinned chats list.
@@ -15275,8 +15366,8 @@ msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
 msgstr ""
-"यह पुष्टि करने के लिए कि यह प्रॉम्प्ट किसी मनुष्य द्वारा बनाया गया था, कृपया निम्नलिखित "
-"चुनौती को पूरा करें।"
+"यह पुष्टि करने के लिए कि यह प्रॉम्प्ट किसी मनुष्य द्वारा बनाया गया था, कृपया "
+"निम्नलिखित चुनौती को पूरा करें।"
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -15285,8 +15376,8 @@ msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
 msgstr ""
-"यह पुष्टि करने के लिए कि यह खोज किसी मनुष्य द्वारा की गई थी, कृपया निम्नलिखित चुनौती "
-"को पूरा करें।"
+"यह पुष्टि करने के लिए कि यह खोज किसी मनुष्य द्वारा की गई थी, कृपया "
+"निम्नलिखित चुनौती को पूरा करें।"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -15319,8 +15410,8 @@ msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
 msgstr ""
-"कृपया ध्यान दें: किसी भी मॉडल के जरिए नई चैट शुरू करने से आपका मौजूदा चैट सेशन डिलीट हो "
-"जाएगा।"
+"कृपया ध्यान दें: किसी भी मॉडल के जरिए नई चैट शुरू करने से आपका मौजूदा चैट "
+"सेशन डिलीट हो जाएगा।"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15329,8 +15420,9 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
-"अपना सवाल और जो गलत या आपत्तिजनक जवाब मिला है, यहां पेस्ट करें (अपनी कोई भी निजी "
-"जानकारी शामिल न करें), साथ में बताएं कि यह सामग्री क्यों हानिकारक या गैरकानूनी है।"
+"अपना सवाल और जो गलत या आपत्तिजनक जवाब मिला है, यहां पेस्ट करें (अपनी कोई भी "
+"निजी जानकारी शामिल न करें), साथ में बताएं कि यह सामग्री क्यों हानिकारक या "
+"गैरकानूनी है।"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15339,8 +15431,9 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
 msgstr ""
-"अपना सवाल और जो गलत या आपत्तिजनक जवाब मिला है, यहां पेस्ट करें (अपनी कोई भी निजी "
-"जानकारी शामिल न करें), साथ में बताएं कि यह सामग्री क्यों गैरकानूनी या नुकसानदेह है।"
+"अपना सवाल और जो गलत या आपत्तिजनक जवाब मिला है, यहां पेस्ट करें (अपनी कोई भी "
+"निजी जानकारी शामिल न करें), साथ में बताएं कि यह सामग्री क्यों गैरकानूनी या "
+"नुकसानदेह है।"
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -15493,8 +15586,8 @@ msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
 msgstr ""
-"साथ ही, Duck Player में आप जो देखते हैं, वह YouTube पर आपके रिकमंडेशन या सुझावों को "
-"प्रभावित नहीं करेगा।"
+"साथ ही, Duck Player में आप जो देखते हैं, वह YouTube पर आपके रिकमंडेशन या "
+"सुझावों को प्रभावित नहीं करेगा।"
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -15557,7 +15650,8 @@ msgstr "खराब फॉर्मेटिंग"
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
 msgstr ""
-"लोकप्रिय AI मॉडल उपलब्ध हैं। किसी अकाउंट की ज़रूरत नहीं है। चैट हमारे द्वारा अनाम की गईं।"
+"लोकप्रिय AI मॉडल उपलब्ध हैं। किसी अकाउंट की ज़रूरत नहीं है। चैट हमारे द्वारा "
+"अनाम की गईं।"
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -16067,8 +16161,8 @@ msgstr "मुझे प्रॉम्प्ट करें"
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
 msgstr ""
-"नज़दीकी परिणाम प्राप्त करने के लिए मुझे अपने अनुमानित स्थान का उपयोग करने के लिए प्रेरित "
-"करें।"
+"नज़दीकी परिणाम प्राप्त करने के लिए मुझे अपने अनुमानित स्थान का उपयोग करने के "
+"लिए प्रेरित करें।"
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -16087,7 +16181,8 @@ msgstr "खोजते और ब्राउज़ करते समय अ�
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
 msgstr ""
-"सर्च करते समय, ब्राउज़ करते समय, और AI का इस्तेमाल करते हुए अपने डेटा को सुरक्षित रखें।"
+"सर्च करते समय, ब्राउज़ करते समय, और AI का इस्तेमाल करते हुए अपने डेटा को "
+"सुरक्षित रखें।"
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -16104,7 +16199,7 @@ msgstr "सुरक्षित"
 #. Headline in sync-enabled chat history about modals explaining encrypted server storage.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Protected with end-to-end encryption"
-msgstr ""
+msgstr "एंड-टू-एंड एनक्रिप्शन द्वारा सुरक्षित"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -16118,7 +16213,8 @@ msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
 msgstr ""
-"नीचे दिए गए टेक्स्ट को और संक्षिप्त बनाने के लिए कुछ सुझाव दें। [अपना खुद का टेक्स्ट यहां डालें।]"
+"नीचे दिए गए टेक्स्ट को और संक्षिप्त बनाने के लिए कुछ सुझाव दें। [अपना खुद का "
+"टेक्स्ट यहां डालें।]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -16242,7 +16338,7 @@ msgstr "रैंकिंग"
 #. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
 msgctxt "star rating on a product"
 msgid "Rated %s out of %s"
-msgstr ""
+msgstr "%2$s में से %1$s की रेटिंग"
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -16342,16 +16438,16 @@ msgstr "रीज़निंग जटिल सवालों के बे�
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
 msgstr ""
-"रीज़निंग का तरीका ज़्यादा विस्तृत है, लेकिन यह 2-5 गुना जल्दी उपयोग सीमा तक पहुंच जाता "
-"है। %1$s"
+"रीज़निंग का तरीका ज़्यादा विस्तृत है, लेकिन यह 2-5 गुना जल्दी उपयोग सीमा तक "
+"पहुंच जाता है। %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
 msgstr ""
-"रीज़निंग का तरीका ज़्यादा विस्तृत है, लेकिन इसमें लिमिट्स का इस्तेमाल 2-5 गुना तेज़ी से होता "
-"है। %1$s"
+"रीज़निंग का तरीका ज़्यादा विस्तृत है, लेकिन इसमें लिमिट्स का इस्तेमाल 2-5 "
+"गुना तेज़ी से होता है। %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -16401,8 +16497,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"हालिया चैट DuckDuckGo सर्वर या दूसरे रिमोट सर्वर के बजाय आपके डिवाइस पर स्थानीय स्तर "
-"पर स्टोर की जाती हैं।"
+"हालिया चैट DuckDuckGo सर्वर या दूसरे रिमोट सर्वर के बजाय आपके डिवाइस पर "
+"स्थानीय स्तर पर स्टोर की जाती हैं।"
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -16411,8 +16507,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"हालिया चैट DuckDuckGo सर्वर या दूसरे रिमोट सर्वर के बजाय आपके डिवाइस पर स्थानीय स्तर "
-"पर स्टोर की जाती हैं।"
+"हालिया चैट DuckDuckGo सर्वर या दूसरे रिमोट सर्वर के बजाय आपके डिवाइस पर "
+"स्थानीय स्तर पर स्टोर की जाती हैं।"
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -16422,9 +16518,10 @@ msgid ""
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
 msgstr ""
-"हाल की चैट्स आपके डिवाइस पर लोकली स्टोर होती हैं। नए प्रॉम्प्ट और रिस्पॉन्स भेजे जाने के "
-"बाद एन्क्रिप्ट किए जाते हैं और अस्थायी रूप से DuckDuckGo सर्वर पर स्टोर रहते हैं, ताकि यदि "
-"आपका इंटरनेट कनेक्शन खो जाए तो चैट को रिकवर किया जा सके।"
+"हाल की चैट्स आपके डिवाइस पर लोकली स्टोर होती हैं। नए प्रॉम्प्ट और रिस्पॉन्स "
+"भेजे जाने के बाद एन्क्रिप्ट किए जाते हैं और अस्थायी रूप से DuckDuckGo सर्वर "
+"पर स्टोर रहते हैं, ताकि यदि आपका इंटरनेट कनेक्शन खो जाए तो चैट को रिकवर किया "
+"जा सके।"
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -16566,8 +16663,8 @@ msgid ""
 "Reduces extra space in and around results and reduces size of result title "
 "text"
 msgstr ""
-"परिणामों के अंदर और आसपास के अतिरिक्त स्पेस हटाता है और परिणाम टाइटल टेक्स्ट के आकार को "
-"घटाता है"
+"परिणामों के अंदर और आसपास के अतिरिक्त स्पेस हटाता है और परिणाम टाइटल टेक्स्ट "
+"के आकार को घटाता है"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'Refer to me as John'
@@ -16708,8 +16805,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"DuckDuckGo को फिर से लोड करें, इसके लिए निर्देशों का पालन करें या अपने ब्राउज़र के &quot;"
-"रीफ्रेश&quot; या &quot;रीलोड&quot; बटन पर क्लिक करें।"
+"DuckDuckGo को फिर से लोड करें, इसके लिए निर्देशों का पालन करें या अपने "
+"ब्राउज़र के &quot;रीफ्रेश&quot; या &quot;रीलोड&quot; बटन पर क्लिक करें।"
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16817,8 +16914,8 @@ msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
 msgstr ""
-"\"पूछें\" बटन को हटा देता है जिससे प्रासंगिक खोजों के लिए उत्तर स्वचालित रूप से दिखाई देते "
-"हैं। कैश्ड उत्तर हमेशा स्वचालित रूप से प्रदर्शित होते हैं।"
+"\"पूछें\" बटन को हटा देता है जिससे प्रासंगिक खोजों के लिए उत्तर स्वचालित रूप "
+"से दिखाई देते हैं। कैश्ड उत्तर हमेशा स्वचालित रूप से प्रदर्शित होते हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16826,8 +16923,9 @@ msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
 msgstr ""
-"\"जनरेट करें\" बटन को हटा देता है जिससे प्रासंगिक खोजों के लिए उत्तर स्वचालित रूप से दिखाई "
-"देते हैं। कैश्ड उत्तर हमेशा स्वचालित रूप से प्रदर्शित होते हैं।"
+"\"जनरेट करें\" बटन को हटा देता है जिससे प्रासंगिक खोजों के लिए उत्तर "
+"स्वचालित रूप से दिखाई देते हैं। कैश्ड उत्तर हमेशा स्वचालित रूप से प्रदर्शित "
+"होते हैं।"
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -16885,9 +16983,9 @@ msgid ""
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
 msgstr ""
-"रिपोर्ट गुमनाम हैं और हमारी खोज सेवा को बेहतर बनाने में मदद करने के लिए DuckDuckGo को "
-"भेजी जाती हैं। उनकी सेवाओं को बेहतर बनाने में सहायता के लिए आपकी अनाम प्रतिक्रिया भी "
-"%1$s के साथ शेयर की जाती है।"
+"रिपोर्ट गुमनाम हैं और हमारी खोज सेवा को बेहतर बनाने में मदद करने के लिए "
+"DuckDuckGo को भेजी जाती हैं। उनकी सेवाओं को बेहतर बनाने में सहायता के लिए "
+"आपकी अनाम प्रतिक्रिया भी %1$s के साथ शेयर की जाती है।"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16895,8 +16993,8 @@ msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo को भेजी गई रिपोर्टें गुमनाम रहती हैं। कृपया अपने फ़ीडबैक में कोई भी व्यक्तिगत या "
-"पहचान योग्य जानकारी शामिल न करें।"
+"DuckDuckGo को भेजी गई रिपोर्टें गुमनाम रहती हैं। कृपया अपने फ़ीडबैक में कोई "
+"भी व्यक्तिगत या पहचान योग्य जानकारी शामिल न करें।"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16905,9 +17003,9 @@ msgid ""
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo को भेजी गई रिपोर्ट में वे सभी टेक्स्ट शामिल होते हैं, जिन्हें आपने इस पेज लोड के "
-"दौरान अनुवाद के लिए कहा था, और वे गुमनाम हैं। कृपया अपने फ़ीडबैक में कोई भी व्यक्तिगत या "
-"पहचान योग्य जानकारी शामिल न करें।"
+"DuckDuckGo को भेजी गई रिपोर्ट में वे सभी टेक्स्ट शामिल होते हैं, जिन्हें "
+"आपने इस पेज लोड के दौरान अनुवाद के लिए कहा था, और वे गुमनाम हैं। कृपया अपने "
+"फ़ीडबैक में कोई भी व्यक्तिगत या पहचान योग्य जानकारी शामिल न करें।"
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -16999,9 +17097,10 @@ msgid ""
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
-"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें चिकित्सा, कानूनी, "
-"वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना जाना चाहिए। AI की मदद से दिए गए "
-"जवाब हमारी %1$sसेवा की शर्तों%2$s के अधीन हैं।"
+"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें "
+"चिकित्सा, कानूनी, वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना "
+"जाना चाहिए। AI की मदद से दिए गए जवाब हमारी %1$sसेवा की शर्तों%2$s के अधीन "
+"हैं।"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -17010,9 +17109,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
 msgstr ""
-"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें चिकित्सा, कानूनी, "
-"वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना जाना चाहिए। DuckAssist हमारी "
-"%1$sसेवा की शर्तों%2$s के अधीन है।"
+"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें "
+"चिकित्सा, कानूनी, वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना "
+"जाना चाहिए। DuckAssist हमारी %1$sसेवा की शर्तों%2$s के अधीन है।"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -17022,10 +17121,11 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें चिकित्सा, कानूनी, "
-"वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना जाना चाहिए। ये वेब सामग्री के आधार "
-"पर तैयार किए जाते हैं और इनमें कुछ गलतियां भी हो सकती हैं। Search Assist हमारी %1$sसेवा "
-"की शर्तों%2$s के अधीन है।"
+"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें "
+"चिकित्सा, कानूनी, वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना "
+"जाना चाहिए। ये वेब सामग्री के आधार पर तैयार किए जाते हैं और इनमें कुछ "
+"गलतियां भी हो सकती हैं। Search Assist हमारी %1$sसेवा की शर्तों%2$s के अधीन "
+"है।"
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -17102,7 +17202,8 @@ msgstr "परिणामों में ब्लॉक की गई सा�
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
 msgstr ""
-"परिणामों में ब्लॉक की गई साइटें नहीं दिखाई जातीं, आप उन्हें अपने %1$s में मैनेज कर सकते हैं।"
+"परिणामों में ब्लॉक की गई साइटें नहीं दिखाई जातीं, आप उन्हें अपने %1$s में "
+"मैनेज कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -17451,8 +17552,8 @@ msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
 msgstr ""
-"अपने डिवाइस पर अपनी सबसे नई 30 चैट तक स्थानीय रूप से सेव करें, और एन्क्रिप्टेड स्टोरेज के "
-"साथ इससे अधिक चैट सहेजने का विकल्प भी उपलब्ध है।"
+"अपने डिवाइस पर अपनी सबसे नई 30 चैट तक स्थानीय रूप से सेव करें, और "
+"एन्क्रिप्टेड स्टोरेज के साथ इससे अधिक चैट सहेजने का विकल्प भी उपलब्ध है।"
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -17465,7 +17566,9 @@ msgstr "अपनी सबसे हाल की 30 चैट तक को �
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "एंड-टू-एंड एनक्रिप्शन के साथ अपने Duck.ai चैट्स को अपने डिवाइसों के बीच सुरक्षित रखें।"
+msgstr ""
+"एंड-टू-एंड एनक्रिप्शन के साथ अपने Duck.ai चैट्स को अपने डिवाइसों के बीच "
+"सुरक्षित रखें।"
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17477,7 +17580,7 @@ msgstr "अपनी चैट्स को अपने सभी डिवा�
 #. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
 msgctxt "Chat history about modal list item headline"
 msgid "Save your chats on this device"
-msgstr ""
+msgstr "अपनी चैट इस डिवाइस पर सेव करें"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
@@ -17625,8 +17728,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
 msgstr ""
-"नीचे स्क्रॉल करें और %1$sपता बार में खोजें%2$s ढूंढें। %3$sबदलें%4$s (या %5$sनया जोड़ें%6$s) "
-"क्लिक करें"
+"नीचे स्क्रॉल करें और %1$sपता बार में खोजें%2$s ढूंढें। %3$sबदलें%4$s (या "
+"%5$sनया जोड़ें%6$s) क्लिक करें"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17635,8 +17738,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
 msgstr ""
-"नीचे स्क्रॉल करें और %1$sपता बार में खोजें%2$s ढूंढें। %3$sबदलें%4$s पर क्लिक करें (या %5$sनया "
-"जोड़ें%6$s)।"
+"नीचे स्क्रॉल करें और %1$sपता बार में खोजें%2$s ढूंढें। %3$sबदलें%4$s पर "
+"क्लिक करें (या %5$sनया जोड़ें%6$s)।"
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -17655,8 +17758,8 @@ msgstr "नीचे स्क्रॉल करें और सूची म�
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
 msgstr ""
-"नीचे स्क्रॉल करते हुए %1$sDuckDuckGo%2$s पर जाएं और इसे अनुमति दें कि यह आपकी लोकेशन "
-"यानी स्थान का इस्तेमाल कर सके।"
+"नीचे स्क्रॉल करते हुए %1$sDuckDuckGo%2$s पर जाएं और इसे अनुमति दें कि यह "
+"आपकी लोकेशन यानी स्थान का इस्तेमाल कर सके।"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -17687,7 +17790,7 @@ msgctxt ""
 "Placeholder and accessibility label for the search input in the tab picker "
 "dialog"
 msgid "Search"
-msgstr ""
+msgstr "खोजें"
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -17724,11 +17827,12 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist आपके खोज प्रश्नों के जवाब गुमनाम तरीके से तैयार करता है। ऐसा करने के लिए "
-"यह वेब पर संबंधित सामग्री खोजता है और फिर AI की मदद से एक संक्षिप्त जवाब तैयार करता है। "
-"आप चुन सकते हैं कि यह कितनी बार दिखाई दे: कभी नहीं, केवल मांग पर (जब आप 'Assist' पर "
-"क्लिक करें), कभी-कभी (जब यह बहुत प्रासंगिक हो), या अक्सर (जब कई तरह की खोज पर लागू "
-"हो)। फिलहाल, Search Assist केवल कुछ अंग्रेज़ी भाषी क्षेत्रों में ही उपलब्ध है।"
+"Search Assist आपके खोज प्रश्नों के जवाब गुमनाम तरीके से तैयार करता है। ऐसा "
+"करने के लिए यह वेब पर संबंधित सामग्री खोजता है और फिर AI की मदद से एक "
+"संक्षिप्त जवाब तैयार करता है। आप चुन सकते हैं कि यह कितनी बार दिखाई दे: कभी "
+"नहीं, केवल मांग पर (जब आप 'Assist' पर क्लिक करें), कभी-कभी (जब यह बहुत "
+"प्रासंगिक हो), या अक्सर (जब कई तरह की खोज पर लागू हो)। फिलहाल, Search Assist "
+"केवल कुछ अंग्रेज़ी भाषी क्षेत्रों में ही उपलब्ध है।"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -17736,8 +17840,8 @@ msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
 msgstr ""
-"Search Assist को इस प्रश्न का उत्तर जनरेट करने के लिए पर्याप्त विश्वसनीय जानकारी नहीं "
-"मिली। कुछ और सर्च करके देखें।"
+"Search Assist को इस प्रश्न का उत्तर जनरेट करने के लिए पर्याप्त विश्वसनीय "
+"जानकारी नहीं मिली। कुछ और सर्च करके देखें।"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -17746,9 +17850,10 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist एक वैकल्पिक फ़ीचर है जो खोज प्रश्नों के लिए गुमनाम रूप से जवाब तैयार करता "
-"है। ऐसा करने के लिए, यह %1$sवेब पर खोजबीन करता है%2$s ताकि संबंधित सामग्री मिल सके, "
-"और फिर मिली जानकारी के आधार पर AI की मदद से एक संक्षिप्त उत्तर तैयार करता है।"
+"Search Assist एक वैकल्पिक फ़ीचर है जो खोज प्रश्नों के लिए गुमनाम रूप से जवाब "
+"तैयार करता है। ऐसा करने के लिए, यह %1$sवेब पर खोजबीन करता है%2$s ताकि "
+"संबंधित सामग्री मिल सके, और फिर मिली जानकारी के आधार पर AI की मदद से एक "
+"संक्षिप्त उत्तर तैयार करता है।"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -17869,8 +17974,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"%1$s शॉर्टकट के ज़रिए अन्य साइटों को खोजें: \"!w ducks” खोजने पर सीधे Wikipedia पर "
-"“ducks” को खोजा जाएगा।"
+"%1$s शॉर्टकट के ज़रिए अन्य साइटों को खोजें: \"!w ducks” खोजने पर सीधे "
+"Wikipedia पर “ducks” को खोजा जाएगा।"
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -17889,8 +17994,8 @@ msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
-"हमारे ऐप या एक्सटेंशन के साथ गुप्त रूप से खोज करें, अपने पसंदीदा ब्राउज़र में गोपनीय वेब खोज "
-"जोड़ें या सीधा %1$sduckduckgo.com%2$s पर खोजें।"
+"हमारे ऐप या एक्सटेंशन के साथ गुप्त रूप से खोज करें, अपने पसंदीदा ब्राउज़र "
+"में गोपनीय वेब खोज जोड़ें या सीधा %1$sduckduckgo.com%2$s पर खोजें।"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -17898,8 +18003,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"खोज के प्रश्न यूआरएल में शामिल हैं (अगर ऑफ़ किया गया तब खोज द्वारा पोस्ट अनुरोध का उपयोग "
-"होगा)"
+"खोज के प्रश्न यूआरएल में शामिल हैं (अगर ऑफ़ किया गया तब खोज द्वारा पोस्ट "
+"अनुरोध का उपयोग होगा)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -17911,11 +18016,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"खोज सेटिंग को आपके ब्राउज़र में गैर-व्यक्तिगत ब्राउज़र की कुकीज़ और लोकल स्टोरेज में रखा जाता "
-"है. हालांकि, आप चाहें तो Cloud Save का इस्तेमाल करके अपनी सेटिंग को क्लाउड में किसी "
-"रिमोट सर्वर पर गुमनाम रूप से भी सेव कर सकते हैं। क्लाउड में कोई भी व्यक्तिगत रूप से पहचान "
-"योग्य जानकारी स्टोर नहीं की जाएगी, और आपका पासफ्रेज़ कभी भी आपके ब्राउज़र से बाहर नहीं "
-"जाएगा।"
+"खोज सेटिंग को आपके ब्राउज़र में गैर-व्यक्तिगत ब्राउज़र की कुकीज़ और लोकल "
+"स्टोरेज में रखा जाता है. हालांकि, आप चाहें तो Cloud Save का इस्तेमाल करके "
+"अपनी सेटिंग को क्लाउड में किसी रिमोट सर्वर पर गुमनाम रूप से भी सेव कर सकते "
+"हैं। क्लाउड में कोई भी व्यक्तिगत रूप से पहचान योग्य जानकारी स्टोर नहीं की "
+"जाएगी, और आपका पासफ्रेज़ कभी भी आपके ब्राउज़र से बाहर नहीं जाएगा।"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -18018,8 +18123,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित रूप से स्टोर करें, "
-"और उन्हें अपने सभी डिवाइस से एक्सेस करें।"
+"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित "
+"रूप से स्टोर करें, और उन्हें अपने सभी डिवाइस से एक्सेस करें।"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -18028,8 +18133,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित रूप से स्टोर करें, "
-"और उन्हें अपने सभी डिवाइस से एक्सेस करें।"
+"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित "
+"रूप से स्टोर करें, और उन्हें अपने सभी डिवाइस से एक्सेस करें।"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18038,8 +18143,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित रूप से स्टोर करें, "
-"और उन्हें अपने सभी सिंक किए गए डिवाइसों से एक्सेस करें।"
+"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित "
+"रूप से स्टोर करें, और उन्हें अपने सभी सिंक किए गए डिवाइसों से एक्सेस करें।"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18048,8 +18153,8 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके अपनी चैट्स सुरक्षित रूप से स्टोर करें, और "
-"उन्हें अपने सभी डिवाइसों से एक्सेस करें।"
+"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके अपनी चैट्स सुरक्षित रूप "
+"से स्टोर करें, और उन्हें अपने सभी डिवाइसों से एक्सेस करें।"
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -18064,8 +18169,8 @@ msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
 msgstr ""
-"एंड-टू-एंड एनक्रिप्शन के साथ DuckDuckGo के सर्वर पर सुरक्षित रूप से स्टोर किया गया। आपके "
-"अलावा कोई भी आपका डेटा नहीं देख सकता, हम भी नहीं।"
+"एंड-टू-एंड एनक्रिप्शन के साथ DuckDuckGo के सर्वर पर सुरक्षित रूप से स्टोर "
+"किया गया। आपके अलावा कोई भी आपका डेटा नहीं देख सकता, हम भी नहीं।"
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
@@ -18215,7 +18320,9 @@ msgstr "Safari मेनू से %1$s'इस वेबसाइट के ल�
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
-msgstr "%1$sकस्टम%2$s चुनें और इनपुट फ़ील्ड में %3$shttps://duckduckgo.com%4$s दर्ज करें"
+msgstr ""
+"%1$sकस्टम%2$s चुनें और इनपुट फ़ील्ड में %3$shttps://duckduckgo.com%4$s दर्ज "
+"करें"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -18225,13 +18332,17 @@ msgstr "%1$sDuckDuckGo%2$s चुनें और %3$sडिफ़ॉल्ट �
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr "%1$sDuckDuckGo%2$s चुनें और %3$sडिफ़ॉल्ट के रूप में सेट करें%4$s पर क्लिक करें"
+msgstr ""
+"%1$sDuckDuckGo%2$s चुनें और %3$sडिफ़ॉल्ट के रूप में सेट करें%4$s पर क्लिक "
+"करें"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr "%1$sDuckDuckGo%2$s चुनें और %3$sडिफ़ॉल्ट के रूप में सेट करें%4$s पर क्लिक करें।"
+msgstr ""
+"%1$sDuckDuckGo%2$s चुनें और %3$sडिफ़ॉल्ट के रूप में सेट करें%4$s पर क्लिक "
+"करें।"
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -18280,7 +18391,8 @@ msgstr "ड्रॉपडाउन मेनू से %1$sएड-ऑन प्
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
 msgstr ""
-"%1$sOpera > प्राथमिकताएं%2$s (Mac पर) या %3$sमेनू > सेटिंग%4$s (Windows पर) चुनें"
+"%1$sOpera > प्राथमिकताएं%2$s (Mac पर) या %3$sमेनू > सेटिंग%4$s (Windows पर) "
+"चुनें"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -18288,7 +18400,8 @@ msgstr ""
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
 msgstr ""
-"%1$sOpera > प्राथमिकताएं%2$s (Mac पर) या %3$sOpera > विकल्प%4$s (Windows पर) चुनें"
+"%1$sOpera > प्राथमिकताएं%2$s (Mac पर) या %3$sOpera > विकल्प%4$s (Windows पर) "
+"चुनें"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -18353,8 +18466,8 @@ msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
 msgstr ""
-"%1$sइस वेबपेज को अपना एकमात्र होमपेज बनाएं%2$s (या अन्य विकल्पों में से अपनी पसंद का कोई "
-"एक विकल्प) चुनें"
+"%1$sइस वेबपेज को अपना एकमात्र होमपेज बनाएं%2$s (या अन्य विकल्पों में से अपनी "
+"पसंद का कोई एक विकल्प) चुनें"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
@@ -18476,8 +18589,8 @@ msgid ""
 "respond. These instructions will apply to all of your conversations going "
 "forward."
 msgstr ""
-"यह आपके संदेशों के साथ AI मॉडलों को निर्देश भेजता है कि उन्हें कैसे जवाब देना है। ये निर्देश आगे "
-"चलकर आपके सभी वार्तालापों पर लागू होंगे।"
+"यह आपके संदेशों के साथ AI मॉडलों को निर्देश भेजता है कि उन्हें कैसे जवाब "
+"देना है। ये निर्देश आगे चलकर आपके सभी वार्तालापों पर लागू होंगे।"
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -18600,8 +18713,8 @@ msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
 msgstr ""
-"चैट हिस्ट्री चालू करने के बाद Sync & Backup सेट करें ताकि अपनी चैट को सभी डिवाइसों पर "
-"सिंक रख सकें।"
+"चैट हिस्ट्री चालू करने के बाद Sync & Backup सेट करें ताकि अपनी चैट को सभी "
+"डिवाइसों पर सिंक रख सकें।"
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -18708,8 +18821,9 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"AI मॉडलों के साथ शहर वाली आसपास की लोकेशन शेयर करें ताकि उनके जवाबों की सटीकता बेहतर "
-"हो। Duck.ai कभी भी आपकी सटीक लोकेशन हमें या AI मॉडल को नहीं बताता है।"
+"AI मॉडलों के साथ शहर वाली आसपास की लोकेशन शेयर करें ताकि उनके जवाबों की "
+"सटीकता बेहतर हो। Duck.ai कभी भी आपकी सटीक लोकेशन हमें या AI मॉडल को नहीं "
+"बताता है।"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -18805,8 +18919,8 @@ msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
 msgstr ""
-"DuckDuckGo के साथ अपना प्रॉम्प्ट और चैट रिस्पॉन्स शेयर करें (गैरकानूनी और हानिकारक "
-"रिपोर्ट के लिए आवश्यक है)"
+"DuckDuckGo के साथ अपना प्रॉम्प्ट और चैट रिस्पॉन्स शेयर करें (गैरकानूनी और "
+"हानिकारक रिपोर्ट के लिए आवश्यक है)"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -18833,8 +18947,8 @@ msgid ""
 "Shield your online activity with our no-log, fast VPN. Simple to set up and "
 "easy to turn on and off anytime."
 msgstr ""
-"हमारे नो-लॉग, तेज़ VPN के साथ अपनी ऑनलाइन गतिविधि को सुरक्षित रखें। सेटअप करने में सरल "
-"और किसी भी समय चालू या बंद करने में आसान।"
+"हमारे नो-लॉग, तेज़ VPN के साथ अपनी ऑनलाइन गतिविधि को सुरक्षित रखें। सेटअप "
+"करने में सरल और किसी भी समय चालू या बंद करने में आसान।"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -18852,7 +18966,7 @@ msgstr "शॉप"
 #. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
 msgctxt "Button in the merchandise logo modal (mobile)"
 msgid "Shop Now"
-msgstr ""
+msgstr "अभी खरीदें"
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -18961,7 +19075,8 @@ msgstr "DuckAssist <sup>बीटा</sup> दिखाएं"
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
 msgstr ""
-"DuckAssist को अक्सर दिखाएं। (आप चाहें तो इसे पूरी तरह से %1$sबंद%2$s भी कर सकते हैं।)"
+"DuckAssist को अक्सर दिखाएं। (आप चाहें तो इसे पूरी तरह से %1$sबंद%2$s भी कर "
+"सकते हैं।)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -19199,9 +19314,9 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
 msgstr ""
-"यह याद दिलाने के लिए एक रिमाइंडर दिखाता है कि DuckDuckGo पर हरेक सर्च यानी खोज "
-"गोपनीय रहती है। इसे बंद करने से रिमाइंडर छिप जाता है, मगर इससे खोज की गोपनीयता "
-"प्रभावित नहीं होती है।"
+"यह याद दिलाने के लिए एक रिमाइंडर दिखाता है कि DuckDuckGo पर हरेक सर्च यानी "
+"खोज गोपनीय रहती है। इसे बंद करने से रिमाइंडर छिप जाता है, मगर इससे खोज की "
+"गोपनीयता प्रभावित नहीं होती है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19209,9 +19324,9 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
 msgstr ""
-"यह याद दिलाने के लिए एक रिमाइंडर दिखाता है कि DuckDuckGo पर हरेक सर्च यानी खोज "
-"हमेशा सुरक्षित रहती है। इसे बंद करने से रिमाइंडर छिप जाता है, मगर इससे खोज सुरक्षा "
-"प्रभावित नहीं होती है।"
+"यह याद दिलाने के लिए एक रिमाइंडर दिखाता है कि DuckDuckGo पर हरेक सर्च यानी "
+"खोज हमेशा सुरक्षित रहती है। इसे बंद करने से रिमाइंडर छिप जाता है, मगर इससे "
+"खोज सुरक्षा प्रभावित नहीं होती है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19249,7 +19364,8 @@ msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
 msgstr ""
-"DuckDuckGo गोपनीयता न्यूज़लेटर के लिए साइन अप करने के लिए सामयिक रिमांडर दिखाता है"
+"DuckDuckGo गोपनीयता न्यूज़लेटर के लिए साइन अप करने के लिए सामयिक रिमांडर "
+"दिखाता है"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19551,7 +19667,9 @@ msgstr "कभी-कभी"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr "माफ़ करें, मैं मदद करने में असमर्थ हूं। कृपया अपनी इमेज का आइडिया अलग शब्दों में बताएं।"
+msgstr ""
+"माफ़ करें, मैं मदद करने में असमर्थ हूं। कृपया अपनी इमेज का आइडिया अलग शब्दों "
+"में बताएं।"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19590,8 +19708,8 @@ msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
 msgstr ""
-"माफ़ करें, अपलोड की गई इमेज को प्रोसेस नहीं किया जा सका। कृपया कोई दूसरी इमेज या फ़ॉर्मेट "
-"आज़माएं।"
+"माफ़ करें, अपलोड की गई इमेज को प्रोसेस नहीं किया जा सका। कृपया कोई दूसरी "
+"इमेज या फ़ॉर्मेट आज़माएं।"
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -19600,7 +19718,8 @@ msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
 msgstr ""
-"माफ़ करें, यह कोड गलत है। कृपया सुनिश्चित करें कि सही कोड को दर्ज या स्कैन किया गया है।"
+"माफ़ करें, यह कोड गलत है। कृपया सुनिश्चित करें कि सही कोड को दर्ज या स्कैन "
+"किया गया है।"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19615,14 +19734,16 @@ msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
 msgstr ""
-"क्षमा करें, इन परिणामों को प्रदर्शित करने में त्रुटि हुई। फिर से प्रयास करने के लिए, %1$sयहाँ "
-"क्लिक करें%2$s।"
+"क्षमा करें, इन परिणामों को प्रदर्शित करने में त्रुटि हुई। फिर से प्रयास करने "
+"के लिए, %1$sयहाँ क्लिक करें%2$s।"
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "क्षमा करें, हम आपका फ़ीडबैक सबमिट नहीं कर सके। कृपया बाद में फिर से प्रयास करें।"
+msgstr ""
+"क्षमा करें, हम आपका फ़ीडबैक सबमिट नहीं कर सके। कृपया बाद में फिर से प्रयास "
+"करें।"
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19677,8 +19798,8 @@ msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
 msgstr ""
-"सोर्स टेक्स्ट बहुत लंबा है, इसे संक्षेप में बताना संभव नहीं है। थोड़ा छोटा हिस्सा चुनकर फिर से "
-"प्रयास करें।"
+"सोर्स टेक्स्ट बहुत लंबा है, इसे संक्षेप में बताना संभव नहीं है। थोड़ा छोटा "
+"हिस्सा चुनकर फिर से प्रयास करें।"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -20028,8 +20149,8 @@ msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
 msgstr ""
-"Duck.ai में ज़्यादा लिमिट पाने के लिए DuckDuckGo को सब्सक्राइब करें, या अधिक इमेज बनाने "
-"के लिए बाद में वापस आएं।"
+"Duck.ai में ज़्यादा लिमिट पाने के लिए DuckDuckGo को सब्सक्राइब करें, या अधिक "
+"इमेज बनाने के लिए बाद में वापस आएं।"
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -20098,8 +20219,8 @@ msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
 msgstr ""
-"सर्जरी करवाकर ठीक हो रहे किसी व्यक्ति को देने लायक 'स्वास्थ्य शुभकामनाएं' वाले कार्ड पर "
-"लिखने के लिए वाक्य सुझाएं?"
+"सर्जरी करवाकर ठीक हो रहे किसी व्यक्ति को देने लायक 'स्वास्थ्य शुभकामनाएं' "
+"वाले कार्ड पर लिखने के लिए वाक्य सुझाएं?"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
@@ -20436,8 +20557,8 @@ msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
 msgstr ""
-"स्विच करने पर आपकी चैट एक ऐसे मॉडल को भेज दी जाएगी, जिसमें प्रोवाइडर विज़िबिलिटी ज़ीरो "
-"होगी"
+"स्विच करने पर आपकी चैट एक ऐसे मॉडल को भेज दी जाएगी, जिसमें प्रोवाइडर "
+"विज़िबिलिटी ज़ीरो होगी"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -20492,7 +20613,8 @@ msgstr "Sync & Backup चालू है!"
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
-"18 महीने तक निष्क्रिय रहने के बाद, Sync & Backup डेटा को रिकवर नहीं किया जा सकता।"
+"18 महीने तक निष्क्रिय रहने के बाद, Sync & Backup डेटा को रिकवर नहीं किया जा "
+"सकता।"
 
 # smartling.placeholder_format=C
 #. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
@@ -20501,6 +20623,8 @@ msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
 msgstr ""
+"Sync & Backup आपकी ज़्यादा चैट सेव करता है और उन्हें आपके सभी डिवाइसों पर "
+"सिंक करता है।"
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20549,25 +20673,26 @@ msgid ""
 msgstr ""
 "सिंक रिकवरी कोड\n"
 "\n"
-" रिकवरी कोड की मदद से आप कई डिवाइस पर अपने पासवर्ड, ऑटोफ़िल डेटा और Duck.ai चैट को "
-"सिंक कर सकते हैं, और अगर किसी डिवाइस का एक्सेस खो जाए, तो अपना सिंक किया हुआ डेटा "
-"रिकवर कर सकते हैं।\n"
+" रिकवरी कोड की मदद से आप कई डिवाइस पर अपने पासवर्ड, ऑटोफ़िल डेटा और Duck.ai "
+"चैट को सिंक कर सकते हैं, और अगर किसी डिवाइस का एक्सेस खो जाए, तो अपना सिंक "
+"किया हुआ डेटा रिकवर कर सकते हैं।\n"
 "\n"
 "इस जानकारी को सुरक्षित और गोपनीय रखें।\n"
-"जिस किसी के पास भी इस कोड का एक्सेस होगा, वह आपके सिंक किए गए डेटा को एक्सेस कर सकता "
-"है।\n"
+"जिस किसी के पास भी इस कोड का एक्सेस होगा, वह आपके सिंक किए गए डेटा को एक्सेस "
+"कर सकता है।\n"
 "\n"
 "%1$s\n"
 "\n"
 "यह कोड कैसे काम करता है?\n"
 "1. अपने ब्राउज़र में Duck.ai पर जाएं और Duck.ai सेटिंग खोलें।\n"
-"2. \"Sync & Backup चालू करें\" चुनें, फिर \"सिंक किया गया डेटा रिकवर करें\" चुनें\n"
-"3. ऊपर दिए गए रिकवरी कोड को कॉपी करें और उसे वहां पेस्ट करें जहां \"अपना कोड यहां पेस्ट "
-"करें\" कहा गया है\n"
+"2. \"Sync & Backup चालू करें\" चुनें, फिर \"सिंक किया गया डेटा रिकवर करें\" "
+"चुनें\n"
+"3. ऊपर दिए गए रिकवरी कोड को कॉपी करें और उसे वहां पेस्ट करें जहां \"अपना कोड "
+"यहां पेस्ट करें\" कहा गया है\n"
 "\n"
-"अगर आप Sync & Backup चालू होने के बाद भी 18 महीने से ज़्यादा समय तक DuckDuckGo "
-"ब्राउज़र का इस्तेमाल नहीं करते हैं, तो आपका डेटा सर्वर से डिलीट कर दिया जाएगा और उसे "
-"रीस्टोर नहीं किया जा सकेगा।"
+"अगर आप Sync & Backup चालू होने के बाद भी 18 महीने से ज़्यादा समय तक "
+"DuckDuckGo ब्राउज़र का इस्तेमाल नहीं करते हैं, तो आपका डेटा सर्वर से डिलीट "
+"कर दिया जाएगा और उसे रीस्टोर नहीं किया जा सकेगा।"
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -20621,7 +20746,7 @@ msgstr "अपनी चैट्स को अपने सभी डिवा�
 #. Headline in sync-enabled chat history about modals explaining cross-device sync.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Sync your chats across all your devices"
-msgstr ""
+msgstr "अपनी चैट्स को अपने सभी डिवाइसों पर सिंक करें"
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -20706,8 +20831,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
-"Duck.ai को हर जगह अपने साथ रखें। आप कहीं भी हों, तेज़ी से एक्सेस के लिए इसे हमारे मुफ़्त ऐप "
-"में पाएं।"
+"Duck.ai को हर जगह अपने साथ रखें। आप कहीं भी हों, तेज़ी से एक्सेस के लिए इसे "
+"हमारे मुफ़्त ऐप में पाएं।"
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20716,8 +20841,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
-"Duck.ai को हर जगह अपने साथ रखें। आप कहीं भी ब्राउज़ कर रहे हों, तेज़ी से एक्सेस के लिए इसे "
-"हमारे मुफ़्त ब्राउज़र में पाएं।"
+"Duck.ai को हर जगह अपने साथ रखें। आप कहीं भी ब्राउज़ कर रहे हों, तेज़ी से "
+"एक्सेस के लिए इसे हमारे मुफ़्त ब्राउज़र में पाएं।"
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20961,9 +21086,9 @@ msgid ""
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
 msgstr ""
-"इसका मतलब हैं कि आपके डिवाइस और इस लिंक के पीछे के वेबपेज के बीच भेजी गई जानकारी को "
-"किसी तीसरे पक्ष द्वारा इंटरसेप्ट किए जाने का जोखिम बढ़ रहा है। कम मामलों में इसमें पासवर्ड, "
-"या भुगतान विवरण शामिल होते हैं।"
+"इसका मतलब हैं कि आपके डिवाइस और इस लिंक के पीछे के वेबपेज के बीच भेजी गई "
+"जानकारी को किसी तीसरे पक्ष द्वारा इंटरसेप्ट किए जाने का जोखिम बढ़ रहा है। कम "
+"मामलों में इसमें पासवर्ड, या भुगतान विवरण शामिल होते हैं।"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -20972,8 +21097,8 @@ msgid ""
 "The Cloud Save bookmarklet allows any changes you make to your settings to "
 "automatically save in the cloud."
 msgstr ""
-"Cloud Save बुकमार्कलेट आपको क्लाउड में ऑटोमैटिकली सेव करने के लिए अपनी सेटिंग्स में कोई भी "
-"बदलाव करने की अनुमति देता है।"
+"Cloud Save बुकमार्कलेट आपको क्लाउड में ऑटोमैटिकली सेव करने के लिए अपनी "
+"सेटिंग्स में कोई भी बदलाव करने की अनुमति देता है।"
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -21003,8 +21128,8 @@ msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
 msgstr ""
-"'एनक्रिप्शन की' केवल आपके ब्राउज़र के लोकल स्टोरेज में सेव रहती है, और सिर्फ़ आप ही इसे एक्सेस "
-"कर सकते हैं।"
+"'एनक्रिप्शन की' केवल आपके ब्राउज़र के लोकल स्टोरेज में सेव रहती है, और "
+"सिर्फ़ आप ही इसे एक्सेस कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider deletes all chat data within 30 days.
@@ -21084,8 +21209,8 @@ msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
 msgstr ""
-"इस चैट को लोकल स्टोरेज में सेव करने के दौरान कोई गड़बड़ी हुई। कृपया अपनी ब्राउज़र सेटिंग जांचें "
-"और सुनिश्चित करें कि लोकल डेटा स्टोरेज चालू है।"
+"इस चैट को लोकल स्टोरेज में सेव करने के दौरान कोई गड़बड़ी हुई। कृपया अपनी "
+"ब्राउज़र सेटिंग जांचें और सुनिश्चित करें कि लोकल डेटा स्टोरेज चालू है।"
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -21100,8 +21225,8 @@ msgid ""
 "There was still an error displaying the search results. Please wait a few "
 "minutes before you try again."
 msgstr ""
-"खोज परिणाम दिखाने में अभी भी गड़बड़ी हो रही है। कृपया दोबारा कोशिश करने से पहले कुछ "
-"मिनट इंतज़ार करें।"
+"खोज परिणाम दिखाने में अभी भी गड़बड़ी हो रही है। कृपया दोबारा कोशिश करने से "
+"पहले कुछ मिनट इंतज़ार करें।"
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
@@ -21120,9 +21245,9 @@ msgid ""
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
 msgstr ""
-"इन ब्राउज़र अनुमतियों को आपके द्वारा देखी जाने वाली वेबसाइटों पर छिपे ट्रैकर ब्लॉक करके, "
-"संभव होने पर कनेक्शन एन्क्रिप्ट करके और DuckDuckGo को आपका डिफ़ॉल्ट खोज इंजन बनाकर "
-"गोपनीयता सुरक्षा जोड़ने के लिए उपयोग किया जाता है।"
+"इन ब्राउज़र अनुमतियों को आपके द्वारा देखी जाने वाली वेबसाइटों पर छिपे ट्रैकर "
+"ब्लॉक करके, संभव होने पर कनेक्शन एन्क्रिप्ट करके और DuckDuckGo को आपका "
+"डिफ़ॉल्ट खोज इंजन बनाकर गोपनीयता सुरक्षा जोड़ने के लिए उपयोग किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -21160,7 +21285,8 @@ msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
 msgstr ""
-"यह AI मॉडल अब उपलब्ध नहीं है। किसी दूसरे मॉडल के साथ नई चैट शुरू करने की कोशिश करें।"
+"यह AI मॉडल अब उपलब्ध नहीं है। किसी दूसरे मॉडल के साथ नई चैट शुरू करने की "
+"कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -21169,8 +21295,8 @@ msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
 msgstr ""
-"AI मॉडल के इस वर्ज़न के लिए अब सपोर्ट उपलब्ध नहीं है। इस मॉडल के सबसे नए वर्ज़न के साथ नई "
-"चैट शुरू करें।"
+"AI मॉडल के इस वर्ज़न के लिए अब सपोर्ट उपलब्ध नहीं है। इस मॉडल के सबसे नए "
+"वर्ज़न के साथ नई चैट शुरू करें।"
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -21205,12 +21331,14 @@ msgid ""
 "This chat and its generated images become public when you create and copy "
 "the link."
 msgstr ""
+"लिंक बनाने और कॉपी करने पर, यह चैट और इससे जनरेट की गई इमेज पब्लिक हो जाती "
+"हैं।"
 
 # smartling.placeholder_format=C
 #. Explains that creating and copying a share link makes the selected chat content public.
 msgctxt "Share modal info bullet about public access"
 msgid "This chat becomes public when you create and copy the link."
-msgstr ""
+msgstr "लिंक बनाने और कॉपी करने पर, यह चैट पब्लिक हो जाती है।"
 
 # smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
@@ -21225,8 +21353,9 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"यह बातचीत Duck.ai (%1$s) के जरिए %2$s के %3$s मॉडल का इस्तेमाल करके जनरेट की गई। "
-"AI चैट में गलत या आपत्तिजनक जानकारी दिखाई दे सकती है (ज़्यादा जानकारी के लिए %4$s देखें)।"
+"यह बातचीत Duck.ai (%1$s) के जरिए %2$s के %3$s मॉडल का इस्तेमाल करके जनरेट की "
+"गई। AI चैट में गलत या आपत्तिजनक जानकारी दिखाई दे सकती है (ज़्यादा जानकारी के "
+"लिए %4$s देखें)।"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21236,8 +21365,9 @@ msgid ""
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"यह बातचीत Duck.ai (%1$s) में कई चैट मॉडल इस्तेमाल करके तैयार की गई थी. एआई चैट में गलत "
-"या आपत्तिजनक जानकारी दिखाई दे सकती है (ज़्यादा जानकारी के लिए %2$s देखें)."
+"यह बातचीत Duck.ai (%1$s) में कई चैट मॉडल इस्तेमाल करके तैयार की गई थी. एआई "
+"चैट में गलत या आपत्तिजनक जानकारी दिखाई दे सकती है (ज़्यादा जानकारी के लिए "
+"%2$s देखें)."
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21246,8 +21376,8 @@ msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
 msgstr ""
-"यह बातचीत Duck.ai वॉयस चैट (%1$s) से जनरेट हुई थी। AI गलत या आपत्तिजनक जानकारी भी "
-"प्रदान कर सकता है। (ज़्यादा जानकारी के लिए %2$s देखें।)"
+"यह बातचीत Duck.ai वॉयस चैट (%1$s) से जनरेट हुई थी। AI गलत या आपत्तिजनक "
+"जानकारी भी प्रदान कर सकता है। (ज़्यादा जानकारी के लिए %2$s देखें।)"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -21257,9 +21387,9 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"यह बातचीत %2$s के %3$s मॉडल का इस्तेमाल करके DuckDuckGo AI Chat (%1$s) के जरिए "
-"जनरेट की गई। AI चैट में गलत या आपत्तिजनक जानकारी दिखाई दे सकती है (ज़्यादा जानकारी के "
-"लिए %4$s देखें)।"
+"यह बातचीत %2$s के %3$s मॉडल का इस्तेमाल करके DuckDuckGo AI Chat (%1$s) के "
+"जरिए जनरेट की गई। AI चैट में गलत या आपत्तिजनक जानकारी दिखाई दे सकती है "
+"(ज़्यादा जानकारी के लिए %4$s देखें)।"
 
 # smartling.placeholder_format=C
 #. Renders to the right of the device name for the row that matches this device's id.
@@ -21276,8 +21406,8 @@ msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
 msgstr ""
-"यह डिवाइस अब दूसरे डिवाइस पर आपके सिंक किए गए डेटा को ऐक्सेस नहीं कर पाएगा. पिछली "
-"%1$s चैट अभी भी लोकल स्टोरेज में उपलब्ध रहेंगी."
+"यह डिवाइस अब दूसरे डिवाइस पर आपके सिंक किए गए डेटा को ऐक्सेस नहीं कर पाएगा. "
+"पिछली %1$s चैट अभी भी लोकल स्टोरेज में उपलब्ध रहेंगी."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21349,7 +21479,8 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
 msgstr ""
-"इस इमेज प्रकार को सपोर्ट हासिल नहीं है, कृपया कोई JPG, PNG, WebP या GIF अटैच करें"
+"इस इमेज प्रकार को सपोर्ट हासिल नहीं है, कृपया कोई JPG, PNG, WebP या GIF अटैच "
+"करें"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
@@ -21357,7 +21488,8 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
 msgstr ""
-"इस इमेज प्रकार को सपोर्ट हासिल नहीं है, कृपया कोई JPG, PNG, WebP या GIF अटैच करें।"
+"इस इमेज प्रकार को सपोर्ट हासिल नहीं है, कृपया कोई JPG, PNG, WebP या GIF अटैच "
+"करें।"
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -21377,8 +21509,8 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
-"यह केवल एक सैंपल चैट है। इसका मेन्यू (तीन डॉट्स) खोलें, फिर इसे अपनी चैट्स में सबसे ऊपर रखने के "
-"लिए 'पिन करें' चुनें!"
+"यह केवल एक सैंपल चैट है। इसका मेन्यू (तीन डॉट्स) खोलें, फिर इसे अपनी चैट्स "
+"में सबसे ऊपर रखने के लिए 'पिन करें' चुनें!"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -21387,7 +21519,8 @@ msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
 msgstr ""
-"यह केवल एक सैंपल चैट है। इसे डिलीट करने के लिए साइड मेन्यू में Fire Button का इस्तेमाल करें!"
+"यह केवल एक सैंपल चैट है। इसे डिलीट करने के लिए साइड मेन्यू में Fire Button "
+"का इस्तेमाल करें!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -21408,8 +21541,8 @@ msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
 msgstr ""
-"यह मॉडल प्रदाता इस चैट से जुड़ा डेटा 30 दिनों के अंदर डिलीट कर देता है। अन्य मॉडल प्रदाता "
-"'ज़ीरो डेटा रिटेंशन' मॉडल का पालन करते हैं।"
+"यह मॉडल प्रदाता इस चैट से जुड़ा डेटा 30 दिनों के अंदर डिलीट कर देता है। अन्य "
+"मॉडल प्रदाता 'ज़ीरो डेटा रिटेंशन' मॉडल का पालन करते हैं।"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -21418,8 +21551,8 @@ msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
 msgstr ""
-"यह मॉडल प्रदाता इस चैट से जुड़ा कोई भी डेटा स्टोर नहीं करता है। अन्य मॉडल प्रदाता "
-"'सीमित डेटा रिटेंशन' मॉडल का पालन करते हैं।"
+"यह मॉडल प्रदाता इस चैट से जुड़ा कोई भी डेटा स्टोर नहीं करता है। अन्य मॉडल "
+"प्रदाता 'सीमित डेटा रिटेंशन' मॉडल का पालन करते हैं।"
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -21456,8 +21589,8 @@ msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
 msgstr ""
-"यह आपकी चैट्स को DuckDuckGo के सुरक्षित सर्वर पर एंड-टू-एंड एनक्रिप्शन के साथ सेव करता है, "
-"जिसे बाद में किसी भी ब्राउज़र से एक्सेस किया जा सकता है।"
+"यह आपकी चैट्स को DuckDuckGo के सुरक्षित सर्वर पर एंड-टू-एंड एनक्रिप्शन के "
+"साथ सेव करता है, जिसे बाद में किसी भी ब्राउज़र से एक्सेस किया जा सकता है।"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21466,8 +21599,9 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"यह सेटिंग आपके ब्राउज़र में स्टोर रहती है, जिसका मतलब है कि अगर आप duckduckgo.com "
-"ब्राउज़र डेटा मिटाते हैं, तो आपको AI से मिले जवाब फिर से दिख सकते हैं।"
+"यह सेटिंग आपके ब्राउज़र में स्टोर रहती है, जिसका मतलब है कि अगर आप "
+"duckduckgo.com ब्राउज़र डेटा मिटाते हैं, तो आपको AI से मिले जवाब फिर से दिख "
+"सकते हैं।"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21477,9 +21611,10 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"यह सेटिंग आपके ब्राउज़र में स्टोर रहती है, जिसका मतलब है कि अगर आप duckduckgo.com "
-"ब्राउज़र डेटा मिटाते हैं, तो आपको AI से मिले जवाब फिर से दिख सकते हैं। हालांकि, %1$s पर "
-"हमारे पास ऐसा स्टार्ट पेज भी है जो AI से मिलने वाले जवाब कभी नहीं दिखाता।"
+"यह सेटिंग आपके ब्राउज़र में स्टोर रहती है, जिसका मतलब है कि अगर आप "
+"duckduckgo.com ब्राउज़र डेटा मिटाते हैं, तो आपको AI से मिले जवाब फिर से दिख "
+"सकते हैं। हालांकि, %1$s पर हमारे पास ऐसा स्टार्ट पेज भी है जो AI से मिलने "
+"वाले जवाब कभी नहीं दिखाता।"
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
@@ -21520,7 +21655,9 @@ msgstr "यह वीडियो अब तक यहां देखे जा
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "यह वेबपेज एक सुरक्षित, एन्क्रिप्ट किए गए, कनेक्शन (HTTPS) का उपयोग नहीं करता है।"
+msgstr ""
+"यह वेबपेज एक सुरक्षित, एन्क्रिप्ट किए गए, कनेक्शन (HTTPS) का उपयोग नहीं करता "
+"है।"
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21530,8 +21667,9 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"इससे इस ब्राउज़र से आपकी सभी Duck.ai चैट डिलीट हो जाएंगी, और Sync & Backup डिस्कनेक्ट "
-"हो जाएगा। आप Sync & Backup से जुड़े दूसरे ब्राउज़र में भी अपनी चैट एक्सेस कर पाएंगे।"
+"इससे इस ब्राउज़र से आपकी सभी Duck.ai चैट डिलीट हो जाएंगी, और Sync & Backup "
+"डिस्कनेक्ट हो जाएगा। आप Sync & Backup से जुड़े दूसरे ब्राउज़र में भी अपनी "
+"चैट एक्सेस कर पाएंगे।"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -21540,15 +21678,16 @@ msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
 msgstr ""
-"यह आपकी सभी हालिया चैट्स को डिलीट कर देगा, सिवाय उनके जो पिन की गई हैं। इसे पहले जैसा "
-"नहीं किया जा सकता है।"
+"यह आपकी सभी हालिया चैट्स को डिलीट कर देगा, सिवाय उनके जो पिन की गई हैं। इसे "
+"पहले जैसा नहीं किया जा सकता है।"
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
 msgstr ""
-"यह आपके द्वारा चुनी गई इमेज को डिलीट कर देगा। इसे पहले जैसा नहीं किया जा सकता है।"
+"यह आपके द्वारा चुनी गई इमेज को डिलीट कर देगा। इसे पहले जैसा नहीं किया जा "
+"सकता है।"
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -21671,8 +21810,7 @@ msgstr "जारी रखने के लिए, आपको Duck.ai की 
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr ""
-"जारी रखने के लिए, आपको DuckDuckGo AI Chat की %1$s और %2$s से सहमत होना होगा"
+msgstr "जारी रखने के लिए, आपको DuckDuckGo AI Chat की %1$s और %2$s से सहमत होना होगा"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -21681,8 +21819,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"निर्देश प्रिंट करने के लिए:%1$sमैप पर वापस जाएं।%2$sउस रूट को चुनें जिसे आप प्रिंट करना "
-"चाहते हैं।%3$sप्रिंट आइकन पर क्लिक करें।%4$s"
+"निर्देश प्रिंट करने के लिए:%1$sमैप पर वापस जाएं।%2$sउस रूट को चुनें जिसे आप "
+"प्रिंट करना चाहते हैं।%3$sप्रिंट आइकन पर क्लिक करें।%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -21692,9 +21830,10 @@ msgid ""
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
 msgstr ""
-"अपने सिंक किए गए डेटा को रीस्टोर करने के लिए, आपको उस रिकवरी कोड की ज़रूरत होगी जिसे "
-"आपने पहली बार Sync सेटअप करते समय सेव किया था। यह कोड उस डिवाइस पर PDF के रूप में सेव "
-"किया गया हो सकता है, जिसका इस्तेमाल आपने मूल रूप से Sync सेटअप करने के लिए किया था।"
+"अपने सिंक किए गए डेटा को रीस्टोर करने के लिए, आपको उस रिकवरी कोड की ज़रूरत "
+"होगी जिसे आपने पहली बार Sync सेटअप करते समय सेव किया था। यह कोड उस डिवाइस पर "
+"PDF के रूप में सेव किया गया हो सकता है, जिसका इस्तेमाल आपने मूल रूप से Sync "
+"सेटअप करने के लिए किया था।"
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -21703,8 +21842,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"अपनी चैट हिस्ट्री को Duck.ai पर ट्रांसफ़र करने के लिए, कृपया अपने DuckDuckGo ब्राउज़र को "
-"नवीनतम वर्ज़न में अपडेट करें और दोबारा प्रयास करें।"
+"अपनी चैट हिस्ट्री को Duck.ai पर ट्रांसफ़र करने के लिए, कृपया अपने DuckDuckGo "
+"ब्राउज़र को नवीनतम वर्ज़न में अपडेट करें और दोबारा प्रयास करें।"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -21712,8 +21851,8 @@ msgid ""
 "To use dictation, allow your browser to access the microphone in your system "
 "settings."
 msgstr ""
-"डिक्टेशन का इस्तेमाल करने के लिए, अपने सिस्टम सेटिंग में जाकर ब्राउज़र को माइक्रोफ़ोन का "
-"एक्सेस दें।"
+"डिक्टेशन का इस्तेमाल करने के लिए, अपने सिस्टम सेटिंग में जाकर ब्राउज़र को "
+"माइक्रोफ़ोन का एक्सेस दें।"
 
 # smartling.placeholder_format=C
 msgid "Today"
@@ -21735,13 +21874,15 @@ msgstr "आज"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
-msgstr ""
+msgstr "प्राइवेट AI चैट पर टॉगल करें या %1$sसेटिंग में इसे बंद करें%2$s।"
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
-msgstr "प्राइवेट AI चैट आज़माने के लिए टॉगल करें या %1$sइसे %2$s मेन्यू में डिसेबल करें।%3$s"
+msgstr ""
+"प्राइवेट AI चैट आज़माने के लिए टॉगल करें या %1$sइसे %2$s मेन्यू में डिसेबल "
+"करें।%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21915,8 +22056,8 @@ msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
 msgstr ""
-"DuckDuckGo द्वारा ब्लॉक की गई ट्रैकिंग की कोशिशें यहां दिखाई देंगी। ब्राउज़ करते रहें और देखें "
-"हम कितनों को ब्लॉक करते हैं।"
+"DuckDuckGo द्वारा ब्लॉक की गई ट्रैकिंग की कोशिशें यहां दिखाई देंगी। ब्राउज़ "
+"करते रहें और देखें हम कितनों को ब्लॉक करते हैं।"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -21963,7 +22104,9 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "फ्रेंच में इस अंग्रेजी वाक्य का अनुवाद करें: \"मैं निकटतम मूवी थियेटर में कैसे पहुंचूं?\""
+msgstr ""
+"फ्रेंच में इस अंग्रेजी वाक्य का अनुवाद करें: \"मैं निकटतम मूवी थियेटर में "
+"कैसे पहुंचूं?\""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -21972,7 +22115,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"हिन्दी में दिए गए इस वाक्य का अंग्रेज़ी में अनुवाद करें: \"मैं नज़दीकी सिनेमा हॉल तक कैसे पहुंचूं?\""
+"हिन्दी में दिए गए इस वाक्य का अंग्रेज़ी में अनुवाद करें: \"मैं नज़दीकी "
+"सिनेमा हॉल तक कैसे पहुंचूं?\""
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -22220,7 +22364,8 @@ msgstr "अलग कीवर्ड आज़माएं।"
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
 msgstr ""
-"DuckDuckGo पर अधिक परिणाम देखने के लिए अपने विज्ञापन ब्लॉकर को डिसेबल यानी अक्षम करें।"
+"DuckDuckGo पर अधिक परिणाम देखने के लिए अपने विज्ञापन ब्लॉकर को डिसेबल यानी "
+"अक्षम करें।"
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
@@ -22412,7 +22557,8 @@ msgstr "हाल ही में जोड़े गए ओपन-सोर्
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source Llama 3.1 and Mixtral"
 msgstr ""
-"हाल ही में जोड़े गए ओपन-सोर्स यानी मुक्त स्रोत वाले Llama 3.1 और Mixtral को आजमाएं"
+"हाल ही में जोड़े गए ओपन-सोर्स यानी मुक्त स्रोत वाले Llama 3.1 और Mixtral को "
+"आजमाएं"
 
 # smartling.placeholder_format=C
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
@@ -22452,8 +22598,8 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"क्या आप AI फ़ीचर्स को बंद करने की कोशिश कर रहे हैं? अपनी सेटिंग याद रखने के लिए "
-"%1$sDuckDuckGo No AI%2$s सर्च एक्सटेंशन इंस्टॉल करें। %3$sऔर जानें%4$s"
+"क्या आप AI फ़ीचर्स को बंद करने की कोशिश कर रहे हैं? अपनी सेटिंग याद रखने के "
+"लिए %1$sDuckDuckGo No AI%2$s सर्च एक्सटेंशन इंस्टॉल करें। %3$sऔर जानें%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -22462,8 +22608,8 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"क्या आप AI फ़ीचर्स को बंद करने की कोशिश कर रहे हैं? अपनी सेटिंग याद रखने के लिए "
-"%1$sDuckDuckGo No AI%2$s सर्च एक्सटेंशन पर स्विच करें। %3$sऔर जानें%4$s"
+"क्या आप AI फ़ीचर्स को बंद करने की कोशिश कर रहे हैं? अपनी सेटिंग याद रखने के "
+"लिए %1$sDuckDuckGo No AI%2$s सर्च एक्सटेंशन पर स्विच करें। %3$sऔर जानें%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -22664,8 +22810,8 @@ msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
 msgstr ""
-"जनरेट होते ही DuckAssist के उत्तर टाइप हो जाते हैं। इसे बंद करने से खोज और दिखाई देने वाले "
-"उत्तर के बीच थोड़ा समय लग सकता है।"
+"जनरेट होते ही DuckAssist के उत्तर टाइप हो जाते हैं। इसे बंद करने से खोज और "
+"दिखाई देने वाले उत्तर के बीच थोड़ा समय लग सकता है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -22795,8 +22941,8 @@ msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
 msgstr ""
-"%1$sस्टार्टअप पर%2$s के नीचे, %3$sकोई खास पेज खोलें%4$s पर क्लिक करें, फिर %5$sसेट "
-"पेज%6$s पर क्लिक करें।"
+"%1$sस्टार्टअप पर%2$s के नीचे, %3$sकोई खास पेज खोलें%4$s पर क्लिक करें, फिर "
+"%5$sसेट पेज%6$s पर क्लिक करें।"
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
@@ -22804,8 +22950,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"%1$sस्टार्टअप पर%2$s के अंतर्गत, %3$sहोमपेज%4$s चुनें और यह डालें: https://duckduckgo."
-"com"
+"%1$sस्टार्टअप पर%2$s के अंतर्गत, %3$sहोमपेज%4$s चुनें और यह डालें: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -22837,7 +22983,9 @@ msgstr "%1$sसर्च%2$s सेक्शन के नीचे, %3$sसर�
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr "स्टार्टअप चालू करें के अंतर्गत %1$sएक विशिष्ट पेज या कई पेज के सेट खोलें%2$s चुनें"
+msgstr ""
+"स्टार्टअप चालू करें के अंतर्गत %1$sएक विशिष्ट पेज या कई पेज के सेट खोलें%2$s "
+"चुनें"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -22921,8 +23069,8 @@ msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
 msgstr ""
-"Pro में अपग्रेड करके %1$s, बेहतर AI रीज़निंग, और Plus प्लान की तुलना में 2 गुना ज़्यादा "
-"उपयोग सीमाएं अनलॉक करें।"
+"Pro में अपग्रेड करके %1$s, बेहतर AI रीज़निंग, और Plus प्लान की तुलना में 2 "
+"गुना ज़्यादा उपयोग सीमाएं अनलॉक करें।"
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -23080,8 +23228,8 @@ msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
 msgstr ""
-"Duck.ai में अपने सब्सक्रिप्शन को एक्टिव करने और एडवांस्ड मॉडल्स एक्सेस करने के लिए "
-"DuckDuckGo ब्राउज़र को अपडेट करें"
+"Duck.ai में अपने सब्सक्रिप्शन को एक्टिव करने और एडवांस्ड मॉडल्स एक्सेस करने "
+"के लिए DuckDuckGo ब्राउज़र को अपडेट करें"
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -23206,14 +23354,16 @@ msgid ""
 "Upgrade to Pro to unlock 2x higher limits than Plus, or come back later to "
 "create more images."
 msgstr ""
-"Plus से 2 गुना ज़्यादा लिमिट पाने के लिए Pro में अपग्रेड करें, या अधिक इमेज बनाने के लिए "
-"बाद में वापस आएं।"
+"Plus से 2 गुना ज़्यादा लिमिट पाने के लिए Pro में अपग्रेड करें, या अधिक इमेज "
+"बनाने के लिए बाद में वापस आएं।"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr "Plus की तुलना में 2 गुना ज़्यादा उपयोग सीमाएं अनलॉक करने के लिए Pro में अपग्रेड करें"
+msgstr ""
+"Plus की तुलना में 2 गुना ज़्यादा उपयोग सीमाएं अनलॉक करने के लिए Pro में "
+"अपग्रेड करें"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -23309,9 +23459,9 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"ChatGPT, Claude और अन्य AI का उपयोग गोपनीय ढंग से निजी तौर पर करें। चैट्स को हैकर्स, "
-"स्कैमर्स और कंपनियों से सुरक्षित रखें। जानकारी गोपनीय बनाए रखें। मुफ़्त। किसी खाते की ज़रूरत "
-"नहीं है।"
+"ChatGPT, Claude और अन्य AI का उपयोग गोपनीय ढंग से निजी तौर पर करें। चैट्स को "
+"हैकर्स, स्कैमर्स और कंपनियों से सुरक्षित रखें। जानकारी गोपनीय बनाए रखें। "
+"मुफ़्त। किसी खाते की ज़रूरत नहीं है।"
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -23366,8 +23516,8 @@ msgid ""
 "Use this code to restore your data if you lose access to your devices. Keep "
 "it safe."
 msgstr ""
-"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपना डेटा वापस पाने के लिए इस कोड का "
-"इस्तेमाल करें। इसे सुरक्षित संभालकर रखें।"
+"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपना डेटा वापस पाने के लिए इस "
+"कोड का इस्तेमाल करें। इसे सुरक्षित संभालकर रखें।"
 
 # smartling.placeholder_format=C
 #. First sentence of the recovery section. The 18-month inactivity notice is rendered by the component using DUCKCHAT_SYNC_RECOVERY_INACTIVITY_NOTICE so both surfaces stay consistent.
@@ -23375,8 +23525,8 @@ msgctxt "Description for the recovery section inside Manage"
 msgid ""
 "Use this code to restore your saved chats if you lose access to your devices."
 msgstr ""
-"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपनी सेव की गई चैट्स वापस पाने के लिए इस "
-"कोड का इस्तेमाल करें।"
+"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपनी सेव की गई चैट्स वापस पाने "
+"के लिए इस कोड का इस्तेमाल करें।"
 
 # smartling.placeholder_format=C
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
@@ -23526,8 +23676,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
 msgstr ""
-"विज्ञापन देखना DuckDuckGo द्वारा गोपनीयता संरक्षित है। विज्ञापन क्लिक को Microsoft के "
-"विज्ञापन नेटवर्क द्वारा प्रबंधित किया जाता है"
+"विज्ञापन देखना DuckDuckGo द्वारा गोपनीयता संरक्षित है। विज्ञापन क्लिक को "
+"Microsoft के विज्ञापन नेटवर्क द्वारा प्रबंधित किया जाता है"
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -23536,8 +23686,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
 msgstr ""
-"विज्ञापन देखना DuckDuckGo द्वारा गोपनीयता संरक्षित है। विज्ञापन क्लिक TripAdvisor के "
-"विज्ञापन नेटवर्क द्वारा प्रबंधित किए जाते हैं।"
+"विज्ञापन देखना DuckDuckGo द्वारा गोपनीयता संरक्षित है। विज्ञापन क्लिक "
+"TripAdvisor के विज्ञापन नेटवर्क द्वारा प्रबंधित किए जाते हैं।"
 
 # smartling.placeholder_format=C
 #. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
@@ -23546,6 +23696,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Yelp's ad network."
 msgstr ""
+"DuckDuckGo पर विज्ञापन देखने के दौरान आपकी प्राइवेसी सुरक्षित रहती है। "
+"विज्ञापन क्लिक Yelp के विज्ञापन नेटवर्क द्वारा मैनेज किए जाते हैं।"
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -23557,8 +23709,8 @@ msgctxt "duckassist"
 msgid ""
 "Visit %sAssist Settings%s to adjust how this feature works or turn it off."
 msgstr ""
-"इस फ़ीचर के काम करने का तरीका एडजस्ट करने या इसे बंद करने के लिए %1$sAssist सेटिंग%2$s "
-"पर जाएं।"
+"इस फ़ीचर के काम करने का तरीका एडजस्ट करने या इसे बंद करने के लिए %1$sAssist "
+"सेटिंग%2$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
@@ -23567,8 +23719,8 @@ msgid ""
 "Visit %sDuckAssist Settings%s to adjust how this feature works or turn it "
 "off."
 msgstr ""
-"इस फ़ीचर के काम करने का तरीका एडजस्ट करने या इसे बंद करने के लिए %1$sDuckAssist "
-"सेटिंग%2$s पर जाएं।"
+"इस फ़ीचर के काम करने का तरीका एडजस्ट करने या इसे बंद करने के लिए "
+"%1$sDuckAssist सेटिंग%2$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Prompt to visit DuckDuckGo on another device.
@@ -23577,7 +23729,8 @@ msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
 msgstr ""
-"अपने टैबलेट या फ़ोन पर %1$sDuckDuckGo.com%2$s पर जाएं और दिए गए निर्देशों का पालन करें।"
+"अपने टैबलेट या फ़ोन पर %1$sDuckDuckGo.com%2$s पर जाएं और दिए गए निर्देशों का "
+"पालन करें।"
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -23593,8 +23746,8 @@ msgid ""
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
 "अपने दूसरे ब्राउज़र में Duck.ai पर जाकर %1$sDuck.ai सेटिंग%2$s > %3$sSync & "
-"Backup%4$s > %5$sमैनेज करें%6$s पर जाएं और उसके बाद %7$sकिसी दूसरे डिवाइस के साथ सिंक "
-"करें%8$s को चुनें।"
+"Backup%4$s > %5$sमैनेज करें%6$s पर जाएं और उसके बाद %7$sकिसी दूसरे डिवाइस के "
+"साथ सिंक करें%8$s को चुनें।"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23604,9 +23757,9 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"अपने दूसरे ब्राउज़र में Duck.ai पर जाएं और Duck.ai की सेटिंग खोलें। Sync & Backup के "
-"अंतर्गत \"चालू करें\" को चुनें और \"किसी दूसरे डिवाइस के साथ सिंक करें\" को चुनें। या अपनी "
-"रिकवरी PDF पर मौजूद QR कोड स्कैन करें।"
+"अपने दूसरे ब्राउज़र में Duck.ai पर जाएं और Duck.ai की सेटिंग खोलें। Sync & "
+"Backup के अंतर्गत \"चालू करें\" को चुनें और \"किसी दूसरे डिवाइस के साथ सिंक "
+"करें\" को चुनें। या अपनी रिकवरी PDF पर मौजूद QR कोड स्कैन करें।"
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -23616,9 +23769,9 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में Duck.ai पर जाकर %1$sDuck.ai सेटिंग%2$s > "
-"%3$sSync & Backup%4$s > %5$sमैनेज करें%6$s पर जाएं और उसके बाद %7$sकिसी दूसरे डिवाइस "
-"के साथ सिंक करें%8$s को चुनें।"
+"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में Duck.ai पर जाकर %1$sDuck.ai "
+"सेटिंग%2$s > %3$sSync & Backup%4$s > %5$sमैनेज करें%6$s पर जाएं और उसके बाद "
+"%7$sकिसी दूसरे डिवाइस के साथ सिंक करें%8$s को चुनें।"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23628,9 +23781,10 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में Duck.ai पर जाएं और Duck.ai की सेटिंग खोलें। "
-"Sync & Backup के अंतर्गत \"चालू करें\" को चुनें और \"किसी दूसरे डिवाइस के साथ सिंक करें\" "
-"को चुनें। या अपनी रिकवरी PDF पर मौजूद QR कोड स्कैन करें।"
+"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में Duck.ai पर जाएं और Duck.ai की "
+"सेटिंग खोलें। Sync & Backup के अंतर्गत \"चालू करें\" को चुनें और \"किसी "
+"दूसरे डिवाइस के साथ सिंक करें\" को चुनें। या अपनी रिकवरी PDF पर मौजूद QR कोड "
+"स्कैन करें।"
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23683,8 +23837,8 @@ msgstr "वॉयस चैट समाप्त हो गई"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"हम वॉयस चैट को गुमनाम रखते हैं और इसका उपयोग कभी भी AI मॉडल प्रशिक्षित करने के लिए "
-"नहीं किया जाता है।"
+"हम वॉयस चैट को गुमनाम रखते हैं और इसका उपयोग कभी भी AI मॉडल प्रशिक्षित करने "
+"के लिए नहीं किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -23828,8 +23982,8 @@ msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
-"YouTube पर वैयक्तिकृत विज्ञापनों को ब्लॉक करने और अपनी देखने की गतिविधि को YouTube "
-"अनुशंसाओं को प्रभावित करने से रोकने के लिए Duck प्लेयर में देखें।"
+"YouTube पर वैयक्तिकृत विज्ञापनों को ब्लॉक करने और अपनी देखने की गतिविधि को "
+"YouTube अनुशंसाओं को प्रभावित करने से रोकने के लिए Duck प्लेयर में देखें।"
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -23849,9 +24003,10 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"यहाँ वीडियो देखने का अर्थ है कि होस्ट की गई वेबसाइट आपको ट्रैक कर सकती है क्योंकि हमें वहाँ "
-"से कॉन्टेंट स्ट्रीम करना होगा। DuckDuckGo एक स्वतंत्र कंपनी है और इसका YouTube से कोई "
-"संबंध नहीं है, जहाँ अधिकांश वीडियो होस्ट किए जाते हैं।"
+"यहाँ वीडियो देखने का अर्थ है कि होस्ट की गई वेबसाइट आपको ट्रैक कर सकती है "
+"क्योंकि हमें वहाँ से कॉन्टेंट स्ट्रीम करना होगा। DuckDuckGo एक स्वतंत्र "
+"कंपनी है और इसका YouTube से कोई संबंध नहीं है, जहाँ अधिकांश वीडियो होस्ट किए "
+"जाते हैं।"
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -23864,8 +24019,8 @@ msgstr "हम गुमनाम करते हैं"
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
 msgstr ""
-"आपको अधिक सटीक नतीजे दिखाने के लिए हम%1$s आपके स्थान%2$s की जानकारी को गुमनाम रख "
-"सकते हैं।"
+"आपको अधिक सटीक नतीजे दिखाने के लिए हम%1$s आपके स्थान%2$s की जानकारी को "
+"गुमनाम रख सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -23877,9 +24032,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
-"सुधार तभी मुमकिन है, जब कमी नज़र आए। किसी हानिकारक या गैरकानूनी जवाब की रिपोर्ट करने "
-"के लिए, कृपया इस बातचीत को DuckDuckGo के साथ शेयर करें ताकि हम जांच कर सकें और समस्या "
-"का समाधान कर सकें।"
+"सुधार तभी मुमकिन है, जब कमी नज़र आए। किसी हानिकारक या गैरकानूनी जवाब की "
+"रिपोर्ट करने के लिए, कृपया इस बातचीत को DuckDuckGo के साथ शेयर करें ताकि हम "
+"जांच कर सकें और समस्या का समाधान कर सकें।"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -23891,16 +24046,17 @@ msgid ""
 "please share your prompt and response so we can investigate and address the "
 "issue."
 msgstr ""
-"सुधार तभी मुमकिन है, जब कमी नज़र आए। किसी हानिकारक या गैर-कानूनी जवाब की रिपोर्ट "
-"करने के लिए, कृपया अपना प्रॉम्प्ट और जवाब शेयर करें, ताकि हम उस मामले की जांच करके उसे "
-"ठीक कर सकें।"
+"सुधार तभी मुमकिन है, जब कमी नज़र आए। किसी हानिकारक या गैर-कानूनी जवाब की "
+"रिपोर्ट करने के लिए, कृपया अपना प्रॉम्प्ट और जवाब शेयर करें, ताकि हम उस "
+"मामले की जांच करके उसे ठीक कर सकें।"
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can use your anonymous%s location%s to show you nearby results."
 msgstr ""
-"आपको आस-पास के परिणाम दिखाने के लिए हम आपके अनाम%1$s स्थान%2$s का इस्‍तेमाल कर सकते हैं।"
+"आपको आस-पास के परिणाम दिखाने के लिए हम आपके अनाम%1$s स्थान%2$s का इस्‍तेमाल "
+"कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Error message displayed when one or more attached files are encrypted and cannot be read.
@@ -23908,7 +24064,8 @@ msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
 msgstr ""
-"हम अटैच की गई फ़ाइलों को पढ़ नहीं पा रहे हैं, क्योंकि उनमें से कम से कम एक एन्क्रिप्टेड है।"
+"हम अटैच की गई फ़ाइलों को पढ़ नहीं पा रहे हैं, क्योंकि उनमें से कम से कम एक "
+"एन्क्रिप्टेड है।"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23920,7 +24077,8 @@ msgstr "हम विज्ञापनों के साथ आपको फ�
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
 msgstr ""
-"हम यूज़रनेम या किसी भी व्यक्तिगत रूप से पहचान योग्य जानकारी को संग्रहित नहीं करते हैं।"
+"हम यूज़रनेम या किसी भी व्यक्तिगत रूप से पहचान योग्य जानकारी को संग्रहित नहीं "
+"करते हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -23937,8 +24095,8 @@ msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
 msgstr ""
-"हम आपकी गोपनीय जानकारी स्टोर नहीं करते। हम विज्ञापनों के साथ आपको फ़ॉलो नहीं करते हैं। "
-"हम आपको ट्रैक नहीं करते हैं। कभी भी।"
+"हम आपकी गोपनीय जानकारी स्टोर नहीं करते। हम विज्ञापनों के साथ आपको फ़ॉलो नहीं "
+"करते हैं। हम आपको ट्रैक नहीं करते हैं। कभी भी।"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23952,8 +24110,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
 msgstr ""
-"हम आपको ट्रैक नहीं करते हैं, ताकि यह बताने में आपकी मदद ले सके कि आप आज यहां वापस क्यों आए "
-"हैं:"
+"हम आपको ट्रैक नहीं करते हैं, ताकि यह बताने में आपकी मदद ले सके कि आप आज यहां "
+"वापस क्यों आए हैं:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -23962,8 +24120,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
 msgstr ""
-"हम आपको ट्रैक नहीं करते हैं, ताकि यह जानने में आपकी मदद ली जा सके कि आप किस वजह से हमें "
-"आज़माना चाहते हैं:"
+"हम आपको ट्रैक नहीं करते हैं, ताकि यह जानने में आपकी मदद ली जा सके कि आप किस "
+"वजह से हमें आज़माना चाहते हैं:"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24003,8 +24161,9 @@ msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
 msgstr ""
-"हम आपकी खोज का इतिहास स्टोर नहीं करते हैं। इसलिए हमारे पास ऐसे विज्ञापनकर्ताओं को बेचने "
-"के लिए कुछ भी नहीं है जो आपको इंटरनेट पर ट्रैक करते हैं।"
+"हम आपकी खोज का इतिहास स्टोर नहीं करते हैं। इसलिए हमारे पास ऐसे "
+"विज्ञापनकर्ताओं को बेचने के लिए कुछ भी नहीं है जो आपको इंटरनेट पर ट्रैक करते "
+"हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -24030,8 +24189,8 @@ msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
 msgstr ""
-"हम डेटा ब्रोकर साइटों से आपकी व्यक्तिगत जानकारी ढूंढते हैं और हटाते हैं. Plus, VPN और बहुत "
-"कुछ पाएँ."
+"हम डेटा ब्रोकर साइटों से आपकी व्यक्तिगत जानकारी ढूंढते हैं और हटाते हैं. "
+"Plus, VPN और बहुत कुछ पाएँ."
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -24040,8 +24199,8 @@ msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
 msgstr ""
-"हमने सभी AI प्रोवाइडर्स के साथ एग्रीमेंट किए हैं ताकि यह पक्का किया जा सके कि आपकी चैट्स "
-"का इस्तेमाल AI को ट्रेन करने के लिए न हो।"
+"हमने सभी AI प्रोवाइडर्स के साथ एग्रीमेंट किए हैं ताकि यह पक्का किया जा सके "
+"कि आपकी चैट्स का इस्तेमाल AI को ट्रेन करने के लिए न हो।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -24066,8 +24225,8 @@ msgid ""
 "We make money from %sprivacy-respecting search ads%s, not by exploiting your "
 "data."
 msgstr ""
-"हम %1$sगोपनीयता का सम्मान करने वाले खोज विज्ञापनों%2$s से पैसा कमाते हैं, आपके डेटा का "
-"फायदा उठाकर नहीं।"
+"हम %1$sगोपनीयता का सम्मान करने वाले खोज विज्ञापनों%2$s से पैसा कमाते हैं, "
+"आपके डेटा का फायदा उठाकर नहीं।"
 
 # smartling.placeholder_format=C
 #. Message describing how DuckDuckGo users location access anonymously to provide better search results.
@@ -24076,8 +24235,8 @@ msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
 msgstr ""
-"हम आपके करीब आपके अनाम स्थान का इस्‍तेमाल केवल बेहतर परिणाम देने के लिए करते हैं। आप अक्‍सर "
-"बाद में अपना विचार बदल सकते हैं।"
+"हम आपके करीब आपके अनाम स्थान का इस्‍तेमाल केवल बेहतर परिणाम देने के लिए करते "
+"हैं। आप अक्‍सर बाद में अपना विचार बदल सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
@@ -24086,19 +24245,23 @@ msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
 msgstr ""
-"हम आपकी निजी जानकारी के लिए डेटा ब्रोकर साइटों को नियमित तौर से स्कैन करते हैं, और "
-"इस्तेमाल में आसान डैशबोर्ड पर अपनी प्रगति आपके साथ शेयर करते हैं."
+"हम आपकी निजी जानकारी के लिए डेटा ब्रोकर साइटों को नियमित तौर से स्कैन करते "
+"हैं, और इस्तेमाल में आसान डैशबोर्ड पर अपनी प्रगति आपके साथ शेयर करते हैं."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr "हम DuckDuckGo को सबके लिए बेहतर बनाने हेतु आपकी गुमनाम फीडबैक पर निर्भर करते हैं।"
+msgstr ""
+"हम DuckDuckGo को सबके लिए बेहतर बनाने हेतु आपकी गुमनाम फीडबैक पर निर्भर करते "
+"हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr "हम सभी को आपका खोज का इतिहास प्राप्त करने से रोकते हैं, जिनमें हम भी शामिल हैं।"
+msgstr ""
+"हम सभी को आपका खोज का इतिहास प्राप्त करने से रोकते हैं, जिनमें हम भी शामिल "
+"हैं।"
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -24114,15 +24277,16 @@ msgid ""
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
 msgstr ""
-"हम इस तरह की प्रतिक्रिया का उपयोग करते हैं ताकि DuckDuckGo को बेहतर बनाया जा सके। "
-"%1$s के विवेकानुसार सुझावों को शामिल किया जाएगा। हो सकता है कि सुधार तुरंत परिणामों में "
-"दिखाई ना दें।"
+"हम इस तरह की प्रतिक्रिया का उपयोग करते हैं ताकि DuckDuckGo को बेहतर बनाया जा "
+"सके। %1$s के विवेकानुसार सुझावों को शामिल किया जाएगा। हो सकता है कि सुधार "
+"तुरंत परिणामों में दिखाई ना दें।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
 msgstr ""
-"जैसे ही आप ब्राउज़ करेंगे, हम आपके डेटा एकत्र करने का प्रयास करने वाले ट्रैकर्स को ब्लॉक कर देंगे।"
+"जैसे ही आप ब्राउज़ करेंगे, हम आपके डेटा एकत्र करने का प्रयास करने वाले "
+"ट्रैकर्स को ब्लॉक कर देंगे।"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
@@ -24131,8 +24295,8 @@ msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
 msgstr ""
-"हम आपके ईमेल, नाम, पते और अन्य जानकारी के लिए डेटा ब्रोकर साइटों को स्कैन करेंगे, और आपके "
-"बारे में मिलने वाली किसी भी जानकारी को हटवाने का काम करेंगे."
+"हम आपके ईमेल, नाम, पते और अन्य जानकारी के लिए डेटा ब्रोकर साइटों को स्कैन "
+"करेंगे, और आपके बारे में मिलने वाली किसी भी जानकारी को हटवाने का काम करेंगे."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24141,8 +24305,9 @@ msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
 msgstr ""
-"हमें इस समस्या की जानकारी है और फ़िलहाल हम इसे हल करने के लिए काम कर रहे हैं। अगर आपको "
-"यह गड़बड़ी लगातार दिखाई दे रही है, तो कृपया %1$s से संपर्क करें।"
+"हमें इस समस्या की जानकारी है और फ़िलहाल हम इसे हल करने के लिए काम कर रहे "
+"हैं। अगर आपको यह गड़बड़ी लगातार दिखाई दे रही है, तो कृपया %1$s से संपर्क "
+"करें।"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -24151,8 +24316,8 @@ msgid ""
 "We're aware of this issue and are currently working to resolve it. Sometimes "
 "clearing your browser's cache can help."
 msgstr ""
-"हमें इस समस्या की जानकारी है और फ़िलहाल हम इसे हल करने के लिए काम कर रहे हैं। कभी-कभी "
-"अपने ब्राउज़र का कैशे मिटाने से समस्या हल हो जाती है।"
+"हमें इस समस्या की जानकारी है और फ़िलहाल हम इसे हल करने के लिए काम कर रहे "
+"हैं। कभी-कभी अपने ब्राउज़र का कैशे मिटाने से समस्या हल हो जाती है।"
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -24167,7 +24332,8 @@ msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
 msgstr ""
-"इस असुविधा के लिए हमें खेद है। हम आपके अनुभव को बेहतर बनाने के लिए लगातार मेहनत कर रहे हैं।"
+"इस असुविधा के लिए हमें खेद है। हम आपके अनुभव को बेहतर बनाने के लिए लगातार "
+"मेहनत कर रहे हैं।"
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -24176,8 +24342,8 @@ msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
 msgstr ""
-"हमने Duck.ai सेवा को अपडेट कर दिया है। बदलाव प्रभावी होने के लिए, हमें पेज फिर से लोड "
-"करना होगा।"
+"हमने Duck.ai सेवा को अपडेट कर दिया है। बदलाव प्रभावी होने के लिए, हमें पेज "
+"फिर से लोड करना होगा।"
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -24277,7 +24443,9 @@ msgstr "साप्ताहिक उपयोग सीमा पूरी �
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr "साप्ताहिक उपयोग सीमा पूरी हो गई है। आप %1$s के बाद इस चैट को जारी रख सकते हैं।"
+msgstr ""
+"साप्ताहिक उपयोग सीमा पूरी हो गई है। आप %1$s के बाद इस चैट को जारी रख सकते "
+"हैं।"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -24286,8 +24454,8 @@ msgid ""
 "Weekly usage limit reached. You can keep chatting by using your monthly "
 "limit."
 msgstr ""
-"साप्ताहिक उपयोग सीमा पूरी हो गई है। आप अपनी मासिक सीमा का उपयोग करके चैट करना "
-"जारी रख सकते हैं।"
+"साप्ताहिक उपयोग सीमा पूरी हो गई है। आप अपनी मासिक सीमा का उपयोग करके चैट "
+"करना जारी रख सकते हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -24301,8 +24469,9 @@ msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
 msgstr ""
-"Duck.ai में आपका स्वागत है! यहां आपकी सभी चैट गोपनीय रहती हैं, हम उन्हें अनाम कर देते हैं "
-"और उनका इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
+"Duck.ai में आपका स्वागत है! यहां आपकी सभी चैट गोपनीय रहती हैं, हम उन्हें "
+"अनाम कर देते हैं और उनका इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए नहीं "
+"किया जाता।"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -24311,8 +24480,9 @@ msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat में आपका स्वागत है! यहां आपकी सभी चैट गोपनीय रहती हैं, हम उन्हें "
-"अनाम कर देते हैं और उनका इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
+"DuckDuckGo AI Chat में आपका स्वागत है! यहां आपकी सभी चैट गोपनीय रहती हैं, हम "
+"उन्हें अनाम कर देते हैं और उनका इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए "
+"नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -24322,16 +24492,17 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat में आपका स्वागत है! इस चैट सेशन को %1$s का %2$s संचालित करता है। "
-"यहां आपकी सभी चैट निजी हैं और उन्हें DuckDuckGo कभी भी स्टोर नहीं करता है या उनका "
-"उपयोग AI मॉडल को प्रशिक्षित करने में नहीं किया जाता है।"
+"DuckDuckGo AI Chat में आपका स्वागत है! इस चैट सेशन को %1$s का %2$s संचालित "
+"करता है। यहां आपकी सभी चैट निजी हैं और उन्हें DuckDuckGo कभी भी स्टोर नहीं "
+"करता है या उनका उपयोग AI मॉडल को प्रशिक्षित करने में नहीं किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
 msgstr ""
-"नए Duck.ai में आपका स्वागत है! अब आप अपनी डाउनलोड की गई चैट्स को इंपोर्ट कर सकते हैं।"
+"नए Duck.ai में आपका स्वागत है! अब आप अपनी डाउनलोड की गई चैट्स को इंपोर्ट कर "
+"सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24399,8 +24570,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"हमें वाकई खेद है, लेकिन ऐसा लगता है कि Duck.ai को लोड करने में कोई समस्या आई है। पेज को "
-"रीलोड करने की कोशिश करें।"
+"हमें वाकई खेद है, लेकिन ऐसा लगता है कि Duck.ai को लोड करने में कोई समस्या आई "
+"है। पेज को रीलोड करने की कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -24435,7 +24606,8 @@ msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
 msgstr ""
-"\"हमें वास्तव में बेहतर काम करना होगा\" के संदर्भ में 'बेहतर' शब्द के लिए कुछ विकल्प बताएं।"
+"\"हमें वास्तव में बेहतर काम करना होगा\" के संदर्भ में 'बेहतर' शब्द के लिए "
+"कुछ विकल्प बताएं।"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -24460,11 +24632,12 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"Duck.ai इस्तेमाल करने में रुचि रखने वाले लोगों के लिए, DuckDuckGo ब्राउज़र डाउनलोड करने के "
-"क्या फ़ायदे हैं? केवल आधिकारिक DuckDuckGo स्रोतों का ही संदर्भ लें। जवाब को स्पष्ट हिस्सों में "
-"बांटें और हर हिस्से के लिए शीर्षक दें, जिसमें Duck.ai इंटीग्रेशन और प्राइवेसी की रक्षा पर "
-"विशेष ध्यान दिया गया हो। इसे संक्षिप्त, सरल और समझने में आसान रखें, ताकि AI या तकनीकी "
-"अनुभव रखने वाले या न रखने वाले लोग भी इसे आसानी से समझ सकें।"
+"Duck.ai इस्तेमाल करने में रुचि रखने वाले लोगों के लिए, DuckDuckGo ब्राउज़र "
+"डाउनलोड करने के क्या फ़ायदे हैं? केवल आधिकारिक DuckDuckGo स्रोतों का ही "
+"संदर्भ लें। जवाब को स्पष्ट हिस्सों में बांटें और हर हिस्से के लिए शीर्षक "
+"दें, जिसमें Duck.ai इंटीग्रेशन और प्राइवेसी की रक्षा पर विशेष ध्यान दिया गया "
+"हो। इसे संक्षिप्त, सरल और समझने में आसान रखें, ताकि AI या तकनीकी अनुभव रखने "
+"वाले या न रखने वाले लोग भी इसे आसानी से समझ सकें।"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24700,7 +24873,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Cloud Save बुकमार्कलेट क्या है और यह यूआरएल पैरामीटर बुकमार्कलेट से कैसे अलग होता है?"
+"Cloud Save बुकमार्कलेट क्या है और यह यूआरएल पैरामीटर बुकमार्कलेट से कैसे अलग "
+"होता है?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -24776,8 +24950,8 @@ msgstr "आप किस पर फीडबैक देना चाहें�
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
 msgstr ""
-"आप DuckDuckGo में जो देखते हैं, वह YouTube पर आपके रिकमंडेशन या सुझावों को प्रभावित नहीं "
-"करेगा।"
+"आप DuckDuckGo में जो देखते हैं, वह YouTube पर आपके रिकमंडेशन या सुझावों को "
+"प्रभावित नहीं करेगा।"
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -24803,8 +24977,8 @@ msgid ""
 "When buying an electric guitar for a beginner, what are the top product "
 "brands I should consider?"
 msgstr ""
-"एक नौसिखिए के तौर पर, इलेक्ट्रिक गिटार खरीदते समय मुझे किन प्रमुख उत्पाद ब्रांडों पर "
-"विचार करना चाहिए?"
+"एक नौसिखिए के तौर पर, इलेक्ट्रिक गिटार खरीदते समय मुझे किन प्रमुख उत्पाद "
+"ब्रांडों पर विचार करना चाहिए?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -25005,8 +25179,9 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
-"Duck.ai के साथ, आपकी चैट को अनाम रखा जाता है और AI को प्रशिक्षित करने के लिए चैट का "
-"इस्तेमाल कभी नहीं किया जाता। '%1$s' मेन्यू में इसे कभी भी चालू या बंद करें।"
+"Duck.ai के साथ, आपकी चैट को अनाम रखा जाता है और AI को प्रशिक्षित करने के लिए "
+"चैट का इस्तेमाल कभी नहीं किया जाता। '%1$s' मेन्यू में इसे कभी भी चालू या बंद "
+"करें।"
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
@@ -25015,13 +25190,15 @@ msgid ""
 "With chat history on, up to %s of your most recent chats will be saved on "
 "this device."
 msgstr ""
+"चैट हिस्ट्री चालू होने पर, आपकी सबसे हाल की %1$s चैट तक इस डिवाइस पर सेव की "
+"जाएंगी।"
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline in the About Chat History modal.
 msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, your most recent chats will be saved on this device."
-msgstr ""
+msgstr "चैट हिस्ट्री चालू होने पर, आपकी सबसे हालिया चैट इस डिवाइस पर सेव हो जाएंगी।"
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -25036,8 +25213,8 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
-"यह डेटा ब्रोकर साइटों से आपके ईमेल, नाम, पते और अन्य जानकारी को हटाने के लिए सीधे आपके "
-"डिवाइस से काम करता है."
+"यह डेटा ब्रोकर साइटों से आपके ईमेल, नाम, पते और अन्य जानकारी को हटाने के लिए "
+"सीधे आपके डिवाइस से काम करता है."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25286,8 +25463,8 @@ msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
 msgstr ""
-"हां, जब आप इसके साथ काम करते हैं, तो हम डेटा का निस्तारण कर देते हैं और इसे दोबारा प्राप्त "
-"नहीं किया जा सकता है।"
+"हां, जब आप इसके साथ काम करते हैं, तो हम डेटा का निस्तारण कर देते हैं और इसे "
+"दोबारा प्राप्त नहीं किया जा सकता है।"
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -25307,7 +25484,8 @@ msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
 msgstr ""
-"आप %1$s से चैट कर रहे हैं। AI चैट में गलत या आपत्तिजनक जानकारी भी दिखाई दे सकती है।"
+"आप %1$s से चैट कर रहे हैं। AI चैट में गलत या आपत्तिजनक जानकारी भी दिखाई दे "
+"सकती है।"
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -25316,8 +25494,8 @@ msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
 msgstr ""
-"आप चाहें तो यह कर सकते हैं: %1$s या फिर %2$s खोज शॉर्टकट का इस्तेमाल करके DuckDuckGo "
-"से सीधे अन्य खोज इंजनों पर खोज सकते हैं।"
+"आप चाहें तो यह कर सकते हैं: %1$s या फिर %2$s खोज शॉर्टकट का इस्तेमाल करके "
+"DuckDuckGo से सीधे अन्य खोज इंजनों पर खोज सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -25331,8 +25509,8 @@ msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
 msgstr ""
-"आप %1$s के काम करने के तरीके को %2$sखोज सेटिंग%3$s में एडजस्ट कर सकते हैं या इसे कभी भी "
-"बंद कर सकते हैं।"
+"आप %1$s के काम करने के तरीके को %2$sखोज सेटिंग%3$s में एडजस्ट कर सकते हैं या "
+"इसे कभी भी बंद कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -25341,22 +25519,22 @@ msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
 msgstr ""
-"आप %1$sखोज सेटिंग%2$s में जाकर Assist के काम करने के तरीके को एडजस्ट कर सकते हैं या इसे "
-"कभी भी बंद कर सकते हैं।"
+"आप %1$sखोज सेटिंग%2$s में जाकर Assist के काम करने के तरीके को एडजस्ट कर सकते "
+"हैं या इसे कभी भी बंद कर सकते हैं।"
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
 msgstr ""
-"आप सवालों के जवाब देने या टेक्स्ट को सारांशित करने के लिए %1$sDuck.ai%2$s का भी इस्तेमाल "
-"कर सकते हैं।"
+"आप सवालों के जवाब देने या टेक्स्ट को सारांशित करने के लिए %1$sDuck.ai%2$s का "
+"भी इस्तेमाल कर सकते हैं।"
 
 # smartling.placeholder_format=C
 msgid ""
 "You can also use %sDuckDuckGo AI Chat%s to answer questions or summarize "
 "text."
 msgstr ""
-"आप सवालों के जवाब देने या टेक्स्ट को सारांशित करने के लिए %1$sDuckDuckGo AI Chat%2$s "
-"का भी इस्तेमाल कर सकते हैं।"
+"आप सवालों के जवाब देने या टेक्स्ट को सारांशित करने के लिए %1$sDuckDuckGo AI "
+"Chat%2$s का भी इस्तेमाल कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach more text selections than are allowed. Placeholder is the maximum number of text selections. E.g. You can attach up to 5 text selections.
@@ -25370,8 +25548,8 @@ msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
 msgstr ""
-"आपको Search Assist कितनी बार देखना है, इसे %1$sखोज Assist सेटिंग%2$s में जाकर बदल "
-"सकते हैं या इसे पूरी तरह से बंद कर सकते हैं।"
+"आपको Search Assist कितनी बार देखना है, इसे %1$sखोज Assist सेटिंग%2$s में "
+"जाकर बदल सकते हैं या इसे पूरी तरह से बंद कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -25392,8 +25570,8 @@ msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
 msgstr ""
-"आप ऐसा अपनी सेटिंग्स को दूसरे पासफ्रेज़ के अंतर्गत सेव करते हुए कर सकते है और चाहे तो पहली "
-"सेटिंग को डिलीट भी कर सकते हैं।"
+"आप ऐसा अपनी सेटिंग्स को दूसरे पासफ्रेज़ के अंतर्गत सेव करते हुए कर सकते है "
+"और चाहे तो पहली सेटिंग को डिलीट भी कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -25486,8 +25664,8 @@ msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
 msgstr ""
-"आप अधिकतम %1$s साइटें ही ब्लॉक कर सकते हैं। %2$s को ब्लॉक करने के लिए, आपको पहले किसी "
-"अन्य साइट को अनब्लॉक करना होगा।"
+"आप अधिकतम %1$s साइटें ही ब्लॉक कर सकते हैं। %2$s को ब्लॉक करने के लिए, आपको "
+"पहले किसी अन्य साइट को अनब्लॉक करना होगा।"
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -25551,8 +25729,8 @@ msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
 msgstr ""
-"अब आपको %1$s का एक्सेस हासिल है, बेहतर AI तर्क-क्षमता, और Plus की तुलना में 2 गुना "
-"ज़्यादा उपयोग सीमाएं।"
+"अब आपको %1$s का एक्सेस हासिल है, बेहतर AI तर्क-क्षमता, और Plus की तुलना में "
+"2 गुना ज़्यादा उपयोग सीमाएं।"
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -25561,8 +25739,8 @@ msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
 msgstr ""
-"अब आपके पास एडवांस्ड AI मॉडल्स का एक्सेस है। आप DuckDuckGo ब्राउज़र में VPN और अन्य "
-"DuckDuckGo सब्सक्रिप्शन सुरक्षा सुविधाओं का उपयोग कर सकते हैं।"
+"अब आपके पास एडवांस्ड AI मॉडल्स का एक्सेस है। आप DuckDuckGo ब्राउज़र में VPN "
+"और अन्य DuckDuckGo सब्सक्रिप्शन सुरक्षा सुविधाओं का उपयोग कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -25584,8 +25762,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"अब आप इस ब्राउज़र से अपनी सेव की गई चैट्स एक्सेस नहीं कर पाएंगे। पिछली 30 चैट अभी भी "
-"लोकल स्टोरेज में उपलब्ध रहेंगी। इससे एन्क्रिप्टेड सर्वर से आपकी चैट डिलीट नहीं होंगी।"
+"अब आप इस ब्राउज़र से अपनी सेव की गई चैट्स एक्सेस नहीं कर पाएंगे। पिछली 30 "
+"चैट अभी भी लोकल स्टोरेज में उपलब्ध रहेंगी। इससे एन्क्रिप्टेड सर्वर से आपकी "
+"चैट डिलीट नहीं होंगी।"
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -25595,8 +25774,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"अब आप इस ब्राउज़र से अपनी सेव की गई चैट्स एक्सेस नहीं कर पाएंगे। पिछली 30 चैट अभी भी "
-"लोकल स्टोरेज में उपलब्ध रहेंगी। इससे एन्क्रिप्टेड सर्वर से आपकी चैट डिलीट नहीं होंगी।"
+"अब आप इस ब्राउज़र से अपनी सेव की गई चैट्स एक्सेस नहीं कर पाएंगे। पिछली 30 "
+"चैट अभी भी लोकल स्टोरेज में उपलब्ध रहेंगी। इससे एन्क्रिप्टेड सर्वर से आपकी "
+"चैट डिलीट नहीं होंगी।"
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -25624,8 +25804,9 @@ msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
 msgstr ""
-"अभी आप Chrome में गुप्त रूप से खोज रहे हैं। गुप्त रूप से ब्राउज़ करने के लिए भी Chrome की "
-"बजाय हमारे ऐप का उपयोग करेंगे। यह पहले से ही इंस्टॉल हैं और यह कर सकता है:"
+"अभी आप Chrome में गुप्त रूप से खोज रहे हैं। गुप्त रूप से ब्राउज़ करने के लिए "
+"भी Chrome की बजाय हमारे ऐप का उपयोग करेंगे। यह पहले से ही इंस्टॉल हैं और यह "
+"कर सकता है:"
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -25638,8 +25819,8 @@ msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
 msgstr ""
-"अब आप गोपनीयता के साथ खोज कर रहे हैं। %1$sअपने फुटप्रिंट को और भी अधिक कम करने के लिए "
-"सुझाव पाएं।"
+"अब आप गोपनीयता के साथ खोज कर रहे हैं। %1$sअपने फुटप्रिंट को और भी अधिक कम "
+"करने के लिए सुझाव पाएं।"
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -25688,7 +25869,9 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr "आप फिलहाल संदेशों की अधिकतम संख्या तक पहुंच गए हैं। कृपया बाद में फिर से कोशिश करें।"
+msgstr ""
+"आप फिलहाल संदेशों की अधिकतम संख्या तक पहुंच गए हैं। कृपया बाद में फिर से "
+"कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -25707,7 +25890,8 @@ msgstr "आज की वॉयस चैट सीमा पूरी हो �
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
 msgstr ""
-"आपने अपनी डिक्टेशन इस्तेमाल करने की सीमा पूरी कर ली है। कृपया बाद में फिर से कोशिश करें।"
+"आपने अपनी डिक्टेशन इस्तेमाल करने की सीमा पूरी कर ली है। कृपया बाद में फिर से "
+"कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25716,9 +25900,9 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"अटैचमेंट वाली Duck.ai चैट्स के लिए आपके Sync & Backup स्टोरेज की सीमा समाप्त हो गई है। "
-"सिंक फिर से शुरू करने के लिए %1$s सबसे पुरानी चैट डिलीट करें। पिन की गई चैट डिलीट नहीं की "
-"जाएंगी।"
+"अटैचमेंट वाली Duck.ai चैट्स के लिए आपके Sync & Backup स्टोरेज की सीमा समाप्त "
+"हो गई है। सिंक फिर से शुरू करने के लिए %1$s सबसे पुरानी चैट डिलीट करें। पिन "
+"की गई चैट डिलीट नहीं की जाएंगी।"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25728,9 +25912,9 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"आपके Duck.ai चैट्स के लिए आपके Sync & Backup स्टोरेज की सीमा समाप्त हो गई है। सिंक फिर "
-"से शुरू करने के लिए, अटैचमेंट वाली %1$s सबसे पुरानी चैट डिलीट कर दें। पिन की गई चैट डिलीट "
-"नहीं की जाएंगी।"
+"आपके Duck.ai चैट्स के लिए आपके Sync & Backup स्टोरेज की सीमा समाप्त हो गई "
+"है। सिंक फिर से शुरू करने के लिए, अटैचमेंट वाली %1$s सबसे पुरानी चैट डिलीट "
+"कर दें। पिन की गई चैट डिलीट नहीं की जाएंगी।"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -25744,8 +25928,8 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"YouTube (Google के अधीन) आपको गुमनाम रूप से वीडियो नहीं देखने देता है । इस वजह से "
-"YouTube के वीडियो यहां देखने पर YouTube/Google को पता लग जाएगा |"
+"YouTube (Google के अधीन) आपको गुमनाम रूप से वीडियो नहीं देखने देता है । इस "
+"वजह से YouTube के वीडियो यहां देखने पर YouTube/Google को पता लग जाएगा |"
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -25805,8 +25989,8 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
 msgstr ""
-"आपका बैकअप DuckDuckGo के सर्वर से डिलीट कर दिया जाएगा. सभी डिवाइस सिंक से डिस्कनेक्ट "
-"हो जाएँगे."
+"आपका बैकअप DuckDuckGo के सर्वर से डिलीट कर दिया जाएगा. सभी डिवाइस सिंक से "
+"डिस्कनेक्ट हो जाएँगे."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25816,8 +26000,9 @@ msgid ""
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
 msgstr ""
-"आपका बैकअप DuckDuckGo के सर्वर से हटा दिया जाएगा। सभी डिवाइस सिंक से डिस्कनेक्ट हो "
-"जाएंगे। आपकी सबसे हाल की %1$s चैट इन ब्राउज़रों के लोकल स्टोरेज में उपलब्ध होंगी:"
+"आपका बैकअप DuckDuckGo के सर्वर से हटा दिया जाएगा। सभी डिवाइस सिंक से "
+"डिस्कनेक्ट हो जाएंगे। आपकी सबसे हाल की %1$s चैट इन ब्राउज़रों के लोकल "
+"स्टोरेज में उपलब्ध होंगी:"
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -25827,8 +26012,9 @@ msgid ""
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
 msgstr ""
-"आपका बैकअप DuckDuckGo के सर्वर से हटा दिया जाएगा। सभी डिवाइस सिंक से डिस्कनेक्ट हो "
-"जाएंगे। आपकी सबसे हाल की 100 चैट इन ब्राउज़रों के लोकल स्टोरेज में उपलब्ध होंगी:"
+"आपका बैकअप DuckDuckGo के सर्वर से हटा दिया जाएगा। सभी डिवाइस सिंक से "
+"डिस्कनेक्ट हो जाएंगे। आपकी सबसे हाल की 100 चैट इन ब्राउज़रों के लोकल स्टोरेज "
+"में उपलब्ध होंगी:"
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -25853,8 +26039,8 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"आपका ब्राउज़र, आपकी सबसे ज़्यादा देखी गई साइटों की एक सूची प्रदान करता है।DuckDuckGo के "
-"पास कभी भी इस डेटा का एक्सेस नहीं रहता है।"
+"आपका ब्राउज़र, आपकी सबसे ज़्यादा देखी गई साइटों की एक सूची प्रदान करता "
+"है।DuckDuckGo के पास कभी भी इस डेटा का एक्सेस नहीं रहता है।"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -25862,8 +26048,8 @@ msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
 msgstr ""
-"आपका ब्राउज़र सबसे ज़्यादा देखी गई साइटों की सूची प्रदान करता है। DuckDuckGo के पास इस "
-"डेटा का कभी भी एक्सेस नहीं रहा है।"
+"आपका ब्राउज़र सबसे ज़्यादा देखी गई साइटों की सूची प्रदान करता है। DuckDuckGo "
+"के पास इस डेटा का कभी भी एक्सेस नहीं रहा है।"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -25872,8 +26058,8 @@ msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
 msgstr ""
-"%1$s के साथ आपकी चैट गोपनीय रहती है। AI चैट में गलत या आपत्तिजनक जानकारी भी दिखाई दे "
-"सकती है।"
+"%1$s के साथ आपकी चैट गोपनीय रहती है। AI चैट में गलत या आपत्तिजनक जानकारी भी "
+"दिखाई दे सकती है।"
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -25886,8 +26072,8 @@ msgstr "आपकी चैट अब सेव की जा रही है�
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"आपकी चैट निजी रहती हैं, कभी भी इन्हें सेव नहीं किया जाता या इनका इस्तेमाल AI मॉडलों को "
-"प्रशिक्षित करने के लिए नहीं किया जाता"
+"आपकी चैट निजी रहती हैं, कभी भी इन्हें सेव नहीं किया जाता या इनका इस्तेमाल AI "
+"मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
@@ -25901,8 +26087,8 @@ msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"आपकी चैट गोपनीय रहती हैं, हम उन्हें अनाम कर देते हैं, और उनका इस्तेमाल AI मॉडलों को "
-"प्रशिक्षित करने के लिए नहीं किया जाता।"
+"आपकी चैट गोपनीय रहती हैं, हम उन्हें अनाम कर देते हैं, और उनका इस्तेमाल AI "
+"मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
@@ -25910,8 +26096,8 @@ msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"आपकी चैट गोपनीय रहती हैं, हम उन्हें अनाम कर देते हैं, और उनका इस्तेमाल AI मॉडलों को "
-"प्रशिक्षित करने के लिए नहीं किया जाता।"
+"आपकी चैट गोपनीय रहती हैं, हम उन्हें अनाम कर देते हैं, और उनका इस्तेमाल AI "
+"मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -25919,8 +26105,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"आपकी चैट निजी रहती हैं, हमारे द्वारा कभी सेव नहीं की जाती हैं, और इनका इस्तेमाल AI "
-"मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
+"आपकी चैट निजी रहती हैं, हमारे द्वारा कभी सेव नहीं की जाती हैं, और इनका "
+"इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -25928,8 +26114,8 @@ msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"आपकी चैट निजी रहती हैं, हमारे द्वारा कभी सेव नहीं की जाती हैं, और इनका इस्तेमाल AI "
-"मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
+"आपकी चैट निजी रहती हैं, हमारे द्वारा कभी सेव नहीं की जाती हैं, और इनका "
+"इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -25944,9 +26130,9 @@ msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
 msgstr ""
-"आपकी चैट अभी भी गोपनीय हैं, जिन्हें हम अनाम कर देते हैं, और इनका उपयोग AI मॉडल्स को "
-"प्रशिक्षित करने के लिए नहीं किया जाता है। अपनी चैट हिस्ट्री सुरक्षित रखने के लिए इन चरणों "
-"का पालन करें।"
+"आपकी चैट अभी भी गोपनीय हैं, जिन्हें हम अनाम कर देते हैं, और इनका उपयोग AI "
+"मॉडल्स को प्रशिक्षित करने के लिए नहीं किया जाता है। अपनी चैट हिस्ट्री "
+"सुरक्षित रखने के लिए इन चरणों का पालन करें।"
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -25955,7 +26141,8 @@ msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
 msgstr ""
-"आपकी चैट्स इंपोर्ट कर दी गई हैं। आगे बढ़ें और Duck.ai में वहीं से जारी रखें जहां आपने छोड़ा था।"
+"आपकी चैट्स इंपोर्ट कर दी गई हैं। आगे बढ़ें और Duck.ai में वहीं से जारी रखें "
+"जहां आपने छोड़ा था।"
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -25987,8 +26174,8 @@ msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
 msgstr ""
-"आपका ईमेल पता शेयर नहीं किया जाएगा, %1$sया किन्हीं अनाम खोजों के साथ संबद्ध नहीं है। "
-"[%2$sउदाहरण संदेश%3$s]"
+"आपका ईमेल पता शेयर नहीं किया जाएगा, %1$sया किन्हीं अनाम खोजों के साथ संबद्ध "
+"नहीं है। [%2$sउदाहरण संदेश%3$s]"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -26003,8 +26190,8 @@ msgctxt ""
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
 msgstr ""
-"आपकी फ़ीडबैक को अनाम रखा जाता है और इसका इस्तेमाल AI को ट्रेनिंग देने के लिए नहीं किया "
-"जाता।"
+"आपकी फ़ीडबैक को अनाम रखा जाता है और इसका इस्तेमाल AI को ट्रेनिंग देने के लिए "
+"नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -26033,10 +26220,10 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"आपके पासफ़्रेज़ ने %1$sSHA-2%2$s के रूप में ज्ञात सुरक्षित हैश एल्गोरिथम का उपयोग करके '512-"
-"बिट की' जनरेट किया है। केवल 'की' और संबंधित सेटिंग्स फ़ाइल आपके ब्राउज़र को छोड़ देती है। "
-"हम नाम के रूप में 'की' का उपयोग करके सेटिंग्स फ़ाइल को सेव करते हैं। DuckDuckGo कभी भी "
-"आपके पासफ़्रेज़ को नहीं जानता है।"
+"आपके पासफ़्रेज़ ने %1$sSHA-2%2$s के रूप में ज्ञात सुरक्षित हैश एल्गोरिथम का "
+"उपयोग करके '512-बिट की' जनरेट किया है। केवल 'की' और संबंधित सेटिंग्स फ़ाइल "
+"आपके ब्राउज़र को छोड़ देती है। हम नाम के रूप में 'की' का उपयोग करके सेटिंग्स "
+"फ़ाइल को सेव करते हैं। DuckDuckGo कभी भी आपके पासफ़्रेज़ को नहीं जानता है।"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -26051,8 +26238,9 @@ msgid ""
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
 msgstr ""
-"आपके प्रॉम्प्ट DuckDuckGo सर्वर के ज़रिए भेजे जाते हैं और उनसे आपकी पहचान बताने वाला "
-"मेटाडेटा हटा दिया जाता है, ताकि मॉडल प्रदाता आपकी बातचीत को आपसे जोड़ न सकें।"
+"आपके प्रॉम्प्ट DuckDuckGo सर्वर के ज़रिए भेजे जाते हैं और उनसे आपकी पहचान "
+"बताने वाला मेटाडेटा हटा दिया जाता है, ताकि मॉडल प्रदाता आपकी बातचीत को आपसे "
+"जोड़ न सकें।"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -26066,7 +26254,8 @@ msgid ""
 "Your recent chats live here! You can refer to your chats or clear them "
 "anytime."
 msgstr ""
-"आपकी हालिया चैट यहां रहती हैं! आप कभी भी अपनी चैट देख सकते हैं या उन्हें हटा सकते हैं।"
+"आपकी हालिया चैट यहां रहती हैं! आप कभी भी अपनी चैट देख सकते हैं या उन्हें हटा "
+"सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Message on a feedback form.
@@ -26098,8 +26287,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
-"आपकी सेटिंग सेव कर ली गई हैं, लेकिन कुकीज़ हटाने से वे रीसेट हो जाएंगी। इसे परमानेंट करने के "
-"लिए %1$sDuckDuckGo No AI%2$s एक्सटेंशन इनेबल करें।"
+"आपकी सेटिंग सेव कर ली गई हैं, लेकिन कुकीज़ हटाने से वे रीसेट हो जाएंगी। इसे "
+"परमानेंट करने के लिए %1$sDuckDuckGo No AI%2$s एक्सटेंशन इनेबल करें।"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -26108,8 +26297,9 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"आपकी सेटिंग सेव कर ली गई हैं, लेकिन कुकीज़ हटाने से वे रीसेट हो जाएंगी। इसे परमानेंट करने के "
-"लिए %1$sDuckDuckGo No AI%2$s एक्सटेंशन इंस्टॉल करें। %3$sऔर जानें%4$s"
+"आपकी सेटिंग सेव कर ली गई हैं, लेकिन कुकीज़ हटाने से वे रीसेट हो जाएंगी। इसे "
+"परमानेंट करने के लिए %1$sDuckDuckGo No AI%2$s एक्सटेंशन इंस्टॉल करें। %3$sऔर "
+"जानें%4$s"
 
 # smartling.placeholder_format=C
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
@@ -26129,8 +26319,9 @@ msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
 msgstr ""
-"फ़िलहाल, आप Chrome में गोपनीय रूप से सर्च कर रहे हैं। ज़्यादा सुरक्षा के लिए Chrome के बजाय "
-"हमारे ब्राउज़र का इस्तेमाल करें। यह पहले से ही इंस्टॉल है और यहां दिए गए काम कर सकता है:"
+"फ़िलहाल, आप Chrome में गोपनीय रूप से सर्च कर रहे हैं। ज़्यादा सुरक्षा के लिए "
+"Chrome के बजाय हमारे ब्राउज़र का इस्तेमाल करें। यह पहले से ही इंस्टॉल है और "
+"यहां दिए गए काम कर सकता है:"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -26139,8 +26330,8 @@ msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
 msgstr ""
-"आपने संदेश की अधिकतम आकार सीमा पार कर ली है। कृपया अपने संदेश को छोटा करके फिर से "
-"कोशिश करें।"
+"आपने संदेश की अधिकतम आकार सीमा पार कर ली है। कृपया अपने संदेश को छोटा करके "
+"फिर से कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -26149,8 +26340,8 @@ msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
 msgstr ""
-"आप इस बातचीत में अधिकतम चैट अवधि तक पहुंच गए हैं। आगे बढ़ने के लिए, Fire Button की मदद "
-"से इस बातचीत को मिटाएं।"
+"आप इस बातचीत में अधिकतम चैट अवधि तक पहुंच गए हैं। आगे बढ़ने के लिए, Fire "
+"Button की मदद से इस बातचीत को मिटाएं।"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -26159,7 +26350,8 @@ msgid ""
 "You’ve reached the maximum chat length in this conversation. Start a new "
 "chat to continue."
 msgstr ""
-"आप इस बातचीत में अधिकतम चैट अवधि तक पहुंच गए हैं। जारी रखने के लिए एक नई चैट शुरू करें।"
+"आप इस बातचीत में अधिकतम चैट अवधि तक पहुंच गए हैं। जारी रखने के लिए एक नई चैट "
+"शुरू करें।"
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -26174,8 +26366,8 @@ msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
 msgstr ""
-"आप एक दिन में भेजे जाने वाले संदेशों की अधिकतम संख्या तक पहुंच गए हैं। कृपया इस चैट को अब कल "
-"जारी रखें।"
+"आप एक दिन में भेजे जाने वाले संदेशों की अधिकतम संख्या तक पहुंच गए हैं। कृपया "
+"इस चैट को अब कल जारी रखें।"
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -26409,7 +26601,7 @@ msgstr "मि"
 #. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the chat options menu button"
 msgid "menu"
-msgstr ""
+msgstr "मेन्यू"
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.
@@ -26484,7 +26676,8 @@ msgstr "ऑफ़िशियल वेबसाइट"
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
 msgstr ""
-"या जो रंग आप चाहते है उसका कलर कोड लिखे, जैसे %1$s (%2$s एक एनकोडेड %3$s अक्षर है)"
+"या जो रंग आप चाहते है उसका कलर कोड लिखे, जैसे %1$s (%2$s एक एनकोडेड %3$s "
+"अक्षर है)"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/hi_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/hi_IN/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: hi_IN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1202,6 +1202,12 @@ msgid "About our ads"
 msgstr "हमारे विज्ञापनों के बारे में"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1331,6 +1337,20 @@ msgid "Ad is suspicious"
 msgstr "विज्ञापन सन्देहजनक है"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "DuckDuckGo जोड़ें"
@@ -1356,6 +1376,27 @@ msgstr "DuckDuckGo को खोज इंजन के रूप में ज�
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "DuckDuckGo को %1$s में जोड़ें"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1401,6 +1442,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "पेज कंटेंट जोड़ें"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1486,6 +1543,12 @@ msgstr "एड-ऑन"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "अंतिम तैयारी"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1786,6 +1849,12 @@ msgstr "सभी रंग"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "सब हो गया!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3488,6 +3557,14 @@ msgid "Cancel"
 msgstr "कैंसिल करें"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3977,10 +4054,22 @@ msgid "Chat response is offensive"
 msgstr "चैट में मिला जवाब आपत्तिजनक है"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "%1$s से चैट करें"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3999,6 +4088,14 @@ msgstr "चैट"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "चैट"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5584,6 +5681,12 @@ msgid "Current Streak"
 msgstr "मौजूदा स्ट्रीक"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5930,6 +6033,12 @@ msgstr "चैट डिलीट करें"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "30 दिन से पुरानी चैट डिलीट करें"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6343,6 +6452,12 @@ msgstr "हमेशा के लिए निरस्त करें"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "प्रमोशन हटाएं"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7502,6 +7617,12 @@ msgid "Edit Prompt"
 msgstr "प्रॉम्प्ट एडिट करें"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7722,6 +7843,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "एन्क्रिप्ट किया गया मॉडल"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8545,6 +8672,12 @@ msgid "Follow-up question"
 msgstr "फ़ॉलोअप सवाल"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9057,6 +9190,12 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
 "DuckDuckGo VPN, एडवांस्ड Duck.ai, और Identity Theft Restoration प्राप्त करें।"
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10280,6 +10419,12 @@ msgstr "यह अनाम कैसे है?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "यह कैसे काम करता है"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11713,6 +11858,12 @@ msgstr "लाइनआउट जीते"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "लिंक 7 दिनों में समाप्त हो जाएगा।"
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13830,6 +13981,12 @@ msgid "OK, got it!"
 msgstr "ठीक है, समझ गए!"
 
 # smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -15944,6 +16101,12 @@ msgid "Protected"
 msgstr "सुरक्षित"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "सुरक्षा। गोपनीयता। मन का सुकून।"
@@ -16074,6 +16237,12 @@ msgstr "बारिश"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "रैंकिंग"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17305,6 +17474,12 @@ msgid "Save your chats across all your devices."
 msgstr "अपनी चैट्स को अपने सभी डिवाइसों पर सेव करें।"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17505,6 +17680,14 @@ msgstr "खोजें"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "खोजें"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18664,6 +18847,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "शॉप"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20306,6 +20495,14 @@ msgstr ""
 "18 महीने तक निष्क्रिय रहने के बाद, Sync & Backup डेटा को रिकवर नहीं किया जा सकता।"
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20419,6 +20616,12 @@ msgstr "आस-पास के किसी डिवाइस के साथ
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "अपनी चैट्स को अपने सभी डिवाइसों पर सिंक करें।"
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -20994,6 +21197,22 @@ msgid "This Week"
 msgstr "इस सप्ताह"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21511,6 +21730,12 @@ msgstr "आज"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "आज"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23315,6 +23540,14 @@ msgstr ""
 "विज्ञापन नेटवर्क द्वारा प्रबंधित किए जाते हैं।"
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "वर्जिन आइलैंड्स"
 
@@ -24776,6 +25009,21 @@ msgstr ""
 "इस्तेमाल कभी नहीं किया जाता। '%1$s' मेन्यू में इसे कभी भी चालू या बंद करें।"
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26156,6 +26404,12 @@ msgstr "मि"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "मि"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/hr_HR/LC_MESSAGES/duckduckgo.po
+++ b/locales/hr_HR/LC_MESSAGES/duckduckgo.po
@@ -2,16 +2,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: hr_HR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -96,8 +95,7 @@ msgstr "AI modeli %1$s i %2$s"
 #. Message that appears above the search results encouraging them to filter results by domain. The placeholder string would include a the name of a website. E.g. 'Reddit appears in some of the top results for this search.'
 msgctxt "Site filter message"
 msgid "%s appears in some of the top results for this search."
-msgstr ""
-"%1$s se pojavljuje u nekim od najboljih rezultata za ovo pretraživanje."
+msgstr "%1$s se pojavljuje u nekim od najboljih rezultata za ovo pretraživanje."
 
 # smartling.placeholder_format=C
 #. Number of tracking attempts blocked, when there is more than 1. Eg: '2 attempts' or '302 attempts'
@@ -310,8 +308,7 @@ msgstr "Ljestvica %1$s još nije dostupna"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits 2-5x faster than other models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
-msgstr ""
-"%1$s doseže uporabna ograničenja 2 do 5 puta ranije nego osnovni modeli. %2$s"
+msgstr "%1$s doseže uporabna ograničenja 2 do 5 puta ranije nego osnovni modeli. %2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -382,8 +379,7 @@ msgstr "%1$s rabljeno"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
-"%1$s troši uporabna ograničenja do 2 do 5 puta brže od osnovnih modela %2$s"
+msgstr "%1$s troši uporabna ograničenja do 2 do 5 puta brže od osnovnih modela %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -527,8 +523,7 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr ""
-"%1$sPritisni i drži%2$s ikonu aplikacije DuckDuckGo na početnom zaslonu"
+msgstr "%1$sPritisni i drži%2$s ikonu aplikacije DuckDuckGo na početnom zaslonu"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -967,8 +962,7 @@ msgstr "Dostupna je nova verzija AI Chata! Osvježi ovu stranicu za nastavak."
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"Dostupna je nova verzija usluge Duck.ai! Osvježi ovu stranicu za nastavak."
+msgstr "Dostupna je nova verzija usluge Duck.ai! Osvježi ovu stranicu za nastavak."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1224,7 +1218,7 @@ msgstr "O našim oglasima"
 #. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
 msgctxt "Modal header for chat history with sync information"
 msgid "About Chat History with Sync & Backup"
-msgstr ""
+msgstr "O povijesti čavrljanja uz Sync & Backup"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
@@ -1359,7 +1353,7 @@ msgstr "Oglas je sumnjiv"
 #. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
 msgctxt "Button to open menu for attaching images or page context to AI chat"
 msgid "Add"
-msgstr ""
+msgstr "Dodaj"
 
 # smartling.placeholder_format=C
 #. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
@@ -1367,7 +1361,7 @@ msgctxt ""
 "Primary button that attaches the tabs the user checked in the tab picker "
 "dialog"
 msgid "Add"
-msgstr ""
+msgstr "Dodaj"
 
 # smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
@@ -1402,13 +1396,13 @@ msgstr "Dodaj DuckDuckGo u %1$s"
 msgctxt ""
 "Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
 msgid "Add File"
-msgstr ""
+msgstr "Dodaj datoteku"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
 msgid "Add Image"
-msgstr ""
+msgstr "Dodaj sliku"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
@@ -1416,7 +1410,7 @@ msgctxt ""
 "Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
 "item)"
 msgid "Add Image or File"
-msgstr ""
+msgstr "Dodaj sliku ili datoteku"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1469,7 +1463,7 @@ msgctxt ""
 "Open the tab picker to attach browser tab content to the AI chat message "
 "(attach dropdown menu item)"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Dodaj kartice"
 
 # smartling.placeholder_format=C
 #. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
@@ -1477,7 +1471,7 @@ msgctxt ""
 "Title and accessible name of the tab-picker dialog opened from the attach "
 "dropdown menu"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Dodaj kartice"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1568,7 +1562,7 @@ msgstr "Dodavanje završnih detalja"
 #. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
 msgctxt "Aria label for the additional instructions textarea"
 msgid "Additional instructions"
-msgstr ""
+msgstr "Dodatne upute"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1878,7 +1872,7 @@ msgstr "Gotovo!"
 #. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the read-only textarea listing all AI instructions"
 msgid "All instructions"
-msgstr ""
+msgstr "Sve upute"
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2645,8 +2639,7 @@ msgstr "Nakon završetka čavrljanja, zvuk ne pohranjujemo ni mi ni OpenAI."
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"Zvuk ne pohranjujemo ni mi ni OpenAI nakon što se čavrljanje transkribira."
+msgstr "Zvuk ne pohranjujemo ni mi ni OpenAI nakon što se čavrljanje transkribira."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -3097,8 +3090,7 @@ msgstr "Blokiraj ovu stranicu iz svih rezultata"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr ""
-"Blokiraj alate za praćenje i preuzmi kontrolu nad svojim osobnim podacima"
+msgstr "Blokiraj alate za praćenje i preuzmi kontrolu nad svojim osobnim podacima"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3597,7 +3589,7 @@ msgctxt ""
 "Secondary button that dismisses the tab picker dialog without attaching "
 "anything"
 msgid "Cancel"
-msgstr ""
+msgstr "Otkaži"
 
 # smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
@@ -3834,8 +3826,7 @@ msgstr "Promjena načina prikaza URL-ova rezultata"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr ""
-"Promjena načina prikaza zaglavlja i njegova ponašanja tijekom pomicanja"
+msgstr "Promjena načina prikaza zaglavlja i njegova ponašanja tijekom pomicanja"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -4098,7 +4089,7 @@ msgstr "Odgovor na chatu je uvredljiv"
 #. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
 msgctxt "Chat history about modal list item headline"
 msgid "Chat storage varies by browser"
-msgstr ""
+msgstr "Pohrana razgovora ovisi o pregledniku"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4110,7 +4101,7 @@ msgstr "Razgovaraj s %1$s"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Chat with popular AI models, anonymized by us."
-msgstr ""
+msgstr "Razgovaraj s popularnim AI modelima, koje anonimiziramo mi."
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4137,6 +4128,8 @@ msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
 msgstr ""
+"Razgovori se sigurno pohranjuju na poslužitelju DuckDuckGoa s end-to-end "
+"šifriranjem. Nitko osim tebe ne može vidjeti tvoje podatke, čak ni mi."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4684,8 +4677,7 @@ msgstr "Klikni %1$sPostavke%2$s u padajućem izborniku."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Klikni %1$sUpotrijebi trenutačne stranice%2$s zatim %3$sklikni U redu%4$s."
+msgstr "Klikni %1$sUpotrijebi trenutačne stranice%2$s zatim %3$sklikni U redu%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -5330,8 +5322,7 @@ msgstr "Nastavi blokirati oglase"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
-"Nedavna čavrljanja nastavi ovdje. Možeš ih i izbrisati pomoću Fire Buttona."
+msgstr "Nedavna čavrljanja nastavi ovdje. Možeš ih i izbrisati pomoću Fire Buttona."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5555,8 +5546,7 @@ msgstr "Kostarika"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr ""
-"Nije moguće učitati tvoj kôd za oporavak. Zatvori ovo i pokušaj ponovno."
+msgstr "Nije moguće učitati tvoj kôd za oporavak. Zatvori ovo i pokušaj ponovno."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5741,7 +5731,7 @@ msgstr "Trenutačni niz"
 #. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
 msgctxt "Suffix label indicating a tab is the currently active browser tab"
 msgid "Current Tab"
-msgstr ""
+msgstr "Trenutačna kartica"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
@@ -6097,7 +6087,7 @@ msgstr "Izbriši čavrljanja starija od 30 dana"
 #. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
 msgctxt "Button text in the modal for deleting all recent chats"
 msgid "Delete Chats and Shared Links"
-msgstr ""
+msgstr "Izbriši čavrljanja i podijeljene poveznice"
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6424,8 +6414,7 @@ msgstr "Onemogući i isključi"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr ""
-"Onemogućiti povijest čavrljanja i prekinuti vezu s uslugom Sync & Backup?"
+msgstr "Onemogućiti povijest čavrljanja i prekinuti vezu s uslugom Sync & Backup?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6519,7 +6508,7 @@ msgstr "Odbaci promociju"
 #. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the close button on the survey banner"
 msgid "Dismiss survey"
-msgstr ""
+msgstr "Odbaci anketu"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7001,8 +6990,7 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"Duck.ai je najbolji u našem privatnom i besplatnom DuckDuckGo pregledniku!"
+msgstr "Duck.ai je najbolji u našem privatnom i besplatnom DuckDuckGo pregledniku!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -7326,8 +7314,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chat trenutačno nije dostupan. Pokušaj ponovno nešto kasnije."
+msgstr "DuckDuckGo AI Chat trenutačno nije dostupan. Pokušaj ponovno nešto kasnije."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7487,8 +7474,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo anonimizira tvoje razgovore. Klikom na '%1$s' prihvaćaš Duck.ai-"
-"jeve %2$s."
+"DuckDuckGo anonimizira tvoje razgovore. Klikom na '%1$s' prihvaćaš "
+"Duck.ai-jeve %2$s."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7496,8 +7483,7 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr ""
-"DuckDuckGo anonimizira tvoje razgovore. Klikom na '%1$s' prihvaćaš naše %2$s."
+msgstr "DuckDuckGo anonimizira tvoje razgovore. Klikom na '%1$s' prihvaćaš naše %2$s."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7697,7 +7683,7 @@ msgstr "Uredi upit"
 #. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the message-editing text area"
 msgid "Edit message"
-msgstr ""
+msgstr "Uredi poruku"
 
 # smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
@@ -7716,8 +7702,7 @@ msgstr "Slika se uređuje..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr ""
-"Uređivanjem tvoje poruke uklonit će se odgovor ispod nje i generirati novi."
+msgstr "Uređivanjem tvoje poruke uklonit će se odgovor ispod nje i generirati novi."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7924,7 +7909,7 @@ msgstr "Šifrirani model"
 #. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
 msgctxt "Share modal info bullet about encryption"
 msgid "Encrypted so DuckDuckGo can't read your chat."
-msgstr ""
+msgstr "Šifrirano tako da DuckDuckGo ne može pročitati tvoj razgovor."
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8136,8 +8121,7 @@ msgstr "Ekvatorska Gvineja"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"Brzo izbriši svoje podatke o pregledavanju koristeći naš %1$sFire Button%2$s"
+msgstr "Brzo izbriši svoje podatke o pregledavanju koristeći naš %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -8502,8 +8486,8 @@ msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
 msgstr ""
-"Prilagodi donje postavke, a zatim samo kopiraj i zalijepi kôd na svoje web-"
-"mjesto."
+"Prilagodi donje postavke, a zatim samo kopiraj i zalijepi kôd na svoje "
+"web-mjesto."
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8639,8 +8623,7 @@ msgstr "Pronađi <b>%1$s</b> u mapi za preuzimanje"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr ""
-"Pronađi DuckDuckGo u prikazanom popisu i klikni %1$sPostavi za zadano%2$s"
+msgstr "Pronađi DuckDuckGo u prikazanom popisu i klikni %1$sPostavi za zadano%2$s"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8761,7 +8744,7 @@ msgstr "Dodatno pitanje"
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
-msgstr ""
+msgstr "Dodatna pitanja ostaju privatna."
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8867,8 +8850,7 @@ msgstr "Besplatni i privatni razgovori, mi ih anonimiziramo"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Besplatni i privatni razgovori, mi ih anonimiziramo. Nije potreban račun."
+msgstr "Besplatni i privatni razgovori, mi ih anonimiziramo. Nije potreban račun."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9283,7 +9265,7 @@ msgstr "Nabavi DuckDuckGo VPN, napredni Duck.ai i Identity Theft Restoration."
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
 msgctxt "Tooltip on the header logo for sunglasses searches"
 msgid "Get DuckDuckGo sunglasses and other gear."
-msgstr ""
+msgstr "Nabavi DuckDuckGo sunčane naočale i ostalu opremu."
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9505,8 +9487,7 @@ msgstr "Preuzmi aplikaciju"
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
-msgstr ""
-"Nabavi besplatni preglednik DuckDuckGo %1$si blokiraj oglase na YouTubeu.%2$s"
+msgstr "Nabavi besplatni preglednik DuckDuckGo %1$si blokiraj oglase na YouTubeu.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -10094,8 +10075,7 @@ msgstr "Pomozi nam poboljšati DuckDuckGo"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr ""
-"Pomozi nam poboljšati DuckDuckGo pretraživanja svojim povratnim informacijama"
+msgstr "Pomozi nam poboljšati DuckDuckGo pretraživanja svojim povratnim informacijama"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -10520,7 +10500,7 @@ msgstr "Kako funkcionira"
 #. Headline in chat history about modals for the temporary encrypted server storage explanation.
 msgctxt "Chat history about modal list item headline"
 msgid "How it works"
-msgstr ""
+msgstr "Kako to funkcionira"
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -10538,8 +10518,7 @@ msgstr "Kako funkcionira"
 #. Header for the assist settings modal where the user can choose how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How much do you want AI-assisted answers to appear?"
-msgstr ""
-"Koliko često želiš da se pojave odgovori uz pomoć umjetne inteligencije?"
+msgstr "Koliko često želiš da se pojave odgovori uz pomoć umjetne inteligencije?"
 
 # smartling.placeholder_format=C
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
@@ -10798,8 +10777,7 @@ msgstr "Ako nas ipak želiš podržati, %1$spomozi proširiti DuckDuckGo%2$s"
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr ""
-"Želiš li koristiti DuckDuckGo bez JavaScripta, koristi %1$s ili %2$s verziju."
+msgstr "Želiš li koristiti DuckDuckGo bez JavaScripta, koristi %1$s ili %2$s verziju."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -11107,8 +11085,7 @@ msgstr "Lako pregledavanje rezultata pretraživanja za slike i videozapise"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Infinite Scroll for Images, Videos, and Shopping"
-msgstr ""
-"Lako pregledavanje rezultata pretraživanja slika, videozapisa i kupovina"
+msgstr "Lako pregledavanje rezultata pretraživanja slika, videozapisa i kupovina"
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is accurate
@@ -11972,7 +11949,7 @@ msgstr "Poveznica istječe za 7 dana."
 #. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days. People can save a chat copy."
-msgstr ""
+msgstr "Poveznica istječe za 7 dana. Korisnici mogu spremiti kopiju čavrljanja."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -12646,8 +12623,7 @@ msgstr "Mikronezija"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr ""
-"Pristup mikrofona je uskraćen. Dopusti pristup mikrofonu i pokušaj ponovno."
+msgstr "Pristup mikrofona je uskraćen. Dopusti pristup mikrofonu i pokušaj ponovno."
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -14097,7 +14073,7 @@ msgstr "U redu, shvaćam!"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "OPTIONAL"
-msgstr ""
+msgstr "NEOBAVEZNO"
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -15354,8 +15330,7 @@ msgstr "Prikvačeno"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
-"Prikvačena čavrljanja pojavit će se na vrhu tvojih nedavnih čavrljanja."
+msgstr "Prikvačena čavrljanja pojavit će se na vrhu tvojih nedavnih čavrljanja."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -15410,8 +15385,7 @@ msgstr "Ispuni sljedeći upit i potvrdi da je ovo pretraživanje izvršio čovje
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr ""
-"Opiši zašto je odgovor na čavrljanju štetan ili nezakonit. (neobavezno)"
+msgstr "Opiši zašto je odgovor na čavrljanju štetan ili nezakonit. (neobavezno)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -16225,7 +16199,7 @@ msgstr "Zaštićeno"
 #. Headline in sync-enabled chat history about modals explaining encrypted server storage.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Protected with end-to-end encryption"
-msgstr ""
+msgstr "Zaštićeno end-to-end šifriranjem"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -16364,7 +16338,7 @@ msgstr "Ljestvica"
 #. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
 msgctxt "star rating on a product"
 msgid "Rated %s out of %s"
-msgstr ""
+msgstr "Ocijenjeno %1$s od %2$s"
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -16831,8 +16805,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"Ponovno učitaj DuckDuckGo slijedeći upute ili klikom na gumb &quot;"
-"Osvježi&quot; (Refresh) ili &quot;Ponovno učitaj&quot; (Reload) u "
+"Ponovno učitaj DuckDuckGo slijedeći upute ili klikom na gumb "
+"&quot;Osvježi&quot; (Refresh) ili &quot;Ponovno učitaj&quot; (Reload) u "
 "pregledniku."
 
 # smartling.placeholder_format=C
@@ -16843,8 +16817,7 @@ msgstr "Zapamti moj izbor"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Zapamti moj odabir (ovo se može promijeniti u %1$s%2$s%3$sPostavkama%4$s)"
+msgstr "Zapamti moj odabir (ovo se može promijeniti u %1$s%2$s%3$sPostavkama%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -17594,8 +17567,7 @@ msgstr "Spremi do 30 svojih najnovijih čavrljanja lokalno na svom uređaju."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Spremi svoja Duck.ai čavrljanja između uređaja pomoću end-to-end šifriranja."
+msgstr "Spremi svoja Duck.ai čavrljanja između uređaja pomoću end-to-end šifriranja."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17607,7 +17579,7 @@ msgstr "Spremi svoja čavrljanja na svim svojim uređajima."
 #. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
 msgctxt "Chat history about modal list item headline"
 msgid "Save your chats on this device"
-msgstr ""
+msgstr "Spremi svoja čavrljanja na ovom uređaju"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
@@ -17637,8 +17609,7 @@ msgstr "Pozdravi Duck.ai"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr ""
-"Pozdravi Duck.ai – besplatno, privatno AI čavrljanje tvrtke DuckDuckGo."
+msgstr "Pozdravi Duck.ai – besplatno, privatno AI čavrljanje tvrtke DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17793,8 +17764,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr ""
-"Listaj prema dolje do %1$sUsluga%2$s i klikni na %3$sAdresna traka%4$s."
+msgstr "Listaj prema dolje do %1$sUsluga%2$s i klikni na %3$sAdresna traka%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -17819,7 +17789,7 @@ msgctxt ""
 "Placeholder and accessibility label for the search input in the tab picker "
 "dialog"
 msgid "Search"
-msgstr ""
+msgstr "Traži"
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18095,8 +18065,7 @@ msgstr "Pretraži putem DuckDuckGoa"
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid "Search, browse, and chat privately in our free browser"
-msgstr ""
-"Pretražuj, pregledavaj i privatno razgovaraj u našem besplatnom pregledniku"
+msgstr "Pretražuj, pregledavaj i privatno razgovaraj u našem besplatnom pregledniku"
 
 # smartling.placeholder_format=C
 #. Message displayed sometimes at top of results (for bang syntax), e.g. <a href="https://duckduckgo.com/?q=twitter+test">https://duckduckgo.com/?q=twitter+test</a>
@@ -18146,8 +18115,7 @@ msgstr "Drugo mišljenje"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr ""
-"Sigurno spremi i sinkroniziraj svoja čavrljanja na svim svojim uređajima."
+msgstr "Sigurno spremi i sinkroniziraj svoja čavrljanja na svim svojim uređajima."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18196,8 +18164,7 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr ""
-"Sigurno pohranjeno na DuckDuckGo poslužitelju s end-to-end šifriranjem."
+msgstr "Sigurno pohranjeno na DuckDuckGo poslužitelju s end-to-end šifriranjem."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -18389,8 +18356,7 @@ msgstr "Odaberi %1$sDuckDuckGo%2$s u padajućem izborniku zadanih tražilica"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"Odaberi %1$sDuckDuckGo%2$s na popisu i %3$sdopusti%4$s pristup lokaciji"
+msgstr "Odaberi %1$sDuckDuckGo%2$s na popisu i %3$sdopusti%4$s pristup lokaciji"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18509,8 +18475,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"Odaberi %1$ssvoj preglednik%2$s na popisu i %3$sdopusti%4$s pristup lokaciji"
+msgstr "Odaberi %1$ssvoj preglednik%2$s na popisu i %3$sdopusti%4$s pristup lokaciji"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18757,8 +18722,7 @@ msgstr ""
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr ""
-"Ručno postavi lokaciju ili provjeri jesu li omogućene lokacijske usluge."
+msgstr "Ručno postavi lokaciju ili provjeri jesu li omogućene lokacijske usluge."
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -18832,8 +18796,7 @@ msgstr "Podijeli"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Podijeli DuckDuckGo i pomozi prijateljima u vraćanju njihove privatnosti!"
+msgstr "Podijeli DuckDuckGo i pomozi prijateljima u vraćanju njihove privatnosti!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -19006,7 +18969,7 @@ msgstr "Trgovina"
 #. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
 msgctxt "Button in the merchandise logo modal (mobile)"
 msgid "Shop Now"
-msgstr ""
+msgstr "Kupuj odmah"
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -19114,8 +19077,7 @@ msgstr "Prikaži DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"Češće prikazuj DuckAssist. (Također ga možeš potpuno %1$sisključiti%2$s.)"
+msgstr "Češće prikazuj DuckAssist. (Također ga možeš potpuno %1$sisključiti%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -19442,8 +19404,7 @@ msgstr "Prikazuje poruku dobrodošlice na vrhu stranice rezultata pretraživanja
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Prikazuje poruku dobrodošlice korisnicima Androida u EU, u izborniku postavki"
+msgstr "Prikazuje poruku dobrodošlice korisnicima Androida u EU, u izborniku postavki"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -19515,14 +19476,12 @@ msgstr "Nazivi web-mjesta"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr ""
-"Pretraživanje web lokacija privremeno je nedostupno. Radimo na rješenju."
+msgstr "Pretraživanje web lokacija privremeno je nedostupno. Radimo na rješenju."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"Stranice koje blokiraš bit će skrivene iz svih tvojih rezultata pretraživanja"
+msgstr "Stranice koje blokiraš bit će skrivene iz svih tvojih rezultata pretraživanja"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19713,8 +19672,7 @@ msgstr "Ponekad"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr ""
-"Žao mi je što ne mogu pomoći, molim te opiši svoju sliku na drugačiji način."
+msgstr "Žao mi je što ne mogu pomoći, molim te opiši svoju sliku na drugačiji način."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19762,8 +19720,7 @@ msgctxt "Description for the wrong code error screen"
 msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
-msgstr ""
-"Nažalost, ovaj je kôd nevažeći. Provjeri je li unesen ili skeniran točan kôd."
+msgstr "Nažalost, ovaj je kôd nevažeći. Provjeri je li unesen ili skeniran točan kôd."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19843,8 +19800,7 @@ msgstr "Izvorni tekst je izbrisan"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr ""
-"Izvorni tekst je predug za sažimanje. Pokušaj ponovno s kraćim odabirom."
+msgstr "Izvorni tekst je predug za sažimanje. Pokušaj ponovno s kraćim odabirom."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -20049,22 +20005,19 @@ msgstr "Ostani na DuckDuckGou"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr ""
-"Ostani zaštićen i informiran putem naših e-novosti o zaštiti privatnosti."
+msgstr "Ostani zaštićen i informiran putem naših e-novosti o zaštiti privatnosti."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Ostani zaštićen i informiran putem naših biltena o zaštiti privatnosti."
+msgstr "Ostani zaštićen i informiran putem naših biltena o zaštiti privatnosti."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Ostani zaštićen i informiran putem naših biltena o zaštiti privatnosti."
+msgstr "Ostani zaštićen i informiran putem naših biltena o zaštiti privatnosti."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -20102,15 +20055,14 @@ msgstr "Zaustavi generiranje"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr ""
-"Onemogući skrivene alate za praćenje koji vrebaju na drugim web-mjestima."
+msgstr "Onemogući skrivene alate za praćenje koji vrebaju na drugim web-mjestima."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
 msgstr ""
-"Onemogući većinu skrivenih alata za praćenje koji vrebaju na drugim web-"
-"mjestima."
+"Onemogući većinu skrivenih alata za praćenje koji vrebaju na drugim "
+"web-mjestima."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20674,6 +20626,8 @@ msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
 msgstr ""
+"Sync & Backup sprema više tvojih razgovora i sinkronizira ih na svim tvojim "
+"uređajima."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20793,7 +20747,7 @@ msgstr "Sinkroniziraj svoja čavrljanja na svim svojim uređajima."
 #. Headline in sync-enabled chat history about modals explaining cross-device sync.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Sync your chats across all your devices"
-msgstr ""
+msgstr "Sinkroniziraj svoja čavrljanja na svim svojim uređajima"
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21166,8 +21120,7 @@ msgstr "Priložene datoteke prelaze ukupno ograničenje veličine od %1$s MB."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
 msgid "The audio could not be processed. Please try recording again."
-msgstr ""
-"Zvučni zapis nije moguće obraditi. Pokušaj ponovno snimiti zvučni zapis."
+msgstr "Zvučni zapis nije moguće obraditi. Pokušaj ponovno snimiti zvučni zapis."
 
 # smartling.placeholder_format=C
 #. Second paragraph explaining where the encryption key is stored on the entry screen.
@@ -21385,12 +21338,14 @@ msgid ""
 "This chat and its generated images become public when you create and copy "
 "the link."
 msgstr ""
+"Ovo čavrljanje i njegove generirane slike postaju javni kada izradiš i "
+"kopiraš poveznicu."
 
 # smartling.placeholder_format=C
 #. Explains that creating and copying a share link makes the selected chat content public.
 msgctxt "Share modal info bullet about public access"
 msgid "This chat becomes public when you create and copy the link."
-msgstr ""
+msgstr "Ovo čavrljanje postaje javno kada izradiš i kopiraš poveznicu."
 
 # smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
@@ -21619,8 +21574,7 @@ msgstr "Za pravilno funkcioniranje ove stranice potreban je Javascript."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Sadržaj ove stranice bit će poslan alatu Duck.ai zajedno s tvojom porukom"
+msgstr "Sadržaj ove stranice bit će poslan alatu Duck.ai zajedno s tvojom porukom"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21674,8 +21628,7 @@ msgstr ""
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr ""
-"Ovo podijeljeno čavrljanje ne može se otvoriti. Poveznica je možda nepotpuna."
+msgstr "Ovo podijeljeno čavrljanje ne može se otvoriti. Poveznica je možda nepotpuna."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
@@ -21704,8 +21657,7 @@ msgstr "Ovaj je prijevod pogrešan"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Ovaj se videozapis ovdje još ne može gledati. Možeš ga pogledati na %1$s."
+msgstr "Ovaj se videozapis ovdje još ne može gledati. Možeš ga pogledati na %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -21875,8 +21827,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"Za ispis uputa:%1$svrati se na kartu.%2$sOdaberi rutu koju želiš ispisati."
-"%3$sKlikni na ikonu za ispis.%4$s"
+"Za ispis uputa:%1$svrati se na kartu.%2$sOdaberi rutu koju želiš "
+"ispisati.%3$sKlikni na ikonu za ispis.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -21930,14 +21882,13 @@ msgstr "Danas"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
-msgstr ""
+msgstr "Prebaci se na privatno AI čavrljanje ili %1$sonemogući u postavkama%2$s."
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
-msgstr ""
-"Prebaci se na privatni AI chat ili ga %1$sonemogući u izborniku %2$s.%3$s"
+msgstr "Prebaci se na privatni AI chat ili ga %1$sonemogući u izborniku %2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21985,8 +21936,7 @@ msgstr "Previše oglasa"
 #. Displayed when the user has sent too many requests in a short period of time.
 msgctxt "Error message for rate limit"
 msgid "Too many requests. Please take a short break and try again."
-msgstr ""
-"Previše zahtjeva. Molimo te da napraviš kratku pauzu i pokušaš ponovno."
+msgstr "Previše zahtjeva. Molimo te da napraviš kratku pauzu i pokušaš ponovno."
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -22434,8 +22384,7 @@ msgstr "Pokušaj omogućiti anonimnu lokaciju za točnije rezultate."
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Pokušaj eksperimentirati sa svakim modelom - oni će dati različite odgovore."
+msgstr "Pokušaj eksperimentirati sa svakim modelom - oni će dati različite odgovore."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -22799,8 +22748,7 @@ msgstr "Uključi %1$sPreciznu lokaciju%2$s za preciznije rezultate"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr ""
-"Uključi Duck Player za gledanje vidoezapisa na YouTubeu bez ciljanih oglasa"
+msgstr "Uključi Duck Player za gledanje vidoezapisa na YouTubeu bez ciljanih oglasa"
 
 # smartling.placeholder_format=C
 #. Button that enables the Search/Duck.ai toggle.
@@ -22970,8 +22918,7 @@ msgstr "Nije moguće poslati povratne informacije"
 #. Message shown to the user when the voice chat failed to establish a connection, and they should try again later.
 msgctxt "voice chat"
 msgid "Unable to connect to voice chat, please try again later."
-msgstr ""
-"Nije moguće povezivanje s glasovnim čavrljanjem, pokušaj ponovno kasnije."
+msgstr "Nije moguće povezivanje s glasovnim čavrljanjem, pokušaj ponovno kasnije."
 
 # smartling.placeholder_format=C
 #. Message shown to the user when there was an issue connecting to their microphone.
@@ -23023,8 +22970,7 @@ msgstr "Pod %1$sOtvori s%2$s odaberi %3$sOdređenu stranicu ili stranice%4$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"Pod %1$sPRI POKRETANJU > Početna stranica%2$s unesi: https://duckduckgo.com"
+msgstr "Pod %1$sPRI POKRETANJU > Početna stranica%2$s unesi: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23046,15 +22992,13 @@ msgstr "Pod %1$sTraži%2$s, klikni %3$sUpravljaj tražilicama...%4$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr ""
-"Pod Pri pokretanju odaberi %1$sOtvori određenu stranicu ili skup stranica%2$s"
+msgstr "Pod Pri pokretanju odaberi %1$sOtvori određenu stranicu ili skup stranica%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr ""
-"Pod Pretraživanje klikni padajući izbornik i odaberi %1$sDuckDuckGo%2$s"
+msgstr "Pod Pretraživanje klikni padajući izbornik i odaberi %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -23154,8 +23098,7 @@ msgstr "Otključaj uz pretplatu na DuckDuckGo"
 msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
-msgstr ""
-"Otključaj napredne AI modele i viša ograničenja uz pretplatu na DuckDuckGo"
+msgstr "Otključaj napredne AI modele i viša ograničenja uz pretplatu na DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -23407,8 +23350,7 @@ msgctxt ""
 "Description prompting Plus subscribers to upgrade to Pro for higher image "
 "generation limits"
 msgid "Upgrade to Pro to unlock 2x higher limits"
-msgstr ""
-"Nadogradi na Pro verziju za otključavanje dva puta veće količine generiranja"
+msgstr "Nadogradi na Pro verziju za otključavanje dva puta veće količine generiranja"
 
 # smartling.placeholder_format=C
 #. Description shown to Plus subscribers who have reached their image generation limit, encouraging them to upgrade to Pro.
@@ -23763,6 +23705,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Yelp's ad network."
 msgstr ""
+"Prikaz oglasa zaštićen je DuckDuckGo privatnošću. Klikovima na oglase "
+"upravlja Yelpova oglasna mreža."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -23848,8 +23792,8 @@ msgid ""
 msgstr ""
 "Posjeti Duck.ai u svom drugom pregledniku ili u aplikaciji DuckDuckGo i "
 "otvori Postavke Duck.ai. Odaberi „Uključi“ pod Sync & Backup i odaberi "
-"„Sinkronizacija s drugim uređajem“. Ili skeniraj QR kôd na svom Recovery PDF-"
-"u."
+"„Sinkronizacija s drugim uređajem“. Ili skeniraj QR kôd na svom Recovery "
+"PDF-u."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -24128,8 +24072,7 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"Ne možemo pročitati priložene datoteke jer je barem jedna od njih šifrirana."
+msgstr "Ne možemo pročitati priložene datoteke jer je barem jedna od njih šifrirana."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24628,8 +24571,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"Stvarno nam je žao, ali čini se da je došlo do problema s učitavanjem Duck."
-"ai. Pokušaj ponovo učitati stranicu."
+"Stvarno nam je žao, ali čini se da je došlo do problema s učitavanjem "
+"Duck.ai. Pokušaj ponovo učitati stranicu."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -24643,8 +24586,7 @@ msgctxt "Full sentence for improving arguments"
 msgid ""
 "What are some arguments, counter-arguments, and rebuttals to the concept of "
 "a plant-based diet?"
-msgstr ""
-"Koji su neki argumenti, protuargumenti i pobijanja koncepta biljne prehrane?"
+msgstr "Koji su neki argumenti, protuargumenti i pobijanja koncepta biljne prehrane?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
@@ -24934,8 +24876,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Što je to označeni aplet za Cloud Save i kako se razlikuje od parametra URL-"
-"a označenog apleta?"
+"Što je to označeni aplet za Cloud Save i kako se razlikuje od parametra "
+"URL-a označenog apleta?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -25010,8 +24952,7 @@ msgstr "O čemu želiš pružiti povratne informacije?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"Ono što gledaš u DuckDuckGou neće utjecati na tvoje preporuke na YouTubeu."
+msgstr "Ono što gledaš u DuckDuckGou neće utjecati na tvoje preporuke na YouTubeu."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -25043,8 +24984,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"Kada je to omogućeno, Duck.ai će prikazivati izravne odgovore u čavrljanju."
+msgstr "Kada je to omogućeno, Duck.ai će prikazivati izravne odgovore u čavrljanju."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -25062,8 +25002,7 @@ msgstr "Gdje gledati <strong>%1$s</strong>"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr ""
-"Tamo gdje piše Početna stranica, klikni %1$sPostavi na trenutnu stranicu%2$s."
+msgstr "Tamo gdje piše Početna stranica, klikni %1$sPostavi na trenutnu stranicu%2$s."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -25252,6 +25191,8 @@ msgid ""
 "With chat history on, up to %s of your most recent chats will be saved on "
 "this device."
 msgstr ""
+"S uključenom poviješću čavrljanja, na ovom će se uređaju spremiti do %1$s "
+"tvojih najnovijih čavrljanja."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline in the About Chat History modal.
@@ -25259,6 +25200,8 @@ msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, your most recent chats will be saved on this device."
 msgstr ""
+"Kad je povijest čavrljanja uključena, tvoja će se najnovija čavrljanja "
+"spremati na ovom uređaju."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -25522,8 +25465,7 @@ msgstr "Da, novi korisnik!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr ""
-"Da, mi se rješavamo podataka kad ti više ne trebaju i nemoguće ih je vratiti."
+msgstr "Da, mi se rješavamo podataka kad ti više ne trebaju i nemoguće ih je vratiti."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -25614,15 +25556,13 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr ""
-"Ovo možeš promijeniti u svakom trenutku u %1$sPostavke pretraživanja%2$s"
+msgstr "Ovo možeš promijeniti u svakom trenutku u %1$sPostavke pretraživanja%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr ""
-"Ovo čavrljanje možeš nastaviti kada se tvoje ograničenje resetira: %1$s."
+msgstr "Ovo čavrljanje možeš nastaviti kada se tvoje ograničenje resetira: %1$s."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -25661,8 +25601,7 @@ msgstr "Možeš nastaviti razgovarati koristeći svoje mjesečno ograničenje."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Sada možeš spremiti do 100 čavrljanja na ovom uređaju. Sretno čavrljanje!"
+msgstr "Sada možeš spremiti do 100 čavrljanja na ovom uređaju. Sretno čavrljanje!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -25843,8 +25782,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr ""
-"Ovu poruku više nećeš vidjeti osim ako ne izbrišeš podatke svog preglednika."
+msgstr "Ovu poruku više nećeš vidjeti osim ako ne izbrišeš podatke svog preglednika."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -25949,14 +25887,12 @@ msgstr "Dosegao si maksimalno trajanje glasovnog čavrljanja za jednu sesiju."
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"Dosegao si ograničenje glasovnog čavrljanja za danas. Pokušaj ponovno sutra."
+msgstr "Dosegao si ograničenje glasovnog čavrljanja za danas. Pokušaj ponovno sutra."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"Dosegnuto je tvoje ograničenje korištenja diktata. Pokušaj ponovno kasnije."
+msgstr "Dosegnuto je tvoje ograničenje korištenja diktata. Pokušaj ponovno kasnije."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -26146,8 +26082,7 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr ""
-"Tvoji su razgovori privatni i nikada se ne koriste za učenje AI modela."
+msgstr "Tvoji su razgovori privatni i nikada se ne koriste za učenje AI modela."
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -26208,8 +26143,8 @@ msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
 msgstr ""
-"Vaši su razgovori uvezeni. Samo naprijed i nastavi tamo gdje si stao u Duck."
-"ai."
+"Vaši su razgovori uvezeni. Samo naprijed i nastavi tamo gdje si stao u "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -26395,8 +26330,7 @@ msgctxt "Error message for input limit"
 msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
-msgstr ""
-"Premašena je maksimalna duljina poruke. Skrati poruku i pokušaj ponovno."
+msgstr "Premašena je maksimalna duljina poruke. Skrati poruku i pokušaj ponovno."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -26668,7 +26602,7 @@ msgstr "m"
 #. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the chat options menu button"
 msgid "menu"
-msgstr ""
+msgstr "izbornik"
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.
@@ -26742,8 +26676,7 @@ msgstr "službenu web lokaciju"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr ""
-"ili napiši šifru boje koju želiš, npr. %1$s (%2$s je kodirani znak %3$s)."
+msgstr "ili napiši šifru boje koju želiš, npr. %1$s (%2$s je kodirani znak %3$s)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/hr_HR/LC_MESSAGES/duckduckgo.po
+++ b/locales/hr_HR/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: hr_HR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1221,6 +1221,12 @@ msgid "About our ads"
 msgstr "O našim oglasima"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1350,6 +1356,20 @@ msgid "Ad is suspicious"
 msgstr "Oglas je sumnjiv"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Dodaj DuckDuckGo"
@@ -1376,6 +1396,27 @@ msgstr "Dodaj DuckDuckGo kao pretraživač"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Dodaj DuckDuckGo u %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1421,6 +1462,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Dodaj sadržaj stranice"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1506,6 +1563,12 @@ msgstr "Dodaci"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Dodavanje završnih detalja"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1810,6 +1873,12 @@ msgstr "Sve boje"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Gotovo!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3523,6 +3592,14 @@ msgid "Cancel"
 msgstr "Otkaži"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4018,10 +4095,22 @@ msgid "Chat response is offensive"
 msgstr "Odgovor na chatu je uvredljiv"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Razgovaraj s %1$s"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4040,6 +4129,14 @@ msgstr "Čavrljanja"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Čavrljanja"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5641,6 +5738,12 @@ msgid "Current Streak"
 msgstr "Trenutačni niz"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5989,6 +6092,12 @@ msgstr "Izbriši čavrljanja"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Izbriši čavrljanja starija od 30 dana"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6405,6 +6514,12 @@ msgstr "Zauvijek odbaci"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Odbaci promociju"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7579,6 +7694,12 @@ msgid "Edit Prompt"
 msgstr "Uredi upit"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7798,6 +7919,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Šifrirani model"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8631,6 +8758,12 @@ msgid "Follow-up question"
 msgstr "Dodatno pitanje"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9145,6 +9278,12 @@ msgstr ""
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr "Nabavi DuckDuckGo VPN, napredni Duck.ai i Identity Theft Restoration."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10376,6 +10515,12 @@ msgstr "Kako je osigurana anonimnost?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Kako funkcionira"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11822,6 +11967,12 @@ msgstr "Osvojeni lineouti"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "Poveznica istječe za 7 dana."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13941,6 +14092,12 @@ msgstr "U redu"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "U redu, shvaćam!"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16065,6 +16222,12 @@ msgid "Protected"
 msgstr "Zaštićeno"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Zaštita. Privatnost. Bezbrižnost."
@@ -16196,6 +16359,12 @@ msgstr "Kiša"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Ljestvica"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17435,6 +17604,12 @@ msgid "Save your chats across all your devices."
 msgstr "Spremi svoja čavrljanja na svim svojim uređajima."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17637,6 +17812,14 @@ msgstr "Traži"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Traži"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18818,6 +19001,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Trgovina"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20479,6 +20668,14 @@ msgstr ""
 "oporaviti nakon 18 (ili više) mjeseci neaktivnosti."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20591,6 +20788,12 @@ msgstr "Sinkronizacija s obližnjim uređajem."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Sinkroniziraj svoja čavrljanja na svim svojim uređajima."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21174,6 +21377,22 @@ msgid "This Week"
 msgstr "Ovaj tjedan"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21706,6 +21925,12 @@ msgstr "Danas"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Danas"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23532,6 +23757,14 @@ msgstr ""
 "oglasa upravlja TripAdvisorova oglasna mreža."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Djevičanski otoci"
 
@@ -25013,6 +25246,21 @@ msgstr ""
 "izborniku '%1$s'."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26415,6 +26663,12 @@ msgstr "m"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "m"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/hu_HU/LC_MESSAGES/duckduckgo.po
+++ b/locales/hu_HU/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: hu_HU\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -190,9 +190,9 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"A(z) %1$s csak a Pro verzióval érhető el. Frissítsd újra a DuckDuckGo-"
-"előfizetésedet ebben a böngészőben a csevegés folytatásához, vagy válts a "
-"Plus vagy az ingyenes modellre."
+"A(z) %1$s csak a Pro verzióval érhető el. Frissítsd újra a "
+"DuckDuckGo-előfizetésedet ebben a böngészőben a csevegés folytatásához, vagy "
+"válts a Plus vagy az ingyenes modellre."
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -202,9 +202,9 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"A(z) %1$s csak a Pro verzióval érhető el. Frissítsd újra a DuckDuckGo-"
-"előfizetésedet ebben a böngészőben a csevegés folytatásához, vagy válts a "
-"Plus vagy az ingyenes modellre."
+"A(z) %1$s csak a Pro verzióval érhető el. Frissítsd újra a "
+"DuckDuckGo-előfizetésedet ebben a böngészőben a csevegés folytatásához, vagy "
+"válts a Plus vagy az ingyenes modellre."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -498,8 +498,7 @@ msgstr "%1$sTudj meg többet%2$s"
 #. Link to a page with more information about how anonymous location works.
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
-msgstr ""
-"%1$sTudd meg, hogyan őrizzük meg a tartózkodási helyed bizalmasságát%2$s."
+msgstr "%1$sTudd meg, hogyan őrizzük meg a tartózkodási helyed bizalmasságát%2$s."
 
 # smartling.placeholder_format=C
 #. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
@@ -521,15 +520,13 @@ msgstr ""
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr ""
-"%1$sTovábbi részletek%2$s a csevegések eszközön való privát tárolásáról."
+msgstr "%1$sTovábbi részletek%2$s a csevegések eszközön való privát tárolásáról."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr ""
-"%1$sNyomd meg hosszan%2$s a DuckDuckGo alkalmazás ikonját a kezdőképernyőn"
+msgstr "%1$sNyomd meg hosszan%2$s a DuckDuckGo alkalmazás ikonját a kezdőképernyőn"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -886,8 +883,7 @@ msgstr "Elérted a 6 órás használati limitet."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Elérted a 6 órás használati limitet. A csevegést %1$s után folytathatod."
+msgstr "Elérted a 6 órás használati limitet. A csevegést %1$s után folytathatod."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -1012,8 +1008,9 @@ msgstr ""
 "Az AI Chat segítségével névtelen beszélgetéseket folytathatsz harmadik felek "
 "mesterséges intelligencián alapuló csevegési modelljeivel. Ennek "
 "kikapcsolása elrejti az AI Chat funkciót a DuckDuckGo Search "
-"szolgáltatásban. Ha a beállítás ki van kapcsolva, a %1$sduckduckgo.com/"
-"aichat%2$s oldalra látogatva továbbra is elérheted az AI Chatet."
+"szolgáltatásban. Ha a beállítás ki van kapcsolva, a "
+"%1$sduckduckgo.com/aichat%2$s oldalra látogatva továbbra is elérheted az AI "
+"Chatet."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1077,8 +1074,9 @@ msgstr ""
 "Az AI-alapú válaszokra jelenleg nem tehetők fel közvetlenül további "
 "kérdések. Azonban ha újabb kérdést szeretnél feltenni, az OpenAI, az "
 "Anthropic, valamint más szolgáltatók csevegési modelljeit is támogató "
-"mesterségesintelligencia-alapú privát csevegési szolgáltatásunk, a %1$sDuck."
-"ai%2$s használatát is felajánljuk, és gyakran megjelenítjük annak linkjét."
+"mesterségesintelligencia-alapú privát csevegési szolgáltatásunk, a "
+"%1$sDuck.ai%2$s használatát is felajánljuk, és gyakran megjelenítjük annak "
+"linkjét."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1224,7 +1222,7 @@ msgstr "Tudnivalók a hirdetéseinkről"
 #. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
 msgctxt "Modal header for chat history with sync information"
 msgid "About Chat History with Sync & Backup"
-msgstr ""
+msgstr "Csevegési előzmények adatai engedélyezett Sync & Backup esetén"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
@@ -1361,7 +1359,7 @@ msgstr "A hirdetés gyanús"
 #. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
 msgctxt "Button to open menu for attaching images or page context to AI chat"
 msgid "Add"
-msgstr ""
+msgstr "Hozzáadás"
 
 # smartling.placeholder_format=C
 #. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
@@ -1369,7 +1367,7 @@ msgctxt ""
 "Primary button that attaches the tabs the user checked in the tab picker "
 "dialog"
 msgid "Add"
-msgstr ""
+msgstr "Hozzáadás"
 
 # smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
@@ -1404,13 +1402,13 @@ msgstr "DuckDuckGo hozzáadása %1$s-bővítményként"
 msgctxt ""
 "Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
 msgid "Add File"
-msgstr ""
+msgstr "Fájl hozzáadása"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
 msgid "Add Image"
-msgstr ""
+msgstr "Kép hozzáadása"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
@@ -1418,7 +1416,7 @@ msgctxt ""
 "Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
 "item)"
 msgid "Add Image or File"
-msgstr ""
+msgstr "Kép vagy fájl hozzáadása"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1471,7 +1469,7 @@ msgctxt ""
 "Open the tab picker to attach browser tab content to the AI chat message "
 "(attach dropdown menu item)"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Lapok hozzáadása"
 
 # smartling.placeholder_format=C
 #. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
@@ -1479,7 +1477,7 @@ msgctxt ""
 "Title and accessible name of the tab-picker dialog opened from the attach "
 "dropdown menu"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Lapok hozzáadása"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1570,7 +1568,7 @@ msgstr "Utolsó simítások hozzáadása"
 #. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
 msgctxt "Aria label for the additional instructions textarea"
 msgid "Additional instructions"
-msgstr ""
+msgstr "További utasítások"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1880,7 +1878,7 @@ msgstr "Minden kész!"
 #. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the read-only textarea listing all AI instructions"
 msgid "All instructions"
-msgstr ""
+msgstr "Összes utasítás"
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -1969,8 +1967,7 @@ msgstr "Adatvédelmet tiszteletben tartó hirdetések engedélyezése"
 #. Title of the upload consent prompt shown before the first image/file upload in a chat with a zero-provider-visibility model, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Allow anonymous file review for this chat?"
-msgstr ""
-"Engedélyezed a névtelen módon végzett fájlellenőrzést ehhez a csevegéshez?"
+msgstr "Engedélyezed a névtelen módon végzett fájlellenőrzést ehhez a csevegéshez?"
 
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
@@ -2531,9 +2528,9 @@ msgstr ""
 "felhasználói felületét a keresési eredményekből), Igény szerint (csak az "
 "Asszisztens gombra kattintás esetén jelennek meg az AI-alapú válaszok), Néha "
 "(csak akkor jelenik meg AI-alapú válasz, ha nagyon releváns), illetve "
-"Gyakran (gyakrabban jelenik meg, szélesebb körű keresések esetén). Az AI-"
-"alapú válaszok egyelőre csak az Egyesült Államok (angol) régiójában érhetők "
-"el."
+"Gyakran (gyakrabban jelenik meg, szélesebb körű keresések esetén). Az "
+"AI-alapú válaszok egyelőre csak az Egyesült Államok (angol) régiójában "
+"érhetők el."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2640,21 +2637,18 @@ msgstr "Hang"
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"A hanganyagot a csevegés befejezése után mi nem tároljuk, és az OpenAI sem."
+msgstr "A hanganyagot a csevegés befejezése után mi nem tároljuk, és az OpenAI sem."
 
 # smartling.placeholder_format=C
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"A hanganyagot a csevegés befejezése után mi nem tároljuk, és az OpenAI sem."
+msgstr "A hanganyagot a csevegés befejezése után mi nem tároljuk, és az OpenAI sem."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"A hanganyagot a csevegés átírása után mi nem tároljuk, és az OpenAI sem."
+msgstr "A hanganyagot a csevegés átírása után mi nem tároljuk, és az OpenAI sem."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2903,8 +2897,7 @@ msgstr "Vonalkód"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr ""
-"Az oldalon szereplő információk alapján érdemes elvégezni ezt a tanfolyamot?"
+msgstr "Az oldalon szereplő információk alapján érdemes elvégezni ezt a tanfolyamot?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -3107,8 +3100,7 @@ msgstr "Webhely blokkolása minden találatból"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr ""
-"Blokkold a nyomkövetőket, és vedd át az irányítást a személyes adataid felett"
+msgstr "Blokkold a nyomkövetőket, és vedd át az irányítást a személyes adataid felett"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3613,7 +3605,7 @@ msgctxt ""
 "Secondary button that dismisses the tab picker dialog without attaching "
 "anything"
 msgid "Cancel"
-msgstr ""
+msgstr "Mégse"
 
 # smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
@@ -3850,8 +3842,7 @@ msgstr "Módosítja az eredmények URL-jeinek megjelenítési módját"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr ""
-"Módosítja a fejléc megjelenítési módját és viselkedését görgetés közben."
+msgstr "Módosítja a fejléc megjelenítési módját és viselkedését görgetés közben."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -4063,8 +4054,8 @@ msgstr "Privát csevegés"
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
 msgstr ""
-"Csevegj privátban bármely webhelyen az ingyenes böngészőnkbe beépített Duck."
-"ai segítségével."
+"Csevegj privátban bármely webhelyen az ingyenes böngészőnkbe beépített "
+"Duck.ai segítségével."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
@@ -4115,7 +4106,7 @@ msgstr "A csevegés válasza bántó"
 #. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
 msgctxt "Chat history about modal list item headline"
 msgid "Chat storage varies by browser"
-msgstr ""
+msgstr "A csevegési tárhely böngészőnként eltérő"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4127,7 +4118,7 @@ msgstr "Csevegési partner: %1$s"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Chat with popular AI models, anonymized by us."
-msgstr ""
+msgstr "Csevegés népszerű AI-modellekkel, általunk anonimizált módon."
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4154,6 +4145,9 @@ msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
 msgstr ""
+"A csevegések biztonságosan, végpontok közötti titkosítással vannak tárolva a "
+"DuckDuckGo szerverén. Rajtad kívül senki sem láthatja az adataidat, még mi "
+"sem."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4612,8 +4606,8 @@ msgid ""
 msgstr ""
 "Kattints a „Több” lehetőségre, ha többet meg szeretnél tudni egy témáról, és "
 "tegyél fel kapcsolódó kérdéseket az OpenAI, az Anthropic és további "
-"csevegési modelleket támogató privát AI-csevegőszolgáltatásunk, a %1$sDuck."
-"ai%2$s használatával."
+"csevegési modelleket támogató privát AI-csevegőszolgáltatásunk, a "
+"%1$sDuck.ai%2$s használatával."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4640,15 +4634,13 @@ msgstr "Kattints a %1$sHozzáadás%2$s lehetőségre"
 #. Instructions on which buttons the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "Click %sAllow%s, then %sAdd%s."
-msgstr ""
-"Kattints az %1$sEngedélyezés%2$slehetőségre, majd a %3$sHozzáadás%4$s gombra."
+msgstr "Kattints az %1$sEngedélyezés%2$slehetőségre, majd a %3$sHozzáadás%4$s gombra."
 
 #  Firefox 33
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Click %sChange Search Settings%s in the drop down"
-msgstr ""
-"Kattints a %1$sKeresési beállítások módosítása%2$s sorra a lenyíló menüben"
+msgstr "Kattints a %1$sKeresési beállítások módosítása%2$s sorra a lenyíló menüben"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -4682,8 +4674,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr ""
-"Kattints a bal oldali sáv %1$sAdatvédelem és szolgáltatások%2$s elemére."
+msgstr "Kattints a bal oldali sáv %1$sAdatvédelem és szolgáltatások%2$s elemére."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -4764,8 +4755,7 @@ msgstr "Kattints a %1$sBeállítás alapértelmezettként%2$s lehetőségre lent
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sSearch Providers%s under Add-on Types"
-msgstr ""
-"Kattints a %1$sKeresőszolgáltatók%2$s lehetőségre a bővítménytípusoknál"
+msgstr "Kattints a %1$sKeresőszolgáltatók%2$s lehetőségre a bővítménytípusoknál"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -5480,8 +5470,7 @@ msgstr "Másolás"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"Másold ki és illeszd be az %1$sabout:preferences#search%2$s címet a címsorba"
+msgstr "Másold ki és illeszd be az %1$sabout:preferences#search%2$s címet a címsorba"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5777,7 +5766,7 @@ msgstr "Jelenlegi sorozat"
 #. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
 msgctxt "Suffix label indicating a tab is the currently active browser tab"
 msgid "Current Tab"
-msgstr ""
+msgstr "Jelenlegi lap"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
@@ -6131,7 +6120,7 @@ msgstr "30 napnál régebbi csevegések törlése"
 #. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
 msgctxt "Button text in the modal for deleting all recent chats"
 msgid "Delete Chats and Shared Links"
-msgstr ""
+msgstr "Beszélgetések és megosztott linkek törlése"
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6554,7 +6543,7 @@ msgstr "Promóció bezárása"
 #. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the close button on the survey banner"
 msgid "Dismiss survey"
-msgstr ""
+msgstr "Kérdőív elutasítása"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6946,8 +6935,7 @@ msgstr "Dobd ide a fotókat vagy PDF-fájlokat"
 # smartling.placeholder_format=C
 #. A title explaining what Duck Player (DDG's feature to watch youtube videos more privately) does
 msgid "Duck Player lets you watch YouTube without targeted ads"
-msgstr ""
-"A Duck Player segítségével célzott hirdetések nélkül nézheted a YouTube-ot"
+msgstr "A Duck Player segítségével célzott hirdetések nélkül nézheted a YouTube-ot"
 
 # smartling.placeholder_format=C
 #. This is the DDG version of "Google it", meaning "search it".
@@ -7040,8 +7028,7 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"A Duck.ai a privát és ingyenes DuckDuckGo böngészőnkben működik a legjobban!"
+msgstr "A Duck.ai a privát és ingyenes DuckDuckGo böngészőnkben működik a legjobban!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -7084,8 +7071,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"A Duck.ai átmenetileg nem érhető el. Ha ez továbbra is fennáll, küldd el e-"
-"mailben a névtelenségi funkcióhoz szükséges %1$s kódot a következő címre: "
+"A Duck.ai átmenetileg nem érhető el. Ha ez továbbra is fennáll, küldd el "
+"e-mailben a névtelenségi funkcióhoz szükséges %1$s kódot a következő címre: "
 "%2$s"
 
 # smartling.placeholder_format=C
@@ -7093,8 +7080,7 @@ msgstr ""
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr ""
-"A Duck.ai átmenetileg nem érhető el. Frissítsd az oldalt, és próbálkozz újra."
+msgstr "A Duck.ai átmenetileg nem érhető el. Frissítsd az oldalt, és próbálkozz újra."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7108,9 +7094,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"A Duck.ai lehetővé teszi, hogy privát módon beszélgess népszerű MI-"
-"modellekkel. A kikapcsolása elrejti a Duck.ai gombjait és hivatkozásait, de "
-"továbbra is felkeresheted közvetlenül a %1$sduck.ai%2$s webhelyet."
+"A Duck.ai lehetővé teszi, hogy privát módon beszélgess népszerű "
+"MI-modellekkel. A kikapcsolása elrejti a Duck.ai gombjait és hivatkozásait, "
+"de továbbra is felkeresheted közvetlenül a %1$sduck.ai%2$s webhelyet."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7194,8 +7180,8 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, privát AI chatbot, csevegőrobot, ingyenes AI-"
-"csevegés, anonim AI-csevegés, AI-csevegés regisztráció nélkül, OpenAI, "
+"Duck.ai, DuckDuckGo AI, privát AI chatbot, csevegőrobot, ingyenes "
+"AI-csevegés, anonim AI-csevegés, AI-csevegés regisztráció nélkül, OpenAI, "
 "Anthropic, Llama, Mistral, nyílt forráskódú AI modellek, adatvédelemre "
 "összpontosító AI, fiók nélküli AI-csevegés"
 
@@ -7243,8 +7229,8 @@ msgid ""
 msgstr ""
 "A DuckAssist nem tud utólagos kérdésekre válaszolni, viszont kínálatunkban "
 "többek között az OpenAI és az Anthropic csevegési modelljeit támogató "
-"%1$sDuckDuckGo AI Chat%2$s is elérhető, amely egy mesterségesintelligencia-"
-"alapú privát csevegési szolgáltatás."
+"%1$sDuckDuckGo AI Chat%2$s is elérhető, amely egy "
+"mesterségesintelligencia-alapú privát csevegési szolgáltatás."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7372,8 +7358,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"A DuckDuckGo AI Chat átmenetileg nem érhető el. Próbálkozz újra később."
+msgstr "A DuckDuckGo AI Chat átmenetileg nem érhető el. Próbálkozz újra később."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7524,8 +7509,8 @@ msgid ""
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
 "A DuckDuckGo automatikusan anonimizálja ezeket a jelentéseket az olyan "
-"személyazonosításra alkalmas adatok eltávolításával, mint a nevek, az e-mail-"
-"címek, a telefonszámok és az azonosításra alkalmas metaadatok."
+"személyazonosításra alkalmas adatok eltávolításával, mint a nevek, az "
+"e-mail-címek, a telefonszámok és az azonosításra alkalmas metaadatok."
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -7746,7 +7731,7 @@ msgstr "Utasítás szerkesztése"
 #. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the message-editing text area"
 msgid "Edit message"
-msgstr ""
+msgstr "Üzenet szerkesztése"
 
 # smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
@@ -7816,8 +7801,7 @@ msgstr "Emeld ki a fontos információkat a válaszokban"
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Enable 'Sites can ask for my location.'"
-msgstr ""
-"Engedélyezd a „Webhelyek kérhetik a tartózkodási helyemet” lehetőséget."
+msgstr "Engedélyezd a „Webhelyek kérhetik a tartózkodási helyemet” lehetőséget."
 
 # smartling.placeholder_format=C
 #. Button shown during outages to enable AI features
@@ -7918,8 +7902,7 @@ msgstr "Diktálás engedélyezése a Duck.ai felületén"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr ""
-"Az anonim hely használatához engedélyezd a készülékeden a helymeghatározást"
+msgstr "Az anonim hely használatához engedélyezd a készülékeden a helymeghatározást"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -7977,7 +7960,7 @@ msgstr "Titkosított modell"
 #. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
 msgctxt "Share modal info bullet about encryption"
 msgid "Encrypted so DuckDuckGo can't read your chat."
-msgstr ""
+msgstr "Titkosítva, így a DuckDuckGo nem tudja elolvasni a csevegésedet."
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8043,15 +8026,13 @@ msgstr ""
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr ""
-"Győződj meg arról, hogy a „Helyszolgáltatások” %1$sengedélyezve vannak%2$s."
+msgstr "Győződj meg arról, hogy a „Helyszolgáltatások” %1$sengedélyezve vannak%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr ""
-"Győződj meg arról, hogy a „Hely” %1$sengedélyezés%2$s értékre van állítva"
+msgstr "Győződj meg arról, hogy a „Hely” %1$sengedélyezés%2$s értékre van állítva"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -8065,8 +8046,7 @@ msgstr ""
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure Location is set to %sAllow%s"
-msgstr ""
-"Győződj meg arról, hogy a Hely %1$sEngedélyezés%2$s értékre van állítva"
+msgstr "Győződj meg arról, hogy a Hely %1$sEngedélyezés%2$s értékre van állítva"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -8102,15 +8082,13 @@ msgstr ""
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access"
-msgstr ""
-"Győződj meg arról, hogy a böngészőben engedélyezve van a helyhozzáférés"
+msgstr "Győződj meg arról, hogy a böngészőben engedélyezve van a helyhozzáférés"
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr ""
-"Győződj meg arról, hogy böngésződben engedélyezve van a helyhozzáférés."
+msgstr "Győződj meg arról, hogy böngésződben engedélyezve van a helyhozzáférés."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -8821,8 +8799,8 @@ msgstr ""
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
 msgstr ""
-"Kövesd az alábbi lépéseket, ha szeretnéd átvinni a csevegéseket az új Duck."
-"ai felületre"
+"Kövesd az alábbi lépéseket, ha szeretnéd átvinni a csevegéseket az új "
+"Duck.ai felületre"
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8833,7 +8811,7 @@ msgstr "Kapcsolódó kérdés"
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
-msgstr ""
+msgstr "A kapcsolódó kérdések privátak maradnak."
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8939,8 +8917,7 @@ msgstr "Ingyenes és privát csevegések, általunk anonimizálva"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Ingyenes és privát csevegések, általunk anonimizálva. Nincs szükség fiókra."
+msgstr "Ingyenes és privát csevegések, általunk anonimizálva. Nincs szükség fiókra."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9192,15 +9169,13 @@ msgstr "Általános célú mesterséges intelligencia, beépített erős moderá
 #. Text with short description for an AI (Artificial Intelligence) Model that has a low moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with low built-in moderation"
-msgstr ""
-"Általános célú mesterséges intelligencia, beépített gyenge moderálással"
+msgstr "Általános célú mesterséges intelligencia, beépített gyenge moderálással"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a medium moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with medium built-in moderation"
-msgstr ""
-"Általános célú mesterséges intelligencia, beépített közepes moderálással"
+msgstr "Általános célú mesterséges intelligencia, beépített közepes moderálással"
 
 # smartling.placeholder_format=C
 #. Text indicating that the AI (Artificial Intelligence) model is a model for general purpose use. General-purpose AI refers to AI systems that can perform a wide range of tasks, rather than being specialized for a specific task.
@@ -9359,7 +9334,7 @@ msgstr ""
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
 msgctxt "Tooltip on the header logo for sunglasses searches"
 msgid "Get DuckDuckGo sunglasses and other gear."
-msgstr ""
+msgstr "Szerezz DuckDuckGo napszemüveget és más felszerelést."
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9441,9 +9416,9 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, Personal Info Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"Vedd igénybe a gyors, naplózásmentes VPN-t, a választható fejlett AI-"
-"csevegést, a személyes adatok eltávolítására szolgáló Personal Info Removal, "
-"és a személyazonosság helyreállításához használható Identity Theft "
+"Vedd igénybe a gyors, naplózásmentes VPN-t, a választható fejlett "
+"AI-csevegést, a személyes adatok eltávolítására szolgáló Personal Info "
+"Removal, és a személyazonosság helyreállításához használható Identity Theft "
 "Restoration funkciókat."
 
 # smartling.placeholder_format=C
@@ -9453,8 +9428,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, and Identity Theft "
 "Restoration."
 msgstr ""
-"Vedd igénybe a gyors, naplózásmentes VPN-t, a választható fejlett AI-"
-"csevegést, és a személyazonosság helyreállításához használható Identity "
+"Vedd igénybe a gyors, naplózásmentes VPN-t, a választható fejlett "
+"AI-csevegést, és a személyazonosság helyreállításához használható Identity "
 "Theft Restoration funkciókat."
 
 # smartling.placeholder_format=C
@@ -9477,9 +9452,9 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Szerezz hozzáférést a Duck.ai fejlett AI-modelljeihez DuckDuckGo-"
-"előfizetéssel, amely a VPN-megoldásunk mellett további prémium adatvédelmi "
-"szolgáltatásokat is tartalmaz."
+"Szerezz hozzáférést a Duck.ai fejlett AI-modelljeihez "
+"DuckDuckGo-előfizetéssel, amely a VPN-megoldásunk mellett további prémium "
+"adatvédelmi szolgáltatásokat is tartalmaz."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9508,8 +9483,7 @@ msgstr "Kérj számítógépes segítséget"
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr ""
-"DuckDuckGo-előfizetéssel magasabb felhasználási limiteket vehetsz igénybe."
+msgstr "DuckDuckGo-előfizetéssel magasabb felhasználási limiteket vehetsz igénybe."
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -9706,8 +9680,7 @@ msgstr ""
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr ""
-"Lépj az %1$sAdatvédelem és biztonság > Helymeghatározás%2$s lehetőségre"
+msgstr "Lépj az %1$sAdatvédelem és biztonság > Helymeghatározás%2$s lehetőségre"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -10184,8 +10157,7 @@ msgstr "Segíts nekünk a DuckDuckGo fejlesztésében"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr ""
-"A visszajelzéseddel segítesz nekünk a DuckDuckGo-keresések fejlesztésében"
+msgstr "A visszajelzéseddel segítesz nekünk a DuckDuckGo-keresések fejlesztésében"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -10612,7 +10584,7 @@ msgstr "Működés leírása"
 #. Headline in chat history about modals for the temporary encrypted server storage explanation.
 msgctxt "Chat history about modal list item headline"
 msgid "How it works"
-msgstr ""
+msgstr "Működés leírása"
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -10887,8 +10859,7 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"Ha támogatni szeretnél minket, segíts a %1$sDuckDuckGo terjesztésében%2$s"
+msgstr "Ha támogatni szeretnél minket, segíts a %1$sDuckDuckGo terjesztésében%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -11089,8 +11060,7 @@ msgstr ""
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
-msgstr ""
-"A fenti menüben válaszd az %1$sEszközök%2$s > %3$sBeállítások%4$s lehetőséget"
+msgstr "A fenti menüben válaszd az %1$sEszközök%2$s > %3$sBeállítások%4$s lehetőséget"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -12081,7 +12051,7 @@ msgstr "A link 7 nap múlva lejár."
 #. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days. People can save a chat copy."
-msgstr ""
+msgstr "A link 7 nap múlva lejár. A felhasználók elmenthetik a csevegés másolatát."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -12398,8 +12368,7 @@ msgstr "Ügyelj rá, hogy minden szó helyesen legyen írva."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr ""
-"Ne felejtse el bejelölni, hogy %1$s„Legyen ez az alapértelmezett keresőm”%2$s"
+msgstr "Ne felejtse el bejelölni, hogy %1$s„Legyen ez az alapértelmezett keresőm”%2$s"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -14210,7 +14179,7 @@ msgstr "OK, vettem!"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "OPTIONAL"
-msgstr ""
+msgstr "OPCIONÁLIS"
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -14482,8 +14451,7 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr ""
-"Hoppá! Váratlan hiba történt a szöveg fordítása közben. Próbáld újra később."
+msgstr "Hoppá! Váratlan hiba történt a szöveg fordítása közben. Próbáld újra később."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -14846,9 +14814,9 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"Mobiltelefonos böngészőnk keresőmotorunkat, követésvédelmünket, titkosítás-"
-"végrehajtónkat stb. magában foglalva áll rendelkezésedre. %1$siOS és "
-"Android%2$s rendszerhez is elérhető."
+"Mobiltelefonos böngészőnk keresőmotorunkat, követésvédelmünket, "
+"titkosítás-végrehajtónkat stb. magában foglalva áll rendelkezésedre. %1$siOS "
+"és Android%2$s rendszerhez is elérhető."
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -15474,8 +15442,7 @@ msgstr "Kitűzött"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
-"A kitűzött csevegések a legutóbbi csevegések felső részében jelennek meg."
+msgstr "A kitűzött csevegések a legutóbbi csevegések felső részében jelennek meg."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -15516,8 +15483,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr ""
-"A következő feladat elvégzésével igazold, hogy az utasítást ember adta."
+msgstr "A következő feladat elvégzésével igazold, hogy az utasítást ember adta."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -15525,8 +15491,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr ""
-"A következő feladat elvégzésével igazold, hogy a keresést ember végezte."
+msgstr "A következő feladat elvégzésével igazold, hogy a keresést ember végezte."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -15737,8 +15702,8 @@ msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
 msgstr ""
-"Ráadásul az, amit a Duck Playerben nézel, nem fogja befolyásolni a YouTube-"
-"javaslataidat."
+"Ráadásul az, amit a Duck Playerben nézel, nem fogja befolyásolni a "
+"YouTube-javaslataidat."
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -16348,7 +16313,7 @@ msgstr "Védett"
 #. Headline in sync-enabled chat history about modals explaining encrypted server storage.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Protected with end-to-end encryption"
-msgstr ""
+msgstr "Végpontok közötti titkosítással védve"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -16487,7 +16452,7 @@ msgstr "Ranglisták"
 #. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
 msgctxt "star rating on a product"
 msgid "Rated %s out of %s"
-msgstr ""
+msgstr "%2$s csillagból %1$s csillagra értékelve"
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -16568,15 +16533,13 @@ msgstr "Érvelő mesterséges intelligencia, magas szintű beépített moderáci
 #. Text with short description for a reasoning AI (Artificial Intelligence) Model that has a low moderation level. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with low built-in moderation"
-msgstr ""
-"Érvelő mesterséges intelligencia, alacsony szintű beépített moderációval"
+msgstr "Érvelő mesterséges intelligencia, alacsony szintű beépített moderációval"
 
 # smartling.placeholder_format=C
 #. Text with short description for a reasoning AI (Artificial Intelligence) Model that has a medium moderation level. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
-msgstr ""
-"Érvelő mesterséges intelligencia, közepes szintű beépített moderációval"
+msgstr "Érvelő mesterséges intelligencia, közepes szintű beépített moderációval"
 
 # smartling.placeholder_format=C
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
@@ -16588,15 +16551,13 @@ msgstr "Érveléssel jobb válaszok kaphatók az összetett kérdésekre."
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
-msgstr ""
-"Az érvelés alaposabb, de 2–5-ször hamarabb éri el a használati limitet. %1$s"
+msgstr "Az érvelés alaposabb, de 2–5-ször hamarabb éri el a használati limitet. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr ""
-"Az érvelés alaposabb, de 2–5-ször gyorsabban fogyasztja a limitet. %1$s"
+msgstr "Az érvelés alaposabb, de 2–5-ször gyorsabban fogyasztja a limitet. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -16965,8 +16926,7 @@ msgstr "Választott beállítás megjegyzése"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Jegyezze meg a választásomat (módosítható a %1$s%2$s%3$sBeállításokban%4$s)"
+msgstr "Jegyezze meg a választásomat (módosítható a %1$s%2$s%3$sBeállításokban%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -17250,8 +17210,8 @@ msgid ""
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
 "A válaszok kizárólag tájékoztatási célokat szolgálnak, és nem minősülnek "
-"orvosi, jogi, pénzügyi, befektetési vagy egyéb szakmai tanácsnak. Az AI-"
-"alapú válaszok a %1$sSzolgáltatási feltételek%2$s hatálya alá esnek."
+"orvosi, jogi, pénzügyi, befektetési vagy egyéb szakmai tanácsnak. Az "
+"AI-alapú válaszok a %1$sSzolgáltatási feltételek%2$s hatálya alá esnek."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -17346,8 +17306,7 @@ msgstr "A találatok nem tartalmazzák a blokkolt webhelyeket."
 #. Informational banner shown at the top of the Maps search results panel when the user has blocked Yelp or TripAdvisor in their settings. Explains why ratings, reviews, and other details may be missing from place listings.
 msgctxt "Exclusion message at top of maps vertical"
 msgid "Results exclude information from blocked sites."
-msgstr ""
-"A találatok nem tartalmazzák a blokkolt webhelyekről származó információkat."
+msgstr "A találatok nem tartalmazzák a blokkolt webhelyekről származó információkat."
 
 # smartling.placeholder_format=C
 #. Message that appears when results exclude blocked sites
@@ -17732,7 +17691,7 @@ msgstr "Csevegések mentése minden eszközön."
 #. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
 msgctxt "Chat history about modal list item headline"
 msgid "Save your chats on this device"
-msgstr ""
+msgstr "Csevegések mentése ezen az eszközön"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
@@ -17762,8 +17721,7 @@ msgstr "Üdvözöl a Duck.ai"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr ""
-"Üdvözöl a Duck.ai – ingyenes, privát AI-csevegés a DuckDuckGo kínálatában."
+msgstr "Üdvözöl a Duck.ai – ingyenes, privát AI-csevegés a DuckDuckGo kínálatában."
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17950,13 +17908,12 @@ msgctxt ""
 "Placeholder and accessibility label for the search input in the tab picker "
 "dialog"
 msgid "Search"
-msgstr ""
+msgstr "Keresés"
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
 msgid "Search %s to find results closer to you?"
-msgstr ""
-"A helyileg közelebbi találatokhoz a keresési kifejezés legyen inkább „%1$s”?"
+msgstr "A helyileg közelebbi találatokhoz a keresési kifejezés legyen inkább „%1$s”?"
 
 # smartling.placeholder_format=C
 #. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
@@ -18368,8 +18325,7 @@ msgstr "Fényképek megtekintése"
 #. Text for a button that links to the terms of use and privacy policy page.
 msgctxt "Secondary button text in active privacy modal"
 msgid "See Privacy Policy and Terms of Service"
-msgstr ""
-"Tekintse meg az Adatvédelmi szabályzatot és a Szolgáltatási feltételeket"
+msgstr "Tekintse meg az Adatvédelmi szabályzatot és a Szolgáltatási feltételeket"
 
 # smartling.placeholder_format=C
 #. Text of the secondary button in the modal that allows the user to open the terms and privacy policy page.
@@ -18435,8 +18391,7 @@ msgstr "További információ: %1$s"
 # smartling.placeholder_format=C
 #. Title of a notice that DuckDuckGo has noticed the user is blocking its non-tracking ads
 msgid "See more shopping results from popular retailers"
-msgstr ""
-"További vásárlási találatok megtekintése a népszerű kiskereskedők kínálatából"
+msgstr "További vásárlási találatok megtekintése a népszerű kiskereskedők kínálatából"
 
 # smartling.placeholder_format=C
 #. Text for tooltip shown on hover when displaying the number of reviews the product has on an ad, indicating that users can see more ratings on bing.com
@@ -18492,8 +18447,8 @@ msgstr ""
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Válaszd az %1$sEgyéni%2$s lehetőséget, és írd be a %3$shttps://duckduckgo."
-"com%4$s címet a beviteli mezőbe"
+"Válaszd az %1$sEgyéni%2$s lehetőséget, és írd be a "
+"%3$shttps://duckduckgo.com%4$s címet a beviteli mezőbe"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -18541,8 +18496,7 @@ msgstr "Válaszd a %1$sDuckDuckGót%2$s a keresőszolgáltatók listáján"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr ""
-"Válaszd a %1$sDuckDuckGót%2$s az %3$sAlapértelmezett keresőmotor%4$s menüben"
+msgstr "Válaszd a %1$sDuckDuckGót%2$s az %3$sAlapértelmezett keresőmotor%4$s menüben"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -18553,8 +18507,7 @@ msgstr "Válaszd a %1$sDuckDuckGo%2$s lehetőséget."
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr ""
-"Válaszd a %1$sKeresőmotorok szerkesztése%2$s menüpontot a legördülő menüben"
+msgstr "Válaszd a %1$sKeresőmotorok szerkesztése%2$s menüpontot a legördülő menüben"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18597,8 +18550,7 @@ msgstr "Válaszd ki a %1$sKeresőmotor%2$s lehetőséget"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"
-msgstr ""
-"Válaszd a %1$sKeresőmotor%2$s lehetőséget, majd az %3$sEgyéb...%4$s opciót"
+msgstr "Válaszd a %1$sKeresőmotor%2$s lehetőséget, majd az %3$sEgyéb...%4$s opciót"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -18623,8 +18575,7 @@ msgstr "Válaszd ki a %1$sBeállítások%2$s opciót a legördülő menüből."
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sAdvanced settings%s"
-msgstr ""
-"Válaszd a %1$sBeállítások%2$s, majd a %3$sHaladó beállítások%4$s lehetőséget"
+msgstr "Válaszd a %1$sBeállítások%2$s, majd a %3$sHaladó beállítások%4$s lehetőséget"
 
 # smartling.placeholder_format=C
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -18984,8 +18935,7 @@ msgstr "Megosztás"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Terjeszd a DuckDuckGót, és segíts a barátaidnak megvédeni az adataikat!"
+msgstr "Terjeszd a DuckDuckGót, és segíts a barátaidnak megvédeni az adataikat!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -19012,8 +18962,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"A relevancia javítása érdekében oszd meg a városi szintű helyadataidat az AI-"
-"modellekkel. A Duck.ai soha nem árulja el nekünk vagy az AI-modelleknek a "
+"A relevancia javítása érdekében oszd meg a városi szintű helyadataidat az "
+"AI-modellekkel. A Duck.ai soha nem árulja el nekünk vagy az AI-modelleknek a "
 "pontos tartózkodási helyedet."
 
 # smartling.placeholder_format=C
@@ -19099,8 +19049,7 @@ msgstr "Beszélgetés megosztása a DuckDuckGóval"
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share your prompt and chat response with DuckDuckGo"
-msgstr ""
-"Oszd meg az utasításodat és a beszélgetésben kapott választ a DuckDuckGóval"
+msgstr "Oszd meg az utasításodat és a beszélgetésben kapott választ a DuckDuckGóval"
 
 # smartling.placeholder_format=C
 #. Variant of the share toggle label that makes sharing mandatory when reporting harmful or illegal content.
@@ -19158,7 +19107,7 @@ msgstr "Vásárlás"
 #. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
 msgctxt "Button in the merchandise logo modal (mobile)"
 msgid "Shop Now"
-msgstr ""
+msgstr "Vásárlás most"
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -19385,8 +19334,7 @@ msgstr "Minden találat megjelenítése"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show answers more often. (You can also %sturn them off%s.)"
-msgstr ""
-"Gyakrabban jelenítse meg a válaszokat. (%1$sKi is kapcsolhatod%2$s ezeket.)"
+msgstr "Gyakrabban jelenítse meg a válaszokat. (%1$sKi is kapcsolhatod%2$s ezeket.)"
 
 # smartling.placeholder_format=C
 #. Accessible label for the button that reveals a popover listing multiple citation sources in Duck.ai chat responses.
@@ -19549,14 +19497,12 @@ msgstr "A legtöbbször meglátogatott hivatkozások megjelenítése új lapon"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Alkalmi emlékeztetők megjelenítése a DuckDuckGo hozzáadására a böngésződhöz"
+msgstr "Alkalmi emlékeztetők megjelenítése a DuckDuckGo hozzáadására a böngésződhöz"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Alkalmi emlékeztetők megjelenítése a DuckDuckGo hozzáadására az eszközeidhez"
+msgstr "Alkalmi emlékeztetők megjelenítése a DuckDuckGo hozzáadására az eszközeidhez"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19574,8 +19520,7 @@ msgstr "Oldalszám megjelenítése a találati oldalak töréseinél"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows sign-up form for the DuckDuckGo privacy newsletters"
-msgstr ""
-"A DuckDuckGo adatvédelmi hírleveleire való feliratkozási űrlap megjelenítése"
+msgstr "A DuckDuckGo adatvédelmi hírleveleire való feliratkozási űrlap megjelenítése"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/94erFcS.png
@@ -19603,8 +19548,7 @@ msgstr "Üdvözlőüzenet megjelenítése a keresési találati oldal tetején"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Üdvözlő üzenet megjelenítése az EU-s Android-preferencia menü felhasználóinak"
+msgstr "Üdvözlő üzenet megjelenítése az EU-s Android-preferencia menü felhasználóinak"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -19681,8 +19625,7 @@ msgstr "Az oldalkeresés átmenetileg nem érhető el. Dolgozunk a megoldáson."
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"Az általad blokkolt webhelyek el lesznek rejtve minden keresési találatból"
+msgstr "Az általad blokkolt webhelyek el lesznek rejtve minden keresési találatból"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -20827,6 +20770,8 @@ msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
 msgstr ""
+"A Sync & Backup több csevegést ment, és szinkronizálja őket az összes "
+"eszközödön."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20949,7 +20894,7 @@ msgstr "Csevegések szinkronizálása minden eszközön."
 #. Headline in sync-enabled chat history about modals explaining cross-device sync.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Sync your chats across all your devices"
-msgstr ""
+msgstr "Csevegések szinkronizálása minden eszközödön"
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21145,8 +21090,7 @@ msgstr "Koppints a címsorban található %1$sengedélyek ikonra%2$s"
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Tap the vertical dots in the DuckDuckGo app."
-msgstr ""
-"Koppints a függőlegesen elhelyezkedő pontokra a DuckDuckGo alkalmazásban."
+msgstr "Koppints a függőlegesen elhelyezkedő pontokra a DuckDuckGo alkalmazásban."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a teacher in its responses.
@@ -21315,21 +21259,18 @@ msgstr "Gambia"
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB"
-msgstr ""
-"A csatolt fájlok összmérete meghaladja a maximálisan megengedett %1$s MB-ot"
+msgstr "A csatolt fájlok összmérete meghaladja a maximálisan megengedett %1$s MB-ot"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB."
-msgstr ""
-"A csatolt fájlok összmérete meghaladja a maximálisan megengedett %1$s MB-ot."
+msgstr "A csatolt fájlok összmérete meghaladja a maximálisan megengedett %1$s MB-ot."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
 msgid "The audio could not be processed. Please try recording again."
-msgstr ""
-"A hanganyag feldolgozása sikertelen volt. Próbálkozz újra a felvétellel."
+msgstr "A hanganyag feldolgozása sikertelen volt. Próbálkozz újra a felvétellel."
 
 # smartling.placeholder_format=C
 #. Second paragraph explaining where the encryption key is stored on the entry screen.
@@ -21546,19 +21487,20 @@ msgid ""
 "This chat and its generated images become public when you create and copy "
 "the link."
 msgstr ""
+"A csevegés és a benne generált képek nyilvánossá válnak, amikor létrehozod "
+"és másolod a linket."
 
 # smartling.placeholder_format=C
 #. Explains that creating and copying a share link makes the selected chat content public.
 msgctxt "Share modal info bullet about public access"
 msgid "This chat becomes public when you create and copy the link."
-msgstr ""
+msgstr "A csevegés nyilvánossá válik, amikor létrehozod és másolod a linket."
 
 # smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
-msgstr ""
-"Ez a csevegés a Duck.ai-ban marad, és megőrzi számodra privát jellegét."
+msgstr "Ez a csevegés a Duck.ai-ban marad, és megőrzi számodra privát jellegét."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21695,8 +21637,8 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
 msgstr ""
-"Ez a képtípus nem támogatott. Kérjük, csatolj egy JPG-, PNG-, WebP- vagy GIF-"
-"fájlt"
+"Ez a képtípus nem támogatott. Kérjük, csatolj egy JPG-, PNG-, WebP- vagy "
+"GIF-fájlt"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
@@ -21704,8 +21646,8 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
 msgstr ""
-"Ez a képtípus nem támogatott. Kérjük, csatolj egy JPG-, PNG-, WebP- vagy GIF-"
-"fájlt."
+"Ez a képtípus nem támogatott. Kérjük, csatolj egy JPG-, PNG-, WebP- vagy "
+"GIF-fájlt."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -21815,9 +21757,9 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"Ez a beállítás a böngésződben kerül tárolásra, tehát ha törlöd a duckduckgo."
-"com böngészési adatait, előfordulhat, hogy ismét megjelennek a mesterséges "
-"intelligencia segítségével generált válaszok."
+"Ez a beállítás a böngésződben kerül tárolásra, tehát ha törlöd a "
+"duckduckgo.com böngészési adatait, előfordulhat, hogy ismét megjelennek a "
+"mesterséges intelligencia segítségével generált válaszok."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21827,9 +21769,9 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"Ez a beállítás a böngésződben kerül tárolásra, tehát ha törlöd a duckduckgo."
-"com böngészési adatait, előfordulhat, hogy ismét megjelennek a mesterséges "
-"intelligencia segítségével generált válaszok. Ugyanakkor van egy "
+"Ez a beállítás a böngésződben kerül tárolásra, tehát ha törlöd a "
+"duckduckgo.com böngészési adatait, előfordulhat, hogy ismét megjelennek a "
+"mesterséges intelligencia segítségével generált válaszok. Ugyanakkor van egy "
 "kezdőoldalunk, amely soha nem jelenít meg AI-alapú válaszokat: %1$s."
 
 # smartling.placeholder_format=C
@@ -21873,8 +21815,7 @@ msgstr "Ez a videó még nem tekinthető meg itt. Megnézheted itt: %1$s."
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Ez a weboldal nem használ biztonságos, titkosított kapcsolatot (HTTPS)."
+msgstr "Ez a weboldal nem használ biztonságos, titkosított kapcsolatot (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -22052,8 +21993,8 @@ msgid ""
 "you originally used to set up Sync."
 msgstr ""
 "A szinkronizált adatok visszaállításához szükség lesz a szinkronizálás első "
-"beállításakor mentett helyreállítási kódra. Lehetséges, hogy ez a kód PDF-"
-"fájlként lett mentve a szinkronizálás beállításához eredetileg használt "
+"beállításakor mentett helyreállítási kódra. Lehetséges, hogy ez a kód "
+"PDF-fájlként lett mentve a szinkronizálás beállításához eredetileg használt "
 "eszközre."
 
 # smartling.placeholder_format=C
@@ -22095,7 +22036,7 @@ msgstr "Ma"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
-msgstr ""
+msgstr "Válts privát AI-csevegésre, vagy %1$stiltsd le a beállításokban%2$s."
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -22445,8 +22386,7 @@ msgstr "Próbálkozz ezzel: %1$s"
 # smartling.placeholder_format=C
 #. Prompt for the user to start using our homepage that doesn't show promotional messages. The placeholder is a homepage url (e.g., 'start.duckduckgo.com')
 msgid "Try %s to stop seeing messages like this."
-msgstr ""
-"Próbáld ki a(z) %1$s címet, hogy többé ne jelenjenek meg ilyen üzenetek."
+msgstr "Próbáld ki a(z) %1$s címet, hogy többé ne jelenjenek meg ilyen üzenetek."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
@@ -22597,16 +22537,14 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"A pontosabb eredmények érdekében próbálkozz az anonim hely engedélyezésével."
+msgstr "A pontosabb eredmények érdekében próbálkozz az anonim hely engedélyezésével."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Próbálj kísérletezni az egyes modellekkel – különböző válaszokat generálnak."
+msgstr "Próbálj kísérletezni az egyes modellekkel – különböző válaszokat generálnak."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -22658,8 +22596,7 @@ msgstr "Próbáld ki ingyen"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr ""
-"Próbáld ki ingyen! Biztonságos VPN, fejlett és privát MI, és még sok más."
+msgstr "Próbáld ki ingyen! Biztonságos VPN, fejlett és privát MI, és még sok más."
 
 # smartling.placeholder_format=C
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
@@ -22698,8 +22635,7 @@ msgstr "Próbáld ki a böngészőnket,"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr ""
-"Próbáld ki a kezdőoldalunkat, ahol soha nem mutatjuk ezeket az üzeneteket:"
+msgstr "Próbáld ki a kezdőoldalunkat, ahol soha nem mutatjuk ezeket az üzeneteket:"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time; shown in the US. Invites the user to start a free trial of the paid subscription.
@@ -22976,8 +22912,7 @@ msgstr "A pontosabb találatokhoz kapcsold be a %1$sPontos hely%2$s funkciót"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr ""
-"Duck Player bekapcsolása a YouTube célzott hirdetések nélküli megtekintéséhez"
+msgstr "Duck Player bekapcsolása a YouTube célzott hirdetések nélküli megtekintéséhez"
 
 # smartling.placeholder_format=C
 #. Button that enables the Search/Duck.ai toggle.
@@ -23210,8 +23145,7 @@ msgstr "Az %1$sÁltalános > Kezdőlap%2$s alatt írd be: https://duckduckgo.com
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch Settings%s select %sDuckDuckGo%s"
-msgstr ""
-"A %1$sKeresési beállítások%2$s alatt válaszd a %3$sDuckDuckGo%4$s lehetőséget"
+msgstr "A %1$sKeresési beállítások%2$s alatt válaszd a %3$sDuckDuckGo%4$s lehetőséget"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23320,8 +23254,8 @@ msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
 msgstr ""
-"Válts Pro verzióra, hogy hozzáférj a(z) %1$s modellhez, a fejlettebb MI-"
-"érveléshez és a Plus csomagnál kétszer magasabb használati korlátokhoz."
+"Válts Pro verzióra, hogy hozzáférj a(z) %1$s modellhez, a fejlettebb "
+"MI-érveléshez és a Plus csomagnál kétszer magasabb használati korlátokhoz."
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -23343,8 +23277,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Fejlett MI-modelleket és nagyobb használati kereteket érhetsz el DuckDuckGo-"
-"előfizetéssel"
+"Fejlett MI-modelleket és nagyobb használati kereteket érhetsz el "
+"DuckDuckGo-előfizetéssel"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -23949,6 +23883,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Yelp's ad network."
 msgstr ""
+"A hirdetéseket a DuckDuckGo adatvédelme keretében tekintheted meg. A "
+"hirdetéskattintásokat a Yelp hirdetési hálózata kezeli."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -23996,9 +23932,9 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"Nyisd meg a Duck.ai-t a másik böngésződben, és lépj ide: %1$sDuck.ai-"
-"beállítások%2$s > %3$sSync & Backup%4$s > %5$sKezelés%6$s, majd válaszd a "
-"%7$sSzinkronizálás másik eszközzel%8$s lehetőséget."
+"Nyisd meg a Duck.ai-t a másik böngésződben, és lépj ide: "
+"%1$sDuck.ai-beállítások%2$s > %3$sSync & Backup%4$s > %5$sKezelés%6$s, majd "
+"válaszd a %7$sSzinkronizálás másik eszközzel%8$s lehetőséget."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -24037,8 +23973,8 @@ msgstr ""
 "Látogass el a Duck.ai oldalra a másik böngésződben vagy a DuckDuckGo "
 "alkalmazásban, és nyisd meg a Duck.ai beállításait. Válaszd a „Bekapcsolás” "
 "lehetőséget a Sync & Backup alatt, és válaszd a „Szinkronizálás másik "
-"eszközzel” opciót. Vagy olvasd be a helyreállítási PDF-ben található QR-"
-"kódot."
+"eszközzel” opciót. Vagy olvasd be a helyreállítási PDF-ben található "
+"QR-kódot."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -24091,8 +24027,8 @@ msgstr "A hangcsevegés véget ért"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"A hangcsevegéseket anonim módon kezeljük, és soha nem használjuk fel MI-"
-"modellek betanítására."
+"A hangcsevegéseket anonim módon kezeljük, és soha nem használjuk fel "
+"MI-modellek betanítására."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -24236,8 +24172,9 @@ msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
-"Nézd a tartalmat Duck Playerrel, hogy blokkold a személyre szabott YouTube-"
-"hirdetéseket, és a megtekintéseid ne befolyásolják a YouTube ajánlásait."
+"Nézd a tartalmat Duck Playerrel, hogy blokkold a személyre szabott "
+"YouTube-hirdetéseket, és a megtekintéseid ne befolyásolják a YouTube "
+"ajánlásait."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -24306,16 +24243,14 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can use your anonymous%s location%s to show you nearby results."
-msgstr ""
-"Anonim%1$s helyed%2$s felhasználásával közeli eredményeket mutathatunk neked."
+msgstr "Anonim%1$s helyed%2$s felhasználásával közeli eredményeket mutathatunk neked."
 
 # smartling.placeholder_format=C
 #. Error message displayed when one or more attached files are encrypted and cannot be read.
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"Nem tudjuk olvasni a csatolt fájlokat, mert legalább az egyik titkosítva van."
+msgstr "Nem tudjuk olvasni a csatolt fájlokat, mert legalább az egyik titkosítva van."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24357,8 +24292,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr ""
-"Nem követünk téged, ezért tőled kell megkérdeznünk, hogy mi járatban vagy:"
+msgstr "Nem követünk téged, ezért tőled kell megkérdeznünk, hogy mi járatban vagy:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -24531,8 +24465,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr ""
-"Blokkoljuk a böngészés közben adataid gyűjtésével próbálkozó nyomkövetőket."
+msgstr "Blokkoljuk a böngészés közben adataid gyűjtésével próbálkozó nyomkövetőket."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
@@ -24724,8 +24657,8 @@ msgid ""
 "anonymized by us and not used to train AI models."
 msgstr ""
 "Üdvözöl a DuckDuckGo AI Chat! Minden itt folytatott beszélgetésed privát, "
-"anonimizáljuk azokat, és nem használjuk fel mesterségesintelligencia-"
-"modellek tanítására."
+"anonimizáljuk azokat, és nem használjuk fel "
+"mesterségesintelligencia-modellek tanítására."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -24737,15 +24670,14 @@ msgid ""
 msgstr ""
 "Üdvözöl a DuckDuckGo AI Chat! A csevegést a(z) %1$s %2$s technológiája "
 "szolgáltatja. Minden itt folytatott beszélgetésed privát, melyeket a "
-"DuckDuckGo soha nem tárol, és nem használ fel a mesterségesintelligencia-"
-"modellek tanítására."
+"DuckDuckGo soha nem tárol, és nem használ fel a "
+"mesterségesintelligencia-modellek tanítására."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"Üdvözöl az új Duck.ai! Mostantól importálhatod a letöltött csevegéseidet."
+msgstr "Üdvözöl az új Duck.ai! Mostantól importálhatod a letöltött csevegéseidet."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24844,8 +24776,7 @@ msgstr ""
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr ""
-"Milyen látnivalókat érdemes megnézni Párizsban annak, aki először jár ott?"
+msgstr "Milyen látnivalókat érdemes megnézni Párizsban annak, aki először jár ott?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -25232,8 +25163,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"Engedélyezés esetén a Duck.ai azonnali válaszokat jelenít meg a csevegésben."
+msgstr "Engedélyezés esetén a Duck.ai azonnali válaszokat jelenít meg a csevegésben."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -25251,8 +25181,7 @@ msgstr "Hol nézhető meg a(z) <strong>%1$s</strong>?"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr ""
-"A kezdőoldalon kattints a %1$sJelenlegi oldal beállítása%2$s lehetőségre."
+msgstr "A kezdőoldalon kattints a %1$sJelenlegi oldal beállítása%2$s lehetőségre."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -25441,6 +25370,8 @@ msgid ""
 "With chat history on, up to %s of your most recent chats will be saved on "
 "this device."
 msgstr ""
+"Ha be vannak kapcsolva a csevegési előzmények funkció, legfeljebb %1$s "
+"legutóbbi csevegésed mentve lesz ezen az eszközön."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline in the About Chat History modal.
@@ -25448,6 +25379,8 @@ msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, your most recent chats will be saved on this device."
 msgstr ""
+"Ha be van kapcsolva a csevegési előzmények funkció, a legutóbbi csevegéseid "
+"mentve lesznek ezen az eszközön."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -25750,8 +25683,7 @@ msgstr ""
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
 msgctxt "Information about direct access to DuckDuckGo AI Chat"
 msgid "You can access DuckDuckGo AI Chat directly at %s."
-msgstr ""
-"A DuckDuckGo AI Chat csevegője közvetlenül elérhető a következő címen: %1$s."
+msgstr "A DuckDuckGo AI Chat csevegője közvetlenül elérhető a következő címen: %1$s."
 
 # smartling.placeholder_format=C
 #. Search Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Search Assist.
@@ -25811,8 +25743,7 @@ msgstr "Ezt a %1$sKeresési beállítások%2$s oldalon bármikor módosíthatod"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr ""
-"A csevegést folytathatod, miután a limited alaphelyzetbe áll ekkor: %1$s."
+msgstr "A csevegést folytathatod, miután a limited alaphelyzetbe áll ekkor: %1$s."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -25851,8 +25782,7 @@ msgstr "A havi limit felhasználásával folytathatod a csevegést."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Mostantól akár 100 csevegést is menthetsz ezen az eszközön. Csevegj bátran!"
+msgstr "Mostantól akár 100 csevegést is menthetsz ezen az eszközön. Csevegj bátran!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -26125,8 +26055,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr ""
-"Elérted az üzenetek pillanatnyi maximális számát. Próbálkozz újra később."
+msgstr "Elérted az üzenetek pillanatnyi maximális számát. Próbálkozz újra később."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -26397,22 +26326,19 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr ""
-"A csevegések importálva lettek. Folytasd ott, ahol abbahagytad a Duck.ai-ban."
+msgstr "A csevegések importálva lettek. Folytasd ott, ahol abbahagytad a Duck.ai-ban."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
 msgctxt "Description for the joiner-device success screen"
 msgid "Your chats will now sync between these devices."
-msgstr ""
-"A beszélgetéseid mostantól szinkronizálódnak ezek között az eszközök között."
+msgstr "A beszélgetéseid mostantól szinkronizálódnak ezek között az eszközök között."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the success screen after a successful pairing.
 msgctxt "Description for the success screen"
 msgid "Your chats will now sync between these devices."
-msgstr ""
-"A beszélgetéseid mostantól szinkronizálódnak ezek között az eszközök között."
+msgstr "A beszélgetéseid mostantól szinkronizálódnak ezek között az eszközök között."
 
 # smartling.placeholder_format=C
 #. Description explaining why delegation is needed for image generation.
@@ -26562,8 +26488,7 @@ msgstr ""
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
 msgctxt "Body copy on the recover-data success sheet"
 msgid "Your synced chats are being restored to this device."
-msgstr ""
-"A szinkronizált csevegéseket a rendszer erre az eszközre állítja vissza."
+msgstr "A szinkronizált csevegéseket a rendszer erre az eszközre állítja vissza."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -26623,8 +26548,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr ""
-"Elérted a napi üzenetek maximális számát. Holnap folytasd ezt a csevegést."
+msgstr "Elérted a napi üzenetek maximális számát. Holnap folytasd ezt a csevegést."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -26858,7 +26782,7 @@ msgstr "p"
 #. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the chat options menu button"
 msgid "menu"
-msgstr ""
+msgstr "menü"
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.
@@ -26933,8 +26857,8 @@ msgstr "hivatalos webhely"
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
 msgstr ""
-"vagy írd ki a választott szín kódját, pl. %1$s (%2$s egy kódolt %3$s-"
-"karakter)."
+"vagy írd ki a választott szín kódját, pl. %1$s (%2$s egy kódolt "
+"%3$s-karakter)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/hu_HU/LC_MESSAGES/duckduckgo.po
+++ b/locales/hu_HU/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: hu_HU\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1221,6 +1221,12 @@ msgid "About our ads"
 msgstr "Tudnivalók a hirdetéseinkről"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1352,6 +1358,20 @@ msgid "Ad is suspicious"
 msgstr "A hirdetés gyanús"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "DuckDuckGo hozzáadása"
@@ -1378,6 +1398,27 @@ msgstr "DuckDuckGo hozzáadása keresőmotorként"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "DuckDuckGo hozzáadása %1$s-bővítményként"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1423,6 +1464,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Oldal tartalmának hozzáadása"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1508,6 +1565,12 @@ msgstr "Kiegészítők"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Utolsó simítások hozzáadása"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1812,6 +1875,12 @@ msgstr "Minden szín"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Minden kész!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3539,6 +3608,14 @@ msgid "Cancel"
 msgstr "Mégse"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4035,10 +4112,22 @@ msgid "Chat response is offensive"
 msgstr "A csevegés válasza bántó"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Csevegési partner: %1$s"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4057,6 +4146,14 @@ msgstr "Csevegések"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Csevegések"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5677,6 +5774,12 @@ msgid "Current Streak"
 msgstr "Jelenlegi sorozat"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -6023,6 +6126,12 @@ msgstr "Csevegések törlése"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "30 napnál régebbi csevegések törlése"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6440,6 +6549,12 @@ msgstr "Végleges bezárás"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Promóció bezárása"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7628,6 +7743,12 @@ msgid "Edit Prompt"
 msgstr "Utasítás szerkesztése"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7851,6 +7972,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Titkosított modell"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8703,6 +8830,12 @@ msgid "Follow-up question"
 msgstr "Kapcsolódó kérdés"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9221,6 +9354,12 @@ msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
 "Vedd igénybe a DuckDuckGo VPN-t, a fejlett Duck.ai-t és a személyazonosság "
 "helyreállításához használható Identity Theft Restoration funkciókat."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10468,6 +10607,12 @@ msgstr "Mitől névtelen?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Működés leírása"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11931,6 +12076,12 @@ msgstr "Megnyert bedobások"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "A link 7 nap múlva lejár."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14054,6 +14205,12 @@ msgstr "OK"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "OK, vettem!"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16188,6 +16345,12 @@ msgid "Protected"
 msgstr "Védett"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Védelem. Adatvédelem. Nyugalom."
@@ -16319,6 +16482,12 @@ msgstr "Eső"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Ranglisták"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17560,6 +17729,12 @@ msgid "Save your chats across all your devices."
 msgstr "Csevegések mentése minden eszközön."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17768,6 +17943,14 @@ msgstr "Keresés"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Keresés"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18970,6 +19153,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Vásárlás"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20632,6 +20821,14 @@ msgstr ""
 "helyre."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20747,6 +20944,12 @@ msgstr "Szinkronizálj egy közeli eszközzel."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Csevegések szinkronizálása minden eszközön."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21335,6 +21538,22 @@ msgid "This Week"
 msgstr "Ezen a héten"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21871,6 +22090,12 @@ msgstr "Ma"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Ma"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23718,6 +23943,14 @@ msgstr ""
 "hirdetéskattintásokat a TripAdvisor hirdetési hálózata kezeli."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Virgin-szigetek"
 
@@ -25202,6 +25435,21 @@ msgstr ""
 "a(z) „%1$s” menüben."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26605,6 +26853,12 @@ msgstr "p"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "p"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/hy_AM/LC_MESSAGES/duckduckgo.po
+++ b/locales/hy_AM/LC_MESSAGES/duckduckgo.po
@@ -980,6 +980,11 @@ msgstr "Մեր մասին"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1083,6 +1088,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #  Marked fuzzy because of translated trademark
 #. Link to add the DuckDuckGo extension to the user's web browser.
 #, fuzzy
@@ -1106,6 +1123,24 @@ msgstr ""
 #, fuzzy
 msgid "Add DuckDuckGo to %s"
 msgstr "Ավելացնել DuckDuckGo֊ն %s֊ին"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1144,6 +1179,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1215,6 +1264,11 @@ msgstr "Հավելումներ"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1459,6 +1513,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2810,6 +2869,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3210,9 +3276,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3228,6 +3304,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4487,6 +4570,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4771,6 +4859,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5109,6 +5202,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6013,6 +6111,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6190,6 +6293,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6857,6 +6965,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7275,6 +7388,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8261,6 +8379,11 @@ msgid "How is it anonymous?"
 msgstr "Ինչպե՞ս է սա անստորագիր։"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9418,6 +9541,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11159,6 +11287,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "Լավ, հասկացա՛"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12863,6 +12996,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12969,6 +13107,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13957,6 +14100,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14112,6 +14260,13 @@ msgstr "Փնտրել"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15035,6 +15190,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16376,6 +16536,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16456,6 +16623,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16916,6 +17088,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17318,6 +17504,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18780,6 +18971,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19929,6 +20127,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21017,6 +21228,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/id_ID/LC_MESSAGES/duckduckgo.po
+++ b/locales/id_ID/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: id_ID\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -307,8 +307,7 @@ msgstr "Peringkat %1$s belum tersedia"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits 2-5x faster than other models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
-msgstr ""
-"%1$s mencapai batas penggunaan 2-5x lebih cepat daripada model dasar. %2$s"
+msgstr "%1$s mencapai batas penggunaan 2-5x lebih cepat daripada model dasar. %2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -528,8 +527,7 @@ msgstr "%1$sTekan lama%2$s ikon aplikasi DuckDuckGo di layar beranda"
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr ""
-"%1$sUps!%2$s%3$sAda yang tidak beres. Silakan %4$srefresh%5$s dan coba lagi."
+msgstr "%1$sUps!%2$s%3$sAda yang tidak beres. Silakan %4$srefresh%5$s dan coba lagi."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -953,16 +951,14 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"Versi baru AI Chat tersedia! Silakan refresh halaman ini untuk melanjutkan."
+msgstr "Versi baru AI Chat tersedia! Silakan refresh halaman ini untuk melanjutkan."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"Versi baru Duck.ai tersedia! Silakan refresh halaman ini untuk melanjutkan."
+msgstr "Versi baru Duck.ai tersedia! Silakan refresh halaman ini untuk melanjutkan."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1217,7 +1213,7 @@ msgstr "Tentang iklan kami"
 #. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
 msgctxt "Modal header for chat history with sync information"
 msgid "About Chat History with Sync & Backup"
-msgstr ""
+msgstr "Tentang Riwayat Obrolan dengan Sync & Backup"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
@@ -1352,7 +1348,7 @@ msgstr "Iklannya mencurigakan"
 #. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
 msgctxt "Button to open menu for attaching images or page context to AI chat"
 msgid "Add"
-msgstr ""
+msgstr "Tambahkan"
 
 # smartling.placeholder_format=C
 #. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
@@ -1360,7 +1356,7 @@ msgctxt ""
 "Primary button that attaches the tabs the user checked in the tab picker "
 "dialog"
 msgid "Add"
-msgstr ""
+msgstr "Tambahkan"
 
 # smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
@@ -1395,13 +1391,13 @@ msgstr "Tambahkan DuckDuckGo ke %1$s"
 msgctxt ""
 "Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
 msgid "Add File"
-msgstr ""
+msgstr "Tambahkan File"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
 msgid "Add Image"
-msgstr ""
+msgstr "Tambahkan Gambar"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
@@ -1409,7 +1405,7 @@ msgctxt ""
 "Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
 "item)"
 msgid "Add Image or File"
-msgstr ""
+msgstr "Tambahkan Gambar atau File"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1462,7 +1458,7 @@ msgctxt ""
 "Open the tab picker to attach browser tab content to the AI chat message "
 "(attach dropdown menu item)"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Tambahkan Tab"
 
 # smartling.placeholder_format=C
 #. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
@@ -1470,7 +1466,7 @@ msgctxt ""
 "Title and accessible name of the tab-picker dialog opened from the attach "
 "dropdown menu"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Tambahkan Tab"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1561,7 +1557,7 @@ msgstr "Menambahkan sentuhan akhir"
 #. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
 msgctxt "Aria label for the additional instructions textarea"
 msgid "Additional instructions"
-msgstr ""
+msgstr "Instruksi tambahan"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1868,7 +1864,7 @@ msgstr "Selesai!"
 #. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the read-only textarea listing all AI instructions"
 msgid "All instructions"
-msgstr ""
+msgstr "Semua instruksi"
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -1882,8 +1878,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr ""
-"Semua penyedia model dicegah melatih AI mereka menggunakan percakapan Anda."
+msgstr "Semua penyedia model dicegah melatih AI mereka menggunakan percakapan Anda."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -2295,15 +2290,13 @@ msgstr "Apa kamu masih di sana?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"Apakah kamu yakin ingin menghapus semua obrolanmu? Ini tidak bisa dibatalkan."
+msgstr "Apakah kamu yakin ingin menghapus semua obrolanmu? Ini tidak bisa dibatalkan."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr ""
-"Apakah Anda yakin ingin menghapus percakapan ini dan memulai yang baru?"
+msgstr "Apakah Anda yakin ingin menghapus percakapan ini dan memulai yang baru?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2627,21 +2620,18 @@ msgstr "Suara"
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"Audio tidak disimpan oleh kami atau oleh OpenAI setelah obrolan berakhir."
+msgstr "Audio tidak disimpan oleh kami atau oleh OpenAI setelah obrolan berakhir."
 
 # smartling.placeholder_format=C
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"Audio tidak disimpan oleh kami atau oleh OpenAI setelah obrolan berakhir."
+msgstr "Audio tidak disimpan oleh kami atau oleh OpenAI setelah obrolan berakhir."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"Audio tidak disimpan oleh kami atau OpenAI setelah obrolan ditranskripsikan."
+msgstr "Audio tidak disimpan oleh kami atau OpenAI setelah obrolan ditranskripsikan."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -3592,7 +3582,7 @@ msgctxt ""
 "Secondary button that dismisses the tab picker dialog without attaching "
 "anything"
 msgid "Cancel"
-msgstr ""
+msgstr "Batalkan"
 
 # smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
@@ -3854,8 +3844,7 @@ msgstr "Mengubah warna latar belakang hasil hover, modul, dan menu dropdown"
 #. http://i.imgur.com/NdpkbY0.png
 msgctxt "settings"
 msgid "Changes the background color when hovering over a result"
-msgstr ""
-"Mengubah warna latar belakang saat mengarahkan kursor ke atas suatu hasil"
+msgstr "Mengubah warna latar belakang saat mengarahkan kursor ke atas suatu hasil"
 
 # smartling.placeholder_format=C
 #. Description of a setting managing the color of search result snippet text.
@@ -3982,8 +3971,8 @@ msgstr ""
 "anonim dengan model chat AI pihak ketiga, yang mendukung model dari OpenAI, "
 "Anthropic, dan lainnya. Menonaktifkan pengaturan ini akan menyembunyikan "
 "tombol dan tautan Chat di DuckDuckGo Search. Namun, Anda masih dapat "
-"mengakses Chat saat setelan ini dinonaktifkan dengan mengunjungi %1$shttps://"
-"duck.ai%2$s langsung."
+"mengakses Chat saat setelan ini dinonaktifkan dengan mengunjungi "
+"%1$shttps://duck.ai%2$s langsung."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4091,7 +4080,7 @@ msgstr "Tanggapan obrolan menyinggung"
 #. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
 msgctxt "Chat history about modal list item headline"
 msgid "Chat storage varies by browser"
-msgstr ""
+msgstr "Penyimpanan obrolan berbeda-beda di setiap browser"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4103,7 +4092,7 @@ msgstr "Mengobrol dengan %1$s"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Chat with popular AI models, anonymized by us."
-msgstr ""
+msgstr "Mengobrol dengan model AI populer, dianonimkan oleh kami."
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4130,6 +4119,9 @@ msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
 msgstr ""
+"Obrolan tersimpan dengan aman di server DuckDuckGo dengan enkripsi ujung ke "
+"ujung. Tidak ada orang selain kamu yang dapat melihat datamu, bahkan kami "
+"pun tidak."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4251,8 +4243,7 @@ msgstr ""
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr ""
-"Periksa halaman status untuk mendapatkan pembaruan mengenai gangguan ini."
+msgstr "Periksa halaman status untuk mendapatkan pembaruan mengenai gangguan ini."
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4644,8 +4635,7 @@ msgstr "Klik %1$sDi sini%2$s untuk mengunduh ekstensi DuckDuckGo"
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr ""
-"Klik %1$sBuka%2$s untuk mengunduh dan membuka ekstensi DuckDuckGo di Safari"
+msgstr "Klik %1$sBuka%2$s untuk mengunduh dan membuka ekstensi DuckDuckGo di Safari"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4690,8 +4680,7 @@ msgstr "Klik %1$sYa%2$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
-msgstr ""
-"Klik %1$spengaturan/ikon hamburger %2$s di bilah alat Chrome (kanan atas)."
+msgstr "Klik %1$spengaturan/ikon hamburger %2$s di bilah alat Chrome (kanan atas)."
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -5730,7 +5719,7 @@ msgstr "Catatan Saat Ini"
 #. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
 msgctxt "Suffix label indicating a tab is the currently active browser tab"
 msgid "Current Tab"
-msgstr ""
+msgstr "Tab Saat Ini"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
@@ -6086,7 +6075,7 @@ msgstr "Hapus Obrolan Lebih Lama Dari 30 Hari"
 #. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
 msgctxt "Button text in the modal for deleting all recent chats"
 msgid "Delete Chats and Shared Links"
-msgstr ""
+msgstr "Hapus Obrolan dan Tautan yang Dibagikan"
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6508,7 +6497,7 @@ msgstr "Tolak promosi"
 #. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the close button on the survey banner"
 msgid "Dismiss survey"
-msgstr ""
+msgstr "Tutup survei"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6538,8 +6527,7 @@ msgstr "Bahasa Tampilan"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Displays a checkmark to the left of results you've visited"
-msgstr ""
-"Menampilkan tanda centang di sebelah kiri hasil yang telah kamu kunjungi"
+msgstr "Menampilkan tanda centang di sebelah kiri hasil yang telah kamu kunjungi"
 
 # smartling.placeholder_format=C
 #. This is the description of a user setting
@@ -6819,8 +6807,8 @@ msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
 msgstr ""
-"Buatlah beberapa opsi untuk postingan media sosial yang mengundang orang-"
-"orang ke pesta saya yang akan datang."
+"Buatlah beberapa opsi untuk postingan media sosial yang mengundang "
+"orang-orang ke pesta saya yang akan datang."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6992,8 +6980,7 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"Duck.ai adalah yang terbaik di browser DuckDuckGo pribadi dan gratis kami!"
+msgstr "Duck.ai adalah yang terbaik di browser DuckDuckGo pribadi dan gratis kami!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -7083,8 +7070,7 @@ msgstr ""
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
 msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid "Duck.ai may display inaccurate or offensive information."
-msgstr ""
-"Duck.ai mungkin menampilkan informasi yang tidak akurat atau menyinggung."
+msgstr "Duck.ai mungkin menampilkan informasi yang tidak akurat atau menyinggung."
 
 # smartling.placeholder_format=C
 #. Error modal body line 2.
@@ -7133,8 +7119,7 @@ msgstr "Duck.ai ditingkatkan!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.ai bekerja paling baik di aplikasi DuckDuckGo pribadi dan gratis kamu!"
+msgstr "Duck.ai bekerja paling baik di aplikasi DuckDuckGo pribadi dan gratis kamu!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7320,8 +7305,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chat untuk sementara tidak tersedia. Silakan coba lagi nanti."
+msgstr "DuckDuckGo AI Chat untuk sementara tidak tersedia. Silakan coba lagi nanti."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7633,9 +7617,9 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"Tiap kali kamu meminta saran frasa sandi, kami menerima daftar berisi kata-"
-"kata acak dari server DuckDuckGo. Di browser, kami kemudian memilih 4—5 kata "
-"acak dari daftar itu, dengan memastikan bahwa frasa sandinya minimal "
+"Tiap kali kamu meminta saran frasa sandi, kami menerima daftar berisi "
+"kata-kata acak dari server DuckDuckGo. Di browser, kami kemudian memilih 4—5 "
+"kata acak dari daftar itu, dengan memastikan bahwa frasa sandinya minimal "
 "sepanjang 18—20 karakter."
 
 # smartling.placeholder_format=C
@@ -7693,7 +7677,7 @@ msgstr "Edit Prompt"
 #. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the message-editing text area"
 msgid "Edit message"
-msgstr ""
+msgstr "Sunting pesan"
 
 # smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
@@ -7864,8 +7848,7 @@ msgstr "Aktifkan Dikte dalam Duck.ai"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr ""
-"Aktifkan pengaturan lokasi di perangkatmu untuk menggunakan lokasi anonim"
+msgstr "Aktifkan pengaturan lokasi di perangkatmu untuk menggunakan lokasi anonim"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -7922,7 +7905,7 @@ msgstr "Model terenkripsi"
 #. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
 msgctxt "Share modal info bullet about encryption"
 msgid "Encrypted so DuckDuckGo can't read your chat."
-msgstr ""
+msgstr "Terenkripsi sehingga DuckDuckGo tidak bisa membaca obrolanmu."
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8240,8 +8223,7 @@ msgstr "Jelaskan jawaban yang diterima dengan bahasa yang sederhana."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr ""
-"Jelaskan konsep dasar lubang hitam kepada saya di tingkat sekolah menengah."
+msgstr "Jelaskan konsep dasar lubang hitam kepada saya di tingkat sekolah menengah."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -8675,8 +8657,7 @@ msgstr "Temukan hasil yang lebih dekat dari lokasimu."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr ""
-"Temukan hasil di dekatmu. %1$sLokasimu tetap pribadi, aman, dan anonim."
+msgstr "Temukan hasil di dekatmu. %1$sLokasimu tetap pribadi, aman, dan anonim."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8747,8 +8728,7 @@ msgstr ""
 #. Privacy reassurance and instructions intro.
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
-msgstr ""
-"Ikuti langkah-langkah berikut untuk memindahkan obrolanmu ke Duck.ai baru"
+msgstr "Ikuti langkah-langkah berikut untuk memindahkan obrolanmu ke Duck.ai baru"
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8759,7 +8739,7 @@ msgstr "Pertanyaan lanjutan"
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
-msgstr ""
+msgstr "Pesan lanjutan tetap pribadi."
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8979,8 +8959,8 @@ msgid ""
 "strong>."
 msgstr ""
 "Dari bilah menu aplikasi di Mac, pilih <strong>DuckDuckGo</strong> &gt; "
-"<strong>Periksa Pembaruan...</strong>, lalu pilih <strong>Instal Pembaruan</"
-"strong>."
+"<strong>Periksa Pembaruan...</strong>, lalu pilih <strong>Instal "
+"Pembaruan</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9281,7 +9261,7 @@ msgstr ""
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
 msgctxt "Tooltip on the header logo for sunglasses searches"
 msgid "Get DuckDuckGo sunglasses and other gear."
-msgstr ""
+msgstr "Dapatkan kacamata hitam DuckDuckGo dan merchandise lainnya."
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9425,8 +9405,7 @@ msgstr "Dapatkan bantuan komputer"
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr ""
-"Dapatkan batas penggunaan yang lebih tinggi dengan langganan DuckDuckGo."
+msgstr "Dapatkan batas penggunaan yang lebih tinggi dengan langganan DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -9505,8 +9484,7 @@ msgstr "Dapatkan aplikasinya"
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
-msgstr ""
-"Dapatkan Browser DuckDuckGo gratis %1$suntuk memblokir iklan di YouTube.%2$s"
+msgstr "Dapatkan Browser DuckDuckGo gratis %1$suntuk memblokir iklan di YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -10518,7 +10496,7 @@ msgstr "Cara Kerja"
 #. Headline in chat history about modals for the temporary encrypted server storage explanation.
 msgctxt "Chat history about modal list item headline"
 msgid "How it works"
-msgstr ""
+msgstr "Cara Kerja"
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -10662,8 +10640,7 @@ msgstr "Saya tidak paham informasi ini"
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
 msgid "I don’t want to see any information from DuckDuckGo on this page"
-msgstr ""
-"Saya tidak ingin melihat informasi apa pun dari DuckDuckGo di halaman ini"
+msgstr "Saya tidak ingin melihat informasi apa pun dari DuckDuckGo di halaman ini"
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -10702,8 +10679,7 @@ msgstr ""
 #. Option for feedback when the user needs more help or information on how to use the chat.
 msgctxt "Feedback option for difficulty in using chat"
 msgid "I need more help/info on how to use Chat"
-msgstr ""
-"Saya memerlukan bantuan/informasi lebih lanjut tentang cara menggunakan Chat"
+msgstr "Saya memerlukan bantuan/informasi lebih lanjut tentang cara menggunakan Chat"
 
 # smartling.placeholder_format=C
 msgid "IR Iran"
@@ -10991,8 +10967,7 @@ msgstr "Di menu atas, pilih %1$sAlat%2$s > %3$sPengaturan%4$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
-msgstr ""
-"Di dalam popup, centang %1$sJadikan sebagai mesin pencari default saya%2$s"
+msgstr "Di dalam popup, centang %1$sJadikan sebagai mesin pencari default saya%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -11484,8 +11459,7 @@ msgstr ""
 #. An instruction to state that a list of companies/trackers will be updated with continued use
 msgctxt "tracker_stats"
 msgid "Keep browsing to see how many we block"
-msgstr ""
-"Teruslah menjelajah untuk melihat jumlah perusahaan/pelacak yang kami blokir"
+msgstr "Teruslah menjelajah untuk melihat jumlah perusahaan/pelacak yang kami blokir"
 
 # smartling.placeholder_format=C
 #. Header above social media links.
@@ -11892,8 +11866,8 @@ msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
 msgstr ""
-"Memungkinkan beralih antara mengirimkan kueri pencarian dan perintah ke Duck."
-"ai"
+"Memungkinkan beralih antara mengirimkan kueri pencarian dan perintah ke "
+"Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11975,7 +11949,7 @@ msgstr "Tautan kedaluwarsa dalam 7 hari."
 #. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days. People can save a chat copy."
-msgstr ""
+msgstr "Tautan kedaluwarsa dalam 7 hari. Orang-orang dapat menyimpan salinan obrolan."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13754,8 +13728,7 @@ msgstr "Hasil tidak ditemukan."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr ""
-"Tidak ada ucapan yang terdeteksi. Coba lagi dan bicaralah ke mikrofonmu."
+msgstr "Tidak ada ucapan yang terdeteksi. Coba lagi dan bicaralah ke mikrofonmu."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -14100,7 +14073,7 @@ msgstr "OKE, paham!"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "OPTIONAL"
-msgstr ""
+msgstr "OPSIONAL"
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -15416,15 +15389,13 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr ""
-"Tolong jelaskan mengapa respons obrolan berbahaya atau ilegal. (opsional)"
+msgstr "Tolong jelaskan mengapa respons obrolan berbahaya atau ilegal. (opsional)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr ""
-"Tolong jelaskan mengapa respons obrolan ilegal atau berbahaya. (Opsional)"
+msgstr "Tolong jelaskan mengapa respons obrolan ilegal atau berbahaya. (Opsional)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -15682,8 +15653,7 @@ msgstr "Pemformatan yang buruk"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
-msgstr ""
-"Model AI populer tersedia. Tidak perlu akun. Obrolan dianonimkan oleh kami."
+msgstr "Model AI populer tersedia. Tidak perlu akun. Obrolan dianonimkan oleh kami."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15909,8 +15879,7 @@ msgstr "Harga"
 #. Category of feedback a user can select on a feedback form.
 msgctxt "feedback form"
 msgid "Price shown doesn't reflect merchant site"
-msgstr ""
-"Harga yang ditampilkan berbeda dengan yang ditampilkan di situs penjual"
+msgstr "Harga yang ditampilkan berbeda dengan yang ditampilkan di situs penjual"
 
 # smartling.placeholder_format=C
 #. A button that prints the contents of a page.
@@ -16230,7 +16199,7 @@ msgstr "Dilindungi"
 #. Headline in sync-enabled chat history about modals explaining encrypted server storage.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Protected with end-to-end encryption"
-msgstr ""
+msgstr "Dilindungi dengan enkripsi ujung ke ujung"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -16369,7 +16338,7 @@ msgstr "Peringkat"
 #. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
 msgctxt "star rating on a product"
 msgid "Rated %s out of %s"
-msgstr ""
+msgstr "Rating %1$s dari %2$s"
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -16478,8 +16447,7 @@ msgstr ""
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr ""
-"Penalaran lebih menyeluruh, tetapi menggunakan batas 2-5x lebih cepat. %1$s"
+msgstr "Penalaran lebih menyeluruh, tetapi menggunakan batas 2-5x lebih cepat. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -17232,8 +17200,7 @@ msgstr "Hasil mengecualikan informasi dari situs yang diblokir."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr ""
-"Hasil tidak termasuk situs yang kamu blokir, yang dapat kamu kelola di %1$s."
+msgstr "Hasil tidak termasuk situs yang kamu blokir, yang dapat kamu kelola di %1$s."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -17567,8 +17534,7 @@ msgstr "Simpan dan Keluar"
 #. Description explaining that sync allows saving more chats than local browser storage.
 msgctxt "Sync feature benefit description"
 msgid "Save more chats than you can in your web browser."
-msgstr ""
-"Simpan lebih banyak obrolan daripada yang kamu bisa di browser web kamu."
+msgstr "Simpan lebih banyak obrolan daripada yang kamu bisa di browser web kamu."
 
 # smartling.placeholder_format=C
 #. List item explaining that users can save more chats when Sync & Backup is enabled.
@@ -17611,7 +17577,7 @@ msgstr "Simpan obrolanmu di semua perangkatmu."
 #. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
 msgctxt "Chat history about modal list item headline"
 msgid "Save your chats on this device"
-msgstr ""
+msgstr "Simpan obrolan kamu di perangkat ini"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
@@ -17796,8 +17762,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr ""
-"Gulir ke bawah ke bagian %1$sLayanan%2$s, lalu klik %3$sBilah alamat%4$s."
+msgstr "Gulir ke bawah ke bagian %1$sLayanan%2$s, lalu klik %3$sBilah alamat%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -17822,7 +17787,7 @@ msgctxt ""
 "Placeholder and accessibility label for the search input in the tab picker "
 "dialog"
 msgid "Search"
-msgstr ""
+msgstr "Cari"
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18028,8 +17993,8 @@ msgid ""
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
 "Cari secara pribadi dengan aplikasi atau ekstensi kami, tambahkan pencarian "
-"web pribadi ke browser favoritmu, atau cari langsung di %1$sduckduckgo."
-"com%2$s."
+"web pribadi ke browser favoritmu, atau cari langsung di "
+"%1$sduckduckgo.com%2$s."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -18194,8 +18159,7 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr ""
-"Tersimpan dengan aman di server DuckDuckGo dengan enkripsi ujung ke ujung."
+msgstr "Tersimpan dengan aman di server DuckDuckGo dengan enkripsi ujung ke ujung."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -18385,8 +18349,7 @@ msgstr "Pilih %1$sDuckDuckGo%2$s di menu dropdown Mesin Pencari Default"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"Pilih %1$sDuckDuckGo%2$s dalam daftar dan %3$sbolehkan%4$s akses lokasi"
+msgstr "Pilih %1$sDuckDuckGo%2$s dalam daftar dan %3$sbolehkan%4$s akses lokasi"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18505,8 +18468,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"Pilih %1$sbrowser Anda%2$s dalam daftar dan %3$sizinkan akses lokasi%4$s"
+msgstr "Pilih %1$sbrowser Anda%2$s dalam daftar dan %3$sizinkan akses lokasi%4$s"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -19003,7 +18965,7 @@ msgstr "Belanja"
 #. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
 msgctxt "Button in the merchandise logo modal (mobile)"
 msgid "Shop Now"
-msgstr ""
+msgstr "Belanja Sekarang"
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -19296,8 +19258,7 @@ msgstr "Tampilkan bilah samping"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
-"Tunjukkan tips langkah demi langkah untuk memaksimalkan penggunaan Duck.ai."
+msgstr "Tunjukkan tips langkah demi langkah untuk memaksimalkan penggunaan Duck.ai."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -19374,8 +19335,7 @@ msgstr "Menampilkan garis horizontal di pemisah halaman hasil"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr ""
-"Menampilkan tautan ke petunjuk cara menambahkan DuckDuckGo ke browser-mu"
+msgstr "Menampilkan tautan ke petunjuk cara menambahkan DuckDuckGo ke browser-mu"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -19391,21 +19351,18 @@ msgstr "Menampilkan tautan yang paling banyak dikunjungi di halaman tab baru"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Sesekali menampilkan pengingat untuk menambahkan DuckDuckGo ke browser-mu"
+msgstr "Sesekali menampilkan pengingat untuk menambahkan DuckDuckGo ke browser-mu"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Sesekali menampilkan pengingat untuk menambahkan DuckDuckGo ke perangkatmu"
+msgstr "Sesekali menampilkan pengingat untuk menambahkan DuckDuckGo ke perangkatmu"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
-msgstr ""
-"Sesekali menampilkan pengingat untuk mendaftar ke nawala privasi DuckDuckGo"
+msgstr "Sesekali menampilkan pengingat untuk mendaftar ke nawala privasi DuckDuckGo"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19443,8 +19400,7 @@ msgstr "Menampilkan pesan selamat datang di atas halaman hasil pencarian"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Menampilkan pesan selamat datang kepada pengguna menu preferensi Android UE"
+msgstr "Menampilkan pesan selamat datang kepada pengguna menu preferensi Android UE"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -19676,8 +19632,7 @@ msgstr "Terjadi kesalahan saat memuat obrolan yang dibagikan ini."
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr ""
-"Terjadi kesalahan saat proses penyimpanan ke server. Silakan coba lagi."
+msgstr "Terjadi kesalahan saat proses penyimpanan ke server. Silakan coba lagi."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
@@ -20280,8 +20235,7 @@ msgstr "Sarankan judul untuk postingan blog"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
-"Sarankan artikel atau topik terkait yang layak Anda jelajahi selanjutnya."
+msgstr "Sarankan artikel atau topik terkait yang layak Anda jelajahi selanjutnya."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -20584,8 +20538,7 @@ msgstr "Beralih ke model yang lebih efisien"
 # smartling.placeholder_format=C
 #. Text prompting  users to switch their current search engine to the DuckDuckGo private search engine.
 msgid "Switch to the search engine that doesn't track you. Ever."
-msgstr ""
-"Beralihlah ke mesin pencari yang tidak akan pernah melacakmu. Selamanya."
+msgstr "Beralihlah ke mesin pencari yang tidak akan pernah melacakmu. Selamanya."
 
 # smartling.placeholder_format=C
 #. Re-activates a stacked second opinion, making it the current answer again.
@@ -20606,8 +20559,7 @@ msgstr "Beralih ke %1$s"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr ""
-"Beralih akan mengirim obrolan kamu ke model tanpa visibilitas penyedia nol"
+msgstr "Beralih akan mengirim obrolan kamu ke model tanpa visibilitas penyedia nol"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -20661,8 +20613,7 @@ msgstr "Sync & Backup Diaktifkan!"
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr ""
-"Data Sync & Backup tidak dapat dipulihkan setelah 18 bulan tidak aktif."
+msgstr "Data Sync & Backup tidak dapat dipulihkan setelah 18 bulan tidak aktif."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
@@ -20671,6 +20622,8 @@ msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
 msgstr ""
+"Sync & Backup menyimpan lebih banyak obrolanmu dan menyinkronkannya di semua "
+"perangkatmu."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20792,7 +20745,7 @@ msgstr "Sinkronkan obrolanmu di semua perangkatmu."
 #. Headline in sync-enabled chat history about modals explaining cross-device sync.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Sync your chats across all your devices"
-msgstr ""
+msgstr "Sinkronkan obrolanmu di semua perangkatmu"
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21091,8 +21044,7 @@ msgstr "Thailand (en)"
 #. Message displayed after the user has submitted feedback. It invites the user to share more feedback.
 msgctxt "Feedback toast"
 msgid "Thank you for your feedback. Have more to share?"
-msgstr ""
-"Terima kasih atas masukan kamu. Apakah kamu punya hal lain untuk dibagikan?"
+msgstr "Terima kasih atas masukan kamu. Apakah kamu punya hal lain untuk dibagikan?"
 
 # smartling.placeholder_format=C
 msgid "Thank you!"
@@ -21119,8 +21071,7 @@ msgstr "Terima kasih atas masukanmu!"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row!"
-msgstr ""
-"Terima kasih atas kesabaran Anda sementara kami menyelesaikan semuanya!"
+msgstr "Terima kasih atas kesabaran Anda sementara kami menyelesaikan semuanya!"
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and we are unable to show any results.
@@ -21222,8 +21173,7 @@ msgstr "Permintaan tersebut mengalami batas waktu. Silakan coba lagi."
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "The server encountered an error and could not complete your request."
-msgstr ""
-"Server mengalami kesalahan dan tidak dapat menyelesaikan permintaan Anda."
+msgstr "Server mengalami kesalahan dan tidak dapat menyelesaikan permintaan Anda."
 
 # smartling.placeholder_format=C
 #. Title for the theme menu:
@@ -21389,12 +21339,14 @@ msgid ""
 "This chat and its generated images become public when you create and copy "
 "the link."
 msgstr ""
+"Obrolan ini dan gambar yang dihasilkannya menjadi publik saat kamu membuat "
+"dan menyalin tautan tersebut."
 
 # smartling.placeholder_format=C
 #. Explains that creating and copying a share link makes the selected chat content public.
 msgctxt "Share modal info bullet about public access"
 msgid "This chat becomes public when you create and copy the link."
-msgstr ""
+msgstr "Obrolan ini menjadi publik saat membuat dan menyalin tautan."
 
 # smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
@@ -21536,16 +21488,14 @@ msgstr "Gambar ini tidak dapat dibuat."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr ""
-"Jenis gambar ini tidak didukung, tolong lampirkan JPG, PNG, WebP, atau GIF"
+msgstr "Jenis gambar ini tidak didukung, tolong lampirkan JPG, PNG, WebP, atau GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr ""
-"Jenis gambar ini tidak didukung, tolong lampirkan JPG, PNG, WebP, atau GIF."
+msgstr "Jenis gambar ini tidak didukung, tolong lampirkan JPG, PNG, WebP, atau GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -21676,8 +21626,7 @@ msgstr ""
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr ""
-"Obrolan yang dibagikan ini tidak dapat dibuka. Tautan mungkin tidak lengkap."
+msgstr "Obrolan yang dibagikan ini tidak dapat dibuka. Tautan mungkin tidak lengkap."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
@@ -21712,8 +21661,7 @@ msgstr "Video ini belum bisa ditonton di sini. Kamu bisa menontonnya di %1$s."
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Halaman web ini tidak menggunakan koneksi yang aman dan terenkripsi (HTTPS)."
+msgstr "Halaman web ini tidak menggunakan koneksi yang aman dan terenkripsi (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21868,8 +21816,7 @@ msgstr "Untuk melanjutkan, kamu harus menyetujui %1$s dan %2$sDuck.ai"
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr ""
-"Untuk melanjutkan, Anda harus menyetujui %1$s dan %2$sDuckDuckGo AI Chat"
+msgstr "Untuk melanjutkan, Anda harus menyetujui %1$s dan %2$sDuckDuckGo AI Chat"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -21901,8 +21848,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"Untuk mentransfer riwayat obrolanmu ke Duck.ai, perbarui browser DuckDuckGo-"
-"mu ke versi terbaru dan coba lagi."
+"Untuk mentransfer riwayat obrolanmu ke Duck.ai, perbarui browser "
+"DuckDuckGo-mu ke versi terbaru dan coba lagi."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -21933,15 +21880,15 @@ msgstr "Hari Ini"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
-msgstr ""
+msgstr "Beralih ke obrolan AI pribadi atau %1$snonaktifkan di pengaturan%2$s."
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
-"Beralih untuk mencoba obrolan AI pribadi atau %1$snonaktifkan di menu %2$s."
-"%3$s"
+"Beralih untuk mencoba obrolan AI pribadi atau %1$snonaktifkan di menu "
+"%2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -23028,8 +22975,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"Di bagian %1$sMEMULAI > Halaman beranda%2$s, masukkan: https://duckduckgo.com"
+msgstr "Di bagian %1$sMEMULAI > Halaman beranda%2$s, masukkan: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23433,8 +23379,7 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr ""
-"Tingkatkan ke Pro untuk membuka batas penggunaan 2x lebih tinggi dari Plus"
+msgstr "Tingkatkan ke Pro untuk membuka batas penggunaan 2x lebih tinggi dari Plus"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -23767,6 +23712,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Yelp's ad network."
 msgstr ""
+"Melihat iklan adalah privasi yang dilindungi oleh DuckDuckGo. Klik iklan "
+"dikelola oleh jaringan iklan Yelp."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -24634,8 +24581,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"Kami benar-benar minta maaf, tetapi tampaknya ada masalah saat memuat Duck."
-"ai. Coba muat ulang halaman."
+"Kami benar-benar minta maaf, tetapi tampaknya ada masalah saat memuat "
+"Duck.ai. Coba muat ulang halaman."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -24657,8 +24604,7 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr ""
-"Apa saja faktor yang perlu dipertimbangkan saat membeli monitor komputer?"
+msgstr "Apa saja faktor yang perlu dipertimbangkan saat membeli monitor komputer?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
@@ -25258,6 +25204,8 @@ msgid ""
 "With chat history on, up to %s of your most recent chats will be saved on "
 "this device."
 msgstr ""
+"Dengan riwayat obrolan diaktifkan, hingga %1$s obrolan terbaru kamu akan "
+"disimpan di perangkat ini."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline in the About Chat History modal.
@@ -25265,6 +25213,8 @@ msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, your most recent chats will be saved on this device."
 msgstr ""
+"Saat riwayat obrolan diaktifkan, obrolan terbaru kamu akan disimpan di "
+"perangkat ini."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -25654,8 +25604,7 @@ msgstr "Kamu bisa menemukan file <b>%1$s</b> di folder unduhanmu."
 # smartling.placeholder_format=C
 #. A link to the settings to where the user can hide the private search reminder from the filter bar of search results
 msgid "You can hide this reminder in %sSearch Settings%s"
-msgstr ""
-"Anda dapat menyembunyikan pengingat ini di %1$sPengaturan Pencarian%2$s"
+msgstr "Anda dapat menyembunyikan pengingat ini di %1$sPengaturan Pencarian%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -26033,8 +25982,7 @@ msgstr ""
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr ""
-"Obrolan Duck.ai kamu sedang disinkronkan dengan enkripsi ujung ke ujung."
+msgstr "Obrolan Duck.ai kamu sedang disinkronkan dengan enkripsi ujung ke ujung."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -26397,9 +26345,9 @@ msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
 msgstr ""
-"Anda sedang menelusuri secara pribadi di Chrome. Gunakan browser kami alih-"
-"alih Chrome untuk perlindungan yang lebih baik. Aplikasi sudah terinstal dan "
-"dapat:"
+"Anda sedang menelusuri secara pribadi di Chrome. Gunakan browser kami "
+"alih-alih Chrome untuk perlindungan yang lebih baik. Aplikasi sudah "
+"terinstal dan dapat:"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -26683,7 +26631,7 @@ msgstr "m"
 #. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the chat options menu button"
 msgid "menu"
-msgstr ""
+msgstr "menu"
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/id_ID/LC_MESSAGES/duckduckgo.po
+++ b/locales/id_ID/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: id_ID\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1214,6 +1214,12 @@ msgid "About our ads"
 msgstr "Tentang iklan kami"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1343,6 +1349,20 @@ msgid "Ad is suspicious"
 msgstr "Iklannya mencurigakan"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Tambahkan DuckDuckGo"
@@ -1369,6 +1389,27 @@ msgstr "Tambahkan DuckDuckGo sebagai mesin pencari"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Tambahkan DuckDuckGo ke %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1414,6 +1455,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Tambahkan Konten Halaman"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1499,6 +1556,12 @@ msgstr "Pengaya"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Menambahkan sentuhan akhir"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1800,6 +1863,12 @@ msgstr "Semua warna"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Selesai!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3518,6 +3587,14 @@ msgid "Cancel"
 msgstr "Batalkan"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4011,10 +4088,22 @@ msgid "Chat response is offensive"
 msgstr "Tanggapan obrolan menyinggung"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Mengobrol dengan %1$s"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4033,6 +4122,14 @@ msgstr "Obrolan"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Obrolan"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5630,6 +5727,12 @@ msgid "Current Streak"
 msgstr "Catatan Saat Ini"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5978,6 +6081,12 @@ msgstr "Menghapus Obrolan"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Hapus Obrolan Lebih Lama Dari 30 Hari"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6394,6 +6503,12 @@ msgstr "Tutup selamanya"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Tolak promosi"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7575,6 +7690,12 @@ msgid "Edit Prompt"
 msgstr "Edit Prompt"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7796,6 +7917,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Model terenkripsi"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8629,6 +8756,12 @@ msgid "Follow-up question"
 msgstr "Pertanyaan lanjutan"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9143,6 +9276,12 @@ msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
 "Dapatkan VPN DuckDuckGo, Duck.ai tingkat lanjut, dan Identity Theft "
 "Restoration."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10374,6 +10513,12 @@ msgstr "Bagaimana sampai bisa anonim?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Cara Kerja"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11825,6 +11970,12 @@ msgstr "Lineout dimenangkan"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "Tautan kedaluwarsa dalam 7 hari."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13944,6 +14095,12 @@ msgstr "OKE"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "OKE, paham!"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16070,6 +16227,12 @@ msgid "Protected"
 msgstr "Dilindungi"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Perlindungan. Privasi. Ketenangan pikiran."
@@ -16201,6 +16364,12 @@ msgstr "Hujan"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Peringkat"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17439,6 +17608,12 @@ msgid "Save your chats across all your devices."
 msgstr "Simpan obrolanmu di semua perangkatmu."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17640,6 +17815,14 @@ msgstr "Cari"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Cari"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18815,6 +18998,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Belanja"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20476,6 +20665,14 @@ msgstr ""
 "Data Sync & Backup tidak dapat dipulihkan setelah 18 bulan tidak aktif."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20590,6 +20787,12 @@ msgstr "Sinkronkan dengan perangkat terdekat."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Sinkronkan obrolanmu di semua perangkatmu."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21178,6 +21381,22 @@ msgid "This Week"
 msgstr "Minggu ini"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21709,6 +21928,12 @@ msgstr "Hari Ini"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Hari Ini"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23536,6 +23761,14 @@ msgstr ""
 "dikelola oleh jaringan iklan TripAdvisor."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Kepulauan Virgin"
 
@@ -25019,6 +25252,21 @@ msgstr ""
 "melatih AI. Aktifkan atau matikan kapan saja di menu '%1$s'."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26430,6 +26678,12 @@ msgstr "m"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "m"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/io_XX/LC_MESSAGES/duckduckgo.po
+++ b/locales/io_XX/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Adjuntar DuckDuckGo"
@@ -1099,6 +1116,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr "Augmenti"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1453,6 +1507,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2800,6 +2859,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3200,9 +3266,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3218,6 +3294,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4477,6 +4560,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4761,6 +4849,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5099,6 +5192,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -5995,6 +6093,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6172,6 +6275,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6839,6 +6947,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7257,6 +7370,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8239,6 +8357,11 @@ msgid "How is it anonymous?"
 msgstr "Quale ico esas anonima?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9394,6 +9517,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11131,6 +11259,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12831,6 +12964,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12937,6 +13075,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13925,6 +14068,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14080,6 +14228,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -14995,6 +15150,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16334,6 +16494,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16414,6 +16581,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16874,6 +17046,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17276,6 +17462,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18738,6 +18929,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19887,6 +20085,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20973,6 +21184,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/is_IS/LC_MESSAGES/duckduckgo.po
+++ b/locales/is_IS/LC_MESSAGES/duckduckgo.po
@@ -979,6 +979,11 @@ msgstr "Um okkur"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1082,6 +1087,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "Auglýsingin er grunsamleg"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Bæta DuckDuckGo við"
@@ -1101,6 +1118,24 @@ msgstr "Bæta DuckDuckGo við sem leitarvél"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Bæta DuckDuckGo við %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1139,6 +1174,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1210,6 +1259,11 @@ msgstr "Viðbætur"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1454,6 +1508,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2803,6 +2862,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3203,9 +3269,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3221,6 +3297,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4480,6 +4563,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4764,6 +4852,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5102,6 +5195,11 @@ msgstr "Hunsa að eilífu"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -5999,6 +6097,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6176,6 +6279,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6841,6 +6949,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7259,6 +7372,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8241,6 +8359,11 @@ msgid "How is it anonymous?"
 msgstr "Hvernig er það nafnlaust?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9396,6 +9519,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11133,6 +11261,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "Allt í lagi, ég skil!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12837,6 +12970,11 @@ msgstr "Verndum upplýsingar þínar í öllum þínum tækjum."
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12943,6 +13081,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13931,6 +14074,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14086,6 +14234,13 @@ msgstr "Leita"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15002,6 +15157,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16344,6 +16504,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16424,6 +16591,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16888,6 +17060,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17292,6 +17478,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18757,6 +18948,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19906,6 +20104,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20990,6 +21201,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/it_IT/LC_MESSAGES/duckduckgo.po
+++ b/locales/it_IT/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: it_IT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -526,8 +526,7 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr ""
-"%1$sPremi a lungo%2$s l'icona dell'app DuckDuckGo nella schermata principale"
+msgstr "%1$sPremi a lungo%2$s l'icona dell'app DuckDuckGo nella schermata principale"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -886,8 +885,7 @@ msgstr "Limite di utilizzo di 6 ore raggiunto."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Limite di utilizzo di 6 ore raggiunto. Puoi continuare questa chat dopo %1$s."
+msgstr "Limite di utilizzo di 6 ore raggiunto. Puoi continuare questa chat dopo %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -1016,8 +1014,8 @@ msgstr ""
 "AI Chat consente di conversare in modo anonimo con modelli di chat di terze "
 "parti dotati di intelligenza artificiale. Disattivando questa funzione, AI "
 "Chat verrà nascosta su DuckDuckGo Search. È comunque possibile accedervi "
-"anche quando questa impostazione è disattivata visitando %1$sduckduckgo.com/"
-"aichat%2$s."
+"anche quando questa impostazione è disattivata visitando "
+"%1$sduckduckgo.com/aichat%2$s."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1088,8 +1086,7 @@ msgstr ""
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
 msgctxt "duckassist"
 msgid "AI-assisted answers have been turned off!"
-msgstr ""
-"Le risposte assistite dall'intelligenza artificiale sono state disattivate!"
+msgstr "Le risposte assistite dall'intelligenza artificiale sono state disattivate!"
 
 # smartling.placeholder_format=C
 #. Negative feedback suggestion for when user dislikes AI-generated content
@@ -1229,7 +1226,7 @@ msgstr "Informazioni sui nostri annunci"
 #. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
 msgctxt "Modal header for chat history with sync information"
 msgid "About Chat History with Sync & Backup"
-msgstr ""
+msgstr "Informazioni sulla cronologia chat con Sync & Backup"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
@@ -1364,7 +1361,7 @@ msgstr "Questo annuncio è sospetto"
 #. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
 msgctxt "Button to open menu for attaching images or page context to AI chat"
 msgid "Add"
-msgstr ""
+msgstr "Aggiungi"
 
 # smartling.placeholder_format=C
 #. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
@@ -1372,7 +1369,7 @@ msgctxt ""
 "Primary button that attaches the tabs the user checked in the tab picker "
 "dialog"
 msgid "Add"
-msgstr ""
+msgstr "Aggiungi"
 
 # smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
@@ -1407,13 +1404,13 @@ msgstr "Aggiungi DuckDuckGo a %1$s"
 msgctxt ""
 "Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
 msgid "Add File"
-msgstr ""
+msgstr "Aggiungi file"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
 msgid "Add Image"
-msgstr ""
+msgstr "Aggiungi immagine"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
@@ -1421,7 +1418,7 @@ msgctxt ""
 "Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
 "item)"
 msgid "Add Image or File"
-msgstr ""
+msgstr "Aggiungi immagine o file"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1474,7 +1471,7 @@ msgctxt ""
 "Open the tab picker to attach browser tab content to the AI chat message "
 "(attach dropdown menu item)"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Aggiungi schede"
 
 # smartling.placeholder_format=C
 #. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
@@ -1482,7 +1479,7 @@ msgctxt ""
 "Title and accessible name of the tab-picker dialog opened from the attach "
 "dropdown menu"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Aggiungi schede"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1494,8 +1491,7 @@ msgstr "Aggiungi una casella di ricerca di %1$s al tuo sito!"
 #. Prompt to add locations on a map in order to get directions.
 msgctxt "directions"
 msgid "Add a starting point and destination to find a route."
-msgstr ""
-"Aggiungi un punto di partenza e una destinazione per trovare un percorso."
+msgstr "Aggiungi un punto di partenza e una destinazione per trovare un percorso."
 
 # smartling.placeholder_format=C
 #. Label on the AI model card indicating the model supports file uploads.
@@ -1574,7 +1570,7 @@ msgstr "Aggiungere i tocchi finali"
 #. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
 msgctxt "Aria label for the additional instructions textarea"
 msgid "Additional instructions"
-msgstr ""
+msgstr "Istruzioni aggiuntive"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1884,7 +1880,7 @@ msgstr "Fatto."
 #. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the read-only textarea listing all AI instructions"
 msgid "All instructions"
-msgstr ""
+msgstr "Tutte le istruzioni"
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -1978,8 +1974,7 @@ msgstr "Vuoi consentire la revisione anonima dei file per questa chat?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Consenti annunci che rispettano la privacy su Private Search DuckDuckGo"
+msgstr "Consenti annunci che rispettano la privacy su Private Search DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2649,15 +2644,13 @@ msgstr "Audio"
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"L'audio non viene memorizzato né da noi né da OpenAI dopo la fine della chat."
+msgstr "L'audio non viene memorizzato né da noi né da OpenAI dopo la fine della chat."
 
 # smartling.placeholder_format=C
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"L'audio non viene memorizzato né da noi né da OpenAI dopo la fine della chat."
+msgstr "L'audio non viene memorizzato né da noi né da OpenAI dopo la fine della chat."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
@@ -2962,8 +2955,8 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 "Prima di archiviare questo rapporto, DuckDuckGo renderà anonima la tua "
-"conversazione eliminando le informazioni personali, come nomi, indirizzi e-"
-"mail e metadati identificativi."
+"conversazione eliminando le informazioni personali, come nomi, indirizzi "
+"e-mail e metadati identificativi."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3099,14 +3092,12 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr ""
-"L'elenco dei blocchi non è esaustivo e potrebbe contenere imprecisioni."
+msgstr "L'elenco dei blocchi non è esaustivo e potrebbe contenere imprecisioni."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block most trackers as you browse."
-msgstr ""
-"Blocca la maggior parte dei sistemi di tracciamento durante la navigazione."
+msgstr "Blocca la maggior parte dei sistemi di tracciamento durante la navigazione."
 
 # smartling.placeholder_format=C
 #. Menu option to block a site from the displayed results
@@ -3620,7 +3611,7 @@ msgctxt ""
 "Secondary button that dismisses the tab picker dialog without attaching "
 "anything"
 msgid "Cancel"
-msgstr ""
+msgstr "Annulla"
 
 # smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
@@ -4122,7 +4113,7 @@ msgstr "La risposta della chat è offensiva"
 #. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
 msgctxt "Chat history about modal list item headline"
 msgid "Chat storage varies by browser"
-msgstr ""
+msgstr "L'archiviazione delle chat varia in base al browser"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4134,7 +4125,7 @@ msgstr "Chatta con %1$s"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Chat with popular AI models, anonymized by us."
-msgstr ""
+msgstr "Chatta con i modelli di AI più diffusi, resi anonimi da noi."
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4161,6 +4152,9 @@ msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
 msgstr ""
+"Le chat vengono archiviate in modo sicuro sul server di DuckDuckGo con "
+"crittografia end-to-end. Nessuno tranne te può vedere i tuoi dati, nemmeno "
+"noi."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4779,8 +4773,7 @@ msgstr "Clicca sulla %1$slente di ingrandimento%2$s nella barra di ricerca"
 # smartling.placeholder_format=C
 #. Tells users what icon to click in their browser to change their default search engine.
 msgid "Click on the magnifying glass in the search box at the top right"
-msgstr ""
-"Clicca sulla lente di ingrandimento nella casella di ricerca in alto a destra"
+msgstr "Clicca sulla lente di ingrandimento nella casella di ricerca in alto a destra"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4833,21 +4826,18 @@ msgstr "Clicca sui %1$spuntini di sospensione%2$s nella barra degli strumenti."
 #. Tells users where to click in their browser to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Click the %slock icon%s on the address bar."
-msgstr ""
-"Clicca sull'%1$sicona di blocco%2$s presente nella barra degli indirizzi."
+msgstr "Clicca sull'%1$sicona di blocco%2$s presente nella barra degli indirizzi."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Click the %spermissions icon%s in the address bar"
-msgstr ""
-"Clicca sull'%1$sicona delle autorizzazioni%2$s nella barra degli indirizzi"
+msgstr "Clicca sull'%1$sicona delle autorizzazioni%2$s nella barra degli indirizzi"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr ""
-"Clicca sull'icona dell'anatra in alto nel browser per effettuare una ricerca!"
+msgstr "Clicca sull'icona dell'anatra in alto nel browser per effettuare una ricerca!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -5479,8 +5469,7 @@ msgstr "Copia"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"Copia e incolla %1$sabout:preferences#search%2$s nella barra degli indirizzi"
+msgstr "Copia e incolla %1$sabout:preferences#search%2$s nella barra degli indirizzi"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5586,8 +5575,7 @@ msgstr "Costa Rica"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr ""
-"Impossibile caricare il codice di recupero. Chiudi questa finestra e riprova."
+msgstr "Impossibile caricare il codice di recupero. Chiudi questa finestra e riprova."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5772,7 +5760,7 @@ msgstr "Serie attuale"
 #. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
 msgctxt "Suffix label indicating a tab is the currently active browser tab"
 msgid "Current Tab"
-msgstr ""
+msgstr "Scheda attuale"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
@@ -6128,7 +6116,7 @@ msgstr "Elimina le chat più vecchie di 30 giorni"
 #. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
 msgctxt "Button text in the modal for deleting all recent chats"
 msgid "Delete Chats and Shared Links"
-msgstr ""
+msgstr "Elimina chat e link condivisi"
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6550,7 +6538,7 @@ msgstr "Ignora la promozione"
 #. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the close button on the survey banner"
 msgid "Dismiss survey"
-msgstr ""
+msgstr "Ignora il sondaggio"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7076,8 +7064,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai non è al momento disponibile. Se il problema persiste, invia un'e-"
-"mail con il codice anonimo %1$s a %2$s"
+"Duck.ai non è al momento disponibile. Se il problema persiste, invia "
+"un'e-mail con il codice anonimo %1$s a %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7170,8 +7158,7 @@ msgstr "Duck.ai è stato aggiornato!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.ai funziona al meglio nella nostra app DuckDuckGo, privata e gratuita!"
+msgstr "Duck.ai funziona al meglio nella nostra app DuckDuckGo, privata e gratuita!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7735,7 +7722,7 @@ msgstr "Modifica prompt"
 #. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the message-editing text area"
 msgid "Edit message"
-msgstr ""
+msgstr "Modifica messaggio"
 
 # smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
@@ -7966,7 +7953,7 @@ msgstr "Modello crittografato"
 #. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
 msgctxt "Share modal info bullet about encryption"
 msgid "Encrypted so DuckDuckGo can't read your chat."
-msgstr ""
+msgstr "Crittografata, quindi DuckDuckGo non può leggere la tua chat."
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8032,8 +8019,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr ""
-"Assicurati che l'opzione \"Servizi di localizzazione\" sia %1$sattivata%2$s."
+msgstr "Assicurati che l'opzione \"Servizi di localizzazione\" sia %1$sattivata%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
@@ -8085,15 +8071,13 @@ msgstr ""
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access"
-msgstr ""
-"Assicurati che il tuo browser sia autorizzato ad accedere alla posizione"
+msgstr "Assicurati che il tuo browser sia autorizzato ad accedere alla posizione"
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr ""
-"Assicurati che il tuo browser sia autorizzato ad accedere alla posizione."
+msgstr "Assicurati che il tuo browser sia autorizzato ad accedere alla posizione."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -8377,8 +8361,7 @@ msgstr "Esplora Duck.ai"
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
-msgstr ""
-"Esplora gli ultimi aggiornamenti di prodotti e funzionalità di DuckDuckGo."
+msgstr "Esplora gli ultimi aggiornamenti di prodotti e funzionalità di DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8818,7 +8801,7 @@ msgstr "Domanda di approfondimento"
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
-msgstr ""
+msgstr "Le domande di approfondimento restano private."
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8954,8 +8937,7 @@ msgstr "Condivisione e uso commerciale gratuiti"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr ""
-"Libera spazio eliminando le chat. Le chat fissate non verranno eliminate."
+msgstr "Libera spazio eliminando le chat. Le chat fissate non verranno eliminate."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -9339,7 +9321,7 @@ msgstr ""
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
 msgctxt "Tooltip on the header logo for sunglasses searches"
 msgid "Get DuckDuckGo sunglasses and other gear."
-msgstr ""
+msgstr "Acquista gli occhiali da sole DuckDuckGo e altri gadget."
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9398,8 +9380,7 @@ msgstr "Iniziamo"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the Privacy Pro subscription.
 msgctxt "SERP footer content"
 msgid "Get a VPN + two more protections in one easy subscription."
-msgstr ""
-"Ottieni una VPN + altre due protezioni in un unico semplice abbonamento."
+msgstr "Ottieni una VPN + altre due protezioni in un unico semplice abbonamento."
 
 # smartling.placeholder_format=C
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
@@ -9952,8 +9933,7 @@ msgstr "Guatemala"
 #. Text for a prompt suggestion for guiding through the basic steps of replacing a window wiper.
 msgctxt "Full sentence for learning a new skill"
 msgid "Guide me through the basic steps of replacing a window wiper."
-msgstr ""
-"Indicami i passaggi fondamentali per la sostituzione di un tergicristallo."
+msgstr "Indicami i passaggi fondamentali per la sostituzione di un tergicristallo."
 
 # smartling.placeholder_format=C
 msgid "Guinea"
@@ -10348,8 +10328,7 @@ msgstr "Nascondi il tuo indirizzo e-mail"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Hides search term from being shown in browser tab/history"
-msgstr ""
-"Nasconde i termini di ricerca dalla scheda e dalla cronologia del browser"
+msgstr "Nasconde i termini di ricerca dalla scheda e dalla cronologia del browser"
 
 # smartling.placeholder_format=C
 #. The highest stock price in a day
@@ -10581,7 +10560,7 @@ msgstr "Come funziona"
 #. Headline in chat history about modals for the temporary encrypted server storage explanation.
 msgctxt "Chat history about modal list item headline"
 msgid "How it works"
-msgstr ""
+msgstr "Come funziona"
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -10599,8 +10578,7 @@ msgstr "Come funziona"
 #. Header for the assist settings modal where the user can choose how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How much do you want AI-assisted answers to appear?"
-msgstr ""
-"Quanto vuoi che appaiano le risposte assistite dall'intelligenza artificiale?"
+msgstr "Quanto vuoi che appaiano le risposte assistite dall'intelligenza artificiale?"
 
 # smartling.placeholder_format=C
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
@@ -10850,8 +10828,7 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"Se vuoi supportarci in altri modi, %1$saiuta a diffondere DuckDuckGo%2$s"
+msgstr "Se vuoi supportarci in altri modi, %1$saiuta a diffondere DuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -11054,8 +11031,7 @@ msgstr "Nel menu in alto seleziona %1$sStrumenti%2$s > %3$sImpostazioni%4$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
-msgstr ""
-"Nel popup, seleziona %1$sImposta come provider di ricerca predefinito%2$s"
+msgstr "Nel popup, seleziona %1$sImposta come provider di ricerca predefinito%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -12037,7 +12013,7 @@ msgstr "Il link scade tra 7 giorni."
 #. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days. People can save a chat copy."
-msgstr ""
+msgstr "Il link scade tra 7 giorni. Le persone possono salvare una copia della chat."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -12053,8 +12029,7 @@ msgstr "Link:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
-"Elenca gli strumenti, i materiali o i prerequisiti che mi servono per questo."
+msgstr "Elenca gli strumenti, i materiali o i prerequisiti che mi servono per questo."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12165,8 +12140,7 @@ msgstr "Carica altre immagini durante lo scorrimento"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr ""
-"Carica altri risultati in Immagini, Video e Shopping durante lo scorrimento"
+msgstr "Carica altri risultati in Immagini, Video e Shopping durante lo scorrimento"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -12948,8 +12922,7 @@ msgstr "Limite mensile raggiunto"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Limite di utilizzo mensile raggiunto. Puoi continuare questa chat dopo %1$s."
+msgstr "Limite di utilizzo mensile raggiunto. Puoi continuare questa chat dopo %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -13846,15 +13819,13 @@ msgstr "Nessun sistema di tracciamento bloccato nell'ultima ora"
 #. Refers to how web searches on DuckDuckGo aren't tracked.
 msgctxt "homepage onboarding"
 msgid "No tracking, no ad targeting, just searching!"
-msgstr ""
-"Nessun tracciamento, nessuna pubblicità mirata, solo semplici ricerche!"
+msgstr "Nessun tracciamento, nessuna pubblicità mirata, solo semplici ricerche!"
 
 # smartling.placeholder_format=C
 #. Refers to how web searches on DuckDuckGo aren't tracked.
 msgctxt "homepage onboarding"
 msgid "No tracking, no ad targeting, just searching."
-msgstr ""
-"Nessun tracciamento, nessuna pubblicità mirata, solo semplici ricerche."
+msgstr "Nessun tracciamento, nessuna pubblicità mirata, solo semplici ricerche."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search. The placeholder is the user's search term. For example: 'No videos found for 'bad dogs''
@@ -14169,7 +14140,7 @@ msgstr "OK, capito!"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "OPTIONAL"
-msgstr ""
+msgstr "OPZIONALE"
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -15491,15 +15462,13 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr ""
-"Descrivi perché la risposta nella chat è dannosa o illegale. (facoltativo)"
+msgstr "Descrivi perché la risposta nella chat è dannosa o illegale. (facoltativo)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr ""
-"Descrivi perché la risposta nella chat è illegale o dannosa. (Opzionale)"
+msgstr "Descrivi perché la risposta nella chat è illegale o dannosa. (Opzionale)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -16288,8 +16257,7 @@ msgstr "Proteggi i tuoi dati durante le ricerche e la navigazione."
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
-msgstr ""
-"Proteggi i tuoi dati durante le ricerche, la navigazione e l'uso dell'AI."
+msgstr "Proteggi i tuoi dati durante le ricerche, la navigazione e l'uso dell'AI."
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -16306,7 +16274,7 @@ msgstr "Protetto"
 #. Headline in sync-enabled chat history about modals explaining encrypted server storage.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Protected with end-to-end encryption"
-msgstr ""
+msgstr "Protetto con crittografia end-to-end"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -16445,7 +16413,7 @@ msgstr "Classifiche"
 #. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
 msgctxt "star rating on a product"
 msgid "Rated %s out of %s"
-msgstr ""
+msgstr "Valutato %1$s su %2$s"
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -16589,8 +16557,7 @@ msgstr "Schede recenti"
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
-msgstr ""
-"Lo spazio di archiviazione delle chat recenti può essere regolato in %1$s."
+msgstr "Lo spazio di archiviazione delle chat recenti può essere regolato in %1$s."
 
 # smartling.placeholder_format=C
 #. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
@@ -16913,8 +16880,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"Ricarica DuckDuckGo seguendo le istruzioni o facendo clic sul pulsante &quot;"
-"Aggiorna&quot; o &quot;Ricarica&quot; del browser."
+"Ricarica DuckDuckGo seguendo le istruzioni o facendo clic sul pulsante "
+"&quot;Aggiorna&quot; o &quot;Ricarica&quot; del browser."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16931,8 +16898,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
 msgid "Remember my choice (this can be changed in %sSettings%s)"
-msgstr ""
-"Ricorda la mia scelta (può essere modificata nelle %1$sImpostazioni%2$s)"
+msgstr "Ricorda la mia scelta (può essere modificata nelle %1$sImpostazioni%2$s)"
 
 # smartling.placeholder_format=C
 #. Button to be reminded later to update, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
@@ -17680,8 +17646,8 @@ msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
 msgstr ""
-"Salva le tue chat di Duck.ai tra i tuoi dispositivi con crittografia end-to-"
-"end."
+"Salva le tue chat di Duck.ai tra i tuoi dispositivi con crittografia "
+"end-to-end."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17693,7 +17659,7 @@ msgstr "Salva le tue chat su tutti i tuoi dispositivi."
 #. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
 msgctxt "Chat history about modal list item headline"
 msgid "Save your chats on this device"
-msgstr ""
+msgstr "Salva le tue chat su questo dispositivo"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
@@ -17905,7 +17871,7 @@ msgctxt ""
 "Placeholder and accessibility label for the search input in the tab picker "
 "dialog"
 msgid "Search"
-msgstr ""
+msgstr "Cerca"
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18231,8 +18197,7 @@ msgstr "Seconda opinione"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr ""
-"Salva e sincronizza in modo sicuro le tue chat su tutti i tuoi dispositivi."
+msgstr "Salva e sincronizza in modo sicuro le tue chat su tutti i tuoi dispositivi."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18282,8 +18247,8 @@ msgstr ""
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
 msgstr ""
-"Archiviati in modo sicuro sul server di DuckDuckGo con crittografia end-to-"
-"end."
+"Archiviati in modo sicuro sul server di DuckDuckGo con crittografia "
+"end-to-end."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -18292,8 +18257,8 @@ msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
 msgstr ""
-"Archiviati in modo sicuro sul server di DuckDuckGo con crittografia end-to-"
-"end. Nessuno tranne te può vedere i tuoi dati, nemmeno noi."
+"Archiviati in modo sicuro sul server di DuckDuckGo con crittografia "
+"end-to-end. Nessuno tranne te può vedere i tuoi dati, nemmeno noi."
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
@@ -18448,27 +18413,24 @@ msgstr ""
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Scegli %1$sPersonalizzata%2$s e digita nel campo %3$shttps://duckduckgo."
-"com%4$s"
+"Scegli %1$sPersonalizzata%2$s e digita nel campo "
+"%3$shttps://duckduckgo.com%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sAggiungi come predefinito%4$s!"
+msgstr "Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sAggiungi come predefinito%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sImposta come predefinito%4$s"
+msgstr "Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sImposta come predefinito%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sImposta come predefinito%4$s."
+msgstr "Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sImposta come predefinito%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -18583,8 +18545,7 @@ msgstr "Seleziona %1$sImpostazioni%2$s, poi %3$sImpostazioni avanzate%4$s"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr ""
-"Seleziona %1$sImpostazioni%2$s, poi %3$sMotore di ricerca predefinito%4$s"
+msgstr "Seleziona %1$sImpostazioni%2$s, poi %3$sMotore di ricerca predefinito%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -18680,8 +18641,7 @@ msgstr "Testo selezionato da %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr ""
-"Il testo selezionato è troppo lungo. Riprova con una selezione più breve."
+msgstr "Il testo selezionato è troppo lungo. Riprova con una selezione più breve."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -19108,7 +19068,7 @@ msgstr "Acquista"
 #. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
 msgctxt "Button in the merchandise logo modal (mobile)"
 msgid "Shop Now"
-msgstr ""
+msgstr "Acquista ora"
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -19473,14 +19433,12 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows horizontal lines at result page breaks"
-msgstr ""
-"Mostra linee orizzontali a ogni interruzione della pagina dei risultati"
+msgstr "Mostra linee orizzontali a ogni interruzione della pagina dei risultati"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr ""
-"Mostra link per le istruzioni su come aggiungere DuckDuckGo al tuo browser"
+msgstr "Mostra link per le istruzioni su come aggiungere DuckDuckGo al tuo browser"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -19501,8 +19459,7 @@ msgstr "Mostra promemoria occasionali per aggiungere DuckDuckGo al tuo browser"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Mostra promemoria occasionali per aggiungere DuckDuckGo ai tuoi dispositivi"
+msgstr "Mostra promemoria occasionali per aggiungere DuckDuckGo ai tuoi dispositivi"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19631,8 +19588,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"I siti che blocchi saranno nascosti da tutti i tuoi risultati di ricerca"
+msgstr "I siti che blocchi saranno nascosti da tutti i tuoi risultati di ricerca"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19779,8 +19735,7 @@ msgstr "Si è verificato un errore"
 #. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
 msgctxt "Generic toast for share view load failures"
 msgid "Something went wrong loading this shared chat."
-msgstr ""
-"Si è verificato un errore durante il caricamento di questa chat condivisa."
+msgstr "Si è verificato un errore durante il caricamento di questa chat condivisa."
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -19792,8 +19747,7 @@ msgstr "Qualcosa è andato storto durante il salvataggio nel server, riprova."
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr ""
-"Si è verificato un problema durante l'attivazione di Sync & Backup. Riprova."
+msgstr "Si è verificato un problema durante l'attivazione di Sync & Backup. Riprova."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -19823,8 +19777,7 @@ msgstr "A volte"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr ""
-"Mi dispiace, non posso aiutarti. Descrivi la tua immagine in un modo diverso."
+msgstr "Mi dispiace, non posso aiutarti. Descrivi la tua immagine in un modo diverso."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19900,8 +19853,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Spiacenti, non siamo riusciti a inviare il tuo feedback. Riprova più tardi."
+msgstr "Spiacenti, non siamo riusciti a inviare il tuo feedback. Riprova più tardi."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -20214,8 +20166,7 @@ msgstr "Interrompi la generazione"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr ""
-"Impedisci ai sistemi di tracciamento nascosti di apparire su altri siti."
+msgstr "Impedisci ai sistemi di tracciamento nascosti di apparire su altri siti."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -20698,8 +20649,7 @@ msgstr "Passa a un modello più efficiente"
 # smartling.placeholder_format=C
 #. Text prompting  users to switch their current search engine to the DuckDuckGo private search engine.
 msgid "Switch to the search engine that doesn't track you. Ever."
-msgstr ""
-"Passa al motore di ricerca che non raccoglie i tuoi dati di navigazione. Mai."
+msgstr "Passa al motore di ricerca che non raccoglie i tuoi dati di navigazione. Mai."
 
 # smartling.placeholder_format=C
 #. Re-activates a stacked second opinion, making it the current answer again.
@@ -20720,8 +20670,7 @@ msgstr "Passato a %1$s"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr ""
-"Il passaggio invierà la chat a un modello senza visibilità zero lato provider"
+msgstr "Il passaggio invierà la chat a un modello senza visibilità zero lato provider"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -20785,7 +20734,7 @@ msgctxt "Chat history with sync modal list item description"
 msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
-msgstr ""
+msgstr "Sync & Backup salva più chat e le sincronizza su tutti i tuoi dispositivi."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20845,8 +20794,8 @@ msgstr ""
 "%1$s\n"
 "\n"
 "Come funziona il codice?\n"
-"1. Apri il browser e vai su Duck.ai, quindi apri le impostazioni di Duck."
-"ai.\n"
+"1. Apri il browser e vai su Duck.ai, quindi apri le impostazioni di "
+"Duck.ai.\n"
 "2. Seleziona \"Attiva Sync & Backup\", poi \"Recupera dati sincronizzati\"\n"
 "3. Copia il codice di recupero sopra e incollalo nello spazio \"Incolla qui "
 "il tuo codice\"\n"
@@ -20907,7 +20856,7 @@ msgstr "Sincronizza le tue chat su tutti i tuoi dispositivi."
 #. Headline in sync-enabled chat history about modals explaining cross-device sync.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Sync your chats across all your devices"
-msgstr ""
+msgstr "Sincronizza le tue chat su tutti i tuoi dispositivi"
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21509,12 +21458,14 @@ msgid ""
 "This chat and its generated images become public when you create and copy "
 "the link."
 msgstr ""
+"Questa chat e le immagini generate diventano pubbliche quando crei e copi il "
+"link."
 
 # smartling.placeholder_format=C
 #. Explains that creating and copying a share link makes the selected chat content public.
 msgctxt "Share modal info bullet about public access"
 msgid "This chat becomes public when you create and copy the link."
-msgstr ""
+msgstr "Questa chat diventa pubblica quando crei e copi il link."
 
 # smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
@@ -21656,8 +21607,7 @@ msgstr "Questa immagine non può essere creata."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr ""
-"Questo tipo di immagine non è supportato, allega un file JPG, PNG, WebP o GIF"
+msgstr "Questo tipo di immagine non è supportato, allega un file JPG, PNG, WebP o GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
@@ -21747,8 +21697,7 @@ msgstr "Questa pagina richiede Javascript per funzionare."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Il contenuto di questa pagina verrà inviato con il tuo messaggio a Duck.ai"
+msgstr "Il contenuto di questa pagina verrà inviato con il tuo messaggio a Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21800,8 +21749,7 @@ msgstr ""
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr ""
-"Impossibile aprire questa chat condivisa. Il link potrebbe essere incompleto."
+msgstr "Impossibile aprire questa chat condivisa. Il link potrebbe essere incompleto."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
@@ -22059,15 +22007,15 @@ msgstr "Oggi"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
-msgstr ""
+msgstr "Attiva la chat AI privata oppure %1$sdisabilitala nelle impostazioni%2$s."
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
-"Attiva per provare la chat AI privata oppure %1$sdisabilitala nel menu %2$s."
-"%3$s"
+"Attiva per provare la chat AI privata oppure %1$sdisabilitala nel menu "
+"%2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -22232,8 +22180,7 @@ msgstr "Sistemi di tracciamento bloccati nell'ultima ora"
 #. Placeholder for when we cannot report any blocked trackers yet
 msgctxt "tracker_stats"
 msgid "Trackers that DuckDuckGo blocks will appear here"
-msgstr ""
-"I sistemi di tracciamento bloccati da DuckDuckGo vengono visualizzati qui"
+msgstr "I sistemi di tracciamento bloccati da DuckDuckGo vengono visualizzati qui"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -22249,8 +22196,7 @@ msgstr ""
 #. Placeholder for when we cannot report any blocked trackers yet
 msgctxt "tracker_stats"
 msgid "Tracking attempts blocked by DuckDuckGo will appear here"
-msgstr ""
-"I tentativi di tracciamento bloccati da DuckDuckGo verranno visualizzati qui"
+msgstr "I tentativi di tracciamento bloccati da DuckDuckGo verranno visualizzati qui"
 
 # smartling.placeholder_format=C
 #. Tooltip and accessible label for the confirm (checkmark) button that stops recording and sends audio for transcription.
@@ -22565,8 +22511,7 @@ msgstr "Prova ad abilitare la posizione anonima per risultati più accurati."
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Prova a sperimentare con ogni modello: ciascuno fornirà risposte diverse."
+msgstr "Prova a sperimentare con ogni modello: ciascuno fornirà risposte diverse."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -23143,8 +23088,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"In %1$sAll'avvio%2$s, seleziona %3$sPagina Iniziale%4$s e inserisci: https://"
-"duckduckgo.com"
+"In %1$sAll'avvio%2$s, seleziona %3$sPagina Iniziale%4$s e inserisci: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -23173,8 +23118,8 @@ msgstr ""
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"Nella sezione %1$sRicerca%2$s, clicca su %3$sGestisci motori di ricerca..."
-"%4$s"
+"Nella sezione %1$sRicerca%2$s, clicca su %3$sGestisci motori di "
+"ricerca...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -23188,8 +23133,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr ""
-"In \"Ricerca\" clicca sul menu a tendina e seleziona %1$sDuckDuckGo%2$s"
+msgstr "In \"Ricerca\" clicca sul menu a tendina e seleziona %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -23870,8 +23814,7 @@ msgstr "Visualizza i prezzi per il tuo soggiorno"
 # smartling.placeholder_format=C
 #. A description for the ads tooltip that explains that viewing ads is privacy protected by DuckDuckGo.
 msgid "Viewing ads is privacy protected by DuckDuckGo."
-msgstr ""
-"La visualizzazione degli annunci è protetta dalla privacy di DuckDuckGo."
+msgstr "La visualizzazione degli annunci è protetta dalla privacy di DuckDuckGo."
 
 # smartling.placeholder_format=C
 msgctxt "Ads GDPR, internal use only. Do not change"
@@ -23899,6 +23842,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Yelp's ad network."
 msgstr ""
+"La visualizzazione degli annunci è protetta dalla privacy di DuckDuckGo. I "
+"clic sugli annunci sono gestiti dalla rete pubblicitaria di Yelp."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -24283,8 +24228,7 @@ msgstr "Non memorizziamo nomi utente né informazioni personali."
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr ""
-"Non memorizziamo le tue informazioni personali e non ti tracciamo. Mai."
+msgstr "Non memorizziamo le tue informazioni personali e non ti tracciamo. Mai."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24453,8 +24397,7 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr ""
-"Ci affidiamo alla tua opinione anonima per migliorare DuckDuckGo per tutti."
+msgstr "Ci affidiamo alla tua opinione anonima per migliorare DuckDuckGo per tutti."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -24698,8 +24641,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"Ti diamo il benvenuto al nuovo Duck.ai! Ora puoi importare le chat scaricate."
+msgstr "Ti diamo il benvenuto al nuovo Duck.ai! Ora puoi importare le chat scaricate."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24925,8 +24867,7 @@ msgstr "Quali sono i piatti da provare in questo caso?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
-"Quali sono gli orari di apertura, la posizione e i recapiti di questo luogo?"
+msgstr "Quali sono gli orari di apertura, la posizione e i recapiti di questo luogo?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -25153,8 +25094,7 @@ msgstr "Su cosa vuoi dare un'opinione?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"Ciò che guardi in DuckDuckGo non influenzerà i tuoi consigli su YouTube."
+msgstr "Ciò che guardi in DuckDuckGo non influenzerà i tuoi consigli su YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -25396,6 +25336,8 @@ msgid ""
 "With chat history on, up to %s of your most recent chats will be saved on "
 "this device."
 msgstr ""
+"Con la cronologia chat attiva, verranno salvate su questo dispositivo fino a "
+"%1$s delle tue chat più recenti."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline in the About Chat History modal.
@@ -25403,6 +25345,8 @@ msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, your most recent chats will be saved on this device."
 msgstr ""
+"Con la cronologia chat attiva, le tue chat più recenti verranno salvate su "
+"questo dispositivo."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -25759,8 +25703,7 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr ""
-"Puoi modificarle in qualsiasi momento in %1$sImpostazioni di ricerca%2$s"
+msgstr "Puoi modificarle in qualsiasi momento in %1$sImpostazioni di ricerca%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
@@ -25987,8 +25930,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr ""
-"Non vedrai più questo messaggio a meno che non elimini i dati del browser."
+msgstr "Non vedrai più questo messaggio a meno che non elimini i dati del browser."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -26085,8 +26027,7 @@ msgstr ""
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr ""
-"Hai raggiunto la durata massima della chat vocale per una singola sessione."
+msgstr "Hai raggiunto la durata massima della chat vocale per una singola sessione."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
@@ -26098,8 +26039,7 @@ msgstr "Hai raggiunto il limite di chat vocale per oggi. Riprova domani."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"Hai raggiunto il limite di utilizzo della dettatura. Riprova più tardi."
+msgstr "Hai raggiunto il limite di utilizzo della dettatura. Riprova più tardi."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -26169,8 +26109,8 @@ msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
 msgstr ""
-"Le tue chat di Duck.ai sono in fase di sincronizzazione con crittografia end-"
-"to-end."
+"Le tue chat di Duck.ai sono in fase di sincronizzazione con crittografia "
+"end-to-end."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -26542,8 +26482,7 @@ msgctxt "Error message for input limit"
 msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
-msgstr ""
-"Hai superato la dimensione massima del messaggio. Accorcialo e riprova."
+msgstr "Hai superato la dimensione massima del messaggio. Accorcialo e riprova."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -26577,8 +26516,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr ""
-"Hai raggiunto il numero massimo di messaggi giornalieri. Continua domani."
+msgstr "Hai raggiunto il numero massimo di messaggi giornalieri. Continua domani."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -26667,8 +26605,7 @@ msgstr "di %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"di DuckDuckGo, protezione online scelta da milioni di persone ogni giorno."
+msgstr "di DuckDuckGo, protezione online scelta da milioni di persone ogni giorno."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"
@@ -26813,7 +26750,7 @@ msgstr "m"
 #. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the chat options menu button"
 msgid "menu"
-msgstr ""
+msgstr "menu"
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/it_IT/LC_MESSAGES/duckduckgo.po
+++ b/locales/it_IT/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: it_IT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1226,6 +1226,12 @@ msgid "About our ads"
 msgstr "Informazioni sui nostri annunci"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1355,6 +1361,20 @@ msgid "Ad is suspicious"
 msgstr "Questo annuncio è sospetto"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Aggiungi DuckDuckGo"
@@ -1381,6 +1401,27 @@ msgstr "Aggiungi DuckDuckGo come motore di ricerca"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Aggiungi DuckDuckGo a %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1426,6 +1467,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Aggiungi il contenuto della pagina"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1512,6 +1569,12 @@ msgstr "Add-on"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Aggiungere i tocchi finali"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1816,6 +1879,12 @@ msgstr "Tutti i colori"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Fatto."
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3546,6 +3615,14 @@ msgid "Cancel"
 msgstr "Annulla"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4042,10 +4119,22 @@ msgid "Chat response is offensive"
 msgstr "La risposta della chat è offensiva"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Chatta con %1$s"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4064,6 +4153,14 @@ msgstr "Chat"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Chat"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5672,6 +5769,12 @@ msgid "Current Streak"
 msgstr "Serie attuale"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -6020,6 +6123,12 @@ msgstr "Elimina chat"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Elimina le chat più vecchie di 30 giorni"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6436,6 +6545,12 @@ msgstr "Nascondi definitivamente"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Ignora la promozione"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7617,6 +7732,12 @@ msgid "Edit Prompt"
 msgstr "Modifica prompt"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7840,6 +7961,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Modello crittografato"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8688,6 +8815,12 @@ msgid "Follow-up question"
 msgstr "Domanda di approfondimento"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9201,6 +9334,12 @@ msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
 "Ottieni la VPN di DuckDuckGo, le funzionalità avanzate di Duck.ai e Identity "
 "Theft Restoration."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10437,6 +10576,12 @@ msgstr "Come può essere anonimo?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Come funziona"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11887,6 +12032,12 @@ msgstr "Rimesse laterali vinte"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "Il link scade tra 7 giorni."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14013,6 +14164,12 @@ msgstr "OK"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "OK, capito!"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16146,6 +16303,12 @@ msgid "Protected"
 msgstr "Protetto"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Protezione. Privacy.  Serenità."
@@ -16277,6 +16440,12 @@ msgstr "Pioggia"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Classifiche"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17521,6 +17690,12 @@ msgid "Save your chats across all your devices."
 msgstr "Salva le tue chat su tutti i tuoi dispositivi."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17723,6 +17898,14 @@ msgstr "Ricerca"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Ricerca"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18920,6 +19103,12 @@ msgstr "Shift+Invio"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Acquista"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20591,6 +20780,14 @@ msgstr ""
 "inattività."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20705,6 +20902,12 @@ msgstr "Sincronizza con un dispositivo nelle vicinanze."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Sincronizza le tue chat su tutti i tuoi dispositivi."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21298,6 +21501,22 @@ msgid "This Week"
 msgstr "Questa settimana"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21835,6 +22054,12 @@ msgstr "Oggi"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Oggi"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23668,6 +23893,14 @@ msgstr ""
 "clic sugli annunci sono gestiti dalla rete pubblicitaria di TripAdvisor."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Isole Vergini"
 
@@ -25157,6 +25390,21 @@ msgstr ""
 "per addestrare l'AI. Attiva o disattiva in qualsiasi momento nel menu “%1$s”."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26560,6 +26808,12 @@ msgstr "m"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "m"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/ja_JP/LC_MESSAGES/duckduckgo.po
+++ b/locales/ja_JP/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: ja_JP\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -189,10 +189,7 @@ msgctxt "Error message when a Plus subscriber tries to use a Pro-only model"
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr ""
-"%1$sはProでのみ利用可能です。チャットを続けるには、このブラウザでDuckDuckGoの"
-"サブスクリプションを再度アップグレードするか、Plusまたは無料プランに切り替え"
-"てください。"
+msgstr "%1$sはProでのみ利用可能です。チャットを続けるには、このブラウザでDuckDuckGoのサブスクリプションを再度アップグレードするか、Plusまたは無料プランに切り替えてください。"
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -201,10 +198,7 @@ msgctxt ""
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr ""
-"%1$sはProでのみ利用可能です。チャットを続けるには、このブラウザでDuckDuckGoの"
-"サブスクリプションを再度アップグレードするか、Plusまたは無料プランに切り替え"
-"てください。"
+msgstr "%1$sはProでのみ利用可能です。チャットを続けるには、このブラウザでDuckDuckGoのサブスクリプションを再度アップグレードするか、Plusまたは無料プランに切り替えてください。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -219,10 +213,7 @@ msgid ""
 "%s is only available with a DuckDuckGo subscription. Activate your "
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
-msgstr ""
-"%1$sはDuckDuckGoのサブスクリプションでのみ利用可能です。チャットを続けるに"
-"は、このブラウザでサブスクリプションを再度有効にするか、無料プランに切り替え"
-"てください。"
+msgstr "%1$sはDuckDuckGoのサブスクリプションでのみ利用可能です。チャットを続けるには、このブラウザでサブスクリプションを再度有効にするか、無料プランに切り替えてください。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -230,9 +221,7 @@ msgctxt "Error message for model unavailability"
 msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
-msgstr ""
-"%1$sは一時的に利用できません。 別のモデルに切り替えるか、後でもう一度やり直し"
-"てください。"
+msgstr "%1$sは一時的に利用できません。 別のモデルに切り替えるか、後でもう一度やり直してください。"
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -329,9 +318,8 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$sはTrusted Execution Environmentで動作します。つまり、モデルプロバイダーで"
-"さえあなたのプロンプトやモデルの応答を見ることができず、このチャットをサー"
-"バーに保存することもできません。"
+"%1$sはTrusted Execution "
+"Environmentで動作します。つまり、モデルプロバイダーでさえあなたのプロンプトやモデルの応答を見ることができず、このチャットをサーバーに保存することもできません。"
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -416,9 +404,7 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
-msgstr ""
-"%1$sは%2$s日後（%3$s）にDuck.aiで利用不可になります。その後、モデルを切り替え"
-"てこのチャットを続けることができます。"
+msgstr "%1$sは%2$s日後（%3$s）にDuck.aiで利用不可になります。その後、モデルを切り替えてこのチャットを続けることができます。"
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -428,9 +414,7 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
-msgstr ""
-"%1$sは1日後（%2$s）にDuck.aiで利用不可になります。その後、モデルを切り替えて"
-"このチャットを続けることができます。"
+msgstr "%1$sは1日後（%2$s）にDuck.aiで利用不可になります。その後、モデルを切り替えてこのチャットを続けることができます。"
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -442,9 +426,7 @@ msgstr "%1$s単語"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr ""
-"%1$s%2$s追加ボタンをクリックして%3$s%4$s許可%5$sにチェックを入れ、 %6$sOK%7$s"
-"をクリックしてください"
+msgstr "%1$s%2$s追加ボタンをクリックして%3$s%4$s許可%5$sにチェックを入れ、 %6$sOK%7$sをクリックしてください"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -452,8 +434,8 @@ msgstr ""
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$s%2$s許可%3$sにチェックを入れて、%4$s追加%5$sをクリックし、%6$s許可%7$s"
-"ボックスをオンにしてから %8$sOK%9$sをクリックしてください"
+"%1$s%2$s許可%3$sにチェックを入れて、%4$s追加%5$sをクリックし、%6$s許可%7$sボックスをオンにしてから "
+"%8$sOK%9$sをクリックしてください"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -463,8 +445,8 @@ msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
 msgstr ""
-"%1$s%2$sインストールを続行%3$sをクリックして %4$s追加ボタン%5$sを押し、%6$s許"
-"可%7$sにチェックを入れたら%8$sOK%9$sをクリックしてください"
+"%1$s%2$sインストールを続行%3$sをクリックして "
+"%4$s追加ボタン%5$sを押し、%6$s許可%7$sにチェックを入れたら%8$sOK%9$sをクリックしてください"
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -472,9 +454,7 @@ msgctxt "noresults"
 msgid ""
 "%sClick here%s to try again, if you think there should be results for this "
 "search."
-msgstr ""
-"この検索の結果について再読み込みする場合は、%1$sこちらをクリック%2$sしてもう"
-"一度試します。"
+msgstr "この検索の結果について再読み込みする場合は、%1$sこちらをクリック%2$sしてもう一度試します。"
 
 # smartling.placeholder_format=C
 #. Header for a page with information about sharing DuckDuckGo.
@@ -492,8 +472,7 @@ msgstr "%1$sさらに詳しく%2$s"
 #. Link to a page with more information about how anonymous location works.
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
-msgstr ""
-"%1$sDuckDuckGoが位置情報を保護する方法については、こちらをご覧ください%2$s。"
+msgstr "%1$sDuckDuckGoが位置情報を保護する方法については、こちらをご覧ください%2$s。"
 
 # smartling.placeholder_format=C
 #. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
@@ -507,9 +486,7 @@ msgstr "%1$s詳細情報%2$s"
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr ""
-"DuckDuckGoのサーバー上でチャットが非公開で保存される仕組みについては%1$sこち"
-"ら%2$sをご覧ください。"
+msgstr "DuckDuckGoのサーバー上でチャットが非公開で保存される仕組みについては%1$sこちら%2$sをご覧ください。"
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -527,8 +504,7 @@ msgstr "ホーム画面でDuckDuckGoのアプリアイコンを%1$s長押し%2$s
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr ""
-"%1$s%2$s%3$s問題が発生しました。%4$s更新%5$sして、もう一度お試しください。"
+msgstr "%1$s%2$s%3$s問題が発生しました。%4$s更新%5$sして、もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -886,8 +862,7 @@ msgstr "6時間の使用制限に達しました。このチャットは%1$s以�
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "6-hour usage limit reached. You can keep chatting by using your daily limit."
-msgstr ""
-"6時間の使用制限に達しました。1日の制限時間を使ってチャットを続行できます。"
+msgstr "6時間の使用制限に達しました。1日の制限時間を使ってチャットを続行できます。"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes abbreviation
@@ -940,27 +915,21 @@ msgstr "A"
 msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
-msgstr ""
-"ネットワークの問題により、Search Assistは回答を生成できません。接続を確認し"
-"て、もう一度試してください。"
+msgstr "ネットワークの問題により、Search Assistは回答を生成できません。接続を確認して、もう一度試してください。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"AI Chatの新バージョンが登場！続行するには、このページを再読み込みしてくださ"
-"い。"
+msgstr "AI Chatの新バージョンが登場！続行するには、このページを再読み込みしてください。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"Duck.aiの新バージョンが登場！続行するには、このページを再読み込みしてくださ"
-"い。"
+msgstr "Duck.aiの新バージョンが登場！続行するには、このページを再読み込みしてください。"
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1004,9 +973,8 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"AI Chatでは、サードパーティのAIチャットモデルと匿名で会話できます。設定をオフ"
-"にすると、DuckDuckGo SearchのAI Chat機能は非表示になりますが、%1$sduckduckgo."
-"com/aichat%2$sにアクセスすると、AI Chatをご利用いただけます。"
+"AI Chatでは、サードパーティのAIチャットモデルと匿名で会話できます。設定をオフにすると、DuckDuckGo SearchのAI "
+"Chat機能は非表示になりますが、%1$sduckduckgo.com/aichat%2$sにアクセスすると、AI Chatをご利用いただけます。"
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1066,11 +1034,7 @@ msgid ""
 "However, we also offer and often link to %sDuck.ai%s for follow-up "
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
-msgstr ""
-"AI支援による回答は現在、フォローアップの質問を直接サポートしていません。ただ"
-"し、フォローアップの質問のために%1$sDuck.ai%2$sも（リンク経由を含め）提供して"
-"います。Duck.aiは、OpenAIやAnthropicなどのチャットモデルをサポートするAIを活"
-"用したプライベートチャットサービスです。"
+msgstr "AI支援による回答は現在、フォローアップの質問を直接サポートしていません。ただし、フォローアップの質問のために%1$sDuck.ai%2$sも（リンク経由を含め）提供しています。Duck.aiは、OpenAIやAnthropicなどのチャットモデルをサポートするAIを活用したプライベートチャットサービスです。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1214,7 +1178,7 @@ msgstr "広告について"
 #. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
 msgctxt "Modal header for chat history with sync information"
 msgid "About Chat History with Sync & Backup"
-msgstr ""
+msgstr "Sync & Backup有効時のチャット履歴について"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
@@ -1260,9 +1224,7 @@ msgctxt ""
 msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
-msgstr ""
-"チャットを続けるには、このブラウザで %1$s を再度有効にするか、無料プランに切"
-"り替えてください。"
+msgstr "チャットを続けるには、このブラウザで %1$s を再度有効にするか、無料プランに切り替えてください。"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1297,18 +1259,14 @@ msgstr "広告"
 #. An item in the ads tooltip that explains that ad clicks are managed by the ad network and are not used to profile you. The placeholder is the name of the ad network. For example: Microsoft
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
-msgstr ""
-"広告クリックは%1$sの広告ネットワークによって管理されており、お客様のプロファ"
-"イリングには使用されません。"
+msgstr "広告クリックは%1$sの広告ネットワークによって管理されており、お客様のプロファイリングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
 msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
-msgstr ""
-"広告クリックはMicrosoftの広告ネットワークによって管理されており、お客様のプロ"
-"ファイリングには使用されません。"
+msgstr "広告クリックはMicrosoftの広告ネットワークによって管理されており、お客様のプロファイリングには使用されません。"
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1349,7 +1307,7 @@ msgstr "怪しい広告"
 #. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
 msgctxt "Button to open menu for attaching images or page context to AI chat"
 msgid "Add"
-msgstr ""
+msgstr "追加する"
 
 # smartling.placeholder_format=C
 #. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
@@ -1357,7 +1315,7 @@ msgctxt ""
 "Primary button that attaches the tabs the user checked in the tab picker "
 "dialog"
 msgid "Add"
-msgstr ""
+msgstr "追加する"
 
 # smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
@@ -1372,9 +1330,7 @@ msgstr "DuckDuckGo拡張機能を追加"
 # smartling.placeholder_format=C
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
-msgstr ""
-"DuckDuckGo Privacy Essentialsは一度のダウンロードで、ブラウザに無料で追加でき"
-"ます："
+msgstr "DuckDuckGo Privacy Essentialsは一度のダウンロードで、ブラウザに無料で追加できます："
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1392,13 +1348,13 @@ msgstr "%1$sにDuckDuckGoを追加"
 msgctxt ""
 "Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
 msgid "Add File"
-msgstr ""
+msgstr "ファイルを追加"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
 msgid "Add Image"
-msgstr ""
+msgstr "画像を追加"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
@@ -1406,7 +1362,7 @@ msgctxt ""
 "Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
 "item)"
 msgid "Add Image or File"
-msgstr ""
+msgstr "画像またはファイルを追加"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1459,7 +1415,7 @@ msgctxt ""
 "Open the tab picker to attach browser tab content to the AI chat message "
 "(attach dropdown menu item)"
 msgid "Add Tabs"
-msgstr ""
+msgstr "タブを追加"
 
 # smartling.placeholder_format=C
 #. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
@@ -1467,7 +1423,7 @@ msgctxt ""
 "Title and accessible name of the tab-picker dialog opened from the attach "
 "dropdown menu"
 msgid "Add Tabs"
-msgstr ""
+msgstr "タブを追加"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1558,7 +1514,7 @@ msgstr "仕上げの調整を加える"
 #. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
 msgctxt "Aria label for the additional instructions textarea"
 msgid "Additional instructions"
-msgstr ""
+msgstr "追加の指示"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1650,9 +1606,7 @@ msgctxt ""
 "model picker dropdown"
 msgid ""
 "Advanced models can reach usage limits 2–5x sooner than other models. %s"
-msgstr ""
-"高度なモデルは、他のモデルよりも2～5倍早く使用制限に達する可能性がありま"
-"す。%1$s"
+msgstr "高度なモデルは、他のモデルよりも2～5倍早く使用制限に達する可能性があります。%1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
@@ -1660,9 +1614,7 @@ msgctxt ""
 "Always-visible warning banner shown above the recommended models in the "
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
-msgstr ""
-"高度なモデルは、他のモデルよりも2～5倍早く使用制限に達する可能性がありま"
-"す。%1$s"
+msgstr "高度なモデルは、他のモデルよりも2～5倍早く使用制限に達する可能性があります。%1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1698,16 +1650,13 @@ msgstr "アフリカーンス語"
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid "After it downloads and opens, click %sInstall%s"
-msgstr ""
-"ダウンロード後、ファイルを開いたら%1$sインストール%2$sをクリックしてください"
+msgstr "ダウンロード後、ファイルを開いたら%1$sインストール%2$sをクリックしてください"
 
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr ""
-"ダウンロード後は拡張ファイルの場所に行き、ダブルクリックしてインストールして"
-"ください"
+msgstr "ダウンロード後は拡張ファイルの場所に行き、ダブルクリックしてインストールしてください"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1842,9 +1791,7 @@ msgctxt "Privacy & Terms section description on the Duck.ai settings page"
 msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
-msgstr ""
-"すべてのチャットはDuckDuckGoによって匿名化されます。DuckDuckGoやモデルの提供"
-"元が学習内容をチャットモデルの学習に利用することはありません"
+msgstr "すべてのチャットはDuckDuckGoによって匿名化されます。DuckDuckGoやモデルの提供元が学習内容をチャットモデルの学習に利用することはありません"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1868,7 +1815,7 @@ msgstr "完了！"
 #. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the read-only textarea listing all AI instructions"
 msgid "All instructions"
-msgstr ""
+msgstr "すべての指示"
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -1882,9 +1829,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr ""
-"すべてのモデルプロバイダーは、会話内容に基づくAIのトレーニングを禁止されてい"
-"ます。"
+msgstr "すべてのモデルプロバイダーは、会話内容に基づくAIのトレーニングを禁止されています。"
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1898,9 +1843,7 @@ msgctxt "Body copy for the anonymized card in the How Duck.ai Works panel"
 msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
-msgstr ""
-"AIプロバイダーにチャットを送信する前に、すべての個人メタデータ（IPアドレスな"
-"ど）が削除されます。"
+msgstr "AIプロバイダーにチャットを送信する前に、すべての個人メタデータ（IPアドレスなど）が削除されます。"
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1938,9 +1881,7 @@ msgstr "許可"
 msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
-msgstr ""
-"ボイスチャットを使用するには、システム設定でDuckDuckGoのマイクアクセスを許可"
-"してください。"
+msgstr "ボイスチャットを使用するには、システム設定でDuckDuckGoのマイクアクセスを許可してください。"
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1971,19 +1912,14 @@ msgid ""
 "Allows %s to search the web to improve responses to relevant prompts. Only "
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
-msgstr ""
-"%1$sがウェブを検索して、関連するプロンプトへの応答を改善できるようにします。"
-"AIが生成したクエリのみをデータ保持が制限された検索エンジンに送信します。%2$s"
-"のプロンプトや応答は依然としてプロバイダーに%3$s一切表示されません%4$s。"
+msgstr "%1$sがウェブを検索して、関連するプロンプトへの応答を改善できるようにします。AIが生成したクエリのみをデータ保持が制限された検索エンジンに送信します。%2$sのプロンプトや応答は依然としてプロバイダーに%3$s一切表示されません%4$s。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Allows Cloud Save key to be stored locally on device (required to use Cloud "
 "Save)"
-msgstr ""
-"デバイス上で Cloud Save キーのローカル保存を許可します (Cloud Save を利用する"
-"場合に必須)"
+msgstr "デバイス上で Cloud Save キーのローカル保存を許可します (Cloud Save を利用する場合に必須)"
 
 # smartling.placeholder_format=C
 #. Pending title indicating near completion.
@@ -2120,9 +2056,7 @@ msgctxt "AI Chat description"
 msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
-msgstr ""
-"%1$s、%2$sに加え、オープンソースの%3$sや%4$sなど、人気のAIモデルに匿名でアク"
-"セスできます。"
+msgstr "%1$s、%2$sに加え、オープンソースの%3$sや%4$sなど、人気のAIモデルに匿名でアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -2130,9 +2064,7 @@ msgctxt "Duck.ai description"
 msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
-msgstr ""
-"%1$s、%2$sに加え、オープンソースの%3$sや%4$sなど、人気のAIモデルに匿名でアク"
-"セスできます。"
+msgstr "%1$s、%2$sに加え、オープンソースの%3$sや%4$sなど、人気のAIモデルに匿名でアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -2145,9 +2077,7 @@ msgctxt "settings"
 msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
-msgstr ""
-"ウェブコンテンツに基づいて、検索クエリの回答を匿名で生成します。表示頻度を選"
-"択するか、完全に無効にすることができます。"
+msgstr "ウェブコンテンツに基づいて、検索クエリの回答を匿名で生成します。表示頻度を選択するか、完全に無効にすることができます。"
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2193,9 +2123,7 @@ msgctxt "Placeholder for additional instructions textarea"
 msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
-msgstr ""
-"Duck.aiが従うべき追加の指示はありますか。例えばいつもアヒルについての事実を教"
-"えてください"
+msgstr "Duck.aiが従うべき追加の指示はありますか。例えばいつもアヒルについての事実を教えてください"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2314,9 +2242,7 @@ msgctxt "Body text for disable chat history confirmation modal"
 msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
-msgstr ""
-"履歴を無効にしてもよろしいですか？これにより、ピン留めされたチャットを含むす"
-"べてのチャットが削除されます。"
+msgstr "履歴を無効にしてもよろしいですか？これにより、ピン留めされたチャットを含むすべてのチャットが削除されます。"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2324,9 +2250,7 @@ msgctxt "Body text for disable recent chats confirmation modal"
 msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
-msgstr ""
-"最近のチャットを無効にしてもよろしいですか？無効にすると、現在保存されている"
-"最近のチャットも削除されます。"
+msgstr "最近のチャットを無効にしてもよろしいですか？無効にすると、現在保存されている最近のチャットも削除されます。"
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2363,9 +2287,7 @@ msgstr "最終更新："
 msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
-msgstr ""
-"私達はプライバシーポリシーに従って、個人情報を収集または共有することはありま"
-"せん。これらのプライバシー保護機能はすべてあなたのデバイスで実行されます。"
+msgstr "私達はプライバシーポリシーに従って、個人情報を収集または共有することはありません。これらのプライバシー保護機能はすべてあなたのデバイスで実行されます。"
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2507,12 +2429,9 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assistは、関連するWebコンテンツを要約して、一部の検索に対してAI支援の回答を匿"
-"名で生成できます。Assistの表示頻度は、「なし」（検索結果からAssist UIを完全に"
-"削除）、「オンデマンド」（Assistボタンをクリックした場合にのみAI支援による回"
-"答を表示）、「時々」（関連性の高い場合にのみAI支援による回答を表示）、「頻"
-"繁」（より広範な検索でより頻繁にAIアシストによる回答を表示）から選択できま"
-"す。現時点では、AI支援の回答は米国（英語）地域でのみ利用可能です。"
+""
+"Assistは、関連するWebコンテンツを要約して、一部の検索に対してAI支援の回答を匿名で生成できます。Assistの表示頻度は、「なし」（検索結果からAssist "
+"UIを完全に削除）、「オンデマンド」（Assistボタンをクリックした場合にのみAI支援による回答を表示）、「時々」（関連性の高い場合にのみAI支援による回答を表示）、「頻繁」（より広範な検索でより頻繁にAIアシストによる回答を表示）から選択できます。現時点では、AI支援の回答は米国（英語）地域でのみ利用可能です。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2523,12 +2442,7 @@ msgid ""
 "generate a brief answer based on relevant information found. It’s important "
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
-msgstr ""
-"Assistは、検索クエリに対するAI支援の回答を匿名で生成できる、検索結果のオプ"
-"ション機能です。この機能は、ウェブをスキャンして関連コンテンツを探し、AIを活"
-"用した自然言語技術で見つかった関連情報に基づき、簡単な回答を生成します。回答"
-"は引用元から自動生成され、%1$sウェブのクロール%2$sに基づいて自動生成されるこ"
-"とを覚えておくことが重要です。"
+msgstr "Assistは、検索クエリに対するAI支援の回答を匿名で生成できる、検索結果のオプション機能です。この機能は、ウェブをスキャンして関連コンテンツを探し、AIを活用した自然言語技術で見つかった関連情報に基づき、簡単な回答を生成します。回答は引用元から自動生成され、%1$sウェブのクロール%2$sに基づいて自動生成されることを覚えておくことが重要です。"
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2553,9 +2467,7 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "At the café, airport, or hotel, DuckDuckGo VPN encrypts your connection and "
 "hides your IP address on Wi-Fi."
-msgstr ""
-"DuckDuckGo VPNは、カフェ、空港、ホテルでのWi-Fi接続を暗号化し、IPアドレスを非"
-"表示にして保護します。"
+msgstr "DuckDuckGo VPNは、カフェ、空港、ホテルでのWi-Fi接続を暗号化し、IPアドレスを非表示にして保護します。"
 
 # smartling.placeholder_format=C
 #. In the context of the National Hockey League (NHL), label for teams belonging to the Atlantic division
@@ -2629,8 +2541,7 @@ msgstr "チャット終了後、音声は当社または OpenAI によって保�
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"チャットの文字起こし後、音声データは当社またはOpenAIによって保存されません。"
+msgstr "チャットの文字起こし後、音声データは当社またはOpenAIによって保存されません。"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2671,24 +2582,18 @@ msgstr "自動応答"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr ""
-"リストされたソースに基づいて自動生成されます。不正確な情報が含まれる場合があ"
-"ります。"
+msgstr "リストされたソースに基づいて自動生成されます。不正確な情報が含まれる場合があります。"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
-msgstr ""
-"リストされたソースに基づいて自動生成されます。回答には不正確な情報が含まれる"
-"場合があります。"
+msgstr "リストされたソースに基づいて自動生成されます。回答には不正確な情報が含まれる場合があります。"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
 msgid "Auto-generated from sources. May be inaccurate."
-msgstr ""
-"ソースに基づき自動生成されています。内容に不正確な部分を含む可能性がありま"
-"す。"
+msgstr "ソースに基づき自動生成されています。内容に不正確な部分を含む可能性があります。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2707,10 +2612,7 @@ msgid ""
 "Automatically shows Assist for relevant searches. Assist can anonymously "
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
-msgstr ""
-"関連する検索にAssistを自動表示します。Assistを使用すると、一部の検索に対して"
-"情報を匿名で調べ、要約できます。現時点では、Assistは英語圏でのみ利用可能で"
-"す。"
+msgstr "関連する検索にAssistを自動表示します。Assistを使用すると、一部の検索に対して情報を匿名で調べ、要約できます。現時点では、Assistは英語圏でのみ利用可能です。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2719,16 +2621,14 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"関連する検索に DuckAssist を自動表示します。このツールを使用すると、一部の検"
-"索に対して情報を匿名で調べ、要約できます。現時点では、イングランド地域でのみ"
-"利用可能です。"
+"関連する検索に DuckAssist "
+"を自動表示します。このツールを使用すると、一部の検索に対して情報を匿名で調べ、要約できます。現時点では、イングランド地域でのみ利用可能です。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Autoplay short, silent video previews when you hover over video results."
-msgstr ""
-"動画の結果にカーソルを合わせると、プレビューが短時間無音で自動再生されます。"
+msgstr "動画の結果にカーソルを合わせると、プレビューが短時間無音で自動再生されます。"
 
 # smartling.placeholder_format=C
 #. Title for the menu listing free/degraded models available after the advanced-model usage limit has been reached.
@@ -2927,9 +2827,7 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
-msgstr ""
-"このレポートを保存する前に、DuckDuckGoは名前、メールアドレス、識別メタデータ"
-"などのPIIを削除することで、会話を匿名化します。"
+msgstr "このレポートを保存する前に、DuckDuckGoは名前、メールアドレス、識別メタデータなどのPIIを削除することで、会話を匿名化します。"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3058,15 +2956,12 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Block harmful sites, hide your IP address, plus get more premium protections "
 "with our subscription."
-msgstr ""
-"DuckDuckGoのサブスクリプションなら、有害サイトのブロックやIPアドレスの非表示"
-"などのプレミアム保護を利用できます。"
+msgstr "DuckDuckGoのサブスクリプションなら、有害サイトのブロックやIPアドレスの非表示などのプレミアム保護を利用できます。"
 
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr ""
-"ブロックリストは完全ではなく、不正確な情報が含まれている可能性があります。"
+msgstr "ブロックリストは完全ではなく、不正確な情報が含まれている可能性があります。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3320,28 +3215,20 @@ msgstr "ファイルを参照"
 msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr ""
-"DuckDuckGoなら普段どおりに閲覧しながら、プライバシー保護を強化できます。検索"
-"エンジン、トラッカーブロック、高度な暗号化機能をひとつの%1$s%2$s拡張機能%3$s"
-"にまとめました。"
+msgstr "DuckDuckGoなら普段どおりに閲覧しながら、プライバシー保護を強化できます。検索エンジン、トラッカーブロック、高度な暗号化機能をひとつの%1$s%2$s拡張機能%3$sにまとめました。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr ""
-"いつも通り閲覧して、あとは当社におまかせ。検索エンジン、トラッカーブロック、"
-"高度な暗号化機能を1つの%1$s%2$s拡張機能%3$sにまとめました。"
+msgstr "いつも通り閲覧して、あとは当社におまかせ。検索エンジン、トラッカーブロック、高度な暗号化機能を1つの%1$s%2$s拡張機能%3$sにまとめました。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we’ll take care of the rest. Get bundled private "
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
-msgstr ""
-"いつも通り閲覧して、あとは当社におまかせ。プライベート検索、トラッカーブロッ"
-"ク、サイトの暗号化機能を1つにまとめた%1$s主要なブラウザ%2$s向けツールをダウン"
-"ロードしましょう。"
+msgstr "いつも通り閲覧して、あとは当社におまかせ。プライベート検索、トラッカーブロック、サイトの暗号化機能を1つにまとめた%1$s主要なブラウザ%2$s向けツールをダウンロードしましょう。"
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3427,8 +3314,7 @@ msgstr "「%1$s」をクリックすると、当社の%2$sに同意したこと�
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr ""
-"「%1$s」をクリックすると、Duck.aiの%2$sと%3$sに同意したことになります。"
+msgstr "「%1$s」をクリックすると、Duck.aiの%2$sと%3$sに同意したことになります。"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3449,19 +3335,16 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"初期状態では、設定情報は秘匿されないブラウザのCookieファイル (ブラウザ内) に"
-"保存されます。匿名の Cloud Save 機能を利用すると、設定情報を (クラウド上のリ"
-"モートサーバーに) より長期的に保存できます。個人を特定できる情報がクラウドに"
-"保存されたり、パスフレーズがブラウザ上に残ることもありません。"
+"初期状態では、設定情報は秘匿されないブラウザのCookieファイル (ブラウザ内) に保存されます。匿名の Cloud Save "
+"機能を利用すると、設定情報を (クラウド上のリモートサーバーに) "
+"より長期的に保存できます。個人を特定できる情報がクラウドに保存されたり、パスフレーズがブラウザ上に残ることもありません。"
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
 msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
-msgstr ""
-"音声入力を有効にすると、この機能の使用のために音声データがOpenAIに送信される"
-"ことに同意したことになります。開始する間に当社の%1$sを確認してください。"
+msgstr "音声入力を有効にすると、この機能の使用のために音声データがOpenAIに送信されることに同意したことになります。開始する間に当社の%1$sを確認してください。"
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3470,9 +3353,8 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"ボイスチャットを有効にすると、この機能の使用のために音声データがOpenAI に送信"
-"されることに同意したことになります。開始する間に当社の%1$sを確認してくださ"
-"い。"
+"ボイスチャットを有効にすると、この機能の使用のために音声データがOpenAI "
+"に送信されることに同意したことになります。開始する間に当社の%1$sを確認してください。"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3579,7 +3461,7 @@ msgctxt ""
 "Secondary button that dismisses the tab picker dialog without attaching "
 "anything"
 msgid "Cancel"
-msgstr ""
+msgstr "キャンセル"
 
 # smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
@@ -3835,8 +3717,7 @@ msgstr "サイト全体の背景色を変更する"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr ""
-"マウスオーバー、モジュール、ドロップダウンメニューでの検索結果の背景色を変更"
+msgstr "マウスオーバー、モジュール、ドロップダウンメニューでの検索結果の背景色を変更"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -3965,11 +3846,10 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"チャット（Duck.ai サービス経由）を通じて、OpenAI、Anthropicなどのサードパー"
-"ティのAIチャットモデルと匿名で会話することができます。この設定をオフにする"
-"と、DuckDuckGo Searchのチャットボタンとリンクが非表示になります。ただし、この"
-"設定がオフの場合でも、%1$shttps://duck.ai%2$sにアクセスして直接チャットを利用"
-"できます。"
+"チャット（Duck.ai "
+""
+"サービス経由）を通じて、OpenAI、AnthropicなどのサードパーティのAIチャットモデルと匿名で会話することができます。この設定をオフにすると、DuckDuckGo "
+"Searchのチャットボタンとリンクが非表示になります。ただし、この設定がオフの場合でも、%1$shttps://duck.ai%2$sにアクセスして直接チャットを利用できます。"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4024,18 +3904,14 @@ msgstr "プライベートチャット"
 #. Mobile variant of DUCKCHAT_BROWSER_UPSELL_PROMO_TEXT. Shorter version for the promotional card encouraging third-party browser users to download the DuckDuckGo browser.
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
-msgstr ""
-"無料ブラウザに内蔵されたDuck.aiがあれば、どのウェブサイトでもプライベートに"
-"チャットできます。"
+msgstr "無料ブラウザに内蔵されたDuck.aiがあれば、どのウェブサイトでもプライベートにチャットできます。"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
-msgstr ""
-"無料のDuckDuckGoブラウザのDuck.aiサイドバーを使えば、どのウェブサイトでもプラ"
-"イベートにチャットできます。"
+msgstr "無料のDuckDuckGoブラウザのDuck.aiサイドバーを使えば、どのウェブサイトでもプライベートにチャットできます。"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4077,7 +3953,7 @@ msgstr "チャットの応答が不快だ"
 #. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
 msgctxt "Chat history about modal list item headline"
 msgid "Chat storage varies by browser"
-msgstr ""
+msgstr "チャットの保存容量はブラウザによって異なります"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4089,7 +3965,7 @@ msgstr "%1$sとチャット"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Chat with popular AI models, anonymized by us."
-msgstr ""
+msgstr "人気のAIモデルとのチャットを当社が匿名化します。"
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4115,7 +3991,7 @@ msgctxt "Chat history with sync modal list item description"
 msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
-msgstr ""
+msgstr "チャットはDuckDuckGoのサーバー上にエンドツーエンド暗号化で安全に保存されます。DuckDuckGoを含めて、本人以外のユーザーは閲覧できません。"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4123,10 +3999,7 @@ msgctxt "Description for Chat History feature"
 msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
-msgstr ""
-"チャットは、DuckDuckGoサーバーやリモートサーバーでなく、お使いのデバイスに"
-"ローカルで保存されます。チャット履歴を無効にすると、ピン留めされたチャットが"
-"削除されます。"
+msgstr "チャットは、DuckDuckGoサーバーやリモートサーバーでなく、お使いのデバイスにローカルで保存されます。チャット履歴を無効にすると、ピン留めされたチャットが削除されます。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -4137,12 +4010,7 @@ msgid ""
 "help recover a chat if you lose your internet connection. Disabling chat "
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
-msgstr ""
-"チャットはデバイスのローカルに保存されます。新しいプロンプトやレスポンスは暗"
-"号化され、送信後はDuckDuckGoサーバーに一時的に保存されます。これは、インター"
-"ネット接続が途切れた場合のチャット復旧に役立ちます。チャット履歴を無効にする"
-"と、固定されたチャットが削除され、新しいプロンプトと応答の一時的な保存が無効"
-"になります。"
+msgstr "チャットはデバイスのローカルに保存されます。新しいプロンプトやレスポンスは暗号化され、送信後はDuckDuckGoサーバーに一時的に保存されます。これは、インターネット接続が途切れた場合のチャット復旧に役立ちます。チャット履歴を無効にすると、固定されたチャットが削除され、新しいプロンプトと応答の一時的な保存が無効になります。"
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -4164,19 +4032,14 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
-msgstr ""
-"%1$sとのチャットではプロバイダーの可視性がゼロになりますが、Duck.aiにアップ"
-"ロードされたすべてのファイルは、%2$sを目的としてコンテンツモデレーションプロ"
-"バイダーによって匿名でレビューされます。"
+msgstr "%1$sとのチャットではプロバイダーの可視性がゼロになりますが、Duck.aiにアップロードされたすべてのファイルは、%2$sを目的としてコンテンツモデレーションプロバイダーによって匿名でレビューされます。"
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
 msgctxt "Sync file storage inline disclaimer body"
 msgid ""
 "Chats with attachments have stopped syncing. Free up storage to resume Sync."
-msgstr ""
-"添付ファイル付きのチャットが同期されなくなりました。同期を再開するにはスト"
-"レージを解放してください。"
+msgstr "添付ファイル付きのチャットが同期されなくなりました。同期を再開するにはストレージを解放してください。"
 
 # smartling.placeholder_format=C
 #. Message shown when we have no data from upstream to display
@@ -4235,8 +4098,7 @@ msgstr "この障害に関する最新情報は、DuckDuckGoのサブレディ�
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr ""
-"この停止に関する最新情報については、ステータスページを確認してください。"
+msgstr "この停止に関する最新情報については、ステータスページを確認してください。"
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4301,8 +4163,7 @@ msgstr "%1$sや%2$sを含むAIモデルの選択"
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr ""
-"%1$s初期設定の検索エンジンを保持%2$sを選び、プライバシーを保護しましょう。"
+msgstr "%1$s初期設定の検索エンジンを保持%2$sを選び、プライバシーを保護しましょう。"
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -4333,9 +4194,7 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Choose from 40+ server locations worldwide to help block harmful sites and "
 "scams."
-msgstr ""
-"VPNサーバーは世界中に40以上あり、都合の良い場所を選択して、有害サイトや詐欺サ"
-"イトをブロックできます。"
+msgstr "VPNサーバーは世界中に40以上あり、都合の良い場所を選択して、有害サイトや詐欺サイトをブロックできます。"
 
 # smartling.placeholder_format=C
 #. The title of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -4533,9 +4392,8 @@ msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
-"ブラウザのデータを消去すると、チャットも消去されます。一部のブラウザでは、最"
-"近のチャットが無期限に保存される場合、またはAI Chatの未使用期間が7日を超える"
-"と自動的に削除される場合があります。"
+"ブラウザのデータを消去すると、チャットも消去されます。一部のブラウザでは、最近のチャットが無期限に保存される場合、またはAI "
+"Chatの未使用期間が7日を超えると自動的に削除される場合があります。"
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4544,10 +4402,7 @@ msgid ""
 "Clearing browser data deletes recent chats. Recent chats may be saved "
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
-msgstr ""
-"ブラウザのデータを消去すると、最近のチャットが削除されます。最近のチャットは"
-"無期限に保存されるか、Duck.aiを使用しない場合、7日後に自動削除されることがあ"
-"ります。ブラウザによって異なります。"
+msgstr "ブラウザのデータを消去すると、最近のチャットが削除されます。最近のチャットは無期限に保存されるか、Duck.aiを使用しない場合、7日後に自動削除されることがあります。ブラウザによって異なります。"
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4555,9 +4410,7 @@ msgctxt "settings"
 msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
-msgstr ""
-"ブラウザデータを消去すると、ブロックしたサイトがリセットされます。ブロックリ"
-"ストを当社の無料ブラウザに"
+msgstr "ブラウザデータを消去すると、ブロックしたサイトがリセットされます。ブロックリストを当社の無料ブラウザに"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4565,11 +4418,7 @@ msgid ""
 "Click \"More\" to go deeper on a topic, and ask follow-up questions via "
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
-msgstr ""
-"「詳細」をクリックすると、トピックについてさらに詳しい情報が表示されます。ま"
-"た、フォローアップの質問をするために、%1$sDuck.ai%2$s（OpenAIやAnthropicなど"
-"のチャットモデルをサポートする当社のプライベートAIチャットサービス）も使用で"
-"きます。"
+msgstr "「詳細」をクリックすると、トピックについてさらに詳しい情報が表示されます。また、フォローアップの質問をするために、%1$sDuck.ai%2$s（OpenAIやAnthropicなどのチャットモデルをサポートする当社のプライベートAIチャットサービス）も使用できます。"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4610,9 +4459,7 @@ msgstr "一覧から%1$s検索設定の変更%2$sをクリックしてくださ�
 msgid ""
 "Click %sEdit > Preferences%s (on Windows) %sSeaMonkey > Preferences%s (on "
 "Mac)"
-msgstr ""
-"%1$s編集 > 設定%2$s (Windows) %3$sSeaMonkey > 設定%4$s (Mac) をクリックしてく"
-"ださい"
+msgstr "%1$s編集 > 設定%2$s (Windows) %3$sSeaMonkey > 設定%4$s (Mac) をクリックしてください"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4623,15 +4470,12 @@ msgstr "%1$sここ%2$sをクリックして検索エンジンとして追加し�
 # smartling.placeholder_format=C
 #. Link to add the DuckDuckGo browser extension to Safari.
 msgid "Click %sHere%s to download the DuckDuckGo extension"
-msgstr ""
-"%1$sここ%2$sをクリックしてDuckDuckGoの拡張機能をダウンロードしてください"
+msgstr "%1$sここ%2$sをクリックしてDuckDuckGoの拡張機能をダウンロードしてください"
 
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr ""
-"%1$s開く%2$sをクリックしてDuckDuckGoのSafari拡張設定をダウンロードしてくださ"
-"い"
+msgstr "%1$s開く%2$sをクリックしてDuckDuckGoのSafari拡張設定をダウンロードしてください"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4645,9 +4489,7 @@ msgstr "左側のサイドバーにある%1$sプライバシーとサービス%2
 msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
-msgstr ""
-"%1$sSafari%2$sをトップメニューからクリックしてください(またはWindowsの場合、"
-"右上の%3$s歯車アイコン%4$sをクリックしてください)"
+msgstr "%1$sSafari%2$sをトップメニューからクリックしてください(またはWindowsの場合、右上の%3$s歯車アイコン%4$sをクリックしてください)"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4676,8 +4518,7 @@ msgstr "%1$sはい%2$sをクリックしてください"
 # smartling.placeholder_format=C
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
-msgstr ""
-"Chromeのツールバーで「%1$ssettings/hamburger icon %2$s」をクリックします。"
+msgstr "Chromeのツールバーで「%1$ssettings/hamburger icon %2$s」をクリックします。"
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4713,8 +4554,7 @@ msgstr "下のほうの %1$sデフォルトに設定%2$s をクリックしま�
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sSearch Providers%s under Add-on Types"
-msgstr ""
-"アドオンタイプセクションの下にある%1$s検索エンジン%2$sボタンを押してください"
+msgstr "アドオンタイプセクションの下にある%1$s検索エンジン%2$sボタンを押してください"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -4739,10 +4579,7 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
-msgstr ""
-"「%1$s自分のデータを削除%2$s」をクリックまたはタップします。データはこの操作"
-"によりクラウドから削除されますが、「%3$sすべての検索設定をリセット%4$s」がク"
-"リックまたはタップされるまでブラウザに残ります。"
+msgstr "「%1$s自分のデータを削除%2$s」をクリックまたはタップします。データはこの操作によりクラウドから削除されますが、「%3$sすべての検索設定をリセット%4$s」がクリックまたはタップされるまでブラウザに残ります。"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4752,10 +4589,7 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
-msgstr ""
-"%1$s自分のデータを削除%2$sをクリックまたはタップします。この操作でデータはク"
-"ラウド上から削除されますが、%3$sすべての設定をリセット%4$sをクリック/タップし"
-"ない限り、お使いのブラウザに保存されたままとなります。"
+msgstr "%1$s自分のデータを削除%2$sをクリックまたはタップします。この操作でデータはクラウド上から削除されますが、%3$sすべての設定をリセット%4$sをクリック/タップしない限り、お使いのブラウザに保存されたままとなります。"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4823,18 +4657,14 @@ msgstr "検索ボックスの選択項目をクリック"
 msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
-msgstr ""
-"%1$s「アドレスバーで使用する検索エンジン」の横にあるドロップダウンメニューを"
-"クリック%2$sして、%3$sDuckDuckGo%4$s を選択します。"
+msgstr "%1$s「アドレスバーで使用する検索エンジン」の横にあるドロップダウンメニューをクリック%2$sして、%3$sDuckDuckGo%4$s を選択します。"
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
 msgid ""
 "Click the icon of the ad blocker extension. It's usually in the upper right "
 "hand corner of your browser."
-msgstr ""
-"広告ブロッカー拡張機能のアイコンをクリックします。通常、広告ブロッカー拡張機"
-"能のアイコンはブラウザの右上隅に表示されています。"
+msgstr "広告ブロッカー拡張機能のアイコンをクリックします。通常、広告ブロッカー拡張機能のアイコンはブラウザの右上隅に表示されています。"
 
 #  Safari default search engine instruction
 # smartling.placeholder_format=C
@@ -5034,9 +4864,7 @@ msgctxt "cloudsave"
 msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
-msgstr ""
-"パスワードを入力すれば、Cloud Saveで自分の設定をずっと保存できます。この機能"
-"を使うかどうかはあなた次第。強制ではありません。"
+msgstr "パスワードを入力すれば、Cloud Saveで自分の設定をずっと保存できます。この機能を使うかどうかはあなた次第。強制ではありません。"
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -5307,9 +5135,7 @@ msgstr "広告ブロックを継続"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
-"最近のチャットはここから再開できます。または、Fire Buttonで削除することもでき"
-"ます。"
+msgstr "最近のチャットはここから再開できます。または、Fire Buttonで削除することもできます。"
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5427,8 +5253,7 @@ msgstr "コピー"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"「%1$sabout:preferences#search%2$s」をアドレスバーにコピー＆ペーストします"
+msgstr "「%1$sabout:preferences#search%2$s」をアドレスバーにコピー＆ペーストします"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5481,8 +5306,8 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
-"別のデバイスからコードをコピーしてください。%1$sDuck.ai設定 › チャット › "
-"Sync & Backup › 別のデバイスと同期%2$sに移動して、もう一度お試しください。"
+"別のデバイスからコードをコピーしてください。%1$sDuck.ai設定 › チャット › Sync & Backup › "
+"別のデバイスと同期%2$sに移動して、もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5534,9 +5359,7 @@ msgstr "コスタリカ"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr ""
-"リカバリーコードを読み込めませんでした。これを閉じて、もう一度お試しくださ"
-"い。"
+msgstr "リカバリーコードを読み込めませんでした。これを閉じて、もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5636,9 +5459,7 @@ msgctxt "Share modal info bullet about public access"
 msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
-msgstr ""
-"リンクを作成するとチャットのコピーが作成され、リンクを開いた人なら誰でも閲覧"
-"できるようになります。"
+msgstr "リンクを作成するとチャットのコピーが作成され、リンクを開いた人なら誰でも閲覧できるようになります。"
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5721,7 +5542,7 @@ msgstr "連勝・連敗中"
 #. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
 msgctxt "Suffix label indicating a tab is the currently active browser tab"
 msgid "Current Tab"
-msgstr ""
+msgstr "現在のタブ"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
@@ -5883,8 +5704,7 @@ msgstr "1日の使用制限に達しました。このチャットは%1$s以降�
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Daily usage limit reached. You can keep chatting by using your weekly limit."
-msgstr ""
-"1日の使用制限に達しました。週間制限時間を使ってチャットを続行できます。"
+msgstr "1日の使用制限に達しました。週間制限時間を使ってチャットを続行できます。"
 
 # smartling.placeholder_format=C
 #. The name of the Danish language
@@ -6074,7 +5894,7 @@ msgstr "30日より前のチャットを削除"
 #. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
 msgctxt "Button text in the modal for deleting all recent chats"
 msgid "Delete Chats and Shared Links"
-msgstr ""
+msgstr "チャットと共有リンクを削除"
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6166,8 +5986,7 @@ msgstr "ストレージを解放するために最も古いチャットを削除
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr ""
-"保存容量を空けるために添付ファイル付きの最も古いチャットを削除しますか？"
+msgstr "保存容量を空けるために添付ファイル付きの最も古いチャットを削除しますか？"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
@@ -6201,9 +6020,7 @@ msgctxt "Description at the top of the Duck.ai shared links modal"
 msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
-msgstr ""
-"リンクを削除すると、そのリンクは機能しなくなります。 リンクを開いて会話を自分"
-"のチャットに追加したユーザーは、各自のコピーをそのまま保持します。"
+msgstr "リンクを削除すると、そのリンクは機能しなくなります。 リンクを開いて会話を自分のチャットに追加したユーザーは、各自のコピーをそのまま保持します。"
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6299,9 +6116,7 @@ msgstr "Duck.aiの音声入力"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr ""
-"音声入力は当社によって匿名化されており、AIモデルのトレーニングには使用されま"
-"せん。"
+msgstr "音声入力は当社によって匿名化されており、AIモデルのトレーニングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6318,9 +6133,7 @@ msgstr "音声入力は一時的に利用できません"
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
-msgstr ""
-"音声入力はOpenAIのモデルを使って音声をテキストに変換し、タイピングせずにDuck."
-"aiチャットができます。"
+msgstr "音声入力はOpenAIのモデルを使って音声をテキストに変換し、タイピングせずにDuck.aiチャットができます。"
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6494,7 +6307,7 @@ msgstr "プロモーションを非表示"
 #. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the close button on the survey banner"
 msgid "Dismiss survey"
-msgstr ""
+msgstr "アンケートを閉じる"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6607,15 +6420,13 @@ msgstr "DuckDuckGoがリストにありませんか？"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr ""
-"表示されませんか？ %1$s%2$s%3$s再度ダウンロードするにはここをクリック%4$s"
+msgstr "表示されませんか？ %1$s%2$s%3$s再度ダウンロードするにはここをクリック%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Don't see the checkbox? %sFollow these steps%s."
-msgstr ""
-"チェックボックスが表示されない場合は、%1$s以下の手順に従ってください%2$s。"
+msgstr "チェックボックスが表示されない場合は、%1$s以下の手順に従ってください%2$s。"
 
 # smartling.placeholder_format=C
 #. Setting that hides a user's most visited sites when they open a new browser tab.
@@ -6646,9 +6457,7 @@ msgctxt "settings"
 msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
-msgstr ""
-"AIが不要な場合は、%1$snoai.duckduckgo.com%2$sにアクセスすると、AI機能は提供さ"
-"れず、AI画像は除外されます。%3$s詳細情報%4$s"
+msgstr "AIが不要な場合は、%1$snoai.duckduckgo.com%2$sにアクセスすると、AI機能は提供されず、AI画像は除外されます。%3$s詳細情報%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6656,9 +6465,7 @@ msgctxt "settings"
 msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
-msgstr ""
-"AIが不要な場合は、%1$snoai.duckduckgo.com%2$sにアクセスすると、検索時にAI機能"
-"は使用されず、AI画像は除外されます。%3$s詳細情報%4$s"
+msgstr "AIが不要な場合は、%1$snoai.duckduckgo.com%2$sにアクセスすると、検索時にAI機能は使用されず、AI画像は除外されます。%3$s詳細情報%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6773,9 +6580,7 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for "
 "ceiling fan repair services."
-msgstr ""
-"シーリングファンの修理サービスの見積もりを依頼するベンダーにメールを作成しま"
-"す。内容は、簡潔かつ詳細に入力してください。"
+msgstr "シーリングファンの修理サービスの見積もりを依頼するベンダーにメールを作成します。内容は、簡潔かつ詳細に入力してください。"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion asking for an email draft to a vendor requesting a quote for home refrigerator repair services.
@@ -6783,9 +6588,7 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
-msgstr ""
-"家庭用冷蔵庫の修理サービスの見積もりを依頼する業者にメールを作成します。内容"
-"は、簡潔かつ詳細に入力してください。"
+msgstr "家庭用冷蔵庫の修理サービスの見積もりを依頼する業者にメールを作成します。内容は、簡潔かつ詳細に入力してください。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -6805,9 +6608,7 @@ msgctxt "Full sentence for drafting a social media post"
 msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
-msgstr ""
-"今後のパーティーに人々を招待するソーシャルメディア投稿のオプションをいくつか"
-"作成してください。"
+msgstr "今後のパーティーに人々を招待するソーシャルメディア投稿のオプションをいくつか作成してください。"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6815,9 +6616,7 @@ msgctxt "Full sentence for suggesting a blog post title"
 msgid ""
 "Draft a few options for a title of a post I’m writing about strategies to "
 "increase team collaboration."
-msgstr ""
-"チームコラボレーションを強化するための戦略について書いた投稿のタイトル案をい"
-"くつか作成してください。"
+msgstr "チームコラボレーションを強化するための戦略について書いた投稿のタイトル案をいくつか作成してください。"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for drafting a social media post.
@@ -6951,8 +6750,7 @@ msgid ""
 msgstr ""
 "Duck.aiは、現在表示しているページに関する質問に回答できるようになりました。\n"
 "\n"
-"設定でページを自動添付することを選択しない限り、ページコンテンツは添付したと"
-"きにのみ含まれます。"
+"設定でページを自動添付することを選択しない限り、ページコンテンツは添付したときにのみ含まれます。"
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6961,10 +6759,7 @@ msgctxt ""
 msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
-msgstr ""
-"Duck.aiはローカルストレージにアクセスできないため、チャットを保存できません。"
-"ブラウザの設定を確認するか、拡張機能を無効にしてから、もう一度お試しくださ"
-"い。"
+msgstr "Duck.aiはローカルストレージにアクセスできないため、チャットを保存できません。ブラウザの設定を確認するか、拡張機能を無効にしてから、もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6972,16 +6767,13 @@ msgctxt "Error message for service limit"
 msgid ""
 "Duck.ai has reached the maximum number of messages for one day. Please "
 "continue this chat tomorrow."
-msgstr ""
-"Duck.aiの1日のメッセージ数の上限に達しました。このチャットは明日続行してくだ"
-"さい。"
+msgstr "Duck.aiの1日のメッセージ数の上限に達しました。このチャットは明日続行してください。"
 
 # smartling.placeholder_format=C
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"Duck.aiのパワーはプライベートな無料ブラウザDuckDuckGoで最も発揮されます！"
+msgstr "Duck.aiのパワーはプライベートな無料ブラウザDuckDuckGoで最も発揮されます！"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6990,9 +6782,7 @@ msgid ""
 "Duck.ai is created by DuckDuckGo. We're an independent online protection "
 "company for anyone who wants to take back control of their personal "
 "information."
-msgstr ""
-"Duck.aiのクリエイターであるDuckDuckGoは、自分の個人情報に対する主導権を取り戻"
-"したいユーザーのためにオンライン保護に取り組む独立系企業です。"
+msgstr "Duck.aiのクリエイターであるDuckDuckGoは、自分の個人情報に対する主導権を取り戻したいユーザーのためにオンライン保護に取り組む独立系企業です。"
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -7006,9 +6796,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
-msgstr ""
-"Duck.aiは引き続きDuckDuckGoの製品ですが、今後はウェブ上のホームページが"
-"「https://duck.ai」と覚えやすくなります"
+msgstr "Duck.aiは引き続きDuckDuckGoの製品ですが、今後はウェブ上のホームページが「https://duck.ai」と覚えやすくなります"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -7022,18 +6810,14 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
-msgstr ""
-"Duck.aiは一時的に利用できません。この問題が続く場合は、匿名コード「%1$s」"
-"を%2$s宛てにメールで送信してください"
+msgstr "Duck.aiは一時的に利用できません。この問題が続く場合は、匿名コード「%1$s」を%2$s宛てにメールで送信してください"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr ""
-"Duck.aiは一時的に利用できません。ページを更新して、もう一度やり直してくださ"
-"い。"
+msgstr "Duck.aiは一時的に利用できません。ページを更新して、もう一度やり直してください。"
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7046,10 +6830,7 @@ msgctxt "settings"
 msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
-msgstr ""
-"Duck.aiでは、人気のAIモデルと非公開でチャットできます。無効にするとDuck.aiの"
-"ボタンやリンクは非表示になりますが、%1$sduck.ai%2$sには引き続き直接アクセスで"
-"きます。"
+msgstr "Duck.aiでは、人気のAIモデルと非公開でチャットできます。無効にするとDuck.aiのボタンやリンクは非表示になりますが、%1$sduck.ai%2$sには引き続き直接アクセスできます。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7060,10 +6841,9 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.aiを使用すると、OpenAIやAnthropicなどのサードパーティのAIチャットモデル"
-"と匿名で会話できます。この設定をオフにすると、DuckDuckGo検索上のDuck.aiのボタ"
-"ンやリンクが非表示になります。ただし、この設定がオフの状態でも、%1$shttps://"
-"duck.ai%2$s に直接アクセスすることでDuck.aiを利用できます。"
+""
+"Duck.aiを使用すると、OpenAIやAnthropicなどのサードパーティのAIチャットモデルと匿名で会話できます。この設定をオフにすると、DuckDuckGo検索上のDuck.aiのボタンやリンクが非表示になります。ただし、この設定がオフの状態でも、%1$shttps://duck.ai%2$s "
+"に直接アクセスすることでDuck.aiを利用できます。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -7077,9 +6857,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai might have lost your recent chats. You can still use Duck.ai as "
 "usual."
-msgstr ""
-"Duck.aiの最近のチャットが失われた可能性があります。Duck.aiはいつも通りに使用"
-"できます。"
+msgstr "Duck.aiの最近のチャットが失われた可能性があります。Duck.aiはいつも通りに使用できます。"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -7092,8 +6870,7 @@ msgstr "Duck.aiでPDFを読み、解析できるようになりました。ぜ�
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
-msgstr ""
-"Duck.aiの回答は特定の情報源に基づいておらず、正確性も確認されていません。"
+msgstr "Duck.aiの回答は特定の情報源に基づいておらず、正確性も確認されていません。"
 
 # smartling.placeholder_format=C
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
@@ -7117,8 +6894,7 @@ msgstr "Duck.aiがアップグレードしました！"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.aiと最も相性の良いDuckDuckGoは、プライバシーを重視した無料のアプリです。"
+msgstr "Duck.aiと最も相性の良いDuckDuckGoは、プライバシーを重視した無料のアプリです。"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7128,9 +6904,8 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai、DuckDuckGo AI、プライベートAIチャットボット、無料AIチャット、匿名AI"
-"チャット、サインアップ不要AIチャット、OpenAI、Anthropic、Llama、Mistral、オー"
-"プンソースAIモデル、プライバシー重視AI、アカウント不要AIチャット"
+"Duck.ai、DuckDuckGo "
+"AI、プライベートAIチャットボット、無料AIチャット、匿名AIチャット、サインアップ不要AIチャット、OpenAI、Anthropic、Llama、Mistral、オープンソースAIモデル、プライバシー重視AI、アカウント不要AIチャット"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7158,11 +6933,9 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"このツールを使用すると、一部の検索に対して情報を匿名で調べ、要約できます。"
-"DuckAssistの表示頻度は、なし（検索結果からDuckAssist UIを完全に削除）、オンデ"
-"マンド（[アシスト] ボタンをクリックした場合にのみ表示）、時々（関連性の高い場"
-"合にのみ表示）、頻繁（広範な検索でより頻繁に表示）から選択できます。現時点で"
-"は、米国（英語）地域でのみ利用可能です。"
+"このツールを使用すると、一部の検索に対して情報を匿名で調べ、要約できます。DuckAssistの表示頻度は、なし（検索結果からDuckAssist "
+"UIを完全に削除）、オンデマンド（[アシスト] "
+"ボタンをクリックした場合にのみ表示）、時々（関連性の高い場合にのみ表示）、頻繁（広範な検索でより頻繁に表示）から選択できます。現時点では、米国（英語）地域でのみ利用可能です。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7171,9 +6944,9 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssistは追加の質問には回答できません。ただし、OpenAI、Anthropic、その他か"
-"らチャットモデルをサポートするプライベートAI搭載チャットサービ"
-"ス、%1$sDuckDuckGo AI Chat%2$sもご利用いただけます。"
+""
+"DuckAssistは追加の質問には回答できません。ただし、OpenAI、Anthropic、その他からチャットモデルをサポートするプライベートAI搭載チャットサービス、%1$sDuckDuckGo "
+"AI Chat%2$sもご利用いただけます。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7182,8 +6955,8 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssistは追加の質問には回答できません。ただし、OpenAIとAnthropicのチャット"
-"モデルをサポートするプライベートAI搭載チャットサービス、DuckDuckGo%1$sAI "
+""
+"DuckAssistは追加の質問には回答できません。ただし、OpenAIとAnthropicのチャットモデルをサポートするプライベートAI搭載チャットサービス、DuckDuckGo%1$sAI "
 "Chat%2$sもご利用いただけます。"
 
 # smartling.placeholder_format=C
@@ -7196,11 +6969,9 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssistは、検索クエリに対する回答を匿名で生成できる新しい検索機能です。 こ"
-"れを実現するために、Wikipediaや関連サイトをスキャンして関連コンテンツを探し、"
-"AIを活用した自然言語技術を使用して情報の要約を生成します。 現時点での回答は"
-"Wikipediaおよび関連コンテンツに基づいており、正確性は確認されていないことにご"
-"注意ください。"
+"DuckAssistは、検索クエリに対する回答を匿名で生成できる新しい検索機能です。 "
+"これを実現するために、Wikipediaや関連サイトをスキャンして関連コンテンツを探し、AIを活用した自然言語技術を使用して情報の要約を生成します。 "
+"現時点での回答はWikipediaおよび関連コンテンツに基づいており、正確性は確認されていないことにご注意ください。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7214,22 +6985,15 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssistは、検索クエリに対する回答を匿名で生成できる、検索結果のオプション"
-"機能です。この機能は、ウェブをスキャンして関連コンテンツを探し、AI を活用した"
-"自然言語技術で見つかった関連情報に基づき、簡単な回答を生成します。DuckAssist"
-"の回答は、常に1つか2つの情報源に直接リンクして回答元を引用しています。そのた"
-"め、より詳細な情報を簡単に取得することができます。回答は引用元から自動生成さ"
-"れ、%1$sウェブのクロール%2$sに基づいて自動生成されることを覚えておくことが重"
-"要です。"
+"DuckAssistは、検索クエリに対する回答を匿名で生成できる、検索結果のオプション機能です。この機能は、ウェブをスキャンして関連コンテンツを探し、AI "
+"を活用した自然言語技術で見つかった関連情報に基づき、簡単な回答を生成します。DuckAssistの回答は、常に1つか2つの情報源に直接リンクして回答元を引用しています。そのため、より詳細な情報を簡単に取得することができます。回答は引用元から自動生成され、%1$sウェブのクロール%2$sに基づいて自動生成されることを覚えておくことが重要です。"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "DuckAssist responses are auto-generated based on listed sources and not "
 "checked for accuracy."
-msgstr ""
-"DuckAssistの回答は記載されている情報源に基づいて自動生成され、正確性は確認さ"
-"れません。"
+msgstr "DuckAssistの回答は記載されている情報源に基づいて自動生成され、正確性は確認されません。"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -7237,9 +7001,7 @@ msgctxt "Error message for service limit"
 msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
-msgstr ""
-"DuckDuckGo AI Chatの1日のメッセージ数の上限に達しました。このチャットは明日続"
-"行してください。"
+msgstr "DuckDuckGo AI Chatの1日のメッセージ数の上限に達しました。このチャットは明日続行してください。"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7248,8 +7010,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chatは、現在%1$sの%2$sと%3$sの%4$sチャットモデルをサポートして"
-"いるプライベートAI搭載のチャットサービスです。"
+"DuckDuckGo AI "
+"Chatは、現在%1$sの%2$sと%3$sの%4$sチャットモデルをサポートしているプライベートAI搭載のチャットサービスです。"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7258,8 +7020,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chatは、現在%1$sの%2$sと%3$sの%4$sチャットモデルをサポートして"
-"いるプライベートAI搭載のチャットサービスです。"
+"DuckDuckGo AI "
+"Chatは、現在%1$sの%2$sと%3$sの%4$sチャットモデルをサポートしているプライベートAI搭載のチャットサービスです。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -7267,9 +7029,7 @@ msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid ""
 "DuckDuckGo AI Chat is in Beta, it may display inaccurate or offensive "
 "information."
-msgstr ""
-"DuckDuckGo AI Chatはベータ版であるため、不正確な情報や不快な情報が表示される"
-"可能性があります。"
+msgstr "DuckDuckGo AI Chatはベータ版であるため、不正確な情報や不快な情報が表示される可能性があります。"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat making it unavailable, and asking the user to send an email with a specific code if the error persists. E.g. 'DuckDuckGo AI Chat is temporarily unavailable. If this persists, please email this anonymous code abcdefg12345 to aichat-error@duckduckgo.com'
@@ -7277,9 +7037,7 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
-msgstr ""
-"DuckDuckGo AI Chatは一時的に利用できません。この問題が続く場合は、匿名コード"
-"「%1$s」を%2$s宛てにメールで送信してください"
+msgstr "DuckDuckGo AI Chatは一時的に利用できません。この問題が続く場合は、匿名コード「%1$s」を%2$s宛てにメールで送信してください"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7287,17 +7045,13 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr ""
-"DuckDuckGo AI Chatは一時的に利用できません。 ページを更新して、もう一度やり直"
-"してください。"
+msgstr "DuckDuckGo AI Chatは一時的に利用できません。 ページを更新して、もう一度やり直してください。"
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chatは一時的に利用できません。 時間を置いてもう一度お試しくださ"
-"い。"
+msgstr "DuckDuckGo AI Chatは一時的に利用できません。 時間を置いてもう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7446,18 +7200,14 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
-msgstr ""
-"DuckDuckGoは、名前、メールアドレス、電話番号、識別メタデータなどのPIIを自動的"
-"に削除することで、これらのレポートを匿名化します。"
+msgstr "DuckDuckGoは、名前、メールアドレス、電話番号、識別メタデータなどのPIIを自動的に削除することで、これらのレポートを匿名化します。"
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
 msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
-msgstr ""
-"DuckDuckGoはチャットを匿名化します。「%1$s」をクリックすると、Duck.aiの%2$sに"
-"同意したことになります。"
+msgstr "DuckDuckGoはチャットを匿名化します。「%1$s」をクリックすると、Duck.aiの%2$sに同意したことになります。"
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7465,9 +7215,7 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr ""
-"DuckDuckGoはチャットを匿名化します。「%1$s」をクリックすると、当社の%2$sに同"
-"意したことになります。"
+msgstr "DuckDuckGoはチャットを匿名化します。「%1$s」をクリックすると、当社の%2$sに同意したことになります。"
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7475,9 +7223,7 @@ msgid ""
 "DuckDuckGo blocks trackers on websites you visit, including trackers from "
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
-msgstr ""
-"DuckDuckGoでは、アクセスするウェブサイト上でGoogleやFacebookなどの企業による"
-"追跡行為を阻止することができます。"
+msgstr "DuckDuckGoでは、アクセスするウェブサイト上でGoogleやFacebookなどの企業による追跡行為を阻止することができます。"
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7489,12 +7235,8 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo はプライバシーを保護するように設計されています。位置情報を使用する"
-"場合、ローカルデバイスだけに保存されます。DuckDuckGo は検索時にユーザーのデバ"
-"イスから送信される位置情報を検索結果を向上するために使用します。位置情報は使"
-"用後にすぐ消去されるため、ユーザーは匿名性を保つことができます。%1$sお客様の"
-"プライバシーを保護するため、当社がどのようにこの技術を設計したかについては、"
-"こちらをご覧ください%2$s。"
+"DuckDuckGo はプライバシーを保護するように設計されています。位置情報を使用する場合、ローカルデバイスだけに保存されます。DuckDuckGo "
+"は検索時にユーザーのデバイスから送信される位置情報を検索結果を向上するために使用します。位置情報は使用後にすぐ消去されるため、ユーザーは匿名性を保つことができます。%1$sお客様のプライバシーを保護するため、当社がどのようにこの技術を設計したかについては、こちらをご覧ください%2$s。"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -7513,9 +7255,7 @@ msgctxt "settings"
 msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
-msgstr ""
-"DuckDuckGo はおおよその位置情報のみを使用します。精度の高いローカル検索結果を"
-"表示するのに充分な情報です。%1$sさらに詳しく%2$s。"
+msgstr "DuckDuckGo はおおよその位置情報のみを使用します。精度の高いローカル検索結果を表示するのに充分な情報です。%1$sさらに詳しく%2$s。"
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7606,10 +7346,7 @@ msgid ""
 "random words from the DuckDuckGo servers. In the browser, we then select 4-5 "
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
-msgstr ""
-"パスフレーズ候補を生成する度、DuckDuckGoサーバーからランダムな単語が多数記載"
-"されたリストを取得します。その後お使いのブラウザ内で、そのリストから最低18～"
-"20字のパスフレーズ候補として4、5個の単語が選ばれます。"
+msgstr "パスフレーズ候補を生成する度、DuckDuckGoサーバーからランダムな単語が多数記載されたリストを取得します。その後お使いのブラウザ内で、そのリストから最低18～20字のパスフレーズ候補として4、5個の単語が選ばれます。"
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7666,7 +7403,7 @@ msgstr "プロンプトを編集"
 #. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the message-editing text area"
 msgid "Edit message"
-msgstr ""
+msgstr "メッセージを編集"
 
 # smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
@@ -7685,8 +7422,7 @@ msgstr "画像を編集中..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr ""
-"メッセージを編集すると、以下の応答が削除され、新しい応答が生成されます。"
+msgstr "メッセージを編集すると、以下の応答が削除され、新しい応答が生成されます。"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7823,9 +7559,7 @@ msgstr "ウェブ検索を有効にする"
 msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
-msgstr ""
-"検索結果の精度を高めるには、匿名の位置情報を有効にしてください。この設定は後"
-"でいつでも変更できます。"
+msgstr "検索結果の精度を高めるには、匿名の位置情報を有効にしてください。この設定は後でいつでも変更できます。"
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7867,9 +7601,7 @@ msgctxt "precise_user_location"
 msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
-msgstr ""
-"「匿名の位置情報」機能を有効にすると、より正確な検索結果が得られるうえ、検索"
-"データと正確な位置情報もDuckDuckGoに対して非公開のままとなります。"
+msgstr "「匿名の位置情報」機能を有効にすると、より正確な検索結果が得られるうえ、検索データと正確な位置情報もDuckDuckGoに対して非公開のままとなります。"
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7893,7 +7625,7 @@ msgstr "暗号化モデル"
 #. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
 msgctxt "Share modal info bullet about encryption"
 msgid "Encrypted so DuckDuckGo can't read your chat."
-msgstr ""
+msgstr "暗号化されているため、DuckDuckGoはチャットの内容を読むことができません。"
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -7993,8 +7725,7 @@ msgstr "位置情報へのアクセスは必ず %1$s許可%2$s にします。"
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s"
-msgstr ""
-"ブラウザによる%1$s位置情報へのアクセス%2$sが許可されていることを確認します"
+msgstr "ブラウザによる%1$s位置情報へのアクセス%2$sが許可されていることを確認します"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -8037,9 +7768,7 @@ msgctxt "cloudsave"
 msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
-msgstr ""
-"新しいパスフレーズを入力し、%1$s設定を保存%2$sをクリックまたはタップしてくだ"
-"さい。データが新しいパスフレーズで保存されます。"
+msgstr "新しいパスフレーズを入力し、%1$s設定を保存%2$sをクリックまたはタップしてください。データが新しいパスフレーズで保存されます。"
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -8064,9 +7793,7 @@ msgstr "テキストを入力"
 #. Instructions for how to change the default search engine.
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
-msgstr ""
-"以下の詳細を入力してください: %1$s名前%2$s: DuckDuckGo%3$s URL%4$s: %5$s エイ"
-"リアス%6$s: d%7$s"
+msgstr "以下の詳細を入力してください: %1$s名前%2$s: DuckDuckGo%3$s URL%4$s: %5$s エイリアス%6$s: d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -8449,9 +8176,7 @@ msgstr "フィードバックが送信されました"
 msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
-msgstr ""
-"お寄せくださったフィードバックを私たちの製品の更新と改善に直接活用していきま"
-"す。"
+msgstr "お寄せくださったフィードバックを私たちの製品の更新と改善に直接活用していきます。"
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8459,19 +8184,14 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
-msgstr ""
-"お客様からいただいたフィードバックは、当社の製品のアップデートと改善に活用さ"
-"せていただきます。また、ご指摘についても真摯に受け止め、誠意を持って取り組ん"
-"で参ります。"
+msgstr "お客様からいただいたフィードバックは、当社の製品のアップデートと改善に活用させていただきます。また、ご指摘についても真摯に受け止め、誠意を持って取り組んで参ります。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
 msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
-msgstr ""
-"以下から自由に設定できます。設定後のコードをあなたのウェブサイトにコピー＆"
-"ペーストしてください。"
+msgstr "以下から自由に設定できます。設定後のコードをあなたのウェブサイトにコピー＆ペーストしてください。"
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8589,8 +8309,7 @@ msgstr "金融アドバイザー"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr ""
-"%1$sDuckDuckGo%2$sを検索し、%3$sデフォルトに設定 %4$sをクリックしてください"
+msgstr "%1$sDuckDuckGo%2$sを検索し、%3$sデフォルトに設定 %4$sをクリックしてください"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8602,9 +8321,7 @@ msgstr "ダウンロードフォルダで<b>%1$s</b>を表示"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr ""
-"表示されたリストからDuckDuckGoを探し、%1$sデフォルトに設定%2$sをクリックしま"
-"す"
+msgstr "表示されたリストからDuckDuckGoを探し、%1$sデフォルトに設定%2$sをクリックします"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8641,9 +8358,7 @@ msgstr "あなたにとって最も的確な結果を見つけます。"
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr ""
-"お近くの結果を検索します。%1$s位置情報は非公開、安全、匿名のまま保持されま"
-"す。"
+msgstr "お近くの結果を検索します。%1$s位置情報は非公開、安全、匿名のまま保持されます。"
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8706,9 +8421,7 @@ msgstr "霧"
 msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
-msgstr ""
-"DuckDuckGoの広告ブロッカーをオフにする手順に沿ってお進みください。メニューオ"
-"プションを選択したり、ボタンをクリックする必要がある場合があります。"
+msgstr "DuckDuckGoの広告ブロッカーをオフにする手順に沿ってお進みください。メニューオプションを選択したり、ボタンをクリックする必要がある場合があります。"
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8725,7 +8438,7 @@ msgstr "フォローアップの質問"
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
-msgstr ""
+msgstr "フォローアップは非公開のままとなります。"
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8861,9 +8574,7 @@ msgstr "営利目的で共有、使用が可能"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr ""
-"チャットを削除して容量を空けましょう。ピン留めされたチャットは削除されませ"
-"ん。"
+msgstr "チャットを削除して容量を空けましょう。ピン留めされたチャットは削除されません。"
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8944,9 +8655,8 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Macのアプリメニューバーから <strong>[DuckDuckGo]</strong> &gt; <strong>[アッ"
-"プデートを確認...]</strong>、次に<strong>[アップデートをインストール]</"
-"strong> を選択します。"
+"Macのアプリメニューバーから <strong>[DuckDuckGo]</strong> &gt; "
+"<strong>[アップデートを確認...]</strong>、次に<strong>[アップデートをインストール]</strong> を選択します。"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9232,22 +8942,20 @@ msgid ""
 "Get DuckDuckGo VPN, advanced Duck.ai, Personal Info Removal, and Identity "
 "Theft Restoration."
 msgstr ""
-"DuckDuckGo VPN、高度なDuck.ai、Personal Information Removal（個人情報の削"
-"除）、Identity Theft Restoration（ID盗難後の復旧）機能を利用できます。"
+"DuckDuckGo VPN、高度なDuck.ai、Personal Information Removal（個人情報の削除）、Identity "
+"Theft Restoration（ID盗難後の復旧）機能を利用できます。"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr ""
-"DuckDuckGo VPN、高度なDuck.ai、Identity Theft Restoration（ID盗難後の復旧）機"
-"能を利用できます。"
+msgstr "DuckDuckGo VPN、高度なDuck.ai、Identity Theft Restoration（ID盗難後の復旧）機能を利用できます。"
 
 # smartling.placeholder_format=C
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
 msgctxt "Tooltip on the header logo for sunglasses searches"
 msgid "Get DuckDuckGo sunglasses and other gear."
-msgstr ""
+msgstr "DuckDuckGoのサングラスやその他のグッズを手に入れましょう。"
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9306,9 +9014,7 @@ msgstr "開始"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the Privacy Pro subscription.
 msgctxt "SERP footer content"
 msgid "Get a VPN + two more protections in one easy subscription."
-msgstr ""
-"VPN1件と追加の保護対策2つを組み合わせた手軽なサブスクリプションはいかがです"
-"か。"
+msgstr "VPN1件と追加の保護対策2つを組み合わせた手軽なサブスクリプションはいかがですか。"
 
 # smartling.placeholder_format=C
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
@@ -9329,9 +9035,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, Personal Info Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"ノーログ型高速VPNに加え、高度なAIチャット（オプション）、Personal "
-"Information Removal（個人情報の削除）、Identity Theft Restoration（ID盗難後の"
-"復旧）機能を利用できます。"
+"ノーログ型高速VPNに加え、高度なAIチャット（オプション）、Personal Information "
+"Removal（個人情報の削除）、Identity Theft Restoration（ID盗難後の復旧）機能を利用できます。"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; 'advanced AI chat' refers to Duck.ai; Identity Theft Restoration is a bundled feature.
@@ -9339,9 +9044,7 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, and Identity Theft "
 "Restoration."
-msgstr ""
-"ノーログ型高速VPNに加え、高度なAIチャット（オプション）Identity Theft "
-"Restoration（ID盗難後の復旧）機能を利用できます。"
+msgstr "ノーログ型高速VPNに加え、高度なAIチャット（オプション）Identity Theft Restoration（ID盗難後の復旧）機能を利用できます。"
 
 # smartling.placeholder_format=C
 #. Description for the subscription modal where users can update their subscription to DuckDuckGo.
@@ -9349,9 +9052,7 @@ msgctxt "Description of the modal to upgrade the DuckDuckGo subscription"
 msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
-msgstr ""
-"DuckDuckGoに加入すると、Duck.aiで高度なAIモデルをご利用いただけます。これに"
-"は、VPNやその他のプレミアムなプライバシー保護も含まれています。"
+msgstr "DuckDuckGoに加入すると、Duck.aiで高度なAIモデルをご利用いただけます。これには、VPNやその他のプレミアムなプライバシー保護も含まれています。"
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -9361,9 +9062,7 @@ msgctxt ""
 msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
-msgstr ""
-"DuckDuckGoのサブスクリプションでDuck.aiの高度なAIモデルにアクセスできます。"
-"VPNやその他のプレミアムなプライバシー保護機能も含まれています。"
+msgstr "DuckDuckGoのサブスクリプションでDuck.aiの高度なAIモデルにアクセスできます。VPNやその他のプレミアムなプライバシー保護機能も含まれています。"
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9406,9 +9105,7 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
-msgstr ""
-"ノーログ型高速VPNに加え、高度なAIモデルへのアクセス（コール上限数拡大付きオプ"
-"ション）、その他のプレミアム保護機能を利用できます。"
+msgstr "ノーログ型高速VPNに加え、高度なAIモデルへのアクセス（コール上限数拡大付きオプション）、その他のプレミアム保護機能を利用できます。"
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9417,25 +9114,20 @@ msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, Personal Information Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"ノーログ型の安全なVPNに加え、高度なDuck.ai、Personal Information Removal（個"
-"人情報の削除）、Identity Theft Restoration（ID盗難後の復旧）機能を利用できま"
-"す。"
+"ノーログ型の安全なVPNに加え、高度なDuck.ai、Personal Information Removal（個人情報の削除）、Identity "
+"Theft Restoration（ID盗難後の復旧）機能を利用できます。"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr ""
-"ノーログ型安全なVPNに加え、高度なDuck.ai、Identity Theft Restoration（ID盗難"
-"後の復旧）機能を利用できます。"
+msgstr "ノーログ型安全なVPNに加え、高度なDuck.ai、Identity Theft Restoration（ID盗難後の復旧）機能を利用できます。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
-msgstr ""
-"ブラウザの個人情報をシームレスに保護する無料ツールをワンクリックでダウンロー"
-"ド："
+msgstr "ブラウザの個人情報をシームレスに保護する無料ツールをワンクリックでダウンロード："
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -9471,9 +9163,7 @@ msgstr "アプリをダウンロード"
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
-msgstr ""
-"DuckDuckGoブラウザを無料で入手して、%1$sYouTubeの広告をブロックしましょ"
-"う。%2$s"
+msgstr "DuckDuckGoブラウザを無料で入手して、%1$sYouTubeの広告をブロックしましょう。%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9532,9 +9222,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャッ"
-"ト」 › 「Sync & Backup」 › 「別のデバイスと同期」 › 「テキストコードをコ"
-"ピー」%4$sの順にクリックします"
+"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャット」 › 「Sync & Backup」 › "
+"「別のデバイスと同期」 › 「テキストコードをコピー」%4$sの順にクリックします"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9543,8 +9232,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャッ"
-"ト」 › 「Sync & Backup」 › 「別のデバイスと同期」%4$sの順にクリックします"
+"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャット」 › 「Sync & Backup」 › "
+"「別のデバイスと同期」%4$sの順にクリックします"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9554,9 +9243,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャッ"
-"ト」 › 「Sync & Backup」 › 「別のデバイスと同期」%4$sの順にクリックして、次の"
-"コードをスキャンします。"
+"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャット」 › 「Sync & Backup」 › "
+"「別のデバイスと同期」%4$sの順にクリックして、次のコードをスキャンします。"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9566,9 +9254,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャッ"
-"ト」 › 「Sync & Backup」 › 「別のデバイスと同期」%4$sの順にクリックします。ま"
-"たは、リカバリーPDFのQRコードをスキャンします。"
+"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャット」 › 「Sync & Backup」 › "
+"「別のデバイスと同期」%4$sの順にクリックします。または、リカバリーPDFのQRコードをスキャンします。"
 
 # smartling.placeholder_format=C
 #. Path to the pairing code on the other device. Bold segments are UI path labels.
@@ -9576,16 +9263,13 @@ msgctxt "Detail under the first numbered step on the Enter Code tab"
 msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
-msgstr ""
-"%1$sDuck.ai設定%2$s › %3$sチャット › Sync & Backup › 別のデバイスと同期%4$sに"
-"移動します。"
+msgstr "%1$sDuck.ai設定%2$s › %3$sチャット › Sync & Backup › 別のデバイスと同期%4$sに移動します。"
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr ""
-"%1$s[プライバシーとセキュリティ] > [位置情報サービス]%2$sの順に移動します"
+msgstr "%1$s[プライバシーとセキュリティ] > [位置情報サービス]%2$sの順に移動します"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9594,8 +9278,8 @@ msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
 msgstr ""
-"%1$s [設定] > [プライバシーとセキュリティ] > [位置情報サービス] %2$sに移動"
-"し、[位置情報サービス] がオンになっていることを確認します。"
+"%1$s [設定] > [プライバシーとセキュリティ] > [位置情報サービス] %2$sに移動し、[位置情報サービス] "
+"がオンになっていることを確認します。"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -9604,8 +9288,8 @@ msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
 msgstr ""
-"%1$s[設定] > [プライバシー] > [権限マネージャ] > [位置情報]%2$s に移動し、"
-"[DuckDuckGo] まで下にスクロールします。%3$s%4$s"
+"%1$s[設定] > [プライバシー] > [権限マネージャ] > [位置情報]%2$s に移動し、[DuckDuckGo] "
+"まで下にスクロールします。%3$s%4$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -10293,8 +9977,7 @@ msgctxt "settings"
 msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
-msgstr ""
-"Search Assistの回答で重要な事実を強調表示し、重要な情報を見つけやすくします。"
+msgstr "Search Assistの回答で重要な事実を強調表示し、重要な情報を見つけやすくします。"
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -10321,8 +10004,8 @@ msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
 msgstr ""
-"キーボードの %1$s戻る%2$s キーを押して、%3$sDuckDuckGoをリストに保存しま"
-"す。%4$sそして、%5$sデフォルトに設定%6$sをクリックします"
+"キーボードの %1$s戻る%2$s "
+"キーを押して、%3$sDuckDuckGoをリストに保存します。%4$sそして、%5$sデフォルトに設定%6$sをクリックします"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -10335,9 +10018,7 @@ msgstr "ミャオ語"
 msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
-msgstr ""
-"ご注意ください！元の設定に戻すとDuckDuckGoの拡張機能が無効になり、プライバ"
-"シーが保護されなくなります。"
+msgstr "ご注意ください！元の設定に戻すとDuckDuckGoの拡張機能が無効になり、プライバシーが保護されなくなります。"
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -10386,9 +10067,7 @@ msgstr "猛暑"
 msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
-msgstr ""
-"ホテルの広告クリックはTripadvisorの広告ネットワークによって管理され、お客様の"
-"プロファイリングには使用されません。"
+msgstr "ホテルの広告クリックはTripadvisorの広告ネットワークによって管理され、お客様のプロファイリングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -10485,7 +10164,7 @@ msgstr "DuckDuckGoの仕組み"
 #. Headline in chat history about modals for the temporary encrypted server storage explanation.
 msgctxt "Chat history about modal list item headline"
 msgid "How it works"
-msgstr ""
+msgstr "DuckDuckGoの仕組み"
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -10656,9 +10335,7 @@ msgctxt "Full sentence for recommending a book"
 msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
-msgstr ""
-"私は「風の名前」という本が好きです。 これに最も似ている他の良い本やシリーズは"
-"どんなものですか、またその理由は何ですか？"
+msgstr "私は「風の名前」という本が好きです。 これに最も似ている他の良い本やシリーズはどんなものですか、またその理由は何ですか？"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -10693,8 +10370,8 @@ msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
 msgstr ""
-"それでもブラウザの位置情報を利用できない場合は、%1$s[設定] > [一般] > [リセッ"
-"ト] > [位置情報とプライバシー設定をリセット]%2$s の順に移動します。"
+"それでもブラウザの位置情報を利用できない場合は、%1$s[設定] > [一般] > [リセット] > [位置情報とプライバシー設定をリセット]%2$s "
+"の順に移動します。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10704,9 +10381,8 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"それでもブラウザの位置情報を使用できない場合は、ブラウザで、%1$s「⋮」マーク "
-"> [メニュー] > [設定] > [サイト設定] > [位置情報]%2$s の順に移動し、"
-"DuckDuckGo に位置情報へのアクセスを許可しているか確認します。"
+"それでもブラウザの位置情報を使用できない場合は、ブラウザで、%1$s「⋮」マーク > [メニュー] > [設定] > [サイト設定] > "
+"[位置情報]%2$s の順に移動し、DuckDuckGo に位置情報へのアクセスを許可しているか確認します。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10720,9 +10396,7 @@ msgstr "このエラーが続く場合は、%1$sに連絡してください。"
 msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
-msgstr ""
-"%1$sDuckDuckGo が表示されない場合、%2$s %3$sほかの検索エンジン%4$s リストに追"
-"加する必要があります"
+msgstr "%1$sDuckDuckGo が表示されない場合、%2$s %3$sほかの検索エンジン%4$s リストに追加する必要があります"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -10731,8 +10405,8 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"チャット プロバイダーまたは特定のチャット応答についてご不明な点がある場合"
-"は、%1$sおよび%2$sサポートページに直接お問い合わせいただくこともできます。"
+"チャット "
+"プロバイダーまたは特定のチャット応答についてご不明な点がある場合は、%1$sおよび%2$sサポートページに直接お問い合わせいただくこともできます。"
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10740,18 +10414,13 @@ msgctxt "Body for the Sync & Backup recovery code screen"
 msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
-msgstr ""
-"デバイスにアクセスできなくなった場合、保存されたチャットを回復するためにこの"
-"コードが必要になります。このコードはテキストファイルとしてデバイスに保存でき"
-"ます。"
+msgstr "デバイスにアクセスできなくなった場合、保存されたチャットを回復するためにこのコードが必要になります。このコードはテキストファイルとしてデバイスに保存できます。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"もし、私たちをもっとサポートして頂けるなら、%1$sDuckDuckGoの普及にご協力くだ"
-"さい%2$s"
+msgstr "もし、私たちをもっとサポートして頂けるなら、%1$sDuckDuckGoの普及にご協力ください%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10760,18 +10429,14 @@ msgstr ""
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr ""
-"Javascript 無しで DuckDuckGo をご利用の場合は、 %1$s、または%2$s バージョンを"
-"ご利用ください。"
+msgstr "Javascript 無しで DuckDuckGo をご利用の場合は、 %1$s、または%2$s バージョンをご利用ください。"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
-msgstr ""
-"ご希望であれば、新しいウィンドウと新しいタブの隣に開くホームページを選択して"
-"ください。"
+msgstr "ご希望であれば、新しいウィンドウと新しいタブの隣に開くホームページを選択してください。"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -10911,9 +10576,7 @@ msgctxt "settings"
 msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
-msgstr ""
-"古いブラウザの一部では、検索漏れを防ぐため、当社のサーバーを経由してリダイレ"
-"クトする必要があります。%1$sさらに詳しく%2$s。"
+msgstr "古いブラウザの一部では、検索漏れを防ぐため、当社のサーバーを経由してリダイレクトする必要があります。%1$sさらに詳しく%2$s。"
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -10923,9 +10586,7 @@ msgctxt ""
 msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
-msgstr ""
-"DuckDuckGoブラウザで、「設定」＞「Sync & Backup」に移動し、「別のデバイスと同"
-"期」を選択します。"
+msgstr "DuckDuckGoブラウザで、「設定」＞「Sync & Backup」に移動し、「別のデバイスと同期」を選択します。"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -10939,9 +10600,7 @@ msgctxt "cloudsave"
 msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
-msgstr ""
-"情報透明性の観点から、このデータは暗号化されていません。つまり、DuckDuckGo に"
-"保存されている情報を正確に知ることができます。"
+msgstr "情報透明性の観点から、このデータは暗号化されていません。つまり、DuckDuckGo に保存されている情報を正確に知ることができます。"
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -10951,8 +10610,7 @@ msgstr "上部のメニューから%1$sツール%2$s > %3$s設定%4$sを選択"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
-msgstr ""
-"ポップアップ画面の、%1$s既定の検索エンジンに設定%2$s ボックスをオンにします"
+msgstr "ポップアップ画面の、%1$s既定の検索エンジンに設定%2$s ボックスをオンにします"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -11278,8 +10936,7 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr ""
-"この場所はおすすめですか？レビューと評価に基づいて評判を要約してください。"
+msgstr "この場所はおすすめですか？レビューと評価に基づいて評判を要約してください。"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -11347,11 +11004,7 @@ msgid ""
 "Items are ranked based on relevance to your search terms and are delivered "
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
-msgstr ""
-"アイテムは検索キーワードとの関連性に基づいてランク付けされ、Microsoftの広告"
-"ネットワークを通じて配信されます。クリック後はマーチャントのランディングペー"
-"ジに移動し、広告とは異なり、DuckDuckGoがクリックされた結果に対して報酬を受け"
-"取ることはありません。"
+msgstr "アイテムは検索キーワードとの関連性に基づいてランク付けされ、Microsoftの広告ネットワークを通じて配信されます。クリック後はマーチャントのランディングページに移動し、広告とは異なり、DuckDuckGoがクリックされた結果に対して報酬を受け取ることはありません。"
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -11359,9 +11012,7 @@ msgctxt "cloudsave"
 msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
-msgstr ""
-"ランダムな文字や数字を10個覚えるよりは、単語を4～5つ覚える方が簡単な上、ずっ"
-"と安全です。"
+msgstr "ランダムな文字や数字を10個覚えるよりは、単語を4～5つ覚える方が簡単な上、ずっと安全です。"
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -11433,9 +11084,7 @@ msgstr "両方のデバイスでSync & Backupを開いたままにします。"
 msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Keep all your apps and online activity private on up to 5 devices at once."
-msgstr ""
-"一度に最大5台のデバイスで、すべてのアプリとオンラインの活動のプライバシーを確"
-"保できます。"
+msgstr "一度に最大5台のデバイスで、すべてのアプリとオンラインの活動のプライバシーを確保できます。"
 
 # smartling.placeholder_format=C
 #. An instruction to state that a list of companies/trackers will be updated with continued use
@@ -11847,8 +11496,7 @@ msgstr "DuckDuckGo を使って匿名で検索しましょう"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr ""
-"検索クエリの送信とDuck.aiへのプロンプトの送信を切り替えることができます。"
+msgstr "検索クエリの送信とDuck.aiへのプロンプトの送信を切り替えることができます。"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11930,7 +11578,7 @@ msgstr "リンクは7日後に期限切れとなります。"
 #. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days. People can save a chat copy."
-msgstr ""
+msgstr "リンクは7日後に期限切れとなります。チャットのコピーを保存できます。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -12602,9 +12250,7 @@ msgstr "ミクロネシア"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr ""
-"マイクへのアクセスが拒否されました。マイクアクセスを許可して、もう一度お試し"
-"ください。"
+msgstr "マイクへのアクセスが拒否されました。マイクアクセスを許可して、もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -13387,11 +13033,7 @@ msgid ""
 "DuckDuckGo server after being sent, to help recover a chat if you lose your "
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
-msgstr ""
-"新しいプロンプトやレスポンスは暗号化され、送信後はDuckDuckGoサーバーに一時的"
-"に保存されます。これは、インターネット接続が途切れた場合のチャット復旧に役立"
-"ちます。チャット履歴を無効にすると、固定されたチャットが削除され、新しいプロ"
-"ンプトと応答の一時的な保存が無効になります。"
+msgstr "新しいプロンプトやレスポンスは暗号化され、送信後はDuckDuckGoサーバーに一時的に保存されます。これは、インターネット接続が途切れた場合のチャット復旧に役立ちます。チャット履歴を無効にすると、固定されたチャットが削除され、新しいプロンプトと応答の一時的な保存が無効になります。"
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -13706,8 +13348,7 @@ msgstr "結果が見つかりません。"
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr ""
-"音声が検出されませんでした。再試行時には、マイクに向かって話してください。"
+msgstr "音声が検出されませんでした。再試行時には、マイクに向かって話してください。"
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -14052,7 +13693,7 @@ msgstr "OK、わかりました！"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "OPTIONAL"
-msgstr ""
+msgstr "任意"
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -14219,9 +13860,7 @@ msgstr "オンデマンド"
 msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
-msgstr ""
-"Macでは%1$sMaxthon > 環境設定%2$s、Windowsでは%3$s アイコン > 設定%4$sの順"
-"に%5$sクリックしてください"
+msgstr "Macでは%1$sMaxthon > 環境設定%2$s、Windowsでは%3$s アイコン > 設定%4$sの順に%5$sクリックしてください"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -14229,9 +13868,7 @@ msgctxt "Instruction under the Scan QR tab sub-heading"
 msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
-msgstr ""
-"別のデバイスで%1$sDuck.ai設定%2$s › %3$sチャット › Sync & Backup › 別のデバイ"
-"スと同期%4$sに移動します"
+msgstr "別のデバイスで%1$sDuck.ai設定%2$s › %3$sチャット › Sync & Backup › 別のデバイスと同期%4$sに移動します"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14240,8 +13877,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
 msgstr ""
-"別のデバイスで%1$sDuck.ai設定%2$s › %3$sチャット › Sync & Backup › 別のデバイ"
-"スと同期%4$sに移動して、このコードをスキャンします："
+"別のデバイスで%1$sDuck.ai設定%2$s › %3$sチャット › Sync & Backup › "
+"別のデバイスと同期%4$sに移動して、このコードをスキャンします："
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14250,8 +13887,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
-"別のデバイスで%1$sDuck.ai設定%2$s › %3$sチャット › Sync & Backup › 別のデバイ"
-"スと同期%4$sに移動します。または、リカバリーPDFのQRコードをスキャンします。"
+"別のデバイスで%1$sDuck.ai設定%2$s › %3$sチャット › Sync & Backup › "
+"別のデバイスと同期%4$sに移動します。または、リカバリーPDFのQRコードをスキャンします。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14278,9 +13915,7 @@ msgctxt ""
 msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
-msgstr ""
-"添付ファイルの1点がサポートページ数を超えています。%1$sページ以下のファイルを"
-"アップロードしてください。"
+msgstr "添付ファイルの1点がサポートページ数を超えています。%1$sページ以下のファイルをアップロードしてください。"
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -14306,8 +13941,7 @@ msgctxt "cloudsave"
 msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
-msgstr ""
-"変更した設定のみ。これらの詳細は %1$sURLパラメータ%2$s のページにあります。"
+msgstr "変更した設定のみ。これらの詳細は %1$sURLパラメータ%2$s のページにあります。"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -14321,9 +13955,7 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr ""
-"おっと！このテキストの翻訳中に予期しないエラーが発生しました。少し時間をおい"
-"てからもう一度試してください。"
+msgstr "おっと！このテキストの翻訳中に予期しないエラーが発生しました。少し時間をおいてからもう一度試してください。"
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -14645,9 +14277,7 @@ msgctxt "homepage onboarding"
 msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
-msgstr ""
-"他社の検索エンジンはあなたの検索をプライベートブラウジングでも追跡していま"
-"す。私たちは追跡しません。"
+msgstr "他社の検索エンジンはあなたの検索をプライベートブラウジングでも追跡しています。私たちは追跡しません。"
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -14660,27 +14290,21 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Our fast, no-log VPN comes with smarter AI chats with higher limits, plus "
 "more premium protections. All in one subscription."
-msgstr ""
-"ノーログ型の高速VPNに加え、上級AIチャット（利用上限数拡大）、その他のプレミア"
-"ム保護機能を利用できます。全機能を1つにまとめたサブスクリプションです。"
+msgstr "ノーログ型の高速VPNに加え、上級AIチャット（利用上限数拡大）、その他のプレミアム保護機能を利用できます。全機能を1つにまとめたサブスクリプションです。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
-msgstr ""
-"私たちのプライバシーポリシーはシンプルです。ユーザーの個人情報は一切収集しま"
-"せん。"
+msgstr "私たちのプライバシーポリシーはシンプルです。ユーザーの個人情報は一切収集しません。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Our private browser for mobile comes equipped with our search engine, "
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
-msgstr ""
-"当社のモバイル用プライベートブラウザには、検索エンジン、トラッカーブロック、"
-"強制暗号化機能などが備わっています。%1$siOSとAndroid%2$sに対応。"
+msgstr "当社のモバイル用プライベートブラウザには、検索エンジン、トラッカーブロック、強制暗号化機能などが備わっています。%1$siOSとAndroid%2$sに対応。"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14932,9 +14556,7 @@ msgctxt "cloudsave"
 msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
-msgstr ""
-"当社は、お客様のIPアドレスやブラウザ上の個人を特定できる情報、その他一切の情"
-"報をファイルに関連付けないため、パスフレーズを復元できません。"
+msgstr "当社は、お客様のIPアドレスやブラウザ上の個人を特定できる情報、その他一切の情報をファイルに関連付けないため、パスフレーズを復元できません。"
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -15090,9 +14712,8 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
-"Personal Information Removalは、お客様の個人情報を売買しているデータブロー"
-"カーサイトから、その情報を見つけ出します。そして、お客様に代わって削除に向け"
-"て対応します。"
+"Personal Information "
+"Removalは、お客様の個人情報を売買しているデータブローカーサイトから、その情報を見つけ出します。そして、お客様に代わって削除に向けて対応します。"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15162,10 +14783,7 @@ msgid ""
 "assisted answers more likely to appear automatically and often yields better "
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
-msgstr ""
-"検索を質問として完全な文章で表現すると、AI支援の回答が自動的に表示される可能"
-"性と回答精度が高くなります。オフにしてAssistボタンを非表示にするには、%1$s検"
-"索設定%2$sにアクセスしてください。"
+msgstr "検索を質問として完全な文章で表現すると、AI支援の回答が自動的に表示される可能性と回答精度が高くなります。オフにしてAssistボタンを非表示にするには、%1$s検索設定%2$sにアクセスしてください。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15174,9 +14792,8 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"検索を質問として完全な文章で表現すると、DuckAssistが表示される可能性と回答精"
-"度が高くなります。 この機能の動作を調整したり、オフにするには、%1$sDuckAssist"
-"設定%2$sにアクセスしてください。"
+"検索を質問として完全な文章で表現すると、DuckAssistが表示される可能性と回答精度が高くなります。 "
+"この機能の動作を調整したり、オフにするには、%1$sDuckAssist設定%2$sにアクセスしてください。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15185,10 +14802,7 @@ msgid ""
 "DuckAssist more likely to appear automatically and often yields better "
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
-msgstr ""
-"検索を完全な質問文で表現すると、DuckAssistが自動的に表示される可能性と回答精"
-"度が高くなります。オフにしてAssistボタンを非表示にするには、%1$sDuckAssist設"
-"定%2$sにアクセスしてください。"
+msgstr "検索を完全な質問文で表現すると、DuckAssistが自動的に表示される可能性と回答精度が高くなります。オフにしてAssistボタンを非表示にするには、%1$sDuckAssist設定%2$sにアクセスしてください。"
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -15220,8 +14834,7 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
-msgstr ""
-"GPT-5 mini、Claude Haiku 4.5、Mistralなど人気のAIからチャット相手を選びます。"
+msgstr "GPT-5 mini、Claude Haiku 4.5、Mistralなど人気のAIからチャット相手を選びます。"
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -15229,8 +14842,7 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, "
 "Mistral, etc."
-msgstr ""
-"GPT-5 mini、Claude Haiku 4.5、Mistralなど人気のAIからチャット相手を選びます。"
+msgstr "GPT-5 mini、Claude Haiku 4.5、Mistralなど人気のAIからチャット相手を選びます。"
 
 # smartling.placeholder_format=C
 #. The description of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -15238,9 +14850,7 @@ msgctxt "Third party map app picker"
 msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
-msgstr ""
-"目的地までの経路案内に使用するサービスを選択します。外部アプリにはDuckDuckGo"
-"の保護が付属しません。"
+msgstr "目的地までの経路案内に使用するサービスを選択します。外部アプリにはDuckDuckGoの保護が付属しません。"
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -15340,9 +14950,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr ""
-"このプロンプトがボットにより行われていないことを確認するため、次のチャレンジ"
-"を完了してください。"
+msgstr "このプロンプトがボットにより行われていないことを確認するため、次のチャレンジを完了してください。"
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -15350,9 +14958,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr ""
-"この検索がボットにより行われていないことを確認するため、次のチャレンジを完了"
-"してください。"
+msgstr "この検索がボットにより行われていないことを確認するため、次のチャレンジを完了してください。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -15384,9 +14990,7 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
-msgstr ""
-"注：モデルとの新しいチャットを開始すると、現在のチャットセッションが削除され"
-"ます。"
+msgstr "注：モデルとの新しいチャットを開始すると、現在のチャットセッションが削除されます。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15394,9 +14998,7 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
-msgstr ""
-"プロンプトと問題のある出力（個人情報は削除）を貼り付け、コンテンツが有害また"
-"は違法である理由を説明してください。"
+msgstr "プロンプトと問題のある出力（個人情報は削除）を貼り付け、コンテンツが有害または違法である理由を説明してください。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15404,9 +15006,7 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
-msgstr ""
-"プロンプトと問題のある出力（個人情報は削除）を貼り付け、コンテンツが違法また"
-"は有害である理由を説明してください。"
+msgstr "プロンプトと問題のある出力（個人情報は削除）を貼り付け、コンテンツが違法または有害である理由を説明してください。"
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -15620,9 +15220,7 @@ msgstr "フォーマットが不十分"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
-msgstr ""
-"人気のAIモデルが利用可能です。アカウントは必要ありません。当社によりチャット"
-"は匿名化されます。"
+msgstr "人気のAIモデルが利用可能です。アカウントは必要ありません。当社によりチャットは匿名化されます。"
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -16131,9 +15729,7 @@ msgstr "確認する"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"ローカル検索で利用する、おおよその位置情報の使用を許可するプロンプトを表示し"
-"ます。"
+msgstr "ローカル検索で利用する、おおよその位置情報の使用を許可するプロンプトを表示します。"
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -16168,7 +15764,7 @@ msgstr "保護されています"
 #. Headline in sync-enabled chat history about modals explaining encrypted server storage.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Protected with end-to-end encryption"
-msgstr ""
+msgstr "エンドツーエンド暗号化で保護されています"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -16181,9 +15777,7 @@ msgctxt "Full sentence for critiquing writing"
 msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
-msgstr ""
-"次のテキストをより簡潔にするための提案をいくつか提供してください。 [ここに独"
-"自のテキストを挿入します。]"
+msgstr "次のテキストをより簡潔にするための提案をいくつか提供してください。 [ここに独自のテキストを挿入します。]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -16307,7 +15901,7 @@ msgstr "ランキング"
 #. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
 msgctxt "star rating on a product"
 msgid "Rated %s out of %s"
-msgstr ""
+msgstr "評価スコア：%1$s/%2$s"
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -16461,9 +16055,7 @@ msgctxt "Description for recent chats feature"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr ""
-"最近のチャットは、DuckDuckGoサーバーなどのリモートサーバーでなく、お使いのデ"
-"バイスにローカルで保存されます。"
+msgstr "最近のチャットは、DuckDuckGoサーバーなどのリモートサーバーでなく、お使いのデバイスにローカルで保存されます。"
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -16471,9 +16063,7 @@ msgctxt "Description of where recent chats are stored"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr ""
-"最近のチャットは、DuckDuckGoサーバーなどのリモートサーバーでなく、お使いのデ"
-"バイスにローカルで保存されます。"
+msgstr "最近のチャットは、DuckDuckGoサーバーなどのリモートサーバーでなく、お使いのデバイスにローカルで保存されます。"
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -16482,10 +16072,7 @@ msgid ""
 "Recent chats are stored locally on your device. New prompts and responses "
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
-msgstr ""
-"最近のチャットはデバイスのローカルに保存されます。新しいプロンプトやレスポン"
-"スは暗号化され、送信後はDuckDuckGoサーバーに一時的に保存されます。これは、イ"
-"ンターネット接続が途切れた場合のチャット復旧に役立ちます。"
+msgstr "最近のチャットはデバイスのローカルに保存されます。新しいプロンプトやレスポンスは暗号化され、送信後はDuckDuckGoサーバーに一時的に保存されます。これは、インターネット接続が途切れた場合のチャット復旧に役立ちます。"
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -16626,9 +16213,7 @@ msgctxt "settings"
 msgid ""
 "Reduces extra space in and around results and reduces size of result title "
 "text"
-msgstr ""
-"結果の内部と周辺にある余分なスペースを減らし、結果のタイトルテキストのサイズ"
-"を縮小します"
+msgstr "結果の内部と周辺にある余分なスペースを減らし、結果のタイトルテキストのサイズを縮小します"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'Refer to me as John'
@@ -16769,8 +16354,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"指示に従ってDuckDuckGoを再度読み込みするか、ブラウザの [Refresh（リフレッ"
-"シュ）]、または [Reload（再読み込み）] ボタンをクリックします。"
+"指示に従ってDuckDuckGoを再度読み込みするか、ブラウザの [Refresh（リフレッシュ）]、または [Reload（再読み込み）] "
+"ボタンをクリックします。"
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16877,18 +16462,14 @@ msgctxt "settings"
 msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
-msgstr ""
-"「質問」ボタンを削除して、関連する検索に対して回答が自動的に表示されるように"
-"します。キャッシュされた回答は常に自動的に表示されます。"
+msgstr "「質問」ボタンを削除して、関連する検索に対して回答が自動的に表示されるようにします。キャッシュされた回答は常に自動的に表示されます。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
-msgstr ""
-"「生成」ボタンを削除して、関連する検索に対して回答が自動的に表示されるように"
-"します。キャッシュされた回答は常に自動的に表示されます。"
+msgstr "「生成」ボタンを削除して、関連する検索に対して回答が自動的に表示されるようにします。キャッシュされた回答は常に自動的に表示されます。"
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -16945,18 +16526,14 @@ msgid ""
 "Reports are anonymous and sent to DuckDuckGo to help improve our search "
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
-msgstr ""
-"レポートは匿名で、検索サービスの向上目的でDuckDuckGoに送信されます。お客様の"
-"匿名でのフィードバックはサービス改善に役立てるために%1$sとも共有されます。"
+msgstr "レポートは匿名で、検索サービスの向上目的でDuckDuckGoに送信されます。お客様の匿名でのフィードバックはサービス改善に役立てるために%1$sとも共有されます。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
-msgstr ""
-"DuckDuckGoに送信される報告内容は、匿名です。フィードバックには、個人情報や個"
-"人を特定できる情報を含めないようお願いいたします。"
+msgstr "DuckDuckGoに送信される報告内容は、匿名です。フィードバックには、個人情報や個人を特定できる情報を含めないようお願いいたします。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16964,10 +16541,7 @@ msgid ""
 "Reports sent to DuckDuckGo include all of the text you've asked us to "
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
-msgstr ""
-"DuckDuckGoに送信されるレポートは、このページの読み込み中に翻訳を希望したすべ"
-"てのテキストを含み、匿名になっています。フィードバックには、個人情報や個人を"
-"特定できる情報を含めないようお願いいたします。"
+msgstr "DuckDuckGoに送信されるレポートは、このページの読み込み中に翻訳を希望したすべてのテキストを含み、匿名になっています。フィードバックには、個人情報や個人を特定できる情報を含めないようお願いいたします。"
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -17058,10 +16632,7 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
-msgstr ""
-"回答は教育的な目的のみであり、医療、法律、金融、投資、その他の専門的なアドバ"
-"イスを意図したものではありません。AI支援回答は、当社の%1$s利用規約%2$sの対象"
-"です。"
+msgstr "回答は教育的な目的のみであり、医療、法律、金融、投資、その他の専門的なアドバイスを意図したものではありません。AI支援回答は、当社の%1$s利用規約%2$sの対象です。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -17069,10 +16640,7 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
-msgstr ""
-"回答は教育的な目的のみであり、医療、法律、金融、投資、その他の専門的なアドバ"
-"イスを意図したものではありません。DuckAssistは、当社の%1$s利用規約%2$sの対象"
-"になります。"
+msgstr "回答は教育的な目的のみであり、医療、法律、金融、投資、その他の専門的なアドバイスを意図したものではありません。DuckAssistは、当社の%1$s利用規約%2$sの対象になります。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -17082,10 +16650,9 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"回答は教育的な目的でのみ提供され、医療、法律、金融、投資、その他の専門的なア"
-"ドバイスの提供を意図したものではありません。回答はウェブコンテンツに基づいて"
-"生成されているため、不正確な情報が含まれている可能性があります。Search Assist"
-"には、当社の%1$s利用規約%2$sが適用されます。"
+""
+"回答は教育的な目的でのみ提供され、医療、法律、金融、投資、その他の専門的なアドバイスの提供を意図したものではありません。回答はウェブコンテンツに基づいて生成されているため、不正確な情報が含まれている可能性があります。Search "
+"Assistには、当社の%1$s利用規約%2$sが適用されます。"
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -17509,9 +17076,7 @@ msgctxt "Description for Chat History feature with Encrypted Storage option"
 msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
-msgstr ""
-"最新のチャットを最大30件デバイス上にローカルに保存できます。暗号化ストレージ"
-"を使用すれば、さらに多くのチャットを保存できます。"
+msgstr "最新のチャットを最大30件デバイス上にローカルに保存できます。暗号化ストレージを使用すれば、さらに多くのチャットを保存できます。"
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -17524,9 +17089,7 @@ msgstr "最新のチャットを最大30件デバイスにローカルで保存�
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"エンドツーエンド暗号化を使用して、デバイス間でDuck.aiのチャットを保存しましょ"
-"う。"
+msgstr "エンドツーエンド暗号化を使用して、デバイス間でDuck.aiのチャットを保存しましょう。"
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17538,7 +17101,7 @@ msgstr "チャットをすべてのデバイスに保存します。"
 #. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
 msgctxt "Chat history about modal list item headline"
 msgid "Save your chats on this device"
-msgstr ""
+msgstr "チャットをこのデバイスに保存します"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
@@ -17685,9 +17248,7 @@ msgstr "下方向にスクロールし、%1$s詳細設定を表示%2$s をクリ
 msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
-msgstr ""
-"%1$sアドレスバーで検索%2$sが見つかるまで下方向にスクロールします。%3$s変"
-"更%4$s (または %5$s新たに追加%6$s) をクリックします"
+msgstr "%1$sアドレスバーで検索%2$sが見つかるまで下方向にスクロールします。%3$s変更%4$s (または %5$s新たに追加%6$s) をクリックします"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17696,8 +17257,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
 msgstr ""
-"%1$sアドレスバーで検索%2$s が見つかるまで下方向にスクロールします。%3$s変"
-"更%4$s (または %5$s新たに追加%6$s) をクリックします。"
+"%1$sアドレスバーで検索%2$s が見つかるまで下方向にスクロールします。%3$s変更%4$s (または %5$s新たに追加%6$s) "
+"をクリックします。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -17721,9 +17282,7 @@ msgstr "%1$sDuckDuckGo%2$sまで下にスクロールし、位置情報の使用
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr ""
-"%1$sサービス%2$s セクションまで下方向にスクロールして、%3$sアドレスバー%4$s "
-"をクリックします。"
+msgstr "%1$sサービス%2$s セクションまで下方向にスクロールして、%3$sアドレスバー%4$s をクリックします。"
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -17748,7 +17307,7 @@ msgctxt ""
 "Placeholder and accessibility label for the search input in the tab picker "
 "dialog"
 msgid "Search"
-msgstr ""
+msgstr "検索"
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -17785,20 +17344,17 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assistは検索クエリに対する回答を匿名で生成します。そのために、関連コン"
-"テンツをウェブでスキャンしてから、AIを使用して簡潔な回答を生成します。表示頻"
-"度は、「表示しない」、「要求時（Assistがクリックされたときのみ）」、「時々"
-"（関連性が高いとき）」、「頻繁（検索範囲が広いとき）」から選択できます。"
-"Search Assistは現時点で、英語圏の一部の地域でのみ利用可能です。"
+"Search "
+""
+"Assistは検索クエリに対する回答を匿名で生成します。そのために、関連コンテンツをウェブでスキャンしてから、AIを使用して簡潔な回答を生成します。表示頻度は、「表示しない」、「要求時（Assistがクリックされたときのみ）」、「時々（関連性が高いとき）」、「頻繁（検索範囲が広いとき）」から選択できます。Search "
+"Assistは現時点で、英語圏の一部の地域でのみ利用可能です。"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
 msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
-msgstr ""
-"Search Assistはこの質問の回答を生成するのに十分な信頼できる情報を見つけること"
-"ができませんでした。別の検索をお試しください。"
+msgstr "Search Assistはこの質問の回答を生成するのに十分な信頼できる情報を見つけることができませんでした。別の検索をお試しください。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -17807,9 +17363,8 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assistは、検索クエリに対する回答を匿名で生成するオプション機能です。こ"
-"れを行うには、%1$sウェブをスキャンして%2$s関連コンテンツを探し、見つかった情"
-"報に基づいてAIを使って簡潔な回答を生成します。"
+"Search "
+"Assistは、検索クエリに対する回答を匿名で生成するオプション機能です。これを行うには、%1$sウェブをスキャンして%2$s関連コンテンツを探し、見つかった情報に基づいてAIを使って簡潔な回答を生成します。"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -17929,9 +17484,7 @@ msgctxt "noresults"
 msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
-msgstr ""
-"%1$sのショートカットで他のサイトを検索します：「!w ducks」を検索すると、"
-"Wikipediaで「ducks」を直接検索します。"
+msgstr "%1$sのショートカットで他のサイトを検索します：「!w ducks」を検索すると、Wikipediaで「ducks」を直接検索します。"
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -17949,10 +17502,7 @@ msgstr "プライベートに検索し、トラッカーをブロック"
 msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
-msgstr ""
-"検索時のプライバシーが心配なあなたにぴったりのアプリ・拡張機能。お気に入りの"
-"ブラウザにプライベート検索機能を追加するか、%1$sduckduckgo.com%2$sで直接検索"
-"できます。"
+msgstr "検索時のプライバシーが心配なあなたにぴったりのアプリ・拡張機能。お気に入りのブラウザにプライベート検索機能を追加するか、%1$sduckduckgo.com%2$sで直接検索できます。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -17971,10 +17521,8 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"検索設定は、非個人用のブラウザCookieおよびローカルストレージに保存されます"
-"が、設定をクラウド上のリモートサーバーに匿名で保存できるCloud Saveもご利用い"
-"ただけます。クラウドには個人を特定できる情報は一切保存されず、パスフレーズが"
-"ブラウザの外に送信されることもありません。"
+"検索設定は、非個人用のブラウザCookieおよびローカルストレージに保存されますが、設定をクラウド上のリモートサーバーに匿名で保存できるCloud "
+"Saveもご利用いただけます。クラウドには個人を特定できる情報は一切保存されず、パスフレーズがブラウザの外に送信されることもありません。"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -18076,9 +17624,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr ""
-"エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、"
-"すべてのデバイスから簡単にアクセスできます。"
+msgstr "エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、すべてのデバイスから簡単にアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -18086,9 +17632,7 @@ msgctxt "Description for encrypted storage feature"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr ""
-"エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、"
-"すべてのデバイスから簡単にアクセスできます。"
+msgstr "エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、すべてのデバイスから簡単にアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18096,9 +17640,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
-msgstr ""
-"エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、"
-"すべての同期済みのデバイスから簡単にアクセスできます。"
+msgstr "エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、すべての同期済みのデバイスから簡単にアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18106,9 +17648,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
-msgstr ""
-"チャットはエンドツーエンド暗号化を使用して当社サーバーに安全に保存され、すべ"
-"てのデバイスからアクセスできます。"
+msgstr "チャットはエンドツーエンド暗号化を使用して当社サーバーに安全に保存され、すべてのデバイスからアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -18122,9 +17662,7 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
-msgstr ""
-"データはDuckDuckGoのサーバー上にエンドツーエンド暗号化で安全に保存されます。"
-"DuckDuckGoを含めて、本人以外のユーザーは閲覧できません。"
+msgstr "データはDuckDuckGoのサーバー上にエンドツーエンド暗号化で安全に保存されます。DuckDuckGoを含めて、本人以外のユーザーは閲覧できません。"
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
@@ -18274,41 +17812,35 @@ msgstr "Safariメニューの%1$s「このウェブサイトの設定...」%2$s 
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
-msgstr ""
-"%1$sカスタム%2$s を選択して、入力欄に %3$shttps://duckduckgo.com%4$s と入力"
+msgstr "%1$sカスタム%2$s を選択して、入力欄に %3$shttps://duckduckgo.com%4$s と入力"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトとして追加%4$sをクリックします。"
+msgstr "%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトとして追加%4$sをクリックします。"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトに設定%4$sをクリックしてください"
+msgstr "%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトに設定%4$sをクリックしてください"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトに設定%4$s をクリックします。"
+msgstr "%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトに設定%4$s をクリックします。"
 
 #  Firefox 33
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr ""
-"%1$sDuckDuckGo%2$sをデフォルトの検索エンジン選択メニューから選んでください"
+msgstr "%1$sDuckDuckGo%2$sをデフォルトの検索エンジン選択メニューから選んでください"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"リストで%1$sDuckDuckGo%2$sを選択し、位置情報へのアクセスを%3$s許可%4$sします"
+msgstr "リストで%1$sDuckDuckGo%2$sを選択し、位置情報へのアクセスを%3$s許可%4$sします"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18320,9 +17852,7 @@ msgstr "検索エンジンから%1$sDuckDuckGo%2$sを選択してください"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr ""
-"%1$sデフォルトの検索エンジン%2$sセクションの中にある%3$sDuckDuckGo%4$sを選択"
-"してください"
+msgstr "%1$sデフォルトの検索エンジン%2$sセクションの中にある%3$sDuckDuckGo%4$sを選択してください"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -18333,8 +17863,7 @@ msgstr "選ぶなら%1$sDuckDuckGo%2$s！"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr ""
-"ドロップダウンの中にある%1$s検索エンジンを編集...%2$sボタンを選択してください"
+msgstr "ドロップダウンの中にある%1$s検索エンジンを編集...%2$sボタンを選択してください"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18347,9 +17876,7 @@ msgstr "ドロップダウンメニューの%1$sアドオン管理%2$sを選択�
 #. Tells users where in the settings menu they can change their default search engine.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
-msgstr ""
-"Macの場合、%1$sOpera > 設定%2$sの順に選択してください。Windowsの場合は、%3$s"
-"メニュー > 設定%4$sの順に選択してください"
+msgstr "Macの場合、%1$sOpera > 設定%2$sの順に選択してください。Windowsの場合は、%3$sメニュー > 設定%4$sの順に選択してください"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -18357,8 +17884,8 @@ msgstr ""
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
 msgstr ""
-"Macの場合、%1$sOpera > 環境設定%2$sの順に選択してください。Windowsの場合"
-"は、%3$sOpera > オプション%4$sの順に選択してください"
+"Macの場合、%1$sOpera > 環境設定%2$sの順に選択してください。Windowsの場合は、%3$sOpera > "
+"オプション%4$sの順に選択してください"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -18377,8 +17904,7 @@ msgstr "%1$s検索エンジン%2$s を選択"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"
-msgstr ""
-"%1$s検索エンジン%2$sを選択してから、%3$sその他...%4$sをクリックします。"
+msgstr "%1$s検索エンジン%2$sを選択してから、%3$sその他...%4$sをクリックします。"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -18423,17 +17949,13 @@ msgstr "%1$s設定%2$sを選択し、%3$s検索エンジン%4$sを選択して�
 msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
-msgstr ""
-"%1$sこのページをホームページに設定%2$sを選択してください(または他のお好みのオ"
-"プションをどれか一つどうぞ)"
+msgstr "%1$sこのページをホームページに設定%2$sを選択してください(または他のお好みのオプションをどれか一つどうぞ)"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"リストで%1$sお使いのブラウザ%2$sを選択し、位置情報へのアクセスを%3$s許可%4$s"
-"します"
+msgstr "リストで%1$sお使いのブラウザ%2$sを選択し、位置情報へのアクセスを%3$s許可%4$sします"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18505,9 +18027,7 @@ msgstr "選択テキストの参照元：%1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr ""
-"選択したテキストが長すぎます。ソーステキストを一部選択し、もう一度お試しくだ"
-"さい。"
+msgstr "選択したテキストが長すぎます。ソーステキストを一部選択し、もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -18550,9 +18070,7 @@ msgid ""
 "Sends a prompt to AI models with your messages with instructions on how to "
 "respond. These instructions will apply to all of your conversations going "
 "forward."
-msgstr ""
-"AIモデルに、メッセージに応答する方法を指示したプロンプトを送信します。これら"
-"の指示は、今後のすべての会話に適用されます。"
+msgstr "AIモデルに、メッセージに応答する方法を指示したプロンプトを送信します。これらの指示は、今後のすべての会話に適用されます。"
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -18674,9 +18192,7 @@ msgctxt "Chat history about modal list item"
 msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
-msgstr ""
-"チャット履歴をオンにしてから、チャットがデバイス間で継続的に同期されるように"
-"Sync & Backupを設定します。"
+msgstr "チャット履歴をオンにしてから、チャットがデバイス間で継続的に同期されるようにSync & Backupを設定します。"
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -18782,9 +18298,7 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
-msgstr ""
-"都市レベルの位置情報をAIモデルと共有して関連性を向上させます。Duck.ai は、お"
-"客様の正確な位置情報を当社や AI モデルに決して公開しません。"
+msgstr "都市レベルの位置情報をAIモデルと共有して関連性を向上させます。Duck.ai は、お客様の正確な位置情報を当社や AI モデルに決して公開しません。"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -18879,9 +18393,7 @@ msgctxt ""
 msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
-msgstr ""
-"プロンプトとチャットの回答をDuckDuckGoと共有してください（違法および有害な事"
-"象の報告には必須）"
+msgstr "プロンプトとチャットの回答をDuckDuckGoと共有してください（違法および有害な事象の報告には必須）"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -18907,9 +18419,7 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Shield your online activity with our no-log, fast VPN. Simple to set up and "
 "easy to turn on and off anytime."
-msgstr ""
-"ノーログ型の高速VPNを使って、オンライン活動を保護できます。セットアップは簡単"
-"で、オン/オフの切り替えがいつでも可能です。"
+msgstr "ノーログ型の高速VPNを使って、オンライン活動を保護できます。セットアップは簡単で、オン/オフの切り替えがいつでも可能です。"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -18927,7 +18437,7 @@ msgstr "ショップ"
 #. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
 msgctxt "Button in the merchandise logo modal (mobile)"
 msgid "Shop Now"
-msgstr ""
+msgstr "今すぐ購入"
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -19035,9 +18545,7 @@ msgstr "DuckAssist<sup>ベータ版</sup>を表示"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"DuckAssistをより頻繁に表示します。（完全に%1$sオフにする%2$sこともできま"
-"す。）"
+msgstr "DuckAssistをより頻繁に表示します。（完全に%1$sオフにする%2$sこともできます。）"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -19220,8 +18728,7 @@ msgstr "サイドバーを表示する"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
-"Duck.aiを最大限に活用するためのステップバイステップのヒントを表示します。"
+msgstr "Duck.aiを最大限に活用するためのステップバイステップのヒントを表示します。"
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -19275,18 +18782,14 @@ msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
-msgstr ""
-"DuckDuckGoでの検索が常に非公開であることのリマインダーを表示します。これをオ"
-"フにすると、リマインダーが非表示になり、検索のプライバシーには影響しません。"
+msgstr "DuckDuckGoでの検索が常に非公開であることのリマインダーを表示します。これをオフにすると、リマインダーが非表示になり、検索のプライバシーには影響しません。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
-msgstr ""
-"DuckDuckGoでの検索が常に保護されていることのリマインダーを表示します。これを"
-"オフにするとリマインダーが非表示になりますが、検索の保護には影響しません。"
+msgstr "DuckDuckGoでの検索が常に保護されていることのリマインダーを表示します。これをオフにするとリマインダーが非表示になりますが、検索の保護には影響しません。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19323,8 +18826,7 @@ msgstr "DuckDuckGoを端末に追加するリマインダーを随時表示"
 msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
-msgstr ""
-"DuckDuckGoのプライバシーニュースレターへの登録に関する通知をときどき表示"
+msgstr "DuckDuckGoのプライバシーニュースレターへの登録に関する通知をときどき表示"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19345,9 +18847,7 @@ msgstr "入力に応じて検索ボックスの下に検索候補を表示"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr ""
-"ホームページでDuckDuckGoを利用することで生まれるプライバシー上のメリットを表"
-"示"
+msgstr "ホームページでDuckDuckGoを利用することで生まれるプライバシー上のメリットを表示"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19598,8 +19098,7 @@ msgstr "サーバーへの保存が失敗しました。再度お試しくださ
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr ""
-"Sync & Backupを有効にしている際に問題が発生しました。もう一度お試しください。"
+msgstr "Sync & Backupを有効にしている際に問題が発生しました。もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -19629,8 +19128,7 @@ msgstr "時々表示する"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr ""
-"申し訳ありませんが、お力になれません。別の方法で画像を説明してください。"
+msgstr "申し訳ありませんが、お力になれません。別の方法で画像を説明してください。"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19668,9 +19166,7 @@ msgctxt "Error message when an uploaded image cannot be decoded or processed"
 msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
-msgstr ""
-"申し訳ありませんが、アップロードした画像を処理できませんでした。別の画像また"
-"は形式を試してください。"
+msgstr "申し訳ありませんが、アップロードした画像を処理できませんでした。別の画像または形式を試してください。"
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -19678,17 +19174,13 @@ msgctxt "Description for the wrong code error screen"
 msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
-msgstr ""
-"申し訳ありません。このコードは無効です。正しいコードが入力またはスキャンされ"
-"たことを確認してください。"
+msgstr "申し訳ありません。このコードは無効です。正しいコードが入力またはスキャンされたことを確認してください。"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid ""
 "Sorry, we couldn't generate a richer answer. You can try asking Duck.ai."
-msgstr ""
-"申し訳ありませんが、これ以上豊富な回答を出すことはできませんでした。Duck.ai "
-"に聞いてみてください。"
+msgstr "申し訳ありませんが、これ以上豊富な回答を出すことはできませんでした。Duck.ai に聞いてみてください。"
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and that they could try to refresh the page to resolve the error. Placeholders are for markup, please ignore.
@@ -19696,17 +19188,13 @@ msgctxt "noresults"
 msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
-msgstr ""
-"申し訳ありませんが、これらの結果を表示する際にエラーが発生しました。再試行す"
-"るには、%1$sこちらをクリック%2$sしてください。"
+msgstr "申し訳ありませんが、これらの結果を表示する際にエラーが発生しました。再試行するには、%1$sこちらをクリック%2$sしてください。"
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"申し訳ありませんが、フィードバックを送信できませんでした。少し時間をおいてか"
-"らもう一度試してください。"
+msgstr "申し訳ありませんが、フィードバックを送信できませんでした。少し時間をおいてからもう一度試してください。"
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19760,9 +19248,7 @@ msgstr "ソーステキストが消去されました"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr ""
-"ソーステキストが長すぎて要約できません。ソーステキストを一部選択し、もう一度"
-"お試しください。"
+msgstr "ソーステキストが長すぎて要約できません。ソーステキストを一部選択し、もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -19967,8 +19453,7 @@ msgstr "DuckDuckGoを使用し続ける"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr ""
-"プライバシーニュースレターで、データを常時守り、最新情報を入手しましょう。"
+msgstr "プライバシーニュースレターで、データを常時守り、最新情報を入手しましょう。"
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -20112,9 +19597,7 @@ msgctxt "Description prompting subscription for higher limits"
 msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
-msgstr ""
-"Duck.aiの制限を引き上げるにはDuckDuckGoに登録するか、後で戻ってきてさらに画像"
-"を作成してください。"
+msgstr "Duck.aiの制限を引き上げるにはDuckDuckGoに登録するか、後で戻ってきてさらに画像を作成してください。"
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -20182,8 +19665,7 @@ msgctxt "Full sentence for composing a card"
 msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
-msgstr ""
-"手術したばかりの人宛てのお見舞いのカードに書くフレーズを提案してください。"
+msgstr "手術したばかりの人宛てのお見舞いのカードに書くフレーズを提案してください。"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
@@ -20519,8 +20001,7 @@ msgstr "%1$sに切り替えました"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr ""
-"切り替えると、チャットはプロバイダーの可視性がゼロのモデルに送信されます"
+msgstr "切り替えると、チャットはプロバイダーの可視性がゼロのモデルに送信されます"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -20582,7 +20063,7 @@ msgctxt "Chat history with sync modal list item description"
 msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
-msgstr ""
+msgstr "Sync & Backupは、より多くのチャットを保存し、すべてのデバイス間で同期します。"
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20631,25 +20112,21 @@ msgid ""
 msgstr ""
 "同期リカバリーコード\n"
 "\n"
-"リカバリーコードを使用すると、パスワード、自動入力データ、Duck.aiチャットが複"
-"数のデバイスで同期されるようになり、デバイスにアクセスできなくなった場合に同"
-"期済みのデータを回復できます。\n"
+""
+""
+"リカバリーコードを使用すると、パスワード、自動入力データ、Duck.aiチャットが複数のデバイスで同期されるようになり、デバイスにアクセスできなくなった場合に同期済みのデータを回復できます。\n"
 "\n"
 "この情報は安全に保管してください。\n"
-"このコードにアクセス可能なユーザーは誰でも同期済みデータにアクセスできま"
-"す。\n"
+"このコードにアクセス可能なユーザーは誰でも同期済みデータにアクセスできます。\n"
 "\n"
 "%1$s\n"
 "\n"
 "このコードの仕組みは？\n"
 "1. ブラウザでDuck.aiにアクセスし、Duck.aiの設定を開きます。\n"
-"2. 「Sync & Backupをオンにする」、「同期されたデータを復元」の順に選択しま"
-"す\n"
-"3. リカバリーコードをコピーし、「ここにコードを貼り付けてください」欄に貼り付"
-"けます\n"
+"2. 「Sync & Backupをオンにする」、「同期されたデータを復元」の順に選択します\n"
+"3. リカバリーコードをコピーし、「ここにコードを貼り付けてください」欄に貼り付けます\n"
 "\n"
-"DuckDuckGoブラウザの未使用期間が18か月を超えると、データはサーバーから削除さ"
-"れ、復元できなくなります。"
+"DuckDuckGoブラウザの未使用期間が18か月を超えると、データはサーバーから削除され、復元できなくなります。"
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -20703,7 +20180,7 @@ msgstr "すべてのデバイスでチャットを同期します。"
 #. Headline in sync-enabled chat history about modals explaining cross-device sync.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Sync your chats across all your devices"
-msgstr ""
+msgstr "すべてのデバイスでチャットを同期"
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -20787,9 +20264,7 @@ msgctxt "Product-tour success modal body - mobile variant"
 msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
-msgstr ""
-"Duck.aiをどこへでも連れて行きましょう。どこにいても素早くアクセスできるよう、"
-"無料アプリに組み込めます。"
+msgstr "Duck.aiをどこへでも連れて行きましょう。どこにいても素早くアクセスできるよう、無料アプリに組み込めます。"
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20797,9 +20272,7 @@ msgctxt "Product-tour success modal body"
 msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
-msgstr ""
-"Duck.aiをどこへでも連れて行きましょう。無料ブラウザに組み込むことで、どこから"
-"でも素早くアクセスできます。"
+msgstr "Duck.aiをどこへでも連れて行きましょう。無料ブラウザに組み込むことで、どこからでも素早くアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20822,8 +20295,7 @@ msgstr "個人データを自己管理しましょう！"
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr ""
-"この匿名アンケートに回答して、Duck.aiを改善するためのご意見をお寄せください。"
+msgstr "この匿名アンケートに回答して、Duck.aiを改善するためのご意見をお寄せください。"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -21043,10 +20515,7 @@ msgid ""
 "That means information sent between your device and the webpage behind this "
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
-msgstr ""
-"つまり、お使いのデバイスとこのリンクに接続するウェブページの間で送信される情"
-"報はサードパーティに傍受されるリスクが高いことになります。まれに、パスワード"
-"や支払い情報がこうした情報に含まれる場合もあります。"
+msgstr "つまり、お使いのデバイスとこのリンクに接続するウェブページの間で送信される情報はサードパーティに傍受されるリスクが高いことになります。まれに、パスワードや支払い情報がこうした情報に含まれる場合もあります。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -21054,9 +20523,7 @@ msgctxt "cloudsave"
 msgid ""
 "The Cloud Save bookmarklet allows any changes you make to your settings to "
 "automatically save in the cloud."
-msgstr ""
-"Cloud Save ブックマークレットを使用すると、設定上の変更をすべてクラウドに自動"
-"保存できます。"
+msgstr "Cloud Save ブックマークレットを使用すると、設定上の変更をすべてクラウドに自動保存できます。"
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -21085,18 +20552,14 @@ msgctxt "Second paragraph for the Sync & Backup intro screen"
 msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
-msgstr ""
-"暗号化キーはブラウザのローカルストレージにのみ保存され、アクセスできるのは本"
-"人だけです。"
+msgstr "暗号化キーはブラウザのローカルストレージにのみ保存され、アクセスできるのは本人だけです。"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider deletes all chat data within 30 days.
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr ""
-"モデルプロバイダーはこのチャットに関連するすべてのデータを30日以内に削除しま"
-"す。"
+msgstr "モデルプロバイダーはこのチャットに関連するすべてのデータを30日以内に削除します。"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -21110,8 +20573,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider does not save this chat or any associated data on their "
 "servers."
-msgstr ""
-"モデルプロバイダーは、このチャットや関連データをサーバーに保存しません。"
+msgstr "モデルプロバイダーは、このチャットや関連データをサーバーに保存しません。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -21169,9 +20631,7 @@ msgctxt "Error message when there was an issue saving a chat to the browser"
 msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
-msgstr ""
-"このチャットをローカルに保存する際にエラーが発生しました。ブラウザの設定を確"
-"認し、ローカルデータの保存が有効になっていることをご確認ください。"
+msgstr "このチャットをローカルに保存する際にエラーが発生しました。ブラウザの設定を確認し、ローカルデータの保存が有効になっていることをご確認ください。"
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -21185,9 +20645,7 @@ msgctxt "noresults"
 msgid ""
 "There was still an error displaying the search results. Please wait a few "
 "minutes before you try again."
-msgstr ""
-"検索結果の表示中にまたエラーが発生しました。数分待ってから再試行してくださ"
-"い。"
+msgstr "検索結果の表示中にまたエラーが発生しました。数分待ってから再試行してください。"
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
@@ -21205,10 +20663,7 @@ msgid ""
 "These browser permissions are used to add privacy protection on websites you "
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
-msgstr ""
-"これらのブラウザのアクセス許可は、訪問したWebサイトにプライバシー保護を追加す"
-"るために隠れたトラッカーをブロックし、接続を可能な限り暗号化し、DuckDuckGoを"
-"デフォルトの検索エンジンにするために使用されます。"
+msgstr "これらのブラウザのアクセス許可は、訪問したWebサイトにプライバシー保護を追加するために隠れたトラッカーをブロックし、接続を可能な限り暗号化し、DuckDuckGoをデフォルトの検索エンジンにするために使用されます。"
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -21245,9 +20700,7 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr ""
-"このAIモデルは使用できなくなりました。別のモデルで新しいチャットを開始してみ"
-"てください。"
+msgstr "このAIモデルは使用できなくなりました。別のモデルで新しいチャットを開始してみてください。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -21255,9 +20708,7 @@ msgctxt "AI Chat: Error message for when a model is deprecated"
 msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
-msgstr ""
-"このAIモデル版はサポートされなくなりました。このモデルの最新版で新しいチャッ"
-"トを開始してください。"
+msgstr "このAIモデル版はサポートされなくなりました。このモデルの最新版で新しいチャットを開始してください。"
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -21291,13 +20742,13 @@ msgctxt ""
 msgid ""
 "This chat and its generated images become public when you create and copy "
 "the link."
-msgstr ""
+msgstr "リンクを作成してコピーすると、このチャットと生成された画像が公開されます。"
 
 # smartling.placeholder_format=C
 #. Explains that creating and copying a share link makes the selected chat content public.
 msgctxt "Share modal info bullet about public access"
 msgid "This chat becomes public when you create and copy the link."
-msgstr ""
+msgstr "リンクを作成してコピーすると、このチャットは公開されます。"
 
 # smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
@@ -21311,10 +20762,7 @@ msgctxt "Export chat feature in AI Chat"
 msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
-msgstr ""
-"この会話は、%2$sの%3$sモデルを使用してDuck.ai（%1$s）で生成されました。AI"
-"チャットでは不正確な情報や不快な情報が表示される場合があります（詳細について"
-"は%4$sを参照してください）。"
+msgstr "この会話は、%2$sの%3$sモデルを使用してDuck.ai（%1$s）で生成されました。AIチャットでは不正確な情報や不快な情報が表示される場合があります（詳細については%4$sを参照してください）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21323,10 +20771,7 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using multiple chat "
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
-msgstr ""
-"この会話は、複数のチャットモデルを使用してDuck.ai（%1$s）で生成されました。AI"
-"チャットでは不正確な情報や不快な内容が表示される場合があります（詳細について"
-"は%2$sを参照してください）。"
+msgstr "この会話は、複数のチャットモデルを使用してDuck.ai（%1$s）で生成されました。AIチャットでは不正確な情報や不快な内容が表示される場合があります（詳細については%2$sを参照してください）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21334,9 +20779,7 @@ msgctxt "Export chat feature in AI Chat"
 msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
-msgstr ""
-"この会話はDuck.aiボイスチャット(%1$s)で生成されました。AIは不正確または不快な"
-"情報を提供する可能性があります。（詳細は%2$sを参照してください。）"
+msgstr "この会話はDuck.aiボイスチャット(%1$s)で生成されました。AIは不正確または不快な情報を提供する可能性があります。（詳細は%2$sを参照してください。）"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -21346,9 +20789,8 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"この会話は、%2$sの%3$sモデルを使用してDuckDuckGo AI Chat（%1$s）で生成されま"
-"した。AIチャットでは不正確な情報や不快な情報が表示される場合があります（詳細"
-"については%4$sを参照してください）。"
+"この会話は、%2$sの%3$sモデルを使用してDuckDuckGo AI "
+"Chat（%1$s）で生成されました。AIチャットでは不正確な情報や不快な情報が表示される場合があります（詳細については%4$sを参照してください）。"
 
 # smartling.placeholder_format=C
 #. Renders to the right of the device name for the row that matches this device's id.
@@ -21364,9 +20806,7 @@ msgctxt ""
 msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
-msgstr ""
-"このデバイスは、他のデバイスの同期データにアクセスできなくなります。直近%1$s"
-"件のチャットはローカルストレージで引き続き利用可能です。"
+msgstr "このデバイスは、他のデバイスの同期データにアクセスできなくなります。直近%1$s件のチャットはローカルストレージで引き続き利用可能です。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21398,8 +20838,7 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s"
-msgstr ""
-"このファイル形式はサポートされていません。%1$sまたは%2$sを添付してください。"
+msgstr "このファイル形式はサポートされていません。%1$sまたは%2$sを添付してください。"
 
 # smartling.placeholder_format=C
 #. Error message for unsupported file type when multiple types are accepted. First placeholder is a comma-separated list of all accepted types except the last (e.g. PNG, JPG, WebP, GIF). Second placeholder is the last accepted type (e.g. PDF). Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF
@@ -21407,8 +20846,7 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s."
-msgstr ""
-"このファイル形式はサポートされていません。%1$sまたは%2$sを添付してください。"
+msgstr "このファイル形式はサポートされていません。%1$sまたは%2$sを添付してください。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to upload an unsupported file type and we know which types are accepted. Placeholder is a single accepted type. E.g. This file type is not supported, please attach a PDF
@@ -21439,18 +20877,14 @@ msgstr "この画像は作成できませんでした。"
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr ""
-"この画像形式はサポートされていません。JPG、PNG、WebP、またはGIFを添付してくだ"
-"さい。"
+msgstr "この画像形式はサポートされていません。JPG、PNG、WebP、またはGIFを添付してください。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr ""
-"この画像形式はサポートされていません。JPG、PNG、WebP、またはGIFを添付してくだ"
-"さい。"
+msgstr "この画像形式はサポートされていません。JPG、PNG、WebP、またはGIFを添付してください。"
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -21469,9 +20903,7 @@ msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
-msgstr ""
-"これはサンプルチャットです。メニュー（3つの点）を開き、「ピン留め」を選択する"
-"と、チャットの先頭に固定できます！"
+msgstr "これはサンプルチャットです。メニュー（3つの点）を開き、「ピン留め」を選択すると、チャットの先頭に固定できます！"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -21479,9 +20911,7 @@ msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
-msgstr ""
-"これはサンプルチャットです。サイドメニューのFire Buttonを使って削除してくださ"
-"い！"
+msgstr "これはサンプルチャットです。サイドメニューのFire Buttonを使って削除してください！"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -21501,9 +20931,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
-msgstr ""
-"このモデルプロバイダーは、このチャットに関連するデータを30日以内に削除しま"
-"す。他のモデルプロバイダーは、データを一切保持しないモデルを採用しています。"
+msgstr "このモデルプロバイダーは、このチャットに関連するデータを30日以内に削除します。他のモデルプロバイダーは、データを一切保持しないモデルを採用しています。"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -21511,9 +20939,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
-msgstr ""
-"このモデルプロバイダーはこのチャットに関連するデータを保存していません。他の"
-"モデルプロバイダーは限定的なデータ保持モデルを採用しています。"
+msgstr "このモデルプロバイダーはこのチャットに関連するデータを保存していません。他のモデルプロバイダーは限定的なデータ保持モデルを採用しています。"
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -21549,9 +20975,7 @@ msgctxt "First paragraph for the Sync & Backup intro screen"
 msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
-msgstr ""
-"チャットはエンドツーエンドの暗号化でDuckDuckGoの安全なサーバーに保存され、後"
-"でどのブラウザからでもアクセスできます。"
+msgstr "チャットはエンドツーエンドの暗号化でDuckDuckGoの安全なサーバーに保存され、後でどのブラウザからでもアクセスできます。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21559,9 +20983,7 @@ msgctxt "duckassist"
 msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
-msgstr ""
-"この設定はブラウザに保存されているため、duckduckgo.comのブラウザデータを削除"
-"すると、AI支援の回答が再表示されることがあります。"
+msgstr "この設定はブラウザに保存されているため、duckduckgo.comのブラウザデータを削除すると、AI支援の回答が再表示されることがあります。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21571,17 +20993,15 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"この設定はブラウザに保存されているため、duckduckgo.comのブラウザデータを削除"
-"すると、AI支援の回答が再表示されることがあります。ただし、%1$s にはAI支援の回"
-"答が一切表示されないスタートページもご用意しています。"
+""
+"この設定はブラウザに保存されているため、duckduckgo.comのブラウザデータを削除すると、AI支援の回答が再表示されることがあります。ただし、%1$s "
+"にはAI支援の回答が一切表示されないスタートページもご用意しています。"
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr ""
-"この共有チャットを開くことができませんでした。リンクが不完全な可能性がありま"
-"す。"
+msgstr "この共有チャットを開くことができませんでした。リンクが不完全な可能性があります。"
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
@@ -21610,16 +21030,13 @@ msgstr "この翻訳は正しくありません"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"この動画はまだここで視聴することはできません。この動画は %1$s 上で視聴可能で"
-"す。"
+msgstr "この動画はまだここで視聴することはできません。この動画は %1$s 上で視聴可能です。"
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"このウェブページでは「暗号化された安全な接続(HTTPS)」を利用できません。"
+msgstr "このウェブページでは「暗号化された安全な接続(HTTPS)」を利用できません。"
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21629,9 +21046,8 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"このオプションを選択すると、Duck.aiのチャットがこのブラウザからすべて削除さ"
-"れ、Sync & Backupとの接続は解除されます。Sync & Backupに接続している他のブラ"
-"ウザでは、引き続きチャットにアクセスできます。"
+"このオプションを選択すると、Duck.aiのチャットがこのブラウザからすべて削除され、Sync & Backupとの接続は解除されます。Sync & "
+"Backupに接続している他のブラウザでは、引き続きチャットにアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -21639,9 +21055,7 @@ msgctxt "Body text for clear all recent chats confirmation modal"
 msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
-msgstr ""
-"これにより、ピン留めされていない限り、最近のチャットがすべて削除されます。こ"
-"の操作は取り消せません。"
+msgstr "これにより、ピン留めされていない限り、最近のチャットがすべて削除されます。この操作は取り消せません。"
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -21778,9 +21192,7 @@ msgctxt "directions"
 msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
-msgstr ""
-"ルートの印刷手順：%1$s地図に戻ります。%2$s印刷するルートを選択します。%3$s印"
-"刷アイコンをクリックします。%4$s"
+msgstr "ルートの印刷手順：%1$s地図に戻ります。%2$s印刷するルートを選択します。%3$s印刷アイコンをクリックします。%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -21789,10 +21201,7 @@ msgid ""
 "To restore your synced data, you'll need the Recovery Code you saved when "
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
-msgstr ""
-"同期したデータを復元するには、同期を初めて設定したときに保存したリカバリー"
-"コードが必要です。このコードは、同期設定に最初に使用したデバイスにPDFとして保"
-"存されている可能性があります。"
+msgstr "同期したデータを復元するには、同期を初めて設定したときに保存したリカバリーコードが必要です。このコードは、同期設定に最初に使用したデバイスにPDFとして保存されている可能性があります。"
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -21800,18 +21209,14 @@ msgctxt "duckai_migration"
 msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
-msgstr ""
-"チャット履歴をDuck.aiに転送するには、DuckDuckGoブラウザを最新バージョンにアッ"
-"プデートし、再度お試しください。"
+msgstr "チャット履歴をDuck.aiに転送するには、DuckDuckGoブラウザを最新バージョンにアップデートし、再度お試しください。"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "To use dictation, allow your browser to access the microphone in your system "
 "settings."
-msgstr ""
-"音声入力機能を使用するには、システム設定でブラウザがマイクにアクセスできるよ"
-"うに設定してください。"
+msgstr "音声入力機能を使用するには、システム設定でブラウザがマイクにアクセスできるように設定してください。"
 
 # smartling.placeholder_format=C
 msgid "Today"
@@ -21833,15 +21238,13 @@ msgstr "今日"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
-msgstr ""
+msgstr "トグルを切り替えてプライベートAIチャットにするか、%1$s設定で無効にする%2$sこともできます。"
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
-msgstr ""
-"トグルを切り替えてプライベートAIチャットを試すか、%1$s%2$sメニューで無効にで"
-"きます。%3$s"
+msgstr "トグルを切り替えてプライベートAIチャットを試すか、%1$s%2$sメニューで無効にできます。%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -22014,9 +21417,7 @@ msgctxt "tracker_stats"
 msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
-msgstr ""
-"DuckDuckGoが追跡試行をブロックすると、こちらに表示されます。閲覧を続けると、"
-"ブロック件数が表示されるようになります。"
+msgstr "DuckDuckGoが追跡試行をブロックすると、こちらに表示されます。閲覧を続けると、ブロック件数が表示されるようになります。"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -22063,9 +21464,7 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"この英語の文章をフランス語に翻訳してください。「最寄りの映画館へはどうやって"
-"行けばいいですか？」"
+msgstr "この英語の文章をフランス語に翻訳してください。「最寄りの映画館へはどうやって行けばいいですか？」"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -22073,9 +21472,7 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"この日本語の文章を英語に翻訳してください。「最寄りの映画館へはどうやって行け"
-"ばいいですか？」"
+msgstr "この日本語の文章を英語に翻訳してください。「最寄りの映画館へはどうやって行けばいいですか？」"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -22183,8 +21580,7 @@ msgstr "%1$sを試す"
 # smartling.placeholder_format=C
 #. Prompt for the user to start using our homepage that doesn't show promotional messages. The placeholder is a homepage url (e.g., 'start.duckduckgo.com')
 msgid "Try %s to stop seeing messages like this."
-msgstr ""
-"このようなメッセージが表示されないようにするには、%1$sをお試しください。"
+msgstr "このようなメッセージが表示されないようにするには、%1$sをお試しください。"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
@@ -22194,9 +21590,7 @@ msgstr "プロバイダーの可視性がゼロの最初のモデル%1$sをお�
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
-msgstr ""
-"%1$sDuck.ai%2$sは、個人情報保護に配慮したAIチャットサービスです。ぜひ、お試し"
-"を！"
+msgstr "%1$sDuck.ai%2$sは、個人情報保護に配慮したAIチャットサービスです。ぜひ、お試しを！"
 
 # smartling.placeholder_format=C
 #. Button text to retry loading an explore more question that failed
@@ -22325,16 +21719,13 @@ msgstr "別のキーワードを試してみてください。"
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr ""
-"より多くの結果を表示するには、DuckDuckGoで広告ブロッカーを無効にしてお試しく"
-"ださい。"
+msgstr "より多くの結果を表示するには、DuckDuckGoで広告ブロッカーを無効にしてお試しください。"
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"検索結果の精度を高めるには、匿名の位置情報を使用する設定にしてみてください。"
+msgstr "検索結果の精度を高めるには、匿名の位置情報を使用する設定にしてみてください。"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
@@ -22467,8 +21858,7 @@ msgstr "位置情報を手動で設定してみてください。"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Try the %sDuckDuckGo Browser.%s Fast. Free. Private."
-msgstr ""
-"%1$sDuckDuckGoブラウザ%2$sをお試しください。スピーディで無料、プライベート。"
+msgstr "%1$sDuckDuckGoブラウザ%2$sをお試しください。スピーディで無料、プライベート。"
 
 # smartling.placeholder_format=C
 #. Link to a page where users can download the DuckDuckGo Browser for iOS or Android.
@@ -22526,8 +21916,7 @@ msgstr "最近追加されたオープンソースのLlama 3.1とMixtralをお�
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
-msgstr ""
-"まずはこれらのプロンプトを試すか、以下に独自のプロンプトを入力してください。"
+msgstr "まずはこれらのプロンプトを試すか、以下に独自のプロンプトを入力してください。"
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -22721,8 +22110,7 @@ msgstr "より正確な結果を得るには、「正確な位置情報」をオ
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr ""
-"より正確な結果を得るには、「正確な位置情報を使用」をオンにしてください。"
+msgstr "より正確な結果を得るには、「正確な位置情報を使用」をオンにしてください。"
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -22766,17 +22154,14 @@ msgstr "「%1$sDuckDuckGo%2$s」と %3$s フォームの最初のフィールド
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Type %sduckduckgo.com%s in the %ssecond form field"
-msgstr ""
-"「%1$sduckduckgo.com%2$s」と%3$s フォームの2番目のフィールドに入力します"
+msgstr "「%1$sduckduckgo.com%2$s」と%3$s フォームの2番目のフィールドに入力します"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
-msgstr ""
-"DuckAssist が生成した回答を入力します。このオプションをオフにすると、検索して"
-"から回答が表示されるまでに、多少タイムラグが生じる場合があります。"
+msgstr "DuckAssist が生成した回答を入力します。このオプションをオフにすると、検索してから回答が表示されるまでに、多少タイムラグが生じる場合があります。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -22905,18 +22290,14 @@ msgstr "長所と短所を明らかにする"
 msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
-msgstr ""
-"%1$sスタートの時%2$s の下、%3$sとあるページを開く%4$s をクリックして、%5$s"
-"ページがセレクト%6$s クリックします。"
+msgstr "%1$sスタートの時%2$s の下、%3$sとあるページを開く%4$s をクリックして、%5$sページがセレクト%6$s クリックします。"
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
-msgstr ""
-"%1$sOn startup%2$sの中から%3$sHomepage%4$sを選択してhttps://duckduckgo.comと"
-"入力してください"
+msgstr "%1$sOn startup%2$sの中から%3$sHomepage%4$sを選択してhttps://duckduckgo.comと入力してください"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -22926,8 +22307,7 @@ msgstr "%1$s開く%2$s の中から %3$s特定のページを開く%4$s を選�
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"%1$s起動時 > ホームページ%2$sの中で https://duckduckgo.com と入力してください"
+msgstr "%1$s起動時 > ホームページ%2$sの中で https://duckduckgo.com と入力してください"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22937,17 +22317,13 @@ msgstr "%1$s検索設定%2$sで、%3$sDuckDuckGo%4$sを選択します"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr ""
-"%1$sアドレスバーでの検索時に使う検索プロバイダー%2$sの下の%3$s新たに追加%4$s"
-"を選択します"
+msgstr "%1$sアドレスバーでの検索時に使う検索プロバイダー%2$sの下の%3$s新たに追加%4$sを選択します"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr ""
-"%1$s検索%2$sセクションの下にある「%3$s検索エンジンの管理...%4$s」をクリックし"
-"ます"
+msgstr "%1$s検索%2$sセクションの下にある「%3$s検索エンジンの管理...%4$s」をクリックします"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -23036,9 +22412,7 @@ msgctxt "Description of the modal to upgrade to Pro"
 msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
-msgstr ""
-"Proにアップグレードすると、%1$sのロックが解除され、AI推論能力が向上し、使用上"
-"限がPlusプランの2倍になります。"
+msgstr "Proにアップグレードすると、%1$sのロックが解除され、AI推論能力が向上し、使用上限がPlusプランの2倍になります。"
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -23098,9 +22472,7 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr ""
-"DuckDuckGoのサブスクリプションで、より高性能なAIモデルをアンロックしましょ"
-"う。%1$s"
+msgstr "DuckDuckGoのサブスクリプションで、より高性能なAIモデルをアンロックしましょう。%1$s"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -23197,9 +22569,7 @@ msgctxt "Old app version banner component in Duck.ai"
 msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
-msgstr ""
-"DuckDuckGo ブラウザを更新して、Duck.ai でサブスクリプションを有効にし、高度な"
-"モデルにアクセスしよう"
+msgstr "DuckDuckGo ブラウザを更新して、Duck.ai でサブスクリプションを有効にし、高度なモデルにアクセスしよう"
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -23323,9 +22693,7 @@ msgctxt ""
 msgid ""
 "Upgrade to Pro to unlock 2x higher limits than Plus, or come back later to "
 "create more images."
-msgstr ""
-"ProにアップグレードしてPlusの2倍の制限を活用するか、後で戻ってきてさらに画像"
-"を作成してください。"
+msgstr "ProにアップグレードしてPlusの2倍の制限を活用するか、後で戻ってきてさらに画像を作成してください。"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
@@ -23426,10 +22794,7 @@ msgctxt "duckai_seo"
 msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
-msgstr ""
-"ChatGPT、Claude、その他のAIをプライベートに使いましょう。チャットをハッカー、"
-"詐欺師、企業から守りましょう。情報の機密を保ちましょう。無料。アカウントは必"
-"要ありません。"
+msgstr "ChatGPT、Claude、その他のAIをプライベートに使いましょう。チャットをハッカー、詐欺師、企業から守りましょう。情報の機密を保ちましょう。無料。アカウントは必要ありません。"
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -23441,8 +22806,7 @@ msgstr "DuckDuckGo Private Searchを使う"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"あなたのiPad、iPhoneまたはAndroidで、DuckDuckGoのプライベート検索を使おう！"
+msgstr "あなたのiPad、iPhoneまたはAndroidで、DuckDuckGoのプライベート検索を使おう！"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -23484,18 +22848,14 @@ msgctxt "Description for the joiner-device success screen"
 msgid ""
 "Use this code to restore your data if you lose access to your devices. Keep "
 "it safe."
-msgstr ""
-"デバイスにアクセスできない場合は、このコードを使用してデータを復元します。大"
-"切に保管してください。"
+msgstr "デバイスにアクセスできない場合は、このコードを使用してデータを復元します。大切に保管してください。"
 
 # smartling.placeholder_format=C
 #. First sentence of the recovery section. The 18-month inactivity notice is rendered by the component using DUCKCHAT_SYNC_RECOVERY_INACTIVITY_NOTICE so both surfaces stay consistent.
 msgctxt "Description for the recovery section inside Manage"
 msgid ""
 "Use this code to restore your saved chats if you lose access to your devices."
-msgstr ""
-"デバイスへのアクセスを失った場合に、このコードを使用して保存済みのチャットを"
-"復元してください。"
+msgstr "デバイスへのアクセスを失った場合に、このコードを使用して保存済みのチャットを復元してください。"
 
 # smartling.placeholder_format=C
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
@@ -23644,9 +23004,7 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr ""
-"広告表示機能のプライバシーは DuckDuckGo で保護されます。広告のクリックは "
-"Microsoft の広告ネットワークで管理されています"
+msgstr "広告表示機能のプライバシーは DuckDuckGo で保護されます。広告のクリックは Microsoft の広告ネットワークで管理されています"
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -23654,9 +23012,7 @@ msgctxt "Single Place Hotel Offers Module"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
-msgstr ""
-"広告表示機能のプライバシーは DuckDuckGo で保護されます。広告のクリックは"
-"TripAdvisorの広告ネットワークで管理されています。"
+msgstr "広告表示機能のプライバシーは DuckDuckGo で保護されます。広告のクリックはTripAdvisorの広告ネットワークで管理されています。"
 
 # smartling.placeholder_format=C
 #. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
@@ -23664,7 +23020,7 @@ msgctxt "Ads GDPR"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Yelp's ad network."
-msgstr ""
+msgstr "広告表示機能のプライバシーはDuckDuckGoで保護されます。広告のクリックはYelpの広告ネットワークで管理されています。"
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -23675,9 +23031,7 @@ msgstr "ヴァージン諸島"
 msgctxt "duckassist"
 msgid ""
 "Visit %sAssist Settings%s to adjust how this feature works or turn it off."
-msgstr ""
-"この機能の動作を調整したり、オフにしたりするには、%1$sAssist設定%2$sにアクセ"
-"スしてください。"
+msgstr "この機能の動作を調整したり、オフにしたりするには、%1$sAssist設定%2$sにアクセスしてください。"
 
 # smartling.placeholder_format=C
 #. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
@@ -23685,9 +23039,7 @@ msgctxt "duckassist"
 msgid ""
 "Visit %sDuckAssist Settings%s to adjust how this feature works or turn it "
 "off."
-msgstr ""
-"この機能の動作を調整したり、オフにしたりするには、%1$sDuckAssist設定%2$sにア"
-"クセスしてください。"
+msgstr "この機能の動作を調整したり、オフにしたりするには、%1$sDuckAssist設定%2$sにアクセスしてください。"
 
 # smartling.placeholder_format=C
 #. Prompt to visit DuckDuckGo on another device.
@@ -23695,9 +23047,7 @@ msgctxt "mobile promotion on desktop"
 msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
-msgstr ""
-"タブレットまたは携帯電話で%1$sDuckDuckGo.com%2$sにアクセスして、案内に従って"
-"ください。"
+msgstr "タブレットまたは携帯電話で%1$sDuckDuckGo.com%2$sにアクセスして、案内に従ってください。"
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -23712,9 +23062,8 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"他のブラウザでDuck.aiにアクセスし、%1$sDuck.ai設定%2$s > %3$sSync & "
-"Backup%4$s > %5$s管理%6$s に進み、%7$s別のデバイスと同期%8$sを選択してくださ"
-"い。"
+"他のブラウザでDuck.aiにアクセスし、%1$sDuck.ai設定%2$s > %3$sSync & Backup%4$s > %5$s管理%6$s "
+"に進み、%7$s別のデバイスと同期%8$sを選択してください。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23723,10 +23072,7 @@ msgid ""
 "Visit Duck.ai in your other browser and open Duck.ai Settings. Select “Turn "
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
-msgstr ""
-"別のブラウザでDuck.aiにアクセスし、Duck.aiの設定を開いてください。Sync＆"
-"Backupで「オンにする」を選択し、「別のデバイスと同期」を選択してください。ま"
-"たは、リカバリーPDFのQRコードをスキャンしてください。"
+msgstr "別のブラウザでDuck.aiにアクセスし、Duck.aiの設定を開いてください。Sync＆Backupで「オンにする」を選択し、「別のデバイスと同期」を選択してください。または、リカバリーPDFのQRコードをスキャンしてください。"
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -23736,9 +23082,8 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"他のブラウザまたはDuckDuckGoアプリでDuck.aiにアクセスし、%1$sDuck.ai設定%2$s "
-"> %3$sSync & Backup%4$s > %5$s管理%6$s に進み、%7$s別のデバイスと同期%8$sを選"
-"択してください。"
+"他のブラウザまたはDuckDuckGoアプリでDuck.aiにアクセスし、%1$sDuck.ai設定%2$s > %3$sSync & "
+"Backup%4$s > %5$s管理%6$s に進み、%7$s別のデバイスと同期%8$sを選択してください。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23747,10 +23092,7 @@ msgid ""
 "Visit Duck.ai in your other browser or the DuckDuckGo app and open Duck.ai "
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
-msgstr ""
-"他のブラウザまたはDuckDuckGoアプリでDuck.aiにアクセスし、Duck.aiの設定を開き"
-"ます。Sync＆Backupで「オンにする」を選択し、「別のデバイスと同期」を選択しま"
-"す。または、リカバリーPDFのQRコードをスキャンします。"
+msgstr "他のブラウザまたはDuckDuckGoアプリでDuck.aiにアクセスし、Duck.aiの設定を開きます。Sync＆Backupで「オンにする」を選択し、「別のデバイスと同期」を選択します。または、リカバリーPDFのQRコードをスキャンします。"
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23802,9 +23144,7 @@ msgstr "ボイスチャットは終了しました"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr ""
-"ボイスチャットは当社によって匿名化されており、AIモデルのトレーニングには使用"
-"されません。"
+msgstr "ボイスチャットは当社によって匿名化されており、AIモデルのトレーニングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -23948,8 +23288,8 @@ msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
-"Duck Player で視聴すると、YouTube でパーソナライズ広告がブロックされるため、"
-"YouTube のおすすめに影響されずに動画を視聴できます。"
+"Duck Player で視聴すると、YouTube でパーソナライズ広告がブロックされるため、YouTube "
+"のおすすめに影響されずに動画を視聴できます。"
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -23968,11 +23308,7 @@ msgid ""
 "because we have to stream the content from there. DuckDuckGo is an "
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
-msgstr ""
-"このプラットフォームで動画を視聴する場合、ホストするウェブサイトからコンテン"
-"ツが流されるため、そのウェブサイトは視聴者の追跡が可能になります。DuckDuckGo"
-"は独立した会社であり、ほとんどの動画がホストされているYouTubeとは一切関係ござ"
-"いません。"
+msgstr "このプラットフォームで動画を視聴する場合、ホストするウェブサイトからコンテンツが流されるため、そのウェブサイトは視聴者の追跡が可能になります。DuckDuckGoは独立した会社であり、ほとんどの動画がホストされているYouTubeとは一切関係ございません。"
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -23984,8 +23320,7 @@ msgstr "匿名化に対応"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr ""
-"%1$s位置情報%2$sを匿名化して、より正確な結果が表示されるようにできます。"
+msgstr "%1$s位置情報%2$sを匿名化して、より正確な結果が表示されるようにできます。"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -23996,10 +23331,7 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
-msgstr ""
-"当社が修正できるのは、目に見えるものだけです。有害または違法な回答を通報する"
-"には、DuckDuckGoが問題を調査し、対処できるように、この会話を当社と共有してし"
-"てください。"
+msgstr "当社が修正できるのは、目に見えるものだけです。有害または違法な回答を通報するには、DuckDuckGoが問題を調査し、対処できるように、この会話を当社と共有してしてください。"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -24010,9 +23342,7 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share your prompt and response so we can investigate and address the "
 "issue."
-msgstr ""
-"当社が修正できるのは、目に見えるものだけです。有害または違法な応答を報告する"
-"場合は、問題を調査し対処するために、プロンプトと応答内容をお知らせください。"
+msgstr "当社が修正できるのは、目に見えるものだけです。有害または違法な応答を報告する場合は、問題を調査し対処するために、プロンプトと応答内容をお知らせください。"
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
@@ -24025,9 +23355,7 @@ msgstr "匿名の%1$s位置情報%2$sを使用すると、おおよその結果�
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"添付ファイルのうち少なくとも1つが暗号化されているため、内容を読み取ることがで"
-"きません。"
+msgstr "添付ファイルのうち少なくとも1つが暗号化されているため、内容を読み取ることができません。"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24054,9 +23382,7 @@ msgstr "私たちはあなたの個人情報を保存しません。"
 msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
-msgstr ""
-"個人情報を保存しません。広告で追い回しません。閲覧状況を追跡しません。お約束"
-"します。"
+msgstr "個人情報を保存しません。広告で追い回しません。閲覧状況を追跡しません。お約束します。"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24069,9 +23395,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr ""
-"私たちはあなたを追跡しません。ですから、「もう一度DuckDuckGoを使おうと思った"
-"理由」を教えてください。"
+msgstr "私たちはあなたを追跡しません。ですから、「もう一度DuckDuckGoを使おうと思った理由」を教えてください。"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -24079,9 +23403,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
-msgstr ""
-"私たちはあなたを追跡しません。ですから、「あなたがDuckDuckGoを使ってみようと"
-"思った理由」を教えてください。"
+msgstr "私たちはあなたを追跡しません。ですから、「あなたがDuckDuckGoを使ってみようと思った理由」を教えてください。"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24120,23 +23442,18 @@ msgctxt "homepage onboarding"
 msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
-msgstr ""
-"私たちは、あなたの検索履歴を保存しません。したがって、インターネット経由であ"
-"なたを追跡して、それを広告主に販売することはありません。"
+msgstr "私たちは、あなたの検索履歴を保存しません。したがって、インターネット経由であなたを追跡して、それを広告主に販売することはありません。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr ""
-"私たちは、プライベートブラウジングモードでも、それ以外でも、あなたを追跡しま"
-"せん。"
+msgstr "私たちは、プライベートブラウジングモードでも、それ以外でも、あなたを追跡しません。"
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr ""
-"私たちはあなたを追跡しません。これが私たちのプライバシーポリシーの概要です。"
+msgstr "私たちはあなたを追跡しません。これが私たちのプライバシーポリシーの概要です。"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -24150,9 +23467,7 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
-msgstr ""
-"データブローカーサイトから個人情報を探して削除します。さらにVPNなどの機能もご"
-"利用いただけます。"
+msgstr "データブローカーサイトから個人情報を探して削除します。さらにVPNなどの機能もご利用いただけます。"
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -24160,8 +23475,7 @@ msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
-msgstr ""
-"チャットがAIの学習に使用されない旨の契約をAIプロバイダーと結んでいます。"
+msgstr "チャットがAIの学習に使用されない旨の契約をAIプロバイダーと結んでいます。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -24185,9 +23499,7 @@ msgstr "接続が失われました。メッセージの送信をもう一度お
 msgid ""
 "We make money from %sprivacy-respecting search ads%s, not by exploiting your "
 "data."
-msgstr ""
-"私たちは、あなたのデータを悪用するのではなく、%1$sプライバシーを尊重する検索"
-"広告%2$sから収益を得ています。"
+msgstr "私たちは、あなたのデータを悪用するのではなく、%1$sプライバシーを尊重する検索広告%2$sから収益を得ています。"
 
 # smartling.placeholder_format=C
 #. Message describing how DuckDuckGo users location access anonymously to provide better search results.
@@ -24195,9 +23507,7 @@ msgctxt "precise_user_location"
 msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
-msgstr ""
-"匿名の位置情報は、表示される結果を比較的近くに絞り込む目的でのみ使用されま"
-"す。この設定は後でいつでも変更できます。"
+msgstr "匿名の位置情報は、表示される結果を比較的近くに絞り込む目的でのみ使用されます。この設定は後でいつでも変更できます。"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
@@ -24205,17 +23515,13 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
-msgstr ""
-"当社はデータブローカーサイトを定期的にスキャンしてお客様の個人情報を検索し、"
-"使いやすいダッシュボードで進捗状況を共有します。"
+msgstr "当社はデータブローカーサイトを定期的にスキャンしてお客様の個人情報を検索し、使いやすいダッシュボードで進捗状況を共有します。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr ""
-"DuckDuckGoを誰にとってもより良いものにするために、私たちはみなさまからの匿名"
-"でのフィードバックを頼りにしています。"
+msgstr "DuckDuckGoを誰にとってもより良いものにするために、私たちはみなさまからの匿名でのフィードバックを頼りにしています。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -24235,9 +23541,7 @@ msgid ""
 "We use feedback like this to improve DuckDuckGo. Suggestions will be "
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
-msgstr ""
-"このようなフィードバックをDuckDuckGoの向上に活用します。%1$sは独自の判断でご"
-"提案を採用します。訂正内容は結果にすぐ表示されない場合があります。"
+msgstr "このようなフィードバックをDuckDuckGoの向上に活用します。%1$sは独自の判断でご提案を採用します。訂正内容は結果にすぐ表示されない場合があります。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -24250,9 +23554,7 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
-msgstr ""
-"データブローカーサイトをスキャンして、お客様のメールアドレス、名前、住所など"
-"を探し、見つかった個人情報の削除に向けて対応します。"
+msgstr "データブローカーサイトをスキャンして、お客様のメールアドレス、名前、住所などを探し、見つかった個人情報の削除に向けて対応します。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24260,9 +23562,7 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
-msgstr ""
-"当社はこの問題について認識しており、現在解決に向けて取り組んでいます。このエ"
-"ラーが続く場合は、%1$sに連絡してください。"
+msgstr "当社はこの問題について認識しており、現在解決に向けて取り組んでいます。このエラーが続く場合は、%1$sに連絡してください。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -24270,9 +23570,7 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. Sometimes "
 "clearing your browser's cache can help."
-msgstr ""
-"当社はこの問題について認識しており、現在解決に向けて取り組んでいます。ブラウ"
-"ザのキャッシュをクリアすると解決に役立つ場合があります。"
+msgstr "当社はこの問題について認識しており、現在解決に向けて取り組んでいます。ブラウザのキャッシュをクリアすると解決に役立つ場合があります。"
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -24286,9 +23584,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr ""
-"ご不便をおかけして申し訳ありません。体験の改善のために一生懸命努力していま"
-"す。"
+msgstr "ご不便をおかけして申し訳ありません。体験の改善のために一生懸命努力しています。"
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -24296,9 +23592,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
-msgstr ""
-"Duck.aiサービスを更新しました。変更を有効にするには、ページをリロードする必要"
-"があります。"
+msgstr "Duck.aiサービスを更新しました。変更を有効にするには、ページをリロードする必要があります。"
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -24419,9 +23713,7 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
-msgstr ""
-"Duck.aiへようこそ！ここでのチャットはすべて非公開で、匿名化され、AIモデルのト"
-"レーニングには使用されません。"
+msgstr "Duck.aiへようこそ！ここでのチャットはすべて非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -24429,9 +23721,7 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
-msgstr ""
-"DuckDuckGo AI Chatへようこそ！ここでのチャットはすべて非公開で、匿名化され、"
-"AIモデルのトレーニングには使用されません。"
+msgstr "DuckDuckGo AI Chatへようこそ！ここでのチャットはすべて非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -24441,17 +23731,14 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"DuckDuckGo AI Chatへようこそ！このチャットセッションは%1$sの%2$sを使用してい"
-"ます。ここでのチャットはすべて非公開で、DuckDuckGoに保存されたり、AIモデルの"
-"トレーニングに使用されたりすることはありません。"
+"DuckDuckGo AI "
+"Chatへようこそ！このチャットセッションは%1$sの%2$sを使用しています。ここでのチャットはすべて非公開で、DuckDuckGoに保存されたり、AIモデルのトレーニングに使用されたりすることはありません。"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"新しいDuck.aiへようこそ！ダウンロードしたチャットをインポートできるようになり"
-"ました。"
+msgstr "新しいDuck.aiへようこそ！ダウンロードしたチャットをインポートできるようになりました。"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24518,9 +23805,7 @@ msgctxt "duckai_fatal_error"
 msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
-msgstr ""
-"申し訳ありませんが、Duck.aiの読み込みに問題があったようです。ページを再読み込"
-"みしてみてください。"
+msgstr "申し訳ありませんが、Duck.aiの読み込みに問題があったようです。ページを再読み込みしてみてください。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -24534,9 +23819,7 @@ msgctxt "Full sentence for improving arguments"
 msgid ""
 "What are some arguments, counter-arguments, and rebuttals to the concept of "
 "a plant-based diet?"
-msgstr ""
-"プラントベースの食事の概念に対する議論、反論、反駁にはどのようなものがありま"
-"すか？"
+msgstr "プラントベースの食事の概念に対する議論、反論、反駁にはどのようなものがありますか？"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
@@ -24556,9 +23839,7 @@ msgctxt "Full sentence for finding a better word"
 msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
-msgstr ""
-"「私たちは本当にもっとうまくやる必要がある」という文脈で「もっとうまく」をど"
-"う言い換えられますか？"
+msgstr "「私たちは本当にもっとうまくやる必要がある」という文脈で「もっとうまく」をどう言い換えられますか？"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -24582,12 +23863,7 @@ msgid ""
 "ai integrations, and privacy protections. Keep it quite short, simple, and "
 "easy to understand for people with or without much AI, or technical, "
 "experience."
-msgstr ""
-"Duck.aiの利用に興味があるユーザーが、DuckDuckGoブラウザをダウンロードするメ"
-"リットとは何でしょうか。まず、DuckDuckGoの公式ソースのみ参照します。また、回"
-"答はタイトル付きの明確なセクションに分かれ、Duck.aiの統合とプライバシー保護に"
-"重点が置かれます。簡潔かつシンプルで、AIや技術に関する経験の有無に関わらず、"
-"誰でも簡単に理解できるように回答します。"
+msgstr "Duck.aiの利用に興味があるユーザーが、DuckDuckGoブラウザをダウンロードするメリットとは何でしょうか。まず、DuckDuckGoの公式ソースのみ参照します。また、回答はタイトル付きの明確なセクションに分かれ、Duck.aiの統合とプライバシー保護に重点が置かれます。簡潔かつシンプルで、AIや技術に関する経験の有無に関わらず、誰でも簡単に理解できるように回答します。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24822,9 +24098,7 @@ msgctxt "cloudsave"
 msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
-msgstr ""
-"Cloud Saveブックマークレットとは何ですか？URLパラメータ・ブックマークレットと"
-"の違いは？"
+msgstr "Cloud Saveブックマークレットとは何ですか？URLパラメータ・ブックマークレットとの違いは？"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -24924,9 +24198,7 @@ msgctxt "Full sentence for identifying product brands"
 msgid ""
 "When buying an electric guitar for a beginner, what are the top product "
 "brands I should consider?"
-msgstr ""
-"初心者向けのエレキギターを購入する場合、考慮すべきトップ製品ブランドは何です"
-"か？"
+msgstr "初心者向けのエレキギターを購入する場合、考慮すべきトップ製品ブランドは何ですか？"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -25126,9 +24398,7 @@ msgctxt "new tab page"
 msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
-msgstr ""
-"Duck.aiでは、チャットは匿名化されており、AIのトレーニングに使用されることはあ"
-"りません。「%1$s」メニューでいつでもオン/オフを切り替えられます。"
+msgstr "Duck.aiでは、チャットは匿名化されており、AIのトレーニングに使用されることはありません。「%1$s」メニューでいつでもオン/オフを切り替えられます。"
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
@@ -25136,14 +24406,14 @@ msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, up to %s of your most recent chats will be saved on "
 "this device."
-msgstr ""
+msgstr "チャット履歴をオンにすると、最新のチャットを最大%1$s件このデバイスに保存します。"
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline in the About Chat History modal.
 msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, your most recent chats will be saved on this device."
-msgstr ""
+msgstr "チャット履歴をオンにすると、最新のチャットがこのデバイスに保存されます。"
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -25157,9 +24427,7 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
-msgstr ""
-"お使いのデバイス上で直接動作し、データブローカーサイトからメールアドレス、名"
-"前、住所などの個人情報を削除します。"
+msgstr "お使いのデバイス上で直接動作し、データブローカーサイトからメールアドレス、名前、住所などの個人情報を削除します。"
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25426,9 +24694,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"%1$sとチャット中です。 AIチャットでは不正確な情報や不快な情報が表示される場合"
-"があります。"
+msgstr "%1$sとチャット中です。 AIチャットでは不正確な情報や不快な情報が表示される場合があります。"
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -25436,9 +24702,7 @@ msgctxt "noresults"
 msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
-msgstr ""
-"%1$sか、%2$s検索ショートカットを使用してDuckDuckGoや他の検索エンジンで直接検"
-"索できます。"
+msgstr "%1$sか、%2$s検索ショートカットを使用してDuckDuckGoや他の検索エンジンで直接検索できます。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -25451,8 +24715,7 @@ msgstr "DuckDuckGo AI Chatには%1$sから直接アクセスできます。"
 msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
-msgstr ""
-"%1$sの動作を調整したり、%2$s検索設定%3$sでいつでも無効にしたりできます。"
+msgstr "%1$sの動作を調整したり、%2$s検索設定%3$sでいつでも無効にしたりできます。"
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -25460,22 +24723,17 @@ msgctxt "duckassist"
 msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
-msgstr ""
-"Assistは、動作を調整したり、%1$s検索設定%2$sでいつでもオフにしたりできます。"
+msgstr "Assistは、動作を調整したり、%1$s検索設定%2$sでいつでもオフにしたりできます。"
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
-msgstr ""
-"%1$sDuck.ai%2$sを使用して質問に答えたり、テキストを要約したりすることもできま"
-"す。"
+msgstr "%1$sDuck.ai%2$sを使用して質問に答えたり、テキストを要約したりすることもできます。"
 
 # smartling.placeholder_format=C
 msgid ""
 "You can also use %sDuckDuckGo AI Chat%s to answer questions or summarize "
 "text."
-msgstr ""
-"%1$s DuckDuckGo AI Chat%2$sを使用して質問に答えたり、テキストを要約したりする"
-"こともできます。"
+msgstr "%1$s DuckDuckGo AI Chat%2$sを使用して質問に答えたり、テキストを要約したりすることもできます。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach more text selections than are allowed. Placeholder is the maximum number of text selections. E.g. You can attach up to 5 text selections.
@@ -25488,9 +24746,7 @@ msgstr "添付するテキストは最大%1$sまで選択できます。"
 msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
-msgstr ""
-"Search Assistは、%1$s検索設定%2$sで表示頻度を変更したり、完全に無効にしたりで"
-"きます。"
+msgstr "Search Assistは、%1$s検索設定%2$sで表示頻度を変更したり、完全に無効にしたりできます。"
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -25510,9 +24766,7 @@ msgctxt "cloudsave"
 msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
-msgstr ""
-"設定を別のパスフレーズで保存してください。それまで使っていたパスフレーズも任"
-"意で削除できます。"
+msgstr "設定を別のパスフレーズで保存してください。それまで使っていたパスフレーズも任意で削除できます。"
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -25541,8 +24795,7 @@ msgstr "月間制限時間を使ってチャットを続行できます。"
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"このデバイスでは最大100件のチャットを保存できます。チャットを開始しましょう！"
+msgstr "このデバイスでは最大100件のチャットを保存できます。チャットを開始しましょう！"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -25605,9 +24858,7 @@ msgctxt "Organic result context menu"
 msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
-msgstr ""
-"最大%1$sサイトまでブロックできます。%2$sをブロックするには、まず別のサイトの"
-"ブロックを解除する必要があります。"
+msgstr "最大%1$sサイトまでブロックできます。%2$sをブロックするには、まず別のサイトのブロックを解除する必要があります。"
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -25670,8 +24921,7 @@ msgctxt "Description of the post-upgrade success modal"
 msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
-msgstr ""
-"これで%1$s、より高いAI推論、Plusの2倍の使用制限が利用可能になりました。"
+msgstr "これで%1$s、より高いAI推論、Plusの2倍の使用制限が利用可能になりました。"
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -25679,9 +24929,7 @@ msgctxt "Description text for the subscription welcome modal"
 msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
-msgstr ""
-"高度なAIモデルへのアクセスが可能になりました。VPNやその他のDuckDuckGoサブスク"
-"リプション保護機能は、DuckDuckGoブラウザ内でご利用いただけます。"
+msgstr "高度なAIモデルへのアクセスが可能になりました。VPNやその他のDuckDuckGoサブスクリプション保護機能は、DuckDuckGoブラウザ内でご利用いただけます。"
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -25702,10 +24950,7 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr ""
-"このブラウザからは、保存済みのチャットにアクセスできなくなります。直近30件の"
-"チャットはローカルストレージで引き続き利用可能です。これにより、暗号化された"
-"サーバーからチャットデータが削除されることはありません。"
+msgstr "このブラウザからは、保存済みのチャットにアクセスできなくなります。直近30件のチャットはローカルストレージで引き続き利用可能です。これにより、暗号化されたサーバーからチャットデータが削除されることはありません。"
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -25714,10 +24959,7 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr ""
-"このブラウザからは、保存済みのチャットにアクセスできなくなります。直近30件の"
-"チャットはローカルストレージで引き続き利用可能です。この操作により、暗号化さ"
-"れたサーバーからチャットデータが削除されることはありません。"
+msgstr "このブラウザからは、保存済みのチャットにアクセスできなくなります。直近30件のチャットはローカルストレージで引き続き利用可能です。この操作により、暗号化されたサーバーからチャットデータが削除されることはありません。"
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -25730,8 +24972,7 @@ msgctxt "Update browser banner"
 msgid ""
 "You'll receive automatic DuckDuckGo app updates once you have the latest "
 "version."
-msgstr ""
-"最新バージョンを入手すると、DuckDuckGoアプリの自動アップデートが届きます。"
+msgstr "最新バージョンを入手すると、DuckDuckGoアプリの自動アップデートが届きます。"
 
 # smartling.placeholder_format=C
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
@@ -25745,10 +24986,7 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
-msgstr ""
-"現在、Chromeのプライベート検索を使用しています。Chromeの代わりに当社アプリを"
-"使ってもプライベートに閲覧できます。このアプリはすでにインストールされてお"
-"り、以下が可能になります。"
+msgstr "現在、Chromeのプライベート検索を使用しています。Chromeの代わりに当社アプリを使ってもプライベートに閲覧できます。このアプリはすでにインストールされており、以下が可能になります。"
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -25760,9 +24998,7 @@ msgstr "あなたは今、匿名で検索しています！"
 msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
-msgstr ""
-"今あなたはプライバシーが保護された状態で検索しています。%1$sあなたの痕跡を"
-"もっと減らすヒントを学びましょう。"
+msgstr "今あなたはプライバシーが保護された状態で検索しています。%1$sあなたの痕跡をもっと減らすヒントを学びましょう。"
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -25811,8 +25047,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr ""
-"現在、メッセージ数の上限に達しています。時間を置いてもう一度お試しください。"
+msgstr "現在、メッセージ数の上限に達しています。時間を置いてもう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -25825,14 +25060,12 @@ msgstr "1回のセッションの最大ボイスチャット時間に達しま�
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"本日のボイスチャットの回数制限に達しました。明日もう一度お試しください。"
+msgstr "本日のボイスチャットの回数制限に達しました。明日もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"ディクテーションの利用上限に達しました。時間を置いてもう一度お試しください。"
+msgstr "ディクテーションの利用上限に達しました。時間を置いてもう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25841,9 +25074,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"添付ファイル付きのDuck.aiチャットのSync & Backup用ストレージ容量が不足してい"
-"ます。%1$s件の最も古いチャットを削除して同期を再開してください。ピン留めされ"
-"たチャットは削除されません。"
+"添付ファイル付きのDuck.aiチャットのSync & "
+"Backup用ストレージ容量が不足しています。%1$s件の最も古いチャットを削除して同期を再開してください。ピン留めされたチャットは削除されません。"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25853,9 +25085,8 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"Duck.aiチャットのSync & Backup用ストレージ容量が不足しています。同期を再開す"
-"るには、添付ファイル付きの最も古いチャットを%1$s件削除してください。ピン留め"
-"されたチャットは削除されません。"
+"Duck.aiチャットのSync & "
+"Backup用ストレージ容量が不足しています。同期を再開するには、添付ファイル付きの最も古いチャットを%1$s件削除してください。ピン留めされたチャットは削除されません。"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -25868,9 +25099,7 @@ msgstr "ストレージの容量がいっぱいです"
 msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
-msgstr ""
-"YouTube(Google社)に匿名性はありません。ここで見るビデオはGoogle社によって記録"
-"されています。"
+msgstr "YouTube(Google社)に匿名性はありません。ここで見るビデオはGoogle社によって記録されています。"
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -25891,8 +25120,7 @@ msgctxt ""
 msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
-msgstr ""
-"最新のチャット%1$s件は、次のブラウザのローカルストレージに保存されます。"
+msgstr "最新のチャット%1$s件は、次のブラウザのローカルストレージに保存されます。"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
@@ -25930,9 +25158,7 @@ msgctxt "First body paragraph in the Delete Server Data confirmation modal"
 msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
-msgstr ""
-"バックアップデータはDuckDuckGoのサーバーから削除されます。すべてのデバイスの"
-"同期が解除されます。"
+msgstr "バックアップデータはDuckDuckGoのサーバーから削除されます。すべてのデバイスの同期が解除されます。"
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25941,10 +25167,7 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
-msgstr ""
-"バックアップデータはDuckDuckGoのサーバーから削除されます。すべてのデバイスの"
-"同期が解除されます。最新のチャット%1$s件は、次のブラウザのローカルストレージ"
-"に保存されます。"
+msgstr "バックアップデータはDuckDuckGoのサーバーから削除されます。すべてのデバイスの同期が解除されます。最新のチャット%1$s件は、次のブラウザのローカルストレージに保存されます。"
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -25953,10 +25176,7 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
-msgstr ""
-"バックアップデータはDuckDuckGoのサーバーから削除されます。すべてのデバイスの"
-"同期が解除されます。最新のチャット履歴100件は、以下のブラウザのローカルスト"
-"レージに保存されます。"
+msgstr "バックアップデータはDuckDuckGoのサーバーから削除されます。すべてのデバイスの同期が解除されます。最新のチャット履歴100件は、以下のブラウザのローカルストレージに保存されます。"
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -25980,18 +25200,14 @@ msgctxt "new tab page"
 msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
-msgstr ""
-"お使いのブラウザでは訪問回数が特に多いサイトリストが作成されます。DuckDuckGo"
-"がこのデータにアクセスすることはありません。"
+msgstr "お使いのブラウザでは訪問回数が特に多いサイトリストが作成されます。DuckDuckGoがこのデータにアクセスすることはありません。"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
-msgstr ""
-"ブラウザには、あなたがよくアクセスするサイトの一覧のデータがありますが、"
-"DuckDuckGoはこのデータにアクセスすることはできません。"
+msgstr "ブラウザには、あなたがよくアクセスするサイトの一覧のデータがありますが、DuckDuckGoはこのデータにアクセスすることはできません。"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -25999,9 +25215,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"%1$sとのチャットは非公開です。AIチャットでは不正確な情報や不快な情報が表示さ"
-"れる場合があります。"
+msgstr "%1$sとのチャットは非公開です。AIチャットでは不正確な情報や不快な情報が表示される場合があります。"
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -26013,50 +25227,41 @@ msgstr "チャットが保存されるようになりました。"
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
-msgstr ""
-"チャットは非公開で、保存されたり、AIモデルのトレーニングに使用されることはあ"
-"りません。"
+msgstr "チャットは非公開で、保存されたり、AIモデルのトレーニングに使用されることはありません。"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr ""
-"チャットは非公開であり、AIモデルのトレーニングに使用されることはありません。"
+msgstr "チャットは非公開であり、AIモデルのトレーニングに使用されることはありません。"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
 msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"チャットは非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
+msgstr "チャットは非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
 msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"チャットは非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
+msgstr "チャットは非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
 msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
-msgstr ""
-"チャットは非公開で、当社が保存することはなく、AIモデルのトレーニングにも使用"
-"されません。"
+msgstr "チャットは非公開で、当社が保存することはなく、AIモデルのトレーニングにも使用されません。"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
 msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
-msgstr ""
-"チャットは非公開で、当社が保存することはなく、AIモデルのトレーニングにも使用"
-"されません。"
+msgstr "チャットは非公開で、当社が保存することはなく、AIモデルのトレーニングにも使用されません。"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -26070,9 +25275,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
-msgstr ""
-"チャットは引き続き非公開で、匿名化され、AIモデルのトレーニングには使用されま"
-"せん。チャット履歴を保持するには、以下の手順に従ってください。"
+msgstr "チャットは引き続き非公開で、匿名化され、AIモデルのトレーニングには使用されません。チャット履歴を保持するには、以下の手順に従ってください。"
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -26080,8 +25283,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr ""
-"チャットがインポートされました。Duck.aiで中断したところから続けましょう。"
+msgstr "チャットがインポートされました。Duck.aiで中断したところから続けましょう。"
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -26112,9 +25314,7 @@ msgctxt "newsletter email collection"
 msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
-msgstr ""
-"あなたの電子メールアドレスが他人に共有されることはありませし、%1$s匿名での検"
-"索に紐づけられることもありません。(%2$s例文のサンプル%3$s)"
+msgstr "あなたの電子メールアドレスが他人に共有されることはありませし、%1$s匿名での検索に紐づけられることもありません。(%2$s例文のサンプル%3$s)"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -26157,10 +25357,10 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"パスフレーズは、Secure Hash Algorithm (%1$sSHA-2%2$s) を使用した512ビットの"
-"キーを生成します。ブラウザには、このキーと関連する設定ファイルのみが残りま"
-"す。この設定ファイルは、キーを名前に用いて保存されます。DuckDuckGo がお客様の"
-"パスフレーズを知ることはありません。"
+"パスフレーズは、Secure Hash Algorithm (%1$sSHA-2%2$s) "
+""
+"を使用した512ビットのキーを生成します。ブラウザには、このキーと関連する設定ファイルのみが残ります。この設定ファイルは、キーを名前に用いて保存されます。DuckDuckGo "
+"がお客様のパスフレーズを知ることはありません。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -26174,10 +25374,7 @@ msgid ""
 "Your prompts are relayed through DuckDuckGo servers and stripped of "
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
-msgstr ""
-"プロンプトはDuckDuckGoのサーバーを介して中継され、個人を特定できるメタデータ"
-"が取り除かれるため、モデルプロバイダーが会話を特定の個人に結びつけることはで"
-"きません。"
+msgstr "プロンプトはDuckDuckGoのサーバーを介して中継され、個人を特定できるメタデータが取り除かれるため、モデルプロバイダーが会話を特定の個人に結びつけることはできません。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -26190,9 +25387,7 @@ msgctxt "Popover text for recent chats onboarding"
 msgid ""
 "Your recent chats live here! You can refer to your chats or clear them "
 "anytime."
-msgstr ""
-"最近のチャットはここにあります！チャットはいつでも参照したり、消去したりでき"
-"ます。"
+msgstr "最近のチャットはここにあります！チャットはいつでも参照したり、消去したりできます。"
 
 # smartling.placeholder_format=C
 #. Message on a feedback form.
@@ -26224,8 +25419,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
-"設定は保存されていますが、Cookieを消去するとリセットされます。設定を永続的に"
-"保存するには、%1$sDuckDuckGo No AI%2$s拡張機能を有効にしてください。"
+"設定は保存されていますが、Cookieを消去するとリセットされます。設定を永続的に保存するには、%1$sDuckDuckGo No "
+"AI%2$s拡張機能を有効にしてください。"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -26234,9 +25429,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"設定は保存されていますが、Cookieを消去するとリセットされます。設定を永続的に"
-"保存するには、%1$sDuckDuckGo No AI%2$s拡張機能をインストールしてくださ"
-"い。%3$s詳細情報%4$s"
+"設定は保存されていますが、Cookieを消去するとリセットされます。設定を永続的に保存するには、%1$sDuckDuckGo No "
+"AI%2$s拡張機能をインストールしてください。%3$s詳細情報%4$s"
 
 # smartling.placeholder_format=C
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
@@ -26255,10 +25449,7 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
-msgstr ""
-"現在、Chromeのプライベート検索を使用しています。Chromeの代わりに当社のブラウ"
-"ザをご使用になると、さらにセキュリティを強化できます。このアプリはすでにイン"
-"ストールされており、以下が可能になります。"
+msgstr "現在、Chromeのプライベート検索を使用しています。Chromeの代わりに当社のブラウザをご使用になると、さらにセキュリティを強化できます。このアプリはすでにインストールされており、以下が可能になります。"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -26266,9 +25457,7 @@ msgctxt "Error message for input limit"
 msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
-msgstr ""
-"メッセージの最大サイズを超えました。 メッセージを短くして、もう一度やり直して"
-"ください。"
+msgstr "メッセージの最大サイズを超えました。 メッセージを短くして、もう一度やり直してください。"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -26276,9 +25465,7 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
-msgstr ""
-"この会話のチャットの最大時間に達しました。 この会話をFire Buttonでクリアして"
-"続行します。"
+msgstr "この会話のチャットの最大時間に達しました。 この会話をFire Buttonでクリアして続行します。"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -26286,9 +25473,7 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Start a new "
 "chat to continue."
-msgstr ""
-"この会話のチャットの最大時間に達しました。続行するには、新しいチャットを開始"
-"します。"
+msgstr "この会話のチャットの最大時間に達しました。続行するには、新しいチャットを開始します。"
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -26302,15 +25487,13 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr ""
-"1日のメッセージ数の上限に達しました。このチャットは明日続行してください。"
+msgstr "1日のメッセージ数の上限に達しました。このチャットは明日続行してください。"
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr ""
-"ボイスチャットの回数制限に達しました。時間を置いてもう一度お試しください。"
+msgstr "ボイスチャットの回数制限に達しました。時間を置いてもう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -26393,9 +25576,7 @@ msgstr "（%1$s）"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"DuckDuckGoが提供するオンライン保護は、毎日何百万人ものユーザーから信頼されて"
-"います。"
+msgstr "DuckDuckGoが提供するオンライン保護は、毎日何百万人ものユーザーから信頼されています。"
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"
@@ -26540,7 +25721,7 @@ msgstr "分"
 #. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the chat options menu button"
 msgid "menu"
-msgstr ""
+msgstr "メニュー"
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.
@@ -26614,9 +25795,7 @@ msgstr "公式ウェブサイト"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr ""
-"あるいはカラーコードを指定してください。例：%1$s (%2$s は %3$s をエンコードし"
-"たものです)"
+msgstr "あるいはカラーコードを指定してください。例：%1$s (%2$s は %3$s をエンコードしたものです)"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/ja_JP/LC_MESSAGES/duckduckgo.po
+++ b/locales/ja_JP/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: ja_JP\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1211,6 +1211,12 @@ msgid "About our ads"
 msgstr "広告について"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1340,6 +1346,20 @@ msgid "Ad is suspicious"
 msgstr "怪しい広告"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "DuckDuckGo を追加する"
@@ -1366,6 +1386,27 @@ msgstr "DuckDuckGoを検索エンジンに追加する"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "%1$sにDuckDuckGoを追加"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1411,6 +1452,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "ページコンテンツを追加"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1496,6 +1553,12 @@ msgstr "アドオン"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "仕上げの調整を加える"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1800,6 +1863,12 @@ msgstr "すべての色"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "完了！"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3505,6 +3574,14 @@ msgid "Cancel"
 msgstr "キャンセル"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3997,10 +4074,22 @@ msgid "Chat response is offensive"
 msgstr "チャットの応答が不快だ"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "%1$sとチャット"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4019,6 +4108,14 @@ msgstr "チャット"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "チャット"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5621,6 +5718,12 @@ msgid "Current Streak"
 msgstr "連勝・連敗中"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5966,6 +6069,12 @@ msgstr "チャットを削除"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "30日より前のチャットを削除"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6380,6 +6489,12 @@ msgstr "今後表示しない"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "プロモーションを非表示"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7548,6 +7663,12 @@ msgid "Edit Prompt"
 msgstr "プロンプトを編集"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7767,6 +7888,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "暗号化モデル"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8595,6 +8722,12 @@ msgid "Follow-up question"
 msgstr "フォローアップの質問"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9109,6 +9242,12 @@ msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
 "DuckDuckGo VPN、高度なDuck.ai、Identity Theft Restoration（ID盗難後の復旧）機"
 "能を利用できます。"
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10341,6 +10480,12 @@ msgstr "どのように匿名を実現するのですか？"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "DuckDuckGoの仕組み"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11780,6 +11925,12 @@ msgstr "ラインアウト獲得"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "リンクは7日後に期限切れとなります。"
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13898,6 +14049,12 @@ msgid "OK, got it!"
 msgstr "OK、わかりました！"
 
 # smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -16008,6 +16165,12 @@ msgid "Protected"
 msgstr "保護されています"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "プライバシー。保護。安心。"
@@ -16139,6 +16302,12 @@ msgstr "雨"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "ランキング"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17366,6 +17535,12 @@ msgid "Save your chats across all your devices."
 msgstr "チャットをすべてのデバイスに保存します。"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17566,6 +17741,14 @@ msgstr "検索"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "検索"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18739,6 +18922,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "ショップ"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20388,6 +20577,14 @@ msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr "Sync & Backupのデータは18か月間アクティビティがないと復元できません。"
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20501,6 +20698,12 @@ msgstr "近くのデバイスと同期します。"
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "すべてのデバイスでチャットを同期します。"
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21081,6 +21284,22 @@ msgid "This Week"
 msgstr "今週"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21609,6 +21828,12 @@ msgstr "今日"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "今日"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23434,6 +23659,14 @@ msgstr ""
 "TripAdvisorの広告ネットワークで管理されています。"
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "ヴァージン諸島"
 
@@ -24898,6 +25131,21 @@ msgstr ""
 "りません。「%1$s」メニューでいつでもオン/オフを切り替えられます。"
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26287,6 +26535,12 @@ msgstr "分"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "分"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/ka_GE/LC_MESSAGES/duckduckgo.po
+++ b/locales/ka_GE/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr ""
@@ -1099,6 +1116,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr "ჩასადგმელები"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1453,6 +1507,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2800,6 +2859,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3200,9 +3266,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3218,6 +3294,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4477,6 +4560,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4761,6 +4849,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5099,6 +5192,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -5995,6 +6093,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6172,6 +6275,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6837,6 +6945,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7255,6 +7368,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8237,6 +8355,11 @@ msgid "How is it anonymous?"
 msgstr "როგორ არის ის ანონიმური?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9392,6 +9515,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11129,6 +11257,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12829,6 +12962,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12935,6 +13073,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13923,6 +14066,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14078,6 +14226,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -14993,6 +15148,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16332,6 +16492,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16412,6 +16579,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16872,6 +17044,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17274,6 +17460,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18736,6 +18927,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19885,6 +20083,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20967,6 +21178,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/kab_DZ/LC_MESSAGES/duckduckgo.po
+++ b/locales/kab_DZ/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr "Fell-aɣ"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "Adellel illa deg-s ccek"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Rnu DuckDuckGo"
@@ -1100,6 +1117,24 @@ msgstr "Rnu DuckDuckGo d amsedday n unadi"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Rnu DuckDuckGo ɣer %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr "Izegrar"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1455,6 +1509,11 @@ msgstr "Ini akk"
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2804,6 +2863,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3204,9 +3270,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3222,6 +3298,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4490,6 +4573,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4774,6 +4862,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5112,6 +5205,11 @@ msgstr "Ur ǧǧin ad yesken"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6008,6 +6106,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6185,6 +6288,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6854,6 +6962,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7272,6 +7385,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8256,6 +8374,11 @@ msgid "How is it anonymous?"
 msgstr "D udrig, d acu-t?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9415,6 +9538,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11152,6 +11280,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "IH, Awi-t-id!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12859,6 +12992,11 @@ msgstr "Mmesten isefka-iw deg yal ibenk."
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12965,6 +13103,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13953,6 +14096,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14111,6 +14259,13 @@ msgstr "Nadi"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15034,6 +15189,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16373,6 +16533,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16453,6 +16620,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16920,6 +17092,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17324,6 +17510,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18790,6 +18981,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19947,6 +20145,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21040,6 +21251,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/kn_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/kn_IN/LC_MESSAGES/duckduckgo.po
@@ -980,6 +980,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1083,6 +1088,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "DuckDuckGo ಸೇರಿಸಿ"
@@ -1101,6 +1118,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1140,6 +1175,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1211,6 +1260,11 @@ msgstr "ಆಡ್ ಆನ್ಸ್ (ಅಧಿಕಗಳು)"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1455,6 +1509,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2802,6 +2861,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3203,9 +3269,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3221,6 +3297,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4480,6 +4563,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4764,6 +4852,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5102,6 +5195,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6000,6 +6098,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6177,6 +6280,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6844,6 +6952,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7262,6 +7375,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8244,6 +8362,11 @@ msgid "How is it anonymous?"
 msgstr "ಹೇಗೆ ಇದು ಅನಾಮಧೇಯ?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9400,6 +9523,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11137,6 +11265,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12837,6 +12970,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12943,6 +13081,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13931,6 +14074,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14086,6 +14234,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15003,6 +15158,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16342,6 +16502,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16422,6 +16589,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16882,6 +17054,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17284,6 +17470,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18746,6 +18937,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19895,6 +20093,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20982,6 +21193,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/ko_KR/LC_MESSAGES/duckduckgo.po
+++ b/locales/ko_KR/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: ko_KR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1208,6 +1208,12 @@ msgid "About our ads"
 msgstr "DuckDuckGo 광고 소개"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1337,6 +1343,20 @@ msgid "Ad is suspicious"
 msgstr "사기 등이 의심되는 광고입니다."
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "DuckDuckGo 추가"
@@ -1363,6 +1383,27 @@ msgstr "검색 엔진으로 DuckDuckGo 추가하기"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "%1$s에 DuckDuckGo 확장 프로그램 추가"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1408,6 +1449,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "페이지 내용 추가"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1493,6 +1550,12 @@ msgstr "추가 기능"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "마지막 다듬기"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1794,6 +1857,12 @@ msgstr "모든 색상"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "다 됐어요!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3484,6 +3553,14 @@ msgid "Cancel"
 msgstr "취소"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3976,10 +4053,22 @@ msgid "Chat response is offensive"
 msgstr "채팅 응답이 불쾌"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "%1$s 모델과의 채팅"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3998,6 +4087,14 @@ msgstr "채팅"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "채팅"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5589,6 +5686,12 @@ msgid "Current Streak"
 msgstr "현재 성적"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5936,6 +6039,12 @@ msgstr "채팅 삭제"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "30일 이상 지난 채팅 삭제"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6349,6 +6458,12 @@ msgstr "영원히 보지 않기"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "프로모션 무시하기"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7510,6 +7625,12 @@ msgid "Edit Prompt"
 msgstr "프롬프트 수정"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7728,6 +7849,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "암호화된 모델"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8553,6 +8680,12 @@ msgid "Follow-up question"
 msgstr "후속 질문"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9064,6 +9197,12 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
 "DuckDuckGo VPN, 고급 Duck.ai, Identity Theft Restoration을 이용해 보세요."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10289,6 +10428,12 @@ msgstr "사용자 데이터가 어떻게 익명으로 유지되나요?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "주요 기능 소개"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11717,6 +11862,12 @@ msgstr "획득한 라인아웃"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "링크가 7일 후 만료됩니다."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13834,6 +13985,12 @@ msgid "OK, got it!"
 msgstr "확인"
 
 # smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -15943,6 +16100,12 @@ msgid "Protected"
 msgstr "보호됨"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "보호. 개인정보 보호. 마음의 평화."
@@ -16074,6 +16237,12 @@ msgstr "비"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "순위"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17299,6 +17468,12 @@ msgid "Save your chats across all your devices."
 msgstr "모든 기기에서 채팅 내용을 저장하세요."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17500,6 +17675,14 @@ msgstr "검색"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "검색"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18664,6 +18847,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "구매"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20297,6 +20486,14 @@ msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr "18개월 동안 휴면 상태였던 Sync & Backup 데이터는 복구할 수 없습니다."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20408,6 +20605,12 @@ msgstr "주변에 있는 기기와 동기화하세요."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "모든 기기에서 채팅을 동기화하세요."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -20982,6 +21185,22 @@ msgid "This Week"
 msgstr "이번 주"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21504,6 +21723,12 @@ msgstr "오늘"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "오늘"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23315,6 +23540,14 @@ msgstr ""
 "TripAdvisor의 광고 네트워크에서 관리합니다."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "버진 제도"
 
@@ -24775,6 +25008,21 @@ msgstr ""
 "'%1$s' 메뉴에서 언제든지 켜거나 끌 수 있습니다."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26146,6 +26394,12 @@ msgstr "분"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "분"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/ko_KR/LC_MESSAGES/duckduckgo.po
+++ b/locales/ko_KR/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: ko_KR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -190,9 +190,8 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"%1$s는 Pro를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 DuckDuckGo 구독"
-"을 다시 업그레이드하여 채팅을 계속 이용하거나, Plus 또는 무료 모델로 전환하세"
-"요."
+"%1$s는 Pro를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 DuckDuckGo 구독을 다시 업그레이드하여 채팅을 계속 "
+"이용하거나, Plus 또는 무료 모델로 전환하세요."
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -202,9 +201,8 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"%1$s는 Pro를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 DuckDuckGo 구독"
-"을 다시 업그레이드하여 채팅을 계속 이용하거나, Plus 또는 무료 모델로 전환하세"
-"요."
+"%1$s는 Pro를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 DuckDuckGo 구독을 다시 업그레이드하여 채팅을 계속 "
+"이용하거나, Plus 또는 무료 모델로 전환하세요."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -220,8 +218,8 @@ msgid ""
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
 msgstr ""
-"%1$s 서비스는 DuckDuckGo를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 구"
-"독을 다시 활성화해서 채팅을 계속 이용하거나, 무료 모델로 전환하세요."
+"%1$s 서비스는 DuckDuckGo를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 구독을 다시 활성화해서 채팅을 계속 이용하거나, "
+"무료 모델로 전환하세요."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -229,9 +227,7 @@ msgctxt "Error message for model unavailability"
 msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
-msgstr ""
-"%1$s 모델을 일시적으로 사용할 수 없습니다. 다른 모델로 전환하거나 나중에 다"
-"시 시도하세요."
+msgstr "%1$s 모델을 일시적으로 사용할 수 없습니다. 다른 모델로 전환하거나 나중에 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -328,8 +324,8 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$s(은)는 신뢰할 수 있는 실행 환경에서 실행됩니다. 즉, 모델 제공자조차도 사"
-"용자의 메시지나 모델의 응답을 보거나 서버에 이 채팅을 저장할 수 없습니다."
+"%1$s(은)는 신뢰할 수 있는 실행 환경에서 실행됩니다. 즉, 모델 제공자조차도 사용자의 메시지나 모델의 응답을 보거나 서버에 이 "
+"채팅을 저장할 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -376,8 +372,7 @@ msgstr "%1$s 사용"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
-"%1$s은(는) 기본 모델보다 사용 한도를 최대 2~5배 더 빠르게 소진합니다. %2$s"
+msgstr "%1$s은(는) 기본 모델보다 사용 한도를 최대 2~5배 더 빠르게 소진합니다. %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -415,9 +410,7 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
-msgstr ""
-"%1$s 모델은 %2$s일 후(%3$s)에 Duck.ai에서 제거됩니다. 그 후에는 모델을 바꿔"
-"서 이 채팅을 계속할 수 있습니다."
+msgstr "%1$s 모델은 %2$s일 후(%3$s)에 Duck.ai에서 제거됩니다. 그 후에는 모델을 바꿔서 이 채팅을 계속할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -427,9 +420,7 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
-msgstr ""
-"%1$s 모델은 %2$s일 후에 Duck.ai에서 제거됩니다. 그 후에는 모델을 바꿔서 이 채"
-"팅을 계속할 수 있습니다."
+msgstr "%1$s 모델은 %2$s일 후에 Duck.ai에서 제거됩니다. 그 후에는 모델을 바꿔서 이 채팅을 계속할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -441,9 +432,7 @@ msgstr "단어 %1$s개"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr ""
-"%1$s추가%2$s를 클릭합니다.%3$s허용%4$s에 체크 표시한 후%5$s 확인%6$s을 클릭합"
-"니다.%7$s"
+msgstr "%1$s추가%2$s를 클릭합니다.%3$s허용%4$s에 체크 표시한 후%5$s 확인%6$s을 클릭합니다.%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -451,8 +440,8 @@ msgstr ""
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$s허용%2$s을 클릭합니다.%3$s추가%4$s를 클릭합니다.%5$s허용%6$s에 %7$s체크 "
-"표시한 후 %8$s확인%9$s을 클릭합니다."
+"%1$s허용%2$s을 클릭합니다.%3$s추가%4$s를 클릭합니다.%5$s허용%6$s에 %7$s체크 표시한 후 %8$s확인%9$s을 "
+"클릭합니다."
 
 # Firefox
 # smartling.placeholder_format=C
@@ -462,8 +451,8 @@ msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
 msgstr ""
-"%1$s설치 진행하기%2$s를 클릭합니다.%3$s%4$s추가%5$s를 클릭합니다.%6$s허용%7$s"
-"에 체크 표시한 후 %8$s확인%9$s을 클릭합니다."
+"%1$s설치 진행하기%2$s를 클릭합니다.%3$s%4$s추가%5$s를 클릭합니다.%6$s허용%7$s에 체크 표시한 후 "
+"%8$s확인%9$s을 클릭합니다."
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -471,9 +460,7 @@ msgctxt "noresults"
 msgid ""
 "%sClick here%s to try again, if you think there should be results for this "
 "search."
-msgstr ""
-"이 검색 결과가 표시되어야 한다고 생각되는 경우 %1$s여기%2$s를 클릭해서 다시 "
-"시도해 보세요."
+msgstr "이 검색 결과가 표시되어야 한다고 생각되는 경우 %1$s여기%2$s를 클릭해서 다시 시도해 보세요."
 
 # smartling.placeholder_format=C
 #. Header for a page with information about sharing DuckDuckGo.
@@ -491,8 +478,7 @@ msgstr "%1$s더 알아보기%2$s."
 #. Link to a page with more information about how anonymous location works.
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
-msgstr ""
-"%1$sDuckDuckGo가 사용자의 위치 정보를 어떻게 보호하는지 알아보세요%2$s."
+msgstr "%1$sDuckDuckGo가 사용자의 위치 정보를 어떻게 보호하는지 알아보세요%2$s."
 
 # smartling.placeholder_format=C
 #. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
@@ -506,8 +492,7 @@ msgstr "%1$s자세히 알아보기%2$s"
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr ""
-"DuckDuckGo 서버에 채팅이 비공개로 저장되는 방식 %1$s자세히 알아보기%2$s"
+msgstr "DuckDuckGo 서버에 채팅이 비공개로 저장되는 방식 %1$s자세히 알아보기%2$s"
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -525,8 +510,7 @@ msgstr "홈 화면에서 DuckDuckGo 앱 아이콘을 %1$s길게 누릅니다%2$s
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr ""
-"%1$s이런!%2$s%3$s문제가 발생했습니다. %4$s새로고침%5$s하고 다시 시도하세요."
+msgstr "%1$s이런!%2$s%3$s문제가 발생했습니다. %4$s새로고침%5$s하고 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -877,17 +861,14 @@ msgstr "6시간 사용 제한에 도달했습니다."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"6시간 사용 한도에 도달했습니다. %1$s 이후에 이 채팅을 이어갈 수 있습니다."
+msgstr "6시간 사용 한도에 도달했습니다. %1$s 이후에 이 채팅을 이어갈 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "6-hour usage limit reached. You can keep chatting by using your daily limit."
-msgstr ""
-"6시간 사용 한도에 도달했습니다. 일일 한도를 사용해서 채팅을 이어갈 수 있습니"
-"다."
+msgstr "6시간 사용 한도에 도달했습니다. 일일 한도를 사용해서 채팅을 이어갈 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes abbreviation
@@ -940,17 +921,14 @@ msgstr "A"
 msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
-msgstr ""
-"Search Assist가 네트워크 문제로 답변을 생성하지 못하고 있습니다. 연결 상태를 "
-"확인하고 다시 시도하세요."
+msgstr "Search Assist가 네트워크 문제로 답변을 생성하지 못하고 있습니다. 연결 상태를 확인하고 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"새로운 버전의 AI Chat이 나왔습니다! 이 페이지를 새로고침해서 진행하세요."
+msgstr "새로운 버전의 AI Chat이 나왔습니다! 이 페이지를 새로고침해서 진행하세요."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
@@ -1001,9 +979,9 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"AI Chat을 사용하면 외부 AI Chat 모델과 익명으로 대화할 수 있습니다. 이 기능"
-"을 끄면 DuckDuckGo Search의 AI Chat 기능이 숨겨집니다. 이 설정이 꺼져 있어도 "
-"%1$sduckduckgo.com/aichat%2$s를 통해 AI Chat을 계속 이용할 수 있습니다."
+"AI Chat을 사용하면 외부 AI Chat 모델과 익명으로 대화할 수 있습니다. 이 기능을 끄면 DuckDuckGo Search의 AI "
+"Chat 기능이 숨겨집니다. 이 설정이 꺼져 있어도 %1$sduckduckgo.com/aichat%2$s를 통해 AI Chat을 계속 "
+"이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1064,10 +1042,9 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"현재 AI 지원 답변은 직접적인 후속 질문을 지원하지 않습니다. 하지만 후속 질문"
-"을 위해 %1$sDuck.ai%2$s를 제안하고 링크를 제공하는 경우는 많습니다. Duck.ai"
-"는 OpenAI와 Anthropic 등의 채팅 모델을 지원하는 DuckDuckGo의 비공개 AI 기반 "
-"채팅 서비스입니다."
+"현재 AI 지원 답변은 직접적인 후속 질문을 지원하지 않습니다. 하지만 후속 질문을 위해 %1$sDuck.ai%2$s를 제안하고 링크를 "
+"제공하는 경우는 많습니다. Duck.ai는 OpenAI와 Anthropic 등의 채팅 모델을 지원하는 DuckDuckGo의 비공개 AI "
+"기반 채팅 서비스입니다."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1211,7 +1188,7 @@ msgstr "DuckDuckGo 광고 소개"
 #. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
 msgctxt "Modal header for chat history with sync information"
 msgid "About Chat History with Sync & Backup"
-msgstr ""
+msgstr "Sync & Backup을 사용한 채팅 기록에 대하여"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
@@ -1257,9 +1234,7 @@ msgctxt ""
 msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
-msgstr ""
-"이 브라우저에서 %1$s을 다시 활성화해서 채팅을 계속 이용하거나, 무료 모델로 전"
-"환하세요."
+msgstr "이 브라우저에서 %1$s을 다시 활성화해서 채팅을 계속 이용하거나, 무료 모델로 전환하세요."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1294,18 +1269,14 @@ msgstr "광고"
 #. An item in the ads tooltip that explains that ad clicks are managed by the ad network and are not used to profile you. The placeholder is the name of the ad network. For example: Microsoft
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
-msgstr ""
-"광고 클릭은 %1$s의 광고 네트워크에서 관리되며 사용자의 정보를 수집하는 데 사"
-"용되지 않습니다."
+msgstr "광고 클릭은 %1$s의 광고 네트워크에서 관리되며 사용자의 정보를 수집하는 데 사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
 msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
-msgstr ""
-"광고 클릭은 Microsoft의 광고 네트워크에서 관리되며 사용자의 정보를 수집하는 "
-"데 사용되지 않습니다."
+msgstr "광고 클릭은 Microsoft의 광고 네트워크에서 관리되며 사용자의 정보를 수집하는 데 사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1346,7 +1317,7 @@ msgstr "사기 등이 의심되는 광고입니다."
 #. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
 msgctxt "Button to open menu for attaching images or page context to AI chat"
 msgid "Add"
-msgstr ""
+msgstr "추가"
 
 # smartling.placeholder_format=C
 #. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
@@ -1354,7 +1325,7 @@ msgctxt ""
 "Primary button that attaches the tabs the user checked in the tab picker "
 "dialog"
 msgid "Add"
-msgstr ""
+msgstr "추가"
 
 # smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
@@ -1369,9 +1340,7 @@ msgstr "DuckDuckGo 확장 프로그램 추가"
 # smartling.placeholder_format=C
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
-msgstr ""
-"다운로드 한 번으로 브라우저에 DuckDuckGo Privacy Essentials를 무료로 추가하세"
-"요."
+msgstr "다운로드 한 번으로 브라우저에 DuckDuckGo Privacy Essentials를 무료로 추가하세요."
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1389,13 +1358,13 @@ msgstr "%1$s에 DuckDuckGo 확장 프로그램 추가"
 msgctxt ""
 "Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
 msgid "Add File"
-msgstr ""
+msgstr "파일 추가"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
 msgid "Add Image"
-msgstr ""
+msgstr "이미지 추가"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
@@ -1403,7 +1372,7 @@ msgctxt ""
 "Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
 "item)"
 msgid "Add Image or File"
-msgstr ""
+msgstr "이미지 또는 파일 추가"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1456,7 +1425,7 @@ msgctxt ""
 "Open the tab picker to attach browser tab content to the AI chat message "
 "(attach dropdown menu item)"
 msgid "Add Tabs"
-msgstr ""
+msgstr "탭 추가"
 
 # smartling.placeholder_format=C
 #. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
@@ -1464,7 +1433,7 @@ msgctxt ""
 "Title and accessible name of the tab-picker dialog opened from the attach "
 "dropdown menu"
 msgid "Add Tabs"
-msgstr ""
+msgstr "탭 추가"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1555,7 +1524,7 @@ msgstr "마지막 다듬기"
 #. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
 msgctxt "Aria label for the additional instructions textarea"
 msgid "Additional instructions"
-msgstr ""
+msgstr "추가 지침"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1647,9 +1616,7 @@ msgctxt ""
 "model picker dropdown"
 msgid ""
 "Advanced models can reach usage limits 2–5x sooner than other models. %s"
-msgstr ""
-"고급 모델은 다른 모델보다 사용 한도에 2~5배 더 빠르게 도달할 수 있습니다. "
-"%1$s"
+msgstr "고급 모델은 다른 모델보다 사용 한도에 2~5배 더 빠르게 도달할 수 있습니다. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
@@ -1657,8 +1624,7 @@ msgctxt ""
 "Always-visible warning banner shown above the recommended models in the "
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
-msgstr ""
-"고급 모델은 다른 모델보다 한도를 2~5배 더 빠르게 소진할 수 있습니다. %1$s"
+msgstr "고급 모델은 다른 모델보다 한도를 2~5배 더 빠르게 소진할 수 있습니다. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1700,8 +1666,7 @@ msgstr "다운로드가 완료되고 파일이 열리면 %1$s설치%2$s를 클�
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr ""
-"다운로드가 완료되면 확장 프로그램 파일을 찾아 더블 클릭하여 설치합니다."
+msgstr "다운로드가 완료되면 확장 프로그램 파일을 찾아 더블 클릭하여 설치합니다."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1837,8 +1802,8 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
-"DuckDuckGo가 모든 채팅을 익명화하며, DuckDuckGo 또는 모델 공급사는 사용자의 "
-"대화 내용을 채팅 모델 훈련에 사용하지 않습니다."
+"DuckDuckGo가 모든 채팅을 익명화하며, DuckDuckGo 또는 모델 공급사는 사용자의 대화 내용을 채팅 모델 훈련에 사용하지 "
+"않습니다."
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1862,7 +1827,7 @@ msgstr "다 됐어요!"
 #. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the read-only textarea listing all AI instructions"
 msgid "All instructions"
-msgstr ""
+msgstr "모든 지침"
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -1876,8 +1841,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr ""
-"모든 모델 제공사가 사용자의 대화를 AI에 학습시킬 수 없도록 금지되어 있습니다."
+msgstr "모든 모델 제공사가 사용자의 대화를 AI에 학습시킬 수 없도록 금지되어 있습니다."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1891,9 +1855,7 @@ msgctxt "Body copy for the anonymized card in the How Duck.ai Works panel"
 msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
-msgstr ""
-"AI 제공자에 채팅을 보내기 전에 모든 개인 메타데이터(예: IP 주소)가 제거됩니"
-"다."
+msgstr "AI 제공자에 채팅을 보내기 전에 모든 개인 메타데이터(예: IP 주소)가 제거됩니다."
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1931,8 +1893,7 @@ msgstr "허용"
 msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
-msgstr ""
-"음성 채팅을 사용하려면 시스템 설정에서 DuckDuckGo 마이크 접근을 허용하세요."
+msgstr "음성 채팅을 사용하려면 시스템 설정에서 DuckDuckGo 마이크 접근을 허용하세요."
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1964,17 +1925,15 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"%1$s 모델의 웹 검색을 허용하여 관련 프롬프트에 대한 응답을 향상합니다. 데이"
-"터 보유가 제한된 검색 엔진에만 AI가 생성한 쿼리를 보냅니다. %2$s 모델의 프롬"
-"프트 및 응답은 계속해서 %3$s제공자에게 전혀 노출되지 않습니다%4$s."
+"%1$s 모델의 웹 검색을 허용하여 관련 프롬프트에 대한 응답을 향상합니다. 데이터 보유가 제한된 검색 엔진에만 AI가 생성한 쿼리를 "
+"보냅니다. %2$s 모델의 프롬프트 및 응답은 계속해서 %3$s제공자에게 전혀 노출되지 않습니다%4$s."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Allows Cloud Save key to be stored locally on device (required to use Cloud "
 "Save)"
-msgstr ""
-"Cloud Save 키가 기기에 로컬로 저장되도록 허용(Cloud Save를 사용하는 데 필요)"
+msgstr "Cloud Save 키가 기기에 로컬로 저장되도록 허용(Cloud Save를 사용하는 데 필요)"
 
 # smartling.placeholder_format=C
 #. Pending title indicating near completion.
@@ -2111,8 +2070,7 @@ msgctxt "AI Chat description"
 msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
-msgstr ""
-"%1$s 및 %2$s, 오픈 소스 %3$s 및 %4$s 같은 인기 AI 모델에 익명으로 접속하세요."
+msgstr "%1$s 및 %2$s, 오픈 소스 %3$s 및 %4$s 같은 인기 AI 모델에 익명으로 접속하세요."
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -2120,8 +2078,7 @@ msgctxt "Duck.ai description"
 msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
-msgstr ""
-"%1$s 및 %2$s, 오픈 소스 %3$s 및 %4$s 같은 인기 AI 모델에 익명으로 접속하세요."
+msgstr "%1$s 및 %2$s, 오픈 소스 %3$s 및 %4$s 같은 인기 AI 모델에 익명으로 접속하세요."
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -2134,9 +2091,7 @@ msgctxt "settings"
 msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
-msgstr ""
-"웹 콘텐츠를 기반으로 검색 질의에 익명으로 답변을 생성합니다. 표시 빈도를 선택"
-"하거나 완전히 비활성화할 수 있습니다."
+msgstr "웹 콘텐츠를 기반으로 검색 질의에 익명으로 답변을 생성합니다. 표시 빈도를 선택하거나 완전히 비활성화할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2182,9 +2137,7 @@ msgctxt "Placeholder for additional instructions textarea"
 msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
-msgstr ""
-"Duck.ai가 따랐으면 하는 그 밖의 지침이 있으신가요(예: 항상 오리에 대한 정보"
-"를 들려줘)?"
+msgstr "Duck.ai가 따랐으면 하는 그 밖의 지침이 있으신가요(예: 항상 오리에 대한 정보를 들려줘)?"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2349,8 +2302,8 @@ msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
 msgstr ""
-"DuckDuckGo의 개인정보 보호정책에 따라 DuckDuckGo는 어떠한 개인정보도 수집하거"
-"나 공유하지 않습니다. 모든 개인정보 보호는 사용자의 기기에서 이루어집니다."
+"DuckDuckGo의 개인정보 보호정책에 따라 DuckDuckGo는 어떠한 개인정보도 수집하거나 공유하지 않습니다. 모든 개인정보 보호는 "
+"사용자의 기기에서 이루어집니다."
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2492,11 +2445,10 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assist는 일부 검색에 대해 관련 웹 콘텐츠를 요약하여 익명으로 AI 지원 답변을 "
-"생성할 수 있습니다. Assist 표시 빈도 선택 가능: 안 함(검색 결과에서 Assist UI"
-"를 완전히 제거), 주문형(Assist 버튼을 클릭할 때만 AI 지원 답변 표시), 가끔(관"
-"련성이 높은 경우에만 AI 지원 답변 표시), 자주(광범위한 검색에서 더 자주 표"
-"시). 현재 AI 지원 답변은 미국(영어) 지역에서만 이용 가능합니다."
+"Assist는 일부 검색에 대해 관련 웹 콘텐츠를 요약하여 익명으로 AI 지원 답변을 생성할 수 있습니다. Assist 표시 빈도 선택 "
+"가능: 안 함(검색 결과에서 Assist UI를 완전히 제거), 주문형(Assist 버튼을 클릭할 때만 AI 지원 답변 표시), "
+"가끔(관련성이 높은 경우에만 AI 지원 답변 표시), 자주(광범위한 검색에서 더 자주 표시). 현재 AI 지원 답변은 미국(영어) "
+"지역에서만 이용 가능합니다."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2508,10 +2460,9 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist는 검색 질의에 익명으로 AI 지원 답변을 생성하는 검색 결과 옵션 기능이"
-"며 웹에서 관련 콘텐츠를 검색한 다음 AI 기반 자연어 기술을 사용하여, 검색된 관"
-"련 정보를 바탕으로 간단한 답변을 생성합니다. 답변은 인용된 출처와 %1$s웹 크롤"
-"링%2$s을 기반으로 자동 생성합니다."
+"Assist는 검색 질의에 익명으로 AI 지원 답변을 생성하는 검색 결과 옵션 기능이며 웹에서 관련 콘텐츠를 검색한 다음 AI 기반 "
+"자연어 기술을 사용하여, 검색된 관련 정보를 바탕으로 간단한 답변을 생성합니다. 답변은 인용된 출처와 %1$s웹 크롤링%2$s을 기반으로 "
+"자동 생성합니다."
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2536,9 +2487,7 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "At the café, airport, or hotel, DuckDuckGo VPN encrypts your connection and "
 "hides your IP address on Wi-Fi."
-msgstr ""
-"카페, 공항, 호텔에서 DuckDuckGo VPN을 사용하면 연결을 암호화하고 와이파이에"
-"서 IP 주소를 감출 수 있습니다."
+msgstr "카페, 공항, 호텔에서 DuckDuckGo VPN을 사용하면 연결을 암호화하고 와이파이에서 IP 주소를 감출 수 있습니다."
 
 # smartling.placeholder_format=C
 #. In the context of the National Hockey League (NHL), label for teams belonging to the Atlantic division
@@ -2653,17 +2602,13 @@ msgstr "자동 응답"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr ""
-"나열된 자료를 바탕으로 자동 생성된 응답이며 부정확한 내용이 섞여있을 수 있습"
-"니다."
+msgstr "나열된 자료를 바탕으로 자동 생성된 응답이며 부정확한 내용이 섞여있을 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
-msgstr ""
-"나열된 자료를 바탕으로 자동 생성된 응답이며 부정확한 내용이 포함되어 있을 수 "
-"있습니다."
+msgstr "나열된 자료를 바탕으로 자동 생성된 응답이며 부정확한 내용이 포함되어 있을 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
@@ -2688,9 +2633,8 @@ msgid ""
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
 msgstr ""
-"관련 검색어에 대한 Assist를 자동으로 표시합니다. Assist는 일부 검색에 대하여 "
-"익명으로 정보를 조회하고 요약할 수 있습니다. 현재 Assist 서비스는 영어 사용 "
-"지역에서만 제공됩니다."
+"관련 검색어에 대한 Assist를 자동으로 표시합니다. Assist는 일부 검색에 대하여 익명으로 정보를 조회하고 요약할 수 있습니다. "
+"현재 Assist 서비스는 영어 사용 지역에서만 제공됩니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2699,16 +2643,14 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"관련 검색어에 대한 DuckAssist를 자동으로 표시합니다. DuckAssist는 일부 검색"
-"에 대하여 익명으로 정보를 조회하고 요약할 수 있습니다. 현재 DuckAssist 서비스"
-"는 영어 사용 지역에서만 제공됩니다."
+"관련 검색어에 대한 DuckAssist를 자동으로 표시합니다. DuckAssist는 일부 검색에 대하여 익명으로 정보를 조회하고 요약할 "
+"수 있습니다. 현재 DuckAssist 서비스는 영어 사용 지역에서만 제공됩니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Autoplay short, silent video previews when you hover over video results."
-msgstr ""
-"영상 결과에 마우스를 올리면 짧은 무음 영상 미리 보기가 자동으로 재생됩니다."
+msgstr "영상 결과에 마우스를 올리면 짧은 무음 영상 미리 보기가 자동으로 재생됩니다."
 
 # smartling.placeholder_format=C
 #. Title for the menu listing free/degraded models available after the advanced-model usage limit has been reached.
@@ -2908,8 +2850,8 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
-"이 보고서를 저장하기 전에 DuckDuckGo는 이름, 이메일 주소, 식별 가능한 메타데"
-"이터와 같은 개인정보(PII)를 제거하여 대화 내용을 익명화합니다."
+"이 보고서를 저장하기 전에 DuckDuckGo는 이름, 이메일 주소, 식별 가능한 메타데이터와 같은 개인정보(PII)를 제거하여 대화 "
+"내용을 익명화합니다."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3038,9 +2980,7 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Block harmful sites, hide your IP address, plus get more premium protections "
 "with our subscription."
-msgstr ""
-"구독을 통해 유해 사이트 차단, IP 주소 숨기기, 더 많은 프리미엄 보호 기능을 이"
-"용하세요."
+msgstr "구독을 통해 유해 사이트 차단, IP 주소 숨기기, 더 많은 프리미엄 보호 기능을 이용하세요."
 
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
@@ -3300,18 +3240,16 @@ msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"기존과 동일하게 검색하세요. 개인정보는 저희가 보호해 드릴게요. 하나의 "
-"%1$s%2$s확장 프로그램%3$s으로 검색 엔진, 추적 차단, 암호화 보호 강화 기능을 "
-"이용할 수 있습니다."
+"기존과 동일하게 검색하세요. 개인정보는 저희가 보호해 드릴게요. 하나의 %1$s%2$s확장 프로그램%3$s으로 검색 엔진, 추적 차단, "
+"암호화 보호 강화 기능을 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"기존과 동일하게 검색하세요. 검색 기록이 저장되지 않습니다. 하나의 %1$s%2$s확"
-"장 프로그램%3$s으로 검색 엔진, 추적 차단, 암호화 보호 강화 기능을 이용할 수 "
-"있습니다."
+"기존과 동일하게 검색하세요. 검색 기록이 저장되지 않습니다. 하나의 %1$s%2$s확장 프로그램%3$s으로 검색 엔진, 추적 차단, "
+"암호화 보호 강화 기능을 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3319,9 +3257,8 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"기존과 동일하게 검색하세요. 검색 기록이 저장되지 않습니다. 다운로드 한 번으"
-"로 %1$s주요 브라우저%2$s에서 비공개 검색, 추적 차단, 사이트 암호화 기능을 이"
-"용할 수 있습니다."
+"기존과 동일하게 검색하세요. 검색 기록이 저장되지 않습니다. 다운로드 한 번으로 %1$s주요 브라우저%2$s에서 비공개 검색, 추적 "
+"차단, 사이트 암호화 기능을 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3428,10 +3365,9 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"기본적으로 설정은 비개인 브라우저 쿠키(사용자의 브라우저)에 저장됩니다. 익명 "
-"Cloud Save를 사용하여 설정을 보다 영구적으로 저장할 수 있습니다(클라우드의 원"
-"격 서버에 저장). 클라우드에는 사용자의 개인 신원 정보가 저장되지 않으며, 암"
-"호 또한 서버에 저장되지 않습니다."
+"기본적으로 설정은 비개인 브라우저 쿠키(사용자의 브라우저)에 저장됩니다. 익명 Cloud Save를 사용하여 설정을 보다 영구적으로 "
+"저장할 수 있습니다(클라우드의 원격 서버에 저장). 클라우드에는 사용자의 개인 신원 정보가 저장되지 않으며, 암호 또한 서버에 저장되지 "
+"않습니다."
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
@@ -3439,8 +3375,8 @@ msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"받아쓰기를 활성화함으로써, 이 기능을 사용하기 위해 본인의 음성 데이터가 "
-"OpenAI로 전송되는 것에 동의합니다. 시작하기 전에 %1$s 페이지를 확인하세요."
+"받아쓰기를 활성화함으로써, 이 기능을 사용하기 위해 본인의 음성 데이터가 OpenAI로 전송되는 것에 동의합니다. 시작하기 전에 %1$s "
+"페이지를 확인하세요."
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3449,8 +3385,8 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"음성 채팅을 활성화함으로써, 이 기능을 사용하기 위해 본인의 음성 데이터가 "
-"OpenAI로 전송되는 것에 동의합니다. 시작하기 전에 %1$s 페이지를 확인하세요."
+"음성 채팅을 활성화함으로써, 이 기능을 사용하기 위해 본인의 음성 데이터가 OpenAI로 전송되는 것에 동의합니다. 시작하기 전에 "
+"%1$s 페이지를 확인하세요."
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3485,8 +3421,7 @@ msgstr "카메룬"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr ""
-"닭고기, 브로콜리, 쌀을 재료로 한 몇 가지 간단한 요리법을 만들 수 있나요?"
+msgstr "닭고기, 브로콜리, 쌀을 재료로 한 몇 가지 간단한 요리법을 만들 수 있나요?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3558,7 +3493,7 @@ msgctxt ""
 "Secondary button that dismisses the tab picker dialog without attaching "
 "anything"
 msgid "Cancel"
-msgstr ""
+msgstr "취소"
 
 # smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
@@ -3814,9 +3749,7 @@ msgstr "전체 사이트에 적용되는 배경 색상을 변경합니다."
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr ""
-"검색 결과(마우스 커서를 올렸을 때), 모듈 및 드롭다운 메뉴의 배경 색상을 변경"
-"합니다."
+msgstr "검색 결과(마우스 커서를 올렸을 때), 모듈 및 드롭다운 메뉴의 배경 색상을 변경합니다."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -3945,9 +3878,8 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"Duck.ai 서비스를 통한 채팅을 사용하면 OpenAI, Anthropic 등의 모델을 지원하는 "
-"타사 AI 채팅 모델과 익명으로 대화할 수 있습니다. 이 설정을 끄면 DuckDuckGo "
-"Search에서 채팅 버튼과 링크가 보이지 않습니다. 하지만 이 설정이 꺼져 있어도 "
+"Duck.ai 서비스를 통한 채팅을 사용하면 OpenAI, Anthropic 등의 모델을 지원하는 타사 AI 채팅 모델과 익명으로 대화할 "
+"수 있습니다. 이 설정을 끄면 DuckDuckGo Search에서 채팅 버튼과 링크가 보이지 않습니다. 하지만 이 설정이 꺼져 있어도 "
 "%1$shttps://duck.ai%2$s에 바로 접속해서 채팅을 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
@@ -4003,18 +3935,14 @@ msgstr "비공개로 채팅하기"
 #. Mobile variant of DUCKCHAT_BROWSER_UPSELL_PROMO_TEXT. Shorter version for the promotional card encouraging third-party browser users to download the DuckDuckGo browser.
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
-msgstr ""
-"DuckDuckGo 무료 브라우저에 내장된 Duck.ai로 어떤 웹사이트에서든 비공개로 채팅"
-"하세요."
+msgstr "DuckDuckGo 무료 브라우저에 내장된 Duck.ai로 어떤 웹사이트에서든 비공개로 채팅하세요."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
-msgstr ""
-"DuckDuckGo 무료 브라우저에서 Duck.ai 사이드바를 통해 어떤 웹사이트에서든 비공"
-"개로 채팅하세요."
+msgstr "DuckDuckGo 무료 브라우저에서 Duck.ai 사이드바를 통해 어떤 웹사이트에서든 비공개로 채팅하세요."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4056,7 +3984,7 @@ msgstr "채팅 응답이 불쾌"
 #. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
 msgctxt "Chat history about modal list item headline"
 msgid "Chat storage varies by browser"
-msgstr ""
+msgstr "브라우저에 따라 채팅 저장 공간이 달라집니다"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4068,7 +3996,7 @@ msgstr "%1$s 모델과의 채팅"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Chat with popular AI models, anonymized by us."
-msgstr ""
+msgstr "DuckDuckGo의 익명화를 통해 인기 AI 모델과 채팅하세요."
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4094,7 +4022,7 @@ msgctxt "Chat history with sync modal list item description"
 msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
-msgstr ""
+msgstr "채팅이 DuckDuckGo 서버에 안전하게 저장되고 종단간 암호화가 적용됩니다. 회원님의 데이터는 본인 외에 누구도 볼 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4102,9 +4030,7 @@ msgctxt "Description for Chat History feature"
 msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
-msgstr ""
-"채팅은 DuckDuckGo 서버나 원격 서버가 아닌 사용자의 기기 자체에 저장됩니다. 채"
-"팅 기록을 비활성화하면 고정된 채팅이 삭제돼."
+msgstr "채팅은 DuckDuckGo 서버나 원격 서버가 아닌 사용자의 기기 자체에 저장됩니다. 채팅 기록을 비활성화하면 고정된 채팅이 삭제돼."
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -4116,10 +4042,9 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"채팅은 사용자의 기기에 직접 저장됩니다. 사용자의 인터넷 연결이 끊겼을 때 채팅"
-"을 복원할 수 있도록, 전송된 새 프롬프트와 응답을 암호화하여 DuckDuckGo 서버"
-"에 임시로 저장합니다. 채팅 기록을 비활성화하면 고정된 채팅이 삭제되고, 새로"
-"운 프롬프트와 응답의 임시 저장이 중단됩니다."
+"채팅은 사용자의 기기에 직접 저장됩니다. 사용자의 인터넷 연결이 끊겼을 때 채팅을 복원할 수 있도록, 전송된 새 프롬프트와 응답을 "
+"암호화하여 DuckDuckGo 서버에 임시로 저장합니다. 채팅 기록을 비활성화하면 고정된 채팅이 삭제되고, 새로운 프롬프트와 응답의 임시 "
+"저장이 중단됩니다."
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -4142,17 +4067,15 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"%1$s과(와)의 채팅은 공급자 가시성이 전혀 없지만, Duck.ai에 업로드된 모든 파일"
-"은 %2$s의 콘텐츠 조정 공급자에 의한 익명 검토를 거칩니다."
+"%1$s과(와)의 채팅은 공급자 가시성이 전혀 없지만, Duck.ai에 업로드된 모든 파일은 %2$s의 콘텐츠 조정 공급자에 의한 익명 "
+"검토를 거칩니다."
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
 msgctxt "Sync file storage inline disclaimer body"
 msgid ""
 "Chats with attachments have stopped syncing. Free up storage to resume Sync."
-msgstr ""
-"첨부 파일이 있는 채팅의 동기화가 중단되었습니다. 저장 공간을 확보하면 동기화"
-"를 재개할 수 있습니다."
+msgstr "첨부 파일이 있는 채팅의 동기화가 중단되었습니다. 저장 공간을 확보하면 동기화를 재개할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Message shown when we have no data from upstream to display
@@ -4205,8 +4128,7 @@ msgstr "철자 검사"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr ""
-"DuckDuckGo 서브레딧에서 이번 서비스 중단에 대한 최신 소식을 확인하세요."
+msgstr "DuckDuckGo 서브레딧에서 이번 서비스 중단에 대한 최신 소식을 확인하세요."
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4308,9 +4230,7 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Choose from 40+ server locations worldwide to help block harmful sites and "
 "scams."
-msgstr ""
-"전 세계 40개 이상의 서버 위치를 사용하며 유해 사이트와 온라인 사기를 차단하세"
-"요."
+msgstr "전 세계 40개 이상의 서버 위치를 사용하며 유해 사이트와 온라인 사기를 차단하세요."
 
 # smartling.placeholder_format=C
 #. The title of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -4508,9 +4428,8 @@ msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
-"브라우저 데이터를 삭제하면 채팅이 사라집니다. 일부 브라우저는 최근 채팅을 무"
-"기한으로 보관하거나, AI Chat을 7일 이상 사용하지 않으면 자동으로 삭제할 수 있"
-"습니다."
+"브라우저 데이터를 삭제하면 채팅이 사라집니다. 일부 브라우저는 최근 채팅을 무기한으로 보관하거나, AI Chat을 7일 이상 사용하지 "
+"않으면 자동으로 삭제할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4520,9 +4439,8 @@ msgid ""
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
 msgstr ""
-"브라우저 데이터를 삭제하면 최근 채팅이 삭제됩니다. 브라우저에 따라 최근 채팅"
-"이 무기한으로 저장될 수도 있고, Duck.ai를 7일 이상 사용하지 않으면 자동으로 "
-"삭제될 수도 있습니다."
+"브라우저 데이터를 삭제하면 최근 채팅이 삭제됩니다. 브라우저에 따라 최근 채팅이 무기한으로 저장될 수도 있고, Duck.ai를 7일 이상 "
+"사용하지 않으면 자동으로 삭제될 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4530,9 +4448,7 @@ msgctxt "settings"
 msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
-msgstr ""
-"브라우저 데이터를 삭제하면 차단된 사이트가 초기화됩니다. 차단 목록을 "
-"DuckDuckGo 무료 브라우저에"
+msgstr "브라우저 데이터를 삭제하면 차단된 사이트가 초기화됩니다. 차단 목록을 DuckDuckGo 무료 브라우저에"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4541,9 +4457,8 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"'더 보기'를 클릭해서 주제를 더 깊이 탐색하고, OpenAI와 Anthropic 등의 채팅 모"
-"델을 지원하는 DuckDuckGo의 비공개 AI 기반 채팅 서비스 %1$sDuck.ai%2$s를 통해 "
-"후속 질문을 하세요."
+"'더 보기'를 클릭해서 주제를 더 깊이 탐색하고, OpenAI와 Anthropic 등의 채팅 모델을 지원하는 DuckDuckGo의 비공개 "
+"AI 기반 채팅 서비스 %1$sDuck.ai%2$s를 통해 후속 질문을 하세요."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4584,9 +4499,7 @@ msgstr "드롭다운 메뉴에서 %1$s검색 설정 변경%2$s을 클릭하세�
 msgid ""
 "Click %sEdit > Preferences%s (on Windows) %sSeaMonkey > Preferences%s (on "
 "Mac)"
-msgstr ""
-"Windows에서는 %1$s편집 > 환경설정%2$s을 클릭하고, Mac에서는%3$sSeaMonkey > 환"
-"경설정%4$s을 클릭하세요."
+msgstr "Windows에서는 %1$s편집 > 환경설정%2$s을 클릭하고, Mac에서는%3$sSeaMonkey > 환경설정%4$s을 클릭하세요."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4602,9 +4515,7 @@ msgstr "DuckDuckGo 확장 프로그램을 다운로드하려면 %1$s여기%2$s�
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr ""
-"%1$s열기%2$s를 클릭해서 DuckDuckGo Safari 확장 프로그램을 다운로드하고 여세"
-"요."
+msgstr "%1$s열기%2$s를 클릭해서 DuckDuckGo Safari 확장 프로그램을 다운로드하고 여세요."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4618,9 +4529,7 @@ msgstr "왼쪽 사이드바에서 %1$s개인정보 및 서비스%2$s를 클릭�
 msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
-msgstr ""
-"상단 메뉴의 %1$sSafari%2$s를 클릭하세요(Windows에서는 오른쪽 상단에 있는 %3$s"
-"기어 모양 아이콘%4$s을 클릭하세요)."
+msgstr "상단 메뉴의 %1$sSafari%2$s를 클릭하세요(Windows에서는 오른쪽 상단에 있는 %3$s기어 모양 아이콘%4$s을 클릭하세요)."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4649,8 +4558,7 @@ msgstr "%1$s예%2$s를 클릭하세요."
 # smartling.placeholder_format=C
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
-msgstr ""
-"Chrome 툴바(오른쪽 상단)에서 %1$ssettings/hamburger icon%2$s을 클릭하세요."
+msgstr "Chrome 툴바(오른쪽 상단)에서 %1$ssettings/hamburger icon%2$s을 클릭하세요."
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4712,9 +4620,8 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
 msgstr ""
-"%1$s데이터 삭제하기%2$s를 클릭하거나 누르면 클라우드에서는 데이터가 제거되지"
-"만 브라우저에는 남아있습니다. 남아있는 데이터를 제거하려면 %3$s모든 검색 설"
-"정 초기화%4$s를 클릭하거나 누르세요."
+"%1$s데이터 삭제하기%2$s를 클릭하거나 누르면 클라우드에서는 데이터가 제거되지만 브라우저에는 남아있습니다. 남아있는 데이터를 "
+"제거하려면 %3$s모든 검색 설정 초기화%4$s를 클릭하거나 누르세요."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4725,9 +4632,8 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
 msgstr ""
-"%1$s내 데이터 삭제%2$s를 클릭하거나 누릅니다. 이 작업을 수행하면 클라우드에서"
-"는 데이터가 삭제되지만, %3$s모든 설정 초기화%4$s를 클릭하거나 누를 때까지 브"
-"라우저에는 데이터가 남아 있게 됩니다."
+"%1$s내 데이터 삭제%2$s를 클릭하거나 누릅니다. 이 작업을 수행하면 클라우드에서는 데이터가 삭제되지만, %3$s모든 설정 "
+"초기화%4$s를 클릭하거나 누를 때까지 브라우저에는 데이터가 남아 있게 됩니다."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4795,18 +4701,14 @@ msgstr "검색 창에서 드롭다운을 클릭하세요."
 msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
-msgstr ""
-"주소 표시줄%2$s에 사용된 %1$s검색 엔진 옆 드롭다운 메뉴를 클릭하고 "
-"%3$sDuckDuckGo%4$s를 선택하세요."
+msgstr "주소 표시줄%2$s에 사용된 %1$s검색 엔진 옆 드롭다운 메뉴를 클릭하고 %3$sDuckDuckGo%4$s를 선택하세요."
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
 msgid ""
 "Click the icon of the ad blocker extension. It's usually in the upper right "
 "hand corner of your browser."
-msgstr ""
-"광고 차단 확장 프로그램 아이콘을 클릭하세요. 주로 브라우저 오른쪽 상단 모서리"
-"에 있습니다."
+msgstr "광고 차단 확장 프로그램 아이콘을 클릭하세요. 주로 브라우저 오른쪽 상단 모서리에 있습니다."
 
 #  Safari default search engine instruction
 # smartling.placeholder_format=C
@@ -5006,9 +4908,7 @@ msgctxt "cloudsave"
 msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
-msgstr ""
-"Cloud Save는 현재 설정을 영구적으로 저장하고 암호를 입력해 간편하게 불러올 "
-"수 있는 기능으로, 꼭 사용하실 필요는 없습니다."
+msgstr "Cloud Save는 현재 설정을 영구적으로 저장하고 암호를 입력해 간편하게 불러올 수 있는 기능으로, 꼭 사용하실 필요는 없습니다."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -5279,8 +5179,7 @@ msgstr "광고 차단 계속하기"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
-"최근 채팅을 여기서 계속 이어가거나, Fire Button을 눌러 삭제할 수 있습니다."
+msgstr "최근 채팅을 여기서 계속 이어가거나, Fire Button을 눌러 삭제할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5398,8 +5297,7 @@ msgstr "복사"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"주소 표시줄에 %1$sabout:preferences#search%2$s를 복사하여 붙여넣으세요."
+msgstr "주소 표시줄에 %1$sabout:preferences#search%2$s를 복사하여 붙여넣으세요."
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5452,8 +5350,8 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
-"다른 기기에서 코드를 복사하세요. %1$sDuck.ai Settings › Chats › Sync & "
-"Backup › Sync With Another Device%2$s로 들어가서 다시 시도해 보세요."
+"다른 기기에서 코드를 복사하세요. %1$sDuck.ai Settings › Chats › Sync & Backup › Sync With "
+"Another Device%2$s로 들어가서 다시 시도해 보세요."
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5605,8 +5503,7 @@ msgctxt "Share modal info bullet about public access"
 msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
-msgstr ""
-"링크를 생성하면 링크를 연 모든 사람이 볼 수 있는 채팅 사본이 생성됩니다."
+msgstr "링크를 생성하면 링크를 연 모든 사람이 볼 수 있는 채팅 사본이 생성됩니다."
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5689,7 +5586,7 @@ msgstr "현재 성적"
 #. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
 msgctxt "Suffix label indicating a tab is the currently active browser tab"
 msgid "Current Tab"
-msgstr ""
+msgstr "현재 탭"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
@@ -5844,17 +5741,14 @@ msgstr "일일 한도에 도달했습니다."
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr ""
-"일일 사용 한도에 도달했습니다. %1$s 이후에 이 채팅을 이어갈 수 있습니다."
+msgstr "일일 사용 한도에 도달했습니다. %1$s 이후에 이 채팅을 이어갈 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Daily usage limit reached. You can keep chatting by using your weekly limit."
-msgstr ""
-"일일 사용 한도에 도달했습니다. 주간 채팅 제한을 이용해서 채팅을 이어갈 수 있"
-"습니다."
+msgstr "일일 사용 한도에 도달했습니다. 주간 채팅 제한을 이용해서 채팅을 이어갈 수 있습니다."
 
 # smartling.placeholder_format=C
 #. The name of the Danish language
@@ -6044,7 +5938,7 @@ msgstr "30일 이상 지난 채팅 삭제"
 #. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
 msgctxt "Button text in the modal for deleting all recent chats"
 msgid "Delete Chats and Shared Links"
-msgstr ""
+msgstr "채팅 및 공유 링크 삭제"
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6171,9 +6065,8 @@ msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
 msgstr ""
-"링크를 삭제하면 더 이상 링크를 사용할 수 없습니다. 이미 링크를 열어서 해당 대"
-"화를 자신의 채팅에 추가한 사람은 자신이 추가한 사본을 계속 보유할 수 있습니"
-"다."
+"링크를 삭제하면 더 이상 링크를 사용할 수 없습니다. 이미 링크를 열어서 해당 대화를 자신의 채팅에 추가한 사람은 자신이 추가한 사본을 "
+"계속 보유할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6269,8 +6162,7 @@ msgstr "Duck.ai 받아쓰기"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr ""
-"당사는 받아쓰기 내용을 익명화하며, AI 모델 학습에 절대 사용하지 않습니다."
+msgstr "당사는 받아쓰기 내용을 익명화하며, AI 모델 학습에 절대 사용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6287,9 +6179,7 @@ msgstr "받아쓰기를 일시적으로 사용할 수 없습니다"
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
-msgstr ""
-"받아쓰기 기능은 OpenAI 모델을 사용하여 음성을 텍스트로 변환하므로, 직접 입력"
-"하지 않고도 Duck.ai에서 채팅을 할 수 있습니다."
+msgstr "받아쓰기 기능은 OpenAI 모델을 사용하여 음성을 텍스트로 변환하므로, 직접 입력하지 않고도 Duck.ai에서 채팅을 할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6463,7 +6353,7 @@ msgstr "프로모션 무시하기"
 #. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the close button on the survey banner"
 msgid "Dismiss survey"
-msgstr ""
+msgstr "설문조사 닫기"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6576,9 +6466,7 @@ msgstr "목록에 DuckDuckGo가 보이지 않으시나요?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr ""
-"파일을 찾을 수 없으신가요? %1$s%2$s%3$s여기를 클릭하여 다시 다운로드하세요."
-"%4$s"
+msgstr "파일을 찾을 수 없으신가요? %1$s%2$s%3$s여기를 클릭하여 다시 다운로드하세요.%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6616,8 +6504,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
-"AI를 원치 않으시나요? %1$snoai.duckduckgo.com%2$s은 AI 기능을 제공하지 않고 "
-"AI 이미지를 걸러냅니다. %3$s자세히 알아보세요%4$s"
+"AI를 원치 않으시나요? %1$snoai.duckduckgo.com%2$s은 AI 기능을 제공하지 않고 AI 이미지를 걸러냅니다. "
+"%3$s자세히 알아보세요%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6626,8 +6514,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"AI를 원치 않으시나요? %1$snoai.duckduckgo.com%2$s은 검색에 AI 기능을 사용하"
-"지 않고 AI 이미지를 걸러냅니다. %3$s자세히 알아보세요%4$s"
+"AI를 원치 않으시나요? %1$snoai.duckduckgo.com%2$s은 검색에 AI 기능을 사용하지 않고 AI 이미지를 걸러냅니다. "
+"%3$s자세히 알아보세요%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6742,9 +6630,7 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for "
 "ceiling fan repair services."
-msgstr ""
-"실링 팬 수리 업체에 보낼 견적 요청 이메일 초안을 간결하면서도 상세하게 작성하"
-"세요."
+msgstr "실링 팬 수리 업체에 보낼 견적 요청 이메일 초안을 간결하면서도 상세하게 작성하세요."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion asking for an email draft to a vendor requesting a quote for home refrigerator repair services.
@@ -6752,9 +6638,7 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
-msgstr ""
-"가정용 냉장고 수리 업체에 보낼 견적 요청 이메일 초안을 간결하면서도 상세하게 "
-"작성하세요."
+msgstr "가정용 냉장고 수리 업체에 보낼 견적 요청 이메일 초안을 간결하면서도 상세하게 작성하세요."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -6774,9 +6658,7 @@ msgctxt "Full sentence for drafting a social media post"
 msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
-msgstr ""
-"다가오는 파티에 사람들을 초대하기 위해 SNS에 올릴 글을 몇 가지 버전으로 작성"
-"하세요."
+msgstr "다가오는 파티에 사람들을 초대하기 위해 SNS에 올릴 글을 몇 가지 버전으로 작성하세요."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6784,9 +6666,7 @@ msgctxt "Full sentence for suggesting a blog post title"
 msgid ""
 "Draft a few options for a title of a post I’m writing about strategies to "
 "increase team collaboration."
-msgstr ""
-"팀 협업 강화 전략에 대해 내가 쓰고 있는 게시물의 제목을 여러 가지 버전으로 써"
-"보세요."
+msgstr "팀 협업 강화 전략에 대해 내가 쓰고 있는 게시물의 제목을 여러 가지 버전으로 써보세요."
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for drafting a social media post.
@@ -6918,9 +6798,8 @@ msgid ""
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
 msgstr ""
-"이제 내가 보고있는 페이지에 대해 궁금한 점이 있을 때 Duck.ai가 답해드릴 수 있"
-"습니다. 페이지 내용은 사용자가 첨부할 때만 포함됩니다. 또는 설정에서 페이지 "
-"자동 첨부를 선택하세요."
+"이제 내가 보고있는 페이지에 대해 궁금한 점이 있을 때 Duck.ai가 답해드릴 수 있습니다. 페이지 내용은 사용자가 첨부할 때만 "
+"포함됩니다. 또는 설정에서 페이지 자동 첨부를 선택하세요."
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6930,8 +6809,8 @@ msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
 msgstr ""
-"Duck.ai가 채팅을 저장하기 위해 로컬 저장소에 액세스할 수 없습니다. 브라우저 "
-"설정을 확인하거나 확장 프로그램을 비활성화한 후 다시 시도하세요."
+"Duck.ai가 채팅을 저장하기 위해 로컬 저장소에 액세스할 수 없습니다. 브라우저 설정을 확인하거나 확장 프로그램을 비활성화한 후 다시 "
+"시도하세요."
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6939,16 +6818,13 @@ msgctxt "Error message for service limit"
 msgid ""
 "Duck.ai has reached the maximum number of messages for one day. Please "
 "continue this chat tomorrow."
-msgstr ""
-"Duck.ai의 하루 메시지 전송 한도에 도달했습니다. 내일 대화를 이어가세요."
+msgstr "Duck.ai의 하루 메시지 전송 한도에 도달했습니다. 내일 대화를 이어가세요."
 
 # smartling.placeholder_format=C
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"Duck.ai는 개인정보가 보호되는 무료 브라우저 DuckDuckGo에서 최고 성능을 발휘합"
-"니다!"
+msgstr "Duck.ai는 개인정보가 보호되는 무료 브라우저 DuckDuckGo에서 최고 성능을 발휘합니다!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6957,9 +6833,7 @@ msgid ""
 "Duck.ai is created by DuckDuckGo. We're an independent online protection "
 "company for anyone who wants to take back control of their personal "
 "information."
-msgstr ""
-"Duck.ai를 만든 DuckDuckGo는 자신의 개인정보에 대한 통제권을 되찾고자 하는 사"
-"람들을 위한 독립된 온라인 보호 기업입니다."
+msgstr "Duck.ai를 만든 DuckDuckGo는 자신의 개인정보에 대한 통제권을 되찾고자 하는 사람들을 위한 독립된 온라인 보호 기업입니다."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6973,9 +6847,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
-msgstr ""
-"Duck.ai는 여전히 DuckDuckGo 제품이지만, 웹사이트 주소가 https://duck.ai로 기"
-"억하기 쉽게 바뀌었습니다."
+msgstr "Duck.ai는 여전히 DuckDuckGo 제품이지만, 웹사이트 주소가 https://duck.ai로 기억하기 쉽게 바뀌었습니다."
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6989,18 +6861,14 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
-msgstr ""
-"Duck.ai를 일시적으로 사용할 수 없습니다. 문제가 지속되면 이 익명 코드(%1$s)"
-"를 %2$s 이메일로 보내주세요"
+msgstr "Duck.ai를 일시적으로 사용할 수 없습니다. 문제가 지속되면 이 익명 코드(%1$s)를 %2$s 이메일로 보내주세요"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr ""
-"Duck.ai를 일시적으로 사용할 수 없습니다. 페이지를 새로고침한 후 다시 시도하세"
-"요."
+msgstr "Duck.ai를 일시적으로 사용할 수 없습니다. 페이지를 새로고침한 후 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7014,9 +6882,8 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"Duck.ai를 사용하면 인기 AI 모델과 비공개로 채팅할 수 있습니다. 이 기능을 끄"
-"면 Duck.ai 버튼과 링크가 숨겨지지만 %1$sduck.ai%2$s에 들어가서 직접 기능을 이"
-"용할 수 있습니다."
+"Duck.ai를 사용하면 인기 AI 모델과 비공개로 채팅할 수 있습니다. 이 기능을 끄면 Duck.ai 버튼과 링크가 숨겨지지만 "
+"%1$sduck.ai%2$s에 들어가서 직접 기능을 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7027,10 +6894,9 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai를 사용하면 OpenAI, Anthropic 등의 외부 AI 채팅 모델과 익명으로 대화"
-"할 수 있습니다. 이 설정을 끄면 DuckDuckGo Search에서 Duck.ai 버튼과 링크가 보"
-"이지 않습니다. 하지만 이 설정이 꺼져 있어도 %1$shttps://duck.ai%2$s에 바로 접"
-"속해서 Duck.ai를 이용할 수 있습니다."
+"Duck.ai를 사용하면 OpenAI, Anthropic 등의 외부 AI 채팅 모델과 익명으로 대화할 수 있습니다. 이 설정을 끄면 "
+"DuckDuckGo Search에서 Duck.ai 버튼과 링크가 보이지 않습니다. 하지만 이 설정이 꺼져 있어도 "
+"%1$shttps://duck.ai%2$s에 바로 접속해서 Duck.ai를 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -7044,9 +6910,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai might have lost your recent chats. You can still use Duck.ai as "
 "usual."
-msgstr ""
-"Duck.ai에서 나의 최근 채팅이 사라졌을 수 있습니다. Duck.ai는 평소처럼 사용하"
-"실 수 있습니다."
+msgstr "Duck.ai에서 나의 최근 채팅이 사라졌을 수 있습니다. Duck.ai는 평소처럼 사용하실 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -7083,8 +6947,7 @@ msgstr "Duck.ai가 업그레이드되었습니다!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.ai는 개인정보가 보호되는 무료 DuckDuckGo 앱에서 최고 성능을 발휘합니다!"
+msgstr "Duck.ai는 개인정보가 보호되는 무료 DuckDuckGo 앱에서 최고 성능을 발휘합니다!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7094,9 +6957,8 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, 비공개 AI 챗봇, 무료 AI 채팅, 익명 AI 채팅, 가입 필"
-"요 없는 AI 채팅, OpenAI, Anthropic, Llama, Mistral, 오픈 소스 AI 모델, 프라이"
-"버시 중심 AI, 계정 필요 없는 AI 채팅"
+"Duck.ai, DuckDuckGo AI, 비공개 AI 챗봇, 무료 AI 채팅, 익명 AI 채팅, 가입 필요 없는 AI 채팅, "
+"OpenAI, Anthropic, Llama, Mistral, 오픈 소스 AI 모델, 프라이버시 중심 AI, 계정 필요 없는 AI 채팅"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7124,11 +6986,9 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"DuckAssist는 일부 검색에 대하여 익명으로 정보를 조회하고 요약할 수 있습니다. "
-"DuckAssist 표시 빈도 선택 가능: 안 함(검색 결과에서 DuckAssist UI를 완전히 제"
-"거), 주문형(Assist 버튼을 클릭할 때만 표시), 가끔(관련성이 높은 경우에만 표"
-"시), 자주(광범위한 검색에서 더 자주 표시). 현재 DuckAssist 서비스는 미국(영"
-"어) 지역에서만 제공됩니다."
+"DuckAssist는 일부 검색에 대하여 익명으로 정보를 조회하고 요약할 수 있습니다. DuckAssist 표시 빈도 선택 가능: 안 "
+"함(검색 결과에서 DuckAssist UI를 완전히 제거), 주문형(Assist 버튼을 클릭할 때만 표시), 가끔(관련성이 높은 경우에만 "
+"표시), 자주(광범위한 검색에서 더 자주 표시). 현재 DuckAssist 서비스는 미국(영어) 지역에서만 제공됩니다."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7137,9 +6997,8 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist는 후속 질문에 답변할 수 없지만 OpenAI 및 Anthropic의 채팅 모델을 "
-"지원하는 비공개 AI 기반 채팅 서비스인 %1$sDuckDuckGo AI Chat%2$s도 제공합니"
-"다."
+"DuckAssist는 후속 질문에 답변할 수 없지만 OpenAI 및 Anthropic의 채팅 모델을 지원하는 비공개 AI 기반 채팅 "
+"서비스인 %1$sDuckDuckGo AI Chat%2$s도 제공합니다."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7148,9 +7007,8 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist는 후속 질문에 답변할 수 없지만 OpenAI 및 Anthropic의 채팅 모델을 "
-"지원하는 비공개 AI 기반 채팅 서비스인 DuckDuckGo %1$sAI Chat%2$s도 제공합니"
-"다."
+"DuckAssist는 후속 질문에 답변할 수 없지만 OpenAI 및 Anthropic의 채팅 모델을 지원하는 비공개 AI 기반 채팅 "
+"서비스인 DuckDuckGo %1$sAI Chat%2$s도 제공합니다."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7162,10 +7020,9 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist는 검색 질의에 익명으로 답변을 생성하는 새 기능입니다. Wikipedia와 "
-"관련 사이트에서 의미있는 콘텐츠를 검색한 다음 AI 기반 자연어 기술을 사용하여 "
-"해당 정보를 요약하는 방식으로 답변을 생성합니다. 현재 Wikipedia와 관련 내용"
-"을 기반으로 답변을 제공하며 정확성 검사는 하지 않습니다."
+"DuckAssist는 검색 질의에 익명으로 답변을 생성하는 새 기능입니다. Wikipedia와 관련 사이트에서 의미있는 콘텐츠를 검색한 "
+"다음 AI 기반 자연어 기술을 사용하여 해당 정보를 요약하는 방식으로 답변을 생성합니다. 현재 Wikipedia와 관련 내용을 기반으로 "
+"답변을 제공하며 정확성 검사는 하지 않습니다."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7179,21 +7036,17 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssist는 검색 질의에 익명으로 답변을 생성하는 옵션 기능입니다. 웹에서 관"
-"련 콘텐츠를 검색한 다음 AI 기반 자연어 기술을 사용하여, 검색된 관련 정보를 바"
-"탕으로 간단한 답변을 생성합니다. DuckAssist는 응답을 할 때 항상 출처 1~2개를 "
-"바로 링크하고 답변 출처를 인용하기 때문에 사용자가 쉽게 이동하여 더 자세한 정"
-"보를 얻을 수 있습니다. 답변은 인용된 출처와 %1$s웹 크롤링%2$s을 기반으로 자"
-"동 생성합니다."
+"DuckAssist는 검색 질의에 익명으로 답변을 생성하는 옵션 기능입니다. 웹에서 관련 콘텐츠를 검색한 다음 AI 기반 자연어 기술을 "
+"사용하여, 검색된 관련 정보를 바탕으로 간단한 답변을 생성합니다. DuckAssist는 응답을 할 때 항상 출처 1~2개를 바로 링크하고 "
+"답변 출처를 인용하기 때문에 사용자가 쉽게 이동하여 더 자세한 정보를 얻을 수 있습니다. 답변은 인용된 출처와 %1$s웹 크롤링%2$s을 "
+"기반으로 자동 생성합니다."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "DuckAssist responses are auto-generated based on listed sources and not "
 "checked for accuracy."
-msgstr ""
-"DuckAssist 응답은 나열된 소스를 기반으로 자동 생성하며 정확성을 확인하지 않습"
-"니다."
+msgstr "DuckAssist 응답은 나열된 소스를 기반으로 자동 생성하며 정확성을 확인하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -7201,9 +7054,7 @@ msgctxt "Error message for service limit"
 msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
-msgstr ""
-"하루에 보낼 수 있는 DuckDuckGo AI Chat 메시지 개수 한도에 도달했습니다. 이 채"
-"팅은 내일 계속하세요."
+msgstr "하루에 보낼 수 있는 DuckDuckGo AI Chat 메시지 개수 한도에 도달했습니다. 이 채팅은 내일 계속하세요."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7212,8 +7063,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat은 현재 %1$s의 %2$s, %3$s의 %4$s 채팅 모델을 지원하는 비공"
-"개 AI 기반 채팅 서비스입니다."
+"DuckDuckGo AI Chat은 현재 %1$s의 %2$s, %3$s의 %4$s 채팅 모델을 지원하는 비공개 AI 기반 채팅 "
+"서비스입니다."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7222,8 +7073,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat은 현재 %1$s의 %2$s, %3$s의 %4$s 채팅 모델을 지원하는 비공"
-"개 AI 기반 채팅 서비스입니다."
+"DuckDuckGo AI Chat은 현재 %1$s의 %2$s, %3$s의 %4$s 채팅 모델을 지원하는 비공개 AI 기반 채팅 "
+"서비스입니다."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -7231,9 +7082,7 @@ msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid ""
 "DuckDuckGo AI Chat is in Beta, it may display inaccurate or offensive "
 "information."
-msgstr ""
-"DuckDuckGo AI Chat은 베타 버전이므로 부정확하거나 불쾌한 정보가 표시될 수 있"
-"습니다."
+msgstr "DuckDuckGo AI Chat은 베타 버전이므로 부정확하거나 불쾌한 정보가 표시될 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat making it unavailable, and asking the user to send an email with a specific code if the error persists. E.g. 'DuckDuckGo AI Chat is temporarily unavailable. If this persists, please email this anonymous code abcdefg12345 to aichat-error@duckduckgo.com'
@@ -7241,9 +7090,7 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
-msgstr ""
-"DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 문제가 지속되면 이 익명 "
-"코드(%1$s)를 %2$s 이메일로 보내주세요"
+msgstr "DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 문제가 지속되면 이 익명 코드(%1$s)를 %2$s 이메일로 보내주세요"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7251,16 +7098,13 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr ""
-"DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 페이지를 새로고침한 후 다"
-"시 시도하세요."
+msgstr "DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 페이지를 새로고침한 후 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 잠시 후 다시 시도하세요."
+msgstr "DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 잠시 후 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7410,17 +7254,15 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"DuckDuckGo는 이름, 이메일 주소, 전화번호, 식별 가능한 메타데이터 같은 개인정"
-"보(PII)를 자동으로 제거해 이러한 보고서를 익명화합니다."
+"DuckDuckGo는 이름, 이메일 주소, 전화번호, 식별 가능한 메타데이터 같은 개인정보(PII)를 자동으로 제거해 이러한 보고서를 "
+"익명화합니다."
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
 msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
-msgstr ""
-"DuckDuckGo는 채팅을 익명으로 처리합니다. %1$s 클릭을 통해 Duck.ai의 %2$s에 동"
-"의합니다."
+msgstr "DuckDuckGo는 채팅을 익명으로 처리합니다. %1$s 클릭을 통해 Duck.ai의 %2$s에 동의합니다."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7428,9 +7270,7 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr ""
-"DuckDuckGo는 채팅을 익명으로 처리합니다. %1$s 클릭을 통해 DuckDuckGo의 %2$s"
-"에 동의합니다."
+msgstr "DuckDuckGo는 채팅을 익명으로 처리합니다. %1$s 클릭을 통해 DuckDuckGo의 %2$s에 동의합니다."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7439,8 +7279,8 @@ msgid ""
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
 msgstr ""
-"DuckDuckGo는 사용자가 방문하는 웹사이트의 추적기를 차단하며, 다른 웹사이트에"
-"서 사용자 추적을 시도하는 Google과 Facebook 등의 추적기도 차단합니다."
+"DuckDuckGo는 사용자가 방문하는 웹사이트의 추적기를 차단하며, 다른 웹사이트에서 사용자 추적을 시도하는 Google과 "
+"Facebook 등의 추적기도 차단합니다."
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7452,11 +7292,10 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo는 개인정보 보호를 위한 검색 엔진입니다. 위치 기능을 활성화하면 위"
-"치 정보는 로컬 기기에만 저장됩니다. 사용자가 검색을 하면 사용자의 기기는 해"
-"당 검색 정보를 DuckDuckGo로 전송하며, DuckDuckGo는 이를 검색 결과를 개선하는 "
-"데 사용한 후 즉시 폐기하여 사용자의 검색 기록을 남기지 않습니다. %1$s개인정보"
-"를 보호하기 위해 개발된 DuckDuckGo의 기술에 대해 자세히 알아보세요%2$s."
+"DuckDuckGo는 개인정보 보호를 위한 검색 엔진입니다. 위치 기능을 활성화하면 위치 정보는 로컬 기기에만 저장됩니다. 사용자가 "
+"검색을 하면 사용자의 기기는 해당 검색 정보를 DuckDuckGo로 전송하며, DuckDuckGo는 이를 검색 결과를 개선하는 데 사용한 "
+"후 즉시 폐기하여 사용자의 검색 기록을 남기지 않습니다. %1$s개인정보를 보호하기 위해 개발된 DuckDuckGo의 기술에 대해 자세히 "
+"알아보세요%2$s."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -7476,8 +7315,8 @@ msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
 msgstr ""
-"DuckDuckGo는 사용자의 대략적인 위치만 사용합니다. 이 정보만으로도 충분히 좋"
-"은 결과를 제공할 수 있습니다. %1$s자세히 알아보세요%2$s."
+"DuckDuckGo는 사용자의 대략적인 위치만 사용합니다. 이 정보만으로도 충분히 좋은 결과를 제공할 수 있습니다. %1$s자세히 "
+"알아보세요%2$s."
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7569,9 +7408,8 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"암호 제안 버튼을 클릭할 때마다 DuckDuckGo는 서버에서 무작위 단어로 조합된 긴 "
-"목록을 받습니다. 그러 다음 브라우저에서 목록에 포함된 4~5개의 무작위 단어를 "
-"선택하여 최소 18~20자 이상의 암호를 만듭니다."
+"암호 제안 버튼을 클릭할 때마다 DuckDuckGo는 서버에서 무작위 단어로 조합된 긴 목록을 받습니다. 그러 다음 브라우저에서 목록에 "
+"포함된 4~5개의 무작위 단어를 선택하여 최소 18~20자 이상의 암호를 만듭니다."
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7628,7 +7466,7 @@ msgstr "프롬프트 수정"
 #. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the message-editing text area"
 msgid "Edit message"
-msgstr ""
+msgstr "메시지 편집"
 
 # smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
@@ -7784,9 +7622,7 @@ msgstr "웹 검색 활성화"
 msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
-msgstr ""
-"보다 정확한 결과를 얻으려면 익명 위치 기능을 활성화하세요. 언제든지 설정을 변"
-"경할 수 있습니다."
+msgstr "보다 정확한 결과를 얻으려면 익명 위치 기능을 활성화하세요. 언제든지 설정을 변경할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7828,9 +7664,7 @@ msgctxt "precise_user_location"
 msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
-msgstr ""
-"익명 위치를 활성화하면 더 정확한 결과를 얻으면서도 사용자의 검색과 정확한 위"
-"치는 DuckDuckGo에 공개하지 않을 수 있습니다."
+msgstr "익명 위치를 활성화하면 더 정확한 결과를 얻으면서도 사용자의 검색과 정확한 위치는 DuckDuckGo에 공개하지 않을 수 있습니다."
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7854,7 +7688,7 @@ msgstr "암호화된 모델"
 #. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
 msgctxt "Share modal info bullet about encryption"
 msgid "Encrypted so DuckDuckGo can't read your chat."
-msgstr ""
+msgstr "암호화되어 DuckDuckGo도 채팅 내용을 읽을 수 없어요."
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -7997,9 +7831,7 @@ msgctxt "cloudsave"
 msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
-msgstr ""
-"새 암호를 입력하고 %1$s설정 저장%2$s을 클릭하거나 누르세요. 그러면 해당 데이"
-"터가 새 암호로 저장됩니다."
+msgstr "새 암호를 입력하고 %1$s설정 저장%2$s을 클릭하거나 누르세요. 그러면 해당 데이터가 새 암호로 저장됩니다."
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -8024,9 +7856,7 @@ msgstr "번역할 내용 입력하기"
 #. Instructions for how to change the default search engine.
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
-msgstr ""
-"다음 내용을 적어주세요: %1$s이름%2$s: DuckDuckGo%3$s URL%4$s: %5$s 닉네"
-"임%6$s: d%7$s"
+msgstr "다음 내용을 적어주세요: %1$s이름%2$s: DuckDuckGo%3$s URL%4$s: %5$s 닉네임%6$s: d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -8126,9 +7956,7 @@ msgstr "지도 확장하기"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr ""
-"개인 정보 보호를 덕히 중요하게 생각하는 사람들을 위해 전문성을 다해 만들었습"
-"니다."
+msgstr "개인 정보 보호를 덕히 중요하게 생각하는 사람들을 위해 전문성을 다해 만들었습니다."
 
 # smartling.placeholder_format=C
 #. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
@@ -8411,8 +8239,7 @@ msgstr "피드백이 성공적으로 전송되었습니다."
 msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
-msgstr ""
-"여러분이 주시는 피드백은 제품 업데이트와 개선에 직접적인 영향을 미칩니다."
+msgstr "여러분이 주시는 피드백은 제품 업데이트와 개선에 직접적인 영향을 미칩니다."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8420,9 +8247,7 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
-msgstr ""
-"여러분이 주시는 피드백은 제품 업데이트와 개선에 직접적인 영향을 미칩니다. 사"
-"용자님이 보내주신 문제도 해결하기 위해 노력하겠습니다."
+msgstr "여러분이 주시는 피드백은 제품 업데이트와 개선에 직접적인 영향을 미칩니다. 사용자님이 보내주신 문제도 해결하기 위해 노력하겠습니다."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -8512,16 +8337,13 @@ msgstr "이미지 검색 결과에서 AI가 생성한 이미지를 걸러냅니�
 msgctxt "settings"
 msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
-msgstr ""
-"이미지 검색 결과에서 AI가 생성한 이미지를 걸러냅니다. %1$s자세히 알아보기%2$s"
+msgstr "이미지 검색 결과에서 AI가 생성한 이미지를 걸러냅니다. %1$s자세히 알아보기%2$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
-msgstr ""
-"이미지 검색 결과에서 알려진 AI 스팸 사이트를 걸러냅니다. %1$s자세히 알아보세"
-"요%2$s"
+msgstr "이미지 검색 결과에서 알려진 AI 스팸 사이트를 걸러냅니다. %1$s자세히 알아보세요%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8562,8 +8384,7 @@ msgstr "다운로드 폴더에서 <b>%1$s</b> 파일을 찾으세요"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr ""
-"표시된 목록에서 DuckDuckGo를 찾아 %1$s기본값으로 설정%2$s을 클릭하세요."
+msgstr "표시된 목록에서 DuckDuckGo를 찾아 %1$s기본값으로 설정%2$s을 클릭하세요."
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8600,8 +8421,7 @@ msgstr "여러분과 보다 관련있는 결과를 찾아보세요."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr ""
-"내 주변 결과를 보세요. %1$s내 위치는 익명 비공개로 안전하게 유지됩니다."
+msgstr "내 주변 결과를 보세요. %1$s내 위치는 익명 비공개로 안전하게 유지됩니다."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8664,9 +8484,7 @@ msgstr "안개"
 msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
-msgstr ""
-"안내에 따라 DuckDuckGo의 광고 차단기를 끄세요. 메뉴 옵션을 선택하거나 버튼을 "
-"클릭해야 할 수도 있습니다."
+msgstr "안내에 따라 DuckDuckGo의 광고 차단기를 끄세요. 메뉴 옵션을 선택하거나 버튼을 클릭해야 할 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8683,7 +8501,7 @@ msgstr "후속 질문"
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
-msgstr ""
+msgstr "후속 질문은 비공개로 유지됩니다."
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8789,8 +8607,7 @@ msgstr "DuckDuckGo가 익명화하는 무료 비공개 채팅"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"DuckDuckGo가 익명화하는 무료 비공개 채팅입니다. 계정이 없어도 괜찮습니다."
+msgstr "DuckDuckGo가 익명화하는 무료 비공개 채팅입니다. 계정이 없어도 괜찮습니다."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8901,8 +8718,8 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Mac의 앱 메뉴 표시줄에서 <strong>DuckDuckGo</strong> &gt; <strong>업데이트 확"
-"인...</strong>을 선택한 후 <strong>업데이트 설치</strong>를 선택합니다."
+"Mac의 앱 메뉴 표시줄에서 <strong>DuckDuckGo</strong> &gt; <strong>업데이트 "
+"확인...</strong>을 선택한 후 <strong>업데이트 설치</strong>를 선택합니다."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9195,14 +9012,13 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr ""
-"DuckDuckGo VPN, 고급 Duck.ai, Identity Theft Restoration을 이용해 보세요."
+msgstr "DuckDuckGo VPN, 고급 Duck.ai, Identity Theft Restoration을 이용해 보세요."
 
 # smartling.placeholder_format=C
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
 msgctxt "Tooltip on the header logo for sunglasses searches"
 msgid "Get DuckDuckGo sunglasses and other gear."
-msgstr ""
+msgstr "DuckDuckGo 선글라스를 비롯한 굿즈를 만나보세요."
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9282,8 +9098,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, Personal Info Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"빠른 노로그 VPN, 옵션으로 제공되는 고급 AI 채팅, Personal Info Removal, "
-"Identity Theft Restoration을 이용해 보세요."
+"빠른 노로그 VPN, 옵션으로 제공되는 고급 AI 채팅, Personal Info Removal, Identity Theft "
+"Restoration을 이용해 보세요."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; 'advanced AI chat' refers to Duck.ai; Identity Theft Restoration is a bundled feature.
@@ -9291,9 +9107,7 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, and Identity Theft "
 "Restoration."
-msgstr ""
-"빠른 노로그 VPN, 옵션으로 제공되는 고급 AI 채팅, Identity Theft Restoration"
-"을 이용해 보세요."
+msgstr "빠른 노로그 VPN, 옵션으로 제공되는 고급 AI 채팅, Identity Theft Restoration을 이용해 보세요."
 
 # smartling.placeholder_format=C
 #. Description for the subscription modal where users can update their subscription to DuckDuckGo.
@@ -9301,9 +9115,7 @@ msgctxt "Description of the modal to upgrade the DuckDuckGo subscription"
 msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
-msgstr ""
-"VPN을 비롯한 프리미엄 개인 정보 보호 기능이 제공되는 DuckDuckGo를 구독해 "
-"Duck.ai의 고급 AI 모델을 이용하세요."
+msgstr "VPN을 비롯한 프리미엄 개인 정보 보호 기능이 제공되는 DuckDuckGo를 구독해 Duck.ai의 고급 AI 모델을 이용하세요."
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -9313,9 +9125,7 @@ msgctxt ""
 msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
-msgstr ""
-"VPN을 비롯한 프리미엄 개인 정보 보호 기능이 제공되는 DuckDuckGo 구독을 통해 "
-"Duck.ai의 고급 AI 모델을 이용하세요."
+msgstr "VPN을 비롯한 프리미엄 개인 정보 보호 기능이 제공되는 DuckDuckGo 구독을 통해 Duck.ai의 고급 AI 모델을 이용하세요."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9358,9 +9168,7 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
-msgstr ""
-"빠른 노로그 VPN, 옵션으로 이용 가능한 고급 AI 모델(채팅 한도 더 높음), 그 외 "
-"다양한 프리미엄 보호 기능을 이용해 보세요."
+msgstr "빠른 노로그 VPN, 옵션으로 이용 가능한 고급 AI 모델(채팅 한도 더 높음), 그 외 다양한 프리미엄 보호 기능을 이용해 보세요."
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9369,24 +9177,20 @@ msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, Personal Information Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"안전한 노로그 VPN, 고급 Duck.ai를 사용해 보세요. Personal Information "
-"Removal 및 Identity Theft Restoration을 이용해 보세요."
+"안전한 노로그 VPN, 고급 Duck.ai를 사용해 보세요. Personal Information Removal 및 Identity "
+"Theft Restoration을 이용해 보세요."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr ""
-"안전한 노로그 VPN, 고급 Duck.ai, Identity Theft Restoration 서비스를 이용해 "
-"보세요."
+msgstr "안전한 노로그 VPN, 고급 Duck.ai, Identity Theft Restoration 서비스를 이용해 보세요."
 
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
-msgstr ""
-"다운로드 한 번으로 브라우저에서 무료로 개인정보 보호 기능을 원활하게 이용할 "
-"수 있습니다."
+msgstr "다운로드 한 번으로 브라우저에서 무료로 개인정보 보호 기능을 원활하게 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -9422,8 +9226,7 @@ msgstr "앱 받기"
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
-msgstr ""
-"무료 DuckDuckGo 브라우저를 다운로드하여 %1$sYouTube 광고를 차단하세요.%2$s"
+msgstr "무료 DuckDuckGo 브라우저를 다운로드하여 %1$sYouTube 광고를 차단하세요.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9482,8 +9285,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & "
-"Backup › Sync With Another Device › Copy Text Code%4$s로 들어갑니다."
+"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & Backup › "
+"Sync With Another Device › Copy Text Code%4$s로 들어갑니다."
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9492,8 +9295,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & "
-"Backup › Sync With Another Device%4$s로 들어갑니다."
+"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & Backup › "
+"Sync With Another Device%4$s로 들어갑니다."
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9503,8 +9306,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & "
-"Backup › Sync With Another Device%4$s로 들어가서 코드 스캔:"
+"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & Backup › "
+"Sync With Another Device%4$s로 들어가서 코드 스캔:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9514,9 +9317,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & "
-"Backup › Sync With Another Device%4$s로 들어갑니다. 또는 복구 PDF에 있는 QR"
-"을 스캔하세요."
+"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & Backup › "
+"Sync With Another Device%4$s로 들어갑니다. 또는 복구 PDF에 있는 QR을 스캔하세요."
 
 # smartling.placeholder_format=C
 #. Path to the pairing code on the other device. Bold segments are UI path labels.
@@ -9540,9 +9342,7 @@ msgctxt "precise_user_location"
 msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
-msgstr ""
-"%1$s설정 > 개인 정보 보호 및 보안 > 위치 서비스%2$s로 이동하여 '위치 서비"
-"스'가 켜져 있는지 확인합니다."
+msgstr "%1$s설정 > 개인 정보 보호 및 보안 > 위치 서비스%2$s로 이동하여 '위치 서비스'가 켜져 있는지 확인합니다."
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -9550,9 +9350,7 @@ msgctxt "precise_user_location"
 msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
-msgstr ""
-"%1$s 설정 > 개인 정보 보호 > 권한 관리자 > 위치%2$s에서 화면을 내려 "
-"%3$sDuckDuckGo%4$s를 찾습니다."
+msgstr "%1$s 설정 > 개인 정보 보호 > 권한 관리자 > 위치%2$s에서 화면을 내려 %3$sDuckDuckGo%4$s를 찾습니다."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -10240,9 +10038,7 @@ msgctxt "settings"
 msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
-msgstr ""
-"중요한 정보를 더 빨리 찾는 데 도움이 되도록 Search Assist 답변의 주요 사실을 "
-"강조 표시합니다."
+msgstr "중요한 정보를 더 빨리 찾는 데 도움이 되도록 Search Assist 답변의 주요 사실을 강조 표시합니다."
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -10269,8 +10065,8 @@ msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
 msgstr ""
-"키보드의 %1$sReturn%2$s 키를 눌러 %3$sDuckDuckGo를 목록에 저장하세요. %4$s그"
-"런 다음 %5$s기본값으로 설정%6$s을 클릭하세요"
+"키보드의 %1$sReturn%2$s 키를 눌러 %3$sDuckDuckGo를 목록에 저장하세요. %4$s그런 다음 %5$s기본값으로 "
+"설정%6$s을 클릭하세요"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -10283,9 +10079,7 @@ msgstr "몽족어"
 msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
-msgstr ""
-"잠깐만요! 다시 변경하면 DuckDuckGo 확장 기능프로그램이 비활성화되어 개인정보 "
-"보호 기능을 사용할 수 없게 됩니다."
+msgstr "잠깐만요! 다시 변경하면 DuckDuckGo 확장 기능프로그램이 비활성화되어 개인정보 보호 기능을 사용할 수 없게 됩니다."
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -10334,9 +10128,7 @@ msgstr "더움"
 msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
-msgstr ""
-"호텔 광고 클릭은 Tripadvisor의 광고 네트워크에서 관리되며 사용자의 정보를 수"
-"집하는 데 사용되지 않습니다."
+msgstr "호텔 광고 클릭은 Tripadvisor의 광고 네트워크에서 관리되며 사용자의 정보를 수집하는 데 사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -10433,7 +10225,7 @@ msgstr "주요 기능 소개"
 #. Headline in chat history about modals for the temporary encrypted server storage explanation.
 msgctxt "Chat history about modal list item headline"
 msgid "How it works"
-msgstr ""
+msgstr "주요 기능 소개"
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -10604,9 +10396,7 @@ msgctxt "Full sentence for recommending a book"
 msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
-msgstr ""
-"바람의 이름이라는 책을 좋아합니다. 다른 재미있는 책/시리즈에는 무엇이 있으"
-"며, 그 이유는 무엇인가요?"
+msgstr "바람의 이름이라는 책을 좋아합니다. 다른 재미있는 책/시리즈에는 무엇이 있으며, 그 이유는 무엇인가요?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -10640,9 +10430,7 @@ msgctxt "precise_user_location"
 msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
-msgstr ""
-"여전히 브라우저 위치를 사용할 수 없는 경우 %1$s설정 > 일반 > 재설정 > 위치 "
-"및 개인정보 보호 재설정%2$s으로 이동하세요."
+msgstr "여전히 브라우저 위치를 사용할 수 없는 경우 %1$s설정 > 일반 > 재설정 > 위치 및 개인정보 보호 재설정%2$s으로 이동하세요."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10652,8 +10440,8 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"여전히 브라우저 위치를 사용할 수 없는 경우 브라우저에서 %1$s메뉴 > 설정 > 사"
-"이트 설정 > 위치%2$s로 이동하여 DuckDuckGo의 위치 접근을 허용하세요."
+"여전히 브라우저 위치를 사용할 수 없는 경우 브라우저에서 %1$s메뉴 > 설정 > 사이트 설정 > 위치%2$s로 이동하여 "
+"DuckDuckGo의 위치 접근을 허용하세요."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10667,9 +10455,7 @@ msgstr "이 오류가 계속되면 %1$s에 문의하세요."
 msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
-msgstr ""
-"만약 %1$sDuckDuckGo%2$s가 보이지 않는다면 %3$s기타 검색 엔진%4$s 목록에 추가"
-"해야 합니다."
+msgstr "만약 %1$sDuckDuckGo%2$s가 보이지 않는다면 %3$s기타 검색 엔진%4$s 목록에 추가해야 합니다."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -10677,9 +10463,7 @@ msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
-msgstr ""
-"채팅 또는 특정 채팅 응답에 대해 우려되는 부분이 있으면 %1$s 및 %2$s 지원 페이"
-"지에 직접 문의하실 수도 있습니다."
+msgstr "채팅 또는 특정 채팅 응답에 대해 우려되는 부분이 있으면 %1$s 및 %2$s 지원 페이지에 직접 문의하실 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10687,17 +10471,13 @@ msgctxt "Body for the Sync & Backup recovery code screen"
 msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
-msgstr ""
-"기기에 접근할 수 없게 되었을 때 저장된 채팅을 복구하려면 이 코드가 필요합니"
-"다. 이 코드를 기기에 텍스트 파일로 저장할 수 있습니다."
+msgstr "기기에 접근할 수 없게 되었을 때 저장된 채팅을 복구하려면 이 코드가 필요합니다. 이 코드를 기기에 텍스트 파일로 저장할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"저희를 계속 지원하고 싶으시다면, %1$sDuckDuckGo를 더 많은 사람들에게 소개해주"
-"세요%2$s"
+msgstr "저희를 계속 지원하고 싶으시다면, %1$sDuckDuckGo를 더 많은 사람들에게 소개해주세요%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10706,8 +10486,7 @@ msgstr ""
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr ""
-"JavaScript 없이 DuckDuckGo를 사용하려면 %1$s 또는 %2$s버전을 사용하세요."
+msgstr "JavaScript 없이 DuckDuckGo를 사용하려면 %1$s 또는 %2$s버전을 사용하세요."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10855,8 +10634,8 @@ msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
 msgstr ""
-"일부 이전 버전의 브라우저에서는 검색 결과 유출을 방지하기 위해 클릭한 정보가 "
-"서버를 통해 처리되도록 경로 변경이 필요합니다. %1$s자세히 알아보세요%2$s."
+"일부 이전 버전의 브라우저에서는 검색 결과 유출을 방지하기 위해 클릭한 정보가 서버를 통해 처리되도록 경로 변경이 필요합니다. "
+"%1$s자세히 알아보세요%2$s."
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -10866,9 +10645,7 @@ msgctxt ""
 msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
-msgstr ""
-"DuckDuckGo 브라우저에서 설정 > Sync & Backup으로 이동한 다음 “다른 장치와 동"
-"기화”로 이동하세요."
+msgstr "DuckDuckGo 브라우저에서 설정 > Sync & Backup으로 이동한 다음 “다른 장치와 동기화”로 이동하세요."
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -10882,9 +10659,7 @@ msgctxt "cloudsave"
 msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
-msgstr ""
-"투명성을 위해 이 정보는 암호화되지 않으며, 저장된 정보는 전부 사용자에게 공개"
-"됩니다."
+msgstr "투명성을 위해 이 정보는 암호화되지 않으며, 저장된 정보는 전부 사용자에게 공개됩니다."
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -11289,9 +11064,8 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"항목은 검색어와의 관련성에 따라 순위가 지정되며 Microsoft의 광고 네트워크를 "
-"통해 제공됩니다. 클릭하면 판매자 랜딩 페이지로 바로 연결되며, 광고와는 달리 "
-"DuckDuckGo는 이러한 결과에 대해 수익을 얻지 않습니다."
+"항목은 검색어와의 관련성에 따라 순위가 지정되며 Microsoft의 광고 네트워크를 통해 제공됩니다. 클릭하면 판매자 랜딩 페이지로 바로 "
+"연결되며, 광고와는 달리 DuckDuckGo는 이러한 결과에 대해 수익을 얻지 않습니다."
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -11299,8 +11073,7 @@ msgctxt "cloudsave"
 msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
-msgstr ""
-"임의의 문자 및 숫자 10개보다 단어 4~5개를 기억하는 것이 훨씬 쉽고 안전합니다."
+msgstr "임의의 문자 및 숫자 10개보다 단어 4~5개를 기억하는 것이 훨씬 쉽고 안전합니다."
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -11372,8 +11145,7 @@ msgstr "두 기기 모두에서 Sync & Backup을 열어둘 수 있습니다."
 msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Keep all your apps and online activity private on up to 5 devices at once."
-msgstr ""
-"한번에 최대 5대의 기기에서 모든 앱과 온라인 활동을 비공개로 유지하세요."
+msgstr "한번에 최대 5대의 기기에서 모든 앱과 온라인 활동을 비공개로 유지하세요."
 
 # smartling.placeholder_format=C
 #. An instruction to state that a list of companies/trackers will be updated with continued use
@@ -11867,7 +11639,7 @@ msgstr "링크가 7일 후 만료됩니다."
 #. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days. People can save a chat copy."
-msgstr ""
+msgstr "링크가 7일 후 만료됩니다. 링크를 받은 사람이 채팅 사본을 저장할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -12539,8 +12311,7 @@ msgstr "미크로네시아"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr ""
-"마이크 액세스가 거부되었습니다. 마이크 액세스를 허용하고 다시 시도하세요."
+msgstr "마이크 액세스가 거부되었습니다. 마이크 액세스를 허용하고 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -13324,10 +13095,8 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"사용자의 인터넷 연결이 끊겼을 때 채팅을 복원할 수 있도록, 전송된 새 프롬프트"
-"와 응답을 암호화하여 DuckDuckGo 서버에 임시로 저장합니다. 채팅 기록을 비활성"
-"화하면 고정된 채팅이 삭제되고, 새로운 프롬프트와 응답의 임시 저장이 중단됩니"
-"다."
+"사용자의 인터넷 연결이 끊겼을 때 채팅을 복원할 수 있도록, 전송된 새 프롬프트와 응답을 암호화하여 DuckDuckGo 서버에 임시로 "
+"저장합니다. 채팅 기록을 비활성화하면 고정된 채팅이 삭제되고, 새로운 프롬프트와 응답의 임시 저장이 중단됩니다."
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -13642,8 +13411,7 @@ msgstr "검색 결과가 없습니다."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr ""
-"음성이 감지되지 않았습니다. 다시 시도해 주세요. 마이크에 대고 말씀해 주세요."
+msgstr "음성이 감지되지 않았습니다. 다시 시도해 주세요. 마이크에 대고 말씀해 주세요."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -13988,7 +13756,7 @@ msgstr "확인"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "OPTIONAL"
-msgstr ""
+msgstr "선택 사항"
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -14155,9 +13923,7 @@ msgstr "요청 시"
 msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
-msgstr ""
-"Mac에서는 %1$sMaxthon > 환경설정%2$s을 클릭하고, Windows%3$s에서는 %4$s아이"
-"콘 > 설정을 클릭하세요.%5$s"
+msgstr "Mac에서는 %1$sMaxthon > 환경설정%2$s을 클릭하고, Windows%3$s에서는 %4$s아이콘 > 설정을 클릭하세요.%5$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -14166,8 +13932,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
 msgstr ""
-"다른 기기에서 %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup › Sync "
-"With Another Device%4$s로 들어가세요."
+"다른 기기에서 %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup › Sync With "
+"Another Device%4$s로 들어가세요."
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14176,8 +13942,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
 msgstr ""
-"다른 기기에서 %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup › Sync "
-"With Another Device%4$s로 들어가서 코드 스캔:"
+"다른 기기에서 %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup › Sync With "
+"Another Device%4$s로 들어가서 코드 스캔:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14186,8 +13952,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
-"다른 기기에서 %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup › Sync "
-"With Another Device%4$s로 들어가거나 복구 PDF에 있는 QR 코드를 스캔하세요."
+"다른 기기에서 %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup › Sync With "
+"Another Device%4$s로 들어가거나 복구 PDF에 있는 QR 코드를 스캔하세요."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14214,9 +13980,7 @@ msgctxt ""
 msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
-msgstr ""
-"첨부된 파일 중 하나가 지원 가능한 페이지 수를 초과합니다. %1$s페이지 이하의 "
-"파일을 업로드하세요."
+msgstr "첨부된 파일 중 하나가 지원 가능한 페이지 수를 초과합니다. %1$s페이지 이하의 파일을 업로드하세요."
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -14242,9 +14006,7 @@ msgctxt "cloudsave"
 msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
-msgstr ""
-"사용자가 변경한 설정만 저장됩니다. 자세한 내용은 %1$sURL 매개 변수%2$s 페이지"
-"를 참고하세요."
+msgstr "사용자가 변경한 설정만 저장됩니다. 자세한 내용은 %1$sURL 매개 변수%2$s 페이지를 참고하세요."
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -14258,8 +14020,7 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr ""
-"이런! 번역 중 예기치 않은 오류가 발생했습니다. 나중에 다시 시도해 주세요."
+msgstr "이런! 번역 중 예기치 않은 오류가 발생했습니다. 나중에 다시 시도해 주세요."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -14581,9 +14342,7 @@ msgctxt "homepage onboarding"
 msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
-msgstr ""
-"다른 검색 엔진은 시크릿 모드에서도 사용자를 추적하지만, DuckDuckGo는 절대로 "
-"추적하지 않습니다."
+msgstr "다른 검색 엔진은 시크릿 모드에서도 사용자를 추적하지만, DuckDuckGo는 절대로 추적하지 않습니다."
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -14596,18 +14355,14 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Our fast, no-log VPN comes with smarter AI chats with higher limits, plus "
 "more premium protections. All in one subscription."
-msgstr ""
-"빠른 노로그 VPN과 함께 더 높은 한도의 스마트한 AI 채팅, 그 외 다양한 프리미"
-"엄 보호 기능을 올인원 구독으로 이용해 보세요."
+msgstr "빠른 노로그 VPN과 함께 더 높은 한도의 스마트한 AI 채팅, 그 외 다양한 프리미엄 보호 기능을 올인원 구독으로 이용해 보세요."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
-msgstr ""
-"DuckDuckGo의 개인정보 보호정책은 간단합니다. 어떠한 개인 정보도 수집하거나 공"
-"유하지 않습니다."
+msgstr "DuckDuckGo의 개인정보 보호정책은 간단합니다. 어떠한 개인 정보도 수집하거나 공유하지 않습니다."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -14615,8 +14370,8 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"DuckDuckGo 모바일용 비공개 브라우저에는 검색 엔진, 추적 차단, 암호화 보호 강"
-"화 등의 기능이 탑재되어 있습니다. %1$siOS 및 Android%2$s에서 다운로드하세요."
+"DuckDuckGo 모바일용 비공개 브라우저에는 검색 엔진, 추적 차단, 암호화 보호 강화 등의 기능이 탑재되어 있습니다. %1$siOS "
+"및 Android%2$s에서 다운로드하세요."
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14868,9 +14623,7 @@ msgctxt "cloudsave"
 msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
-msgstr ""
-"해당 파일에는 사용자의 IP 주소, 브라우저 지문 또는 기타 정보가 연결되어 있지 "
-"않기 때문에 암호를 복구할 수 없습니다."
+msgstr "해당 파일에는 사용자의 IP 주소, 브라우저 지문 또는 기타 정보가 연결되어 있지 않기 때문에 암호를 복구할 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -15026,8 +14779,8 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
-"Personal Information Removal은 정보를 판매하는 데이터 브로커 사이트에서 사용"
-"자의 정보를 찾아내서 정보 삭제를 도와드립니다."
+"Personal Information Removal은 정보를 판매하는 데이터 브로커 사이트에서 사용자의 정보를 찾아내서 정보 삭제를 "
+"도와드립니다."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15098,9 +14851,8 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-"검색어를 완전한 문장 형태의 질문으로 작성하면 AI 지원 답변이 자동으로 나오고 "
-"답변 수준이 높아질 수 있습니다. 이 기능을 끄고 Assist 버튼을 숨기려면 %1$s검"
-"색 설정%2$s으로 들어가세요."
+"검색어를 완전한 문장 형태의 질문으로 작성하면 AI 지원 답변이 자동으로 나오고 답변 수준이 높아질 수 있습니다. 이 기능을 끄고 "
+"Assist 버튼을 숨기려면 %1$s검색 설정%2$s으로 들어가세요."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15109,9 +14861,8 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"검색어를 완전한 문장 형태의 질문으로 작성하면 DuckAssist가 나타나고 더 뛰어"
-"난 답을 얻을 가능성이 높아집니다. %1$sDuckAssist 설정%2$s에서 이 기능을 끄거"
-"나 작동 방식을 조정할 수 있습니다."
+"검색어를 완전한 문장 형태의 질문으로 작성하면 DuckAssist가 나타나고 더 뛰어난 답을 얻을 가능성이 높아집니다. "
+"%1$sDuckAssist 설정%2$s에서 이 기능을 끄거나 작동 방식을 조정할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15121,9 +14872,8 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"검색어를 완전한 문장 형태의 질문으로 작성하면, DuckAssist가 자동으로 나오고 "
-"더 좋은 답을 얻을 가능성이 높아집니다. 이 기능을 끄고 Assist 버튼을 감추려면 "
-"%1$sDuckAssist 설정%2$s을 방문하세요."
+"검색어를 완전한 문장 형태의 질문으로 작성하면, DuckAssist가 자동으로 나오고 더 좋은 답을 얻을 가능성이 높아집니다. 이 기능을 "
+"끄고 Assist 버튼을 감추려면 %1$sDuckAssist 설정%2$s을 방문하세요."
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -15155,9 +14905,7 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
-msgstr ""
-"GPT-5 mini, Claude Haiku 4.5, Mistral 등 인기 있는 AI를 선택하여 대화를 나눠"
-"보세요."
+msgstr "GPT-5 mini, Claude Haiku 4.5, Mistral 등 인기 있는 AI를 선택하여 대화를 나눠보세요."
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -15165,9 +14913,7 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, "
 "Mistral, etc."
-msgstr ""
-"GPT-5 mini, Claude Haiku 4.5, Mistral 등 인기 있는 AI를 선택하여 대화를 나눠"
-"보세요."
+msgstr "GPT-5 mini, Claude Haiku 4.5, Mistral 등 인기 있는 AI를 선택하여 대화를 나눠보세요."
 
 # smartling.placeholder_format=C
 #. The description of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -15175,9 +14921,7 @@ msgctxt "Third party map app picker"
 msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
-msgstr ""
-"목적지로 가능 방법을 확인할 서비스를 선택하세요. 외부 앱에서는 DuckDuckGo 보"
-"호 기능이 제공되지 않습니다."
+msgstr "목적지로 가능 방법을 확인할 서비스를 선택하세요. 외부 앱에서는 DuckDuckGo 보호 기능이 제공되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -15325,9 +15069,7 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
-msgstr ""
-"해당 프롬프트와 문제가 있는 산출물(개인 정보 제거)을 붙여 넣고, 콘텐츠가 유해"
-"하거나 불법적인 이유를 설명해 주세요."
+msgstr "해당 프롬프트와 문제가 있는 산출물(개인 정보 제거)을 붙여 넣고, 콘텐츠가 유해하거나 불법적인 이유를 설명해 주세요."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15335,9 +15077,7 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
-msgstr ""
-"해당 프롬프트와 문제가 있는 산출물(개인 정보 제거)을 붙여 넣고, 콘텐츠가 불법"
-"이거나 해로운 이유를 설명해 주세요."
+msgstr "해당 프롬프트와 문제가 있는 산출물(개인 정보 제거)을 붙여 넣고, 콘텐츠가 불법이거나 해로운 이유를 설명해 주세요."
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -15489,9 +15229,7 @@ msgstr "DuckDuckGo를 구독하면 더 많은 프리미엄 기능들도 따라�
 msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
-msgstr ""
-"또한 Duck Player에서 시청하는 콘텐츠는 YouTube의 추천에 영향을 미치지 않습니"
-"다."
+msgstr "또한 Duck Player에서 시청하는 콘텐츠는 YouTube의 추천에 영향을 미치지 않습니다."
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -15553,9 +15291,7 @@ msgstr "형식이 조악함"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
-msgstr ""
-"인기 있는 AI 모델을 사용할 수 있습니다. 계정이 없어도 괜찮습니다. DuckDuckGo"
-"가 익명화하는 채팅입니다."
+msgstr "인기 있는 AI 모델을 사용할 수 있습니다. 계정이 없어도 괜찮습니다. DuckDuckGo가 익명화하는 채팅입니다."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15992,8 +15728,7 @@ msgstr "DuckDuckGo는 절대 저장하지 않는 비공개 채팅"
 #. The device location shared is is not logged by us
 msgctxt "precise_user_location"
 msgid "Private to us and secured on your device"
-msgstr ""
-"DuckDuckGo에는 정보가 기록되지 않고 사용자의 기기에서 보안이 유지됩니다."
+msgstr "DuckDuckGo에는 정보가 기록되지 않고 사용자의 기기에서 보안이 유지됩니다."
 
 # smartling.placeholder_format=C
 #. Heading above the group of Pro-tier locked models in the model picker dropdown, when the user is on the Plus tier.
@@ -16065,9 +15800,7 @@ msgstr "재생하기 전에 물어보기"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"내 대략적인 위치를 사용하여 주변 결과를 표시하라는 메시지가 표시되도록 합니"
-"다."
+msgstr "내 대략적인 위치를 사용하여 주변 결과를 표시하라는 메시지가 표시되도록 합니다."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -16085,8 +15818,7 @@ msgstr "검색과 인터넷 이용 과정에서 데이터를 보호하세요."
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
-msgstr ""
-"검색하고, 인터넷을 이용하고 AI를 사용하는 과정에서 데이터를 보호하세요."
+msgstr "검색하고, 인터넷을 이용하고 AI를 사용하는 과정에서 데이터를 보호하세요."
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -16103,7 +15835,7 @@ msgstr "보호됨"
 #. Headline in sync-enabled chat history about modals explaining encrypted server storage.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Protected with end-to-end encryption"
-msgstr ""
+msgstr "종단간 암호화로 보호"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -16116,9 +15848,7 @@ msgctxt "Full sentence for critiquing writing"
 msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
-msgstr ""
-"다음 글을 더 간결하게 정리하기 위한 제안을 몇 가지 해주세요. [여기에 바로 입"
-"력]"
+msgstr "다음 글을 더 간결하게 정리하기 위한 제안을 몇 가지 해주세요. [여기에 바로 입력]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -16242,7 +15972,7 @@ msgstr "순위"
 #. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
 msgctxt "star rating on a product"
 msgid "Rated %s out of %s"
-msgstr ""
+msgstr "평점: %1$s/%2$s"
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -16341,8 +16071,7 @@ msgstr "추론을 통해 복잡한 질문에 대해 더 나은 답변을 얻을 
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
-msgstr ""
-"추론 기능이 더 뛰어나지만, 사용 한도에 2~5배 더 빠르게 도달합니다. %1$s"
+msgstr "추론 기능이 더 뛰어나지만, 사용 한도에 2~5배 더 빠르게 도달합니다. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
@@ -16397,9 +16126,7 @@ msgctxt "Description for recent chats feature"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr ""
-"최근 채팅은 DuckDuckGo 서버나 다른 원격 서버가 아닌 사용자의 기기 자체에 저장"
-"됩니다."
+msgstr "최근 채팅은 DuckDuckGo 서버나 다른 원격 서버가 아닌 사용자의 기기 자체에 저장됩니다."
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -16407,9 +16134,7 @@ msgctxt "Description of where recent chats are stored"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr ""
-"최근 채팅은 DuckDuckGo 서버나 다른 원격 서버가 아닌 사용자의 기기 자체에 저장"
-"됩니다."
+msgstr "최근 채팅은 DuckDuckGo 서버나 다른 원격 서버가 아닌 사용자의 기기 자체에 저장됩니다."
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -16419,9 +16144,8 @@ msgid ""
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
 msgstr ""
-"최근 채팅은 사용자의 기기에 직접 저장됩니다. 사용자의 인터넷 연결이 끊겼을 "
-"때 채팅을 복원할 수 있도록, 전송된 새 프롬프트와 응답을 암호화하여 "
-"DuckDuckGo 서버에 임시로 저장합니다."
+"최근 채팅은 사용자의 기기에 직접 저장됩니다. 사용자의 인터넷 연결이 끊겼을 때 채팅을 복원할 수 있도록, 전송된 새 프롬프트와 응답을 "
+"암호화하여 DuckDuckGo 서버에 임시로 저장합니다."
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -16702,9 +16426,7 @@ msgstr "Duck.ai를 다시 불러오기"
 msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
-msgstr ""
-"안내된 방법을 따르거나 브라우저에서 '새로고침' 또는 'Reload' 버튼을 눌러 "
-"DuckDuckGo를 새로고침하세요."
+msgstr "안내된 방법을 따르거나 브라우저에서 '새로고침' 또는 'Reload' 버튼을 눌러 DuckDuckGo를 새로고침하세요."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16811,18 +16533,14 @@ msgctxt "settings"
 msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
-msgstr ""
-"'Ask' 버튼을 제거하면 관련 검색 시 답변이 자동으로 표시됩니다. 캐시된 답변이 "
-"항상 자동으로 표시됩니다."
+msgstr "'Ask' 버튼을 제거하면 관련 검색 시 답변이 자동으로 표시됩니다. 캐시된 답변이 항상 자동으로 표시됩니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
-msgstr ""
-"'생성' 버튼을 제거하면 관련 검색 시 답변이 자동으로 표시됩니다. 캐시된 답변"
-"이 항상 자동으로 표시됩니다."
+msgstr "'생성' 버튼을 제거하면 관련 검색 시 답변이 자동으로 표시됩니다. 캐시된 답변이 항상 자동으로 표시됩니다."
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -16880,18 +16598,15 @@ msgid ""
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
 msgstr ""
-"보고서는 익명으로 제공되며, 검색 서비스 향상을 위해 DuckDuckGo로 전송됩니다. "
-"사용자님이 익명으로 보내주신 의견은 %1$s 사에도 서비스 개선을 위해 제공됩니"
-"다."
+"보고서는 익명으로 제공되며, 검색 서비스 향상을 위해 DuckDuckGo로 전송됩니다. 사용자님이 익명으로 보내주신 의견은 %1$s "
+"사에도 서비스 개선을 위해 제공됩니다."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
-msgstr ""
-"DuckDuckGo로 전송되는 보고서는 익명입니다. 피드백에 개인 정보나 식별 정보를 "
-"기재하지 마세요."
+msgstr "DuckDuckGo로 전송되는 보고서는 익명입니다. 피드백에 개인 정보나 식별 정보를 기재하지 마세요."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16900,9 +16615,8 @@ msgid ""
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo로 전송되는 보고서에는 사용자가 이 페이지를 불러오는 중 번역하도록 "
-"요청하는 모든 텍스트가 들어있으며, 이 텍스트는 익명 상태입니다. 피드백에 개"
-"인 정보나 식별 정보를 기재하지 마세요."
+"DuckDuckGo로 전송되는 보고서에는 사용자가 이 페이지를 불러오는 중 번역하도록 요청하는 모든 텍스트가 들어있으며, 이 텍스트는 "
+"익명 상태입니다. 피드백에 개인 정보나 식별 정보를 기재하지 마세요."
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -16994,9 +16708,8 @@ msgid ""
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
-"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적"
-"인 조언을 제공하기 위한 것이 아닙니다. AI 지원 답변에는 %1$s서비스 약관%2$s"
-"이 적용됩니다."
+"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적인 조언을 제공하기 위한 것이 아닙니다. AI 지원 "
+"답변에는 %1$s서비스 약관%2$s이 적용됩니다."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -17005,9 +16718,8 @@ msgid ""
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
 msgstr ""
-"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적"
-"인 조언을 제공하기 위한 것이 아닙니다. DuckAssist에는 %1$s서비스 약관%2$s이 "
-"적용됩니다."
+"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적인 조언을 제공하기 위한 것이 아닙니다. "
+"DuckAssist에는 %1$s서비스 약관%2$s이 적용됩니다."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -17017,10 +16729,8 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적"
-"인 조언을 제공하기 위한 것이 아닙니다. 웹 콘텐츠를 바탕으로 자동 생성된 응답"
-"이며 부정확한 내용이 섞여있을 수 있습니다. Search Assist에는 %1$s서비스 약"
-"관%2$s이 적용됩니다."
+"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적인 조언을 제공하기 위한 것이 아닙니다. 웹 콘텐츠를 "
+"바탕으로 자동 생성된 응답이며 부정확한 내용이 섞여있을 수 있습니다. Search Assist에는 %1$s서비스 약관%2$s이 적용됩니다."
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -17444,9 +17154,7 @@ msgctxt "Description for Chat History feature with Encrypted Storage option"
 msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
-msgstr ""
-"최근 채팅을 30개까지 기기에 로컬로 저장하며, 암호화된 저장소를 사용하면 더 많"
-"이 저장할 수도 있습니다."
+msgstr "최근 채팅을 30개까지 기기에 로컬로 저장하며, 암호화된 저장소를 사용하면 더 많이 저장할 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -17471,7 +17179,7 @@ msgstr "모든 기기에서 채팅 내용을 저장하세요."
 #. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
 msgctxt "Chat history about modal list item headline"
 msgid "Save your chats on this device"
-msgstr ""
+msgstr "이 기기에 채팅 내용을 저장하세요"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
@@ -17501,8 +17209,7 @@ msgstr "안녕하세요, Duck.ai입니다!"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr ""
-"DuckDuckGo가 선보이는 비공개 무료 AI 채팅 서비스, Duck.ai를 만나보세요."
+msgstr "DuckDuckGo가 선보이는 비공개 무료 AI 채팅 서비스, Duck.ai를 만나보세요."
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17619,9 +17326,7 @@ msgstr "아래로 스크롤하여 %1$s고급 설정 보기%2$s를 클릭하세�
 msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
-msgstr ""
-"아래로 스크롤하여 %1$s주소 표시줄에서 검색%2$s을 찾으세요. 그리고 %3$s변"
-"경%4$s(또는 %5$s새로 추가%6$s)을 클릭하세요."
+msgstr "아래로 스크롤하여 %1$s주소 표시줄에서 검색%2$s을 찾으세요. 그리고 %3$s변경%4$s(또는 %5$s새로 추가%6$s)을 클릭하세요."
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17629,9 +17334,7 @@ msgstr ""
 msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
-msgstr ""
-"아래로 스크롤하여 %1$s주소 표시줄에서 검색%2$s을 찾은 후 %3$s변경%4$s(또는 "
-"%5$s새로 추가%6$s)을 클릭하세요."
+msgstr "아래로 스크롤하여 %1$s주소 표시줄에서 검색%2$s을 찾은 후 %3$s변경%4$s(또는 %5$s새로 추가%6$s)을 클릭하세요."
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -17655,9 +17358,7 @@ msgstr "%1$sDuckDuckGo%2$s로 스크롤하여 사용자의 위치를 사용하�
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr ""
-"아래로 스크롤하여 %1$s서비스%2$s 섹션으로 이동한 후 %3$s주소 표시줄%4$s을 클"
-"릭하세요."
+msgstr "아래로 스크롤하여 %1$s서비스%2$s 섹션으로 이동한 후 %3$s주소 표시줄%4$s을 클릭하세요."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -17682,7 +17383,7 @@ msgctxt ""
 "Placeholder and accessibility label for the search input in the tab picker "
 "dialog"
 msgid "Search"
-msgstr ""
+msgstr "검색"
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -17719,12 +17420,10 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist는 검색 질의에 익명으로 답변을 생성하며, 이를 위해 웹에서 관련 "
-"콘텐츠를 검색한 다음 AI를 사용하여 간단한 답변을 생성합니다. 답변 표시 빈도"
-"는 사용자가 직접 선택할 수 있습니다. 안 함, 요청 시(검색 결과에서 Assist를 클"
-"릭했을 때만), 가끔(관련성이 높은 경우에만 표시), 자주(검색 결과가 광범위할 "
-"때 표시) 중 선택하세요. 현재 Search Assist는 영어를 사용하는 일부 지역에만 제"
-"공됩니다."
+"Search Assist는 검색 질의에 익명으로 답변을 생성하며, 이를 위해 웹에서 관련 콘텐츠를 검색한 다음 AI를 사용하여 간단한 "
+"답변을 생성합니다. 답변 표시 빈도는 사용자가 직접 선택할 수 있습니다. 안 함, 요청 시(검색 결과에서 Assist를 클릭했을 때만), "
+"가끔(관련성이 높은 경우에만 표시), 자주(검색 결과가 광범위할 때 표시) 중 선택하세요. 현재 Search Assist는 영어를 "
+"사용하는 일부 지역에만 제공됩니다."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -17732,8 +17431,8 @@ msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
 msgstr ""
-"Search Assist가 이 질문에 대한 답변을 생성하기에 위해 신뢰할 수 있는 정보를 "
-"충분히 찾지 못했습니다. 다른 검색을 시도해 보세요."
+"Search Assist가 이 질문에 대한 답변을 생성하기에 위해 신뢰할 수 있는 정보를 충분히 찾지 못했습니다. 다른 검색을 시도해 "
+"보세요."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -17742,9 +17441,8 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist는 검색 질의에 대해 익명으로 답변을 생성하는 옵션 기능이며, 이"
-"를 위해 %1$s웹에서 관련 콘텐츠를 스캔%2$s 한 다음 AI를 사용하여 찾은 정보를 "
-"기반으로 간단한 답변을 생성합니다."
+"Search Assist는 검색 질의에 대해 익명으로 답변을 생성하는 옵션 기능이며, 이를 위해 %1$s웹에서 관련 콘텐츠를 스캔%2$s "
+"한 다음 AI를 사용하여 찾은 정보를 기반으로 간단한 답변을 생성합니다."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -17865,8 +17563,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"다른 사이트에서 검색할 때 %1$s 단축 키를 사용하세요. '!w ducks'라고 입력하면 "
-"위키피디아에서 바로 'ducks'를 바로 검색합니다."
+"다른 사이트에서 검색할 때 %1$s 단축 키를 사용하세요. '!w ducks'라고 입력하면 위키피디아에서 바로 'ducks'를 바로 "
+"검색합니다."
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -17885,18 +17583,15 @@ msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
-"DuckDuckGo 앱 또는 확장 프로그램을 사용하여 비공개로 검색하거나, 자주 사용하"
-"는 브라우저에 비공개 웹 검색 기능을 설치하거나, %1$sduckduckgo.com%2$s에서 바"
-"로 검색하세요."
+"DuckDuckGo 앱 또는 확장 프로그램을 사용하여 비공개로 검색하거나, 자주 사용하는 브라우저에 비공개 웹 검색 기능을 설치하거나, "
+"%1$sduckduckgo.com%2$s에서 바로 검색하세요."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
 msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
-msgstr ""
-"검색 쿼리가 URL에 포함됩니다('꺼짐'으로 설정된 경우 검색 시 POST 요청을 사용"
-"합니다)."
+msgstr "검색 쿼리가 URL에 포함됩니다('꺼짐'으로 설정된 경우 검색 시 POST 요청을 사용합니다)."
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -17908,10 +17603,9 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"검색 설정은 비개인 브라우저 쿠키와 사용자의 브라우저 안에 있는 로컬 공간에 저"
-"장됩니다. 하지만 Cloud Save를 사용하여 클라우드 원격 서버에 설정을 익명으로 "
-"저장할 수도 있습니다. 클라우드에는 사용자의 개인 신원 정보가 저장되지 않으"
-"며, 암호가 브라우저 밖으로 유출되지 않습니다."
+"검색 설정은 비개인 브라우저 쿠키와 사용자의 브라우저 안에 있는 로컬 공간에 저장됩니다. 하지만 Cloud Save를 사용하여 클라우드 "
+"원격 서버에 설정을 익명으로 저장할 수도 있습니다. 클라우드에는 사용자의 개인 신원 정보가 저장되지 않으며, 암호가 브라우저 밖으로 "
+"유출되지 않습니다."
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -18013,9 +17707,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr ""
-"종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하"
-"고 모든 기기에 접근할 수 있습니다."
+msgstr "종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하고 모든 기기에 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -18023,9 +17715,7 @@ msgctxt "Description for encrypted storage feature"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr ""
-"종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하"
-"고 모든 기기에 접근할 수 있습니다."
+msgstr "종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하고 모든 기기에 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18033,9 +17723,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
-msgstr ""
-"종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하"
-"고 모든 동기화된 기기에 접근할 수 있습니다."
+msgstr "종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하고 모든 동기화된 기기에 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18043,9 +17731,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
-msgstr ""
-"종단간 암호화를 사용해 사용자의 채팅을 Duck.ai 서버에 안전하게 저장하고 모든 "
-"기기에 접근할 수 있습니다."
+msgstr "종단간 암호화를 사용해 사용자의 채팅을 Duck.ai 서버에 안전하게 저장하고 모든 기기에 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -18059,9 +17745,7 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
-msgstr ""
-"DuckDuckGo 서버에 안전하게 저장되며, 종단간 암호화가 적용됩니다. 회원님의 데"
-"이터는 본인 외에 누구도 볼 수 없습니다."
+msgstr "DuckDuckGo 서버에 안전하게 저장되며, 종단간 암호화가 적용됩니다. 회원님의 데이터는 본인 외에 누구도 볼 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
@@ -18211,9 +17895,7 @@ msgstr "Safari 메뉴에서 %1$s'이 웹사이트의 설정'%2$s을 선택하세
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
-msgstr ""
-"%1$s사용자 지정%2$s을 선택하고 입력 창에 %3$shttps://duckduckgo.com%4$s를 입"
-"력하세요."
+msgstr "%1$s사용자 지정%2$s을 선택하고 입력 창에 %3$shttps://duckduckgo.com%4$s를 입력하세요."
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -18277,18 +17959,14 @@ msgstr "드롭다운 메뉴에서 %1$s추가 기능 관리%2$s를 선택하세�
 #. Tells users where in the settings menu they can change their default search engine.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
-msgstr ""
-"Mac에서는 %1$sOpera > 환경설정%2$s을 선택하고, Windows에서는 %3$s메뉴 > 설"
-"정%4$s을 선택하세요."
+msgstr "Mac에서는 %1$sOpera > 환경설정%2$s을 선택하고, Windows에서는 %3$s메뉴 > 설정%4$s을 선택하세요."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
-msgstr ""
-"Mac에서는 %1$sOpera > 환경설정%2$s을 선택하고, Windows에서는 %3$sOpera > 옵"
-"션%4$s을 선택하세요."
+msgstr "Mac에서는 %1$sOpera > 환경설정%2$s을 선택하고, Windows에서는 %3$sOpera > 옵션%4$s을 선택하세요."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -18352,8 +18030,7 @@ msgstr "%1$s설정%2$s을 선택한 다음 %3$s검색 엔진%4$s을 선택하세
 msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
-msgstr ""
-"%1$s이 웹페이지를 홈 화면으로 사용%2$s을 선택하세요(다른 옵션도 선택 가능)."
+msgstr "%1$s이 웹페이지를 홈 화면으로 사용%2$s을 선택하세요(다른 옵션도 선택 가능)."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
@@ -18474,9 +18151,7 @@ msgid ""
 "Sends a prompt to AI models with your messages with instructions on how to "
 "respond. These instructions will apply to all of your conversations going "
 "forward."
-msgstr ""
-"AI 모델에 메시지와 응답 방법에 대한 지침을 프롬프트로 보냅니다. 이 지침은 앞"
-"으로 나와 나누는 모든 대화에 적용됩니다."
+msgstr "AI 모델에 메시지와 응답 방법에 대한 지침을 프롬프트로 보냅니다. 이 지침은 앞으로 나와 나누는 모든 대화에 적용됩니다."
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -18598,9 +18273,7 @@ msgctxt "Chat history about modal list item"
 msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
-msgstr ""
-"채팅 기록을 켜고 Sync & Backup을 설정하여 기기 간 채팅을 동기화된 상태로 유지"
-"하세요."
+msgstr "채팅 기록을 켜고 Sync & Backup을 설정하여 기기 간 채팅을 동기화된 상태로 유지하세요."
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -18680,9 +18353,7 @@ msgstr "공유"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"DuckDuckGo를 더 많은 친구들에게 알려서 개인정보를 보호할 수 있도록 도와주세"
-"요!"
+msgstr "DuckDuckGo를 더 많은 친구들에게 알려서 개인정보를 보호할 수 있도록 도와주세요!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -18709,8 +18380,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"관련성을 높이기 위해, 어느 도시에 있는지 AI 모델에 알려주세요. Duck.ai는 사용"
-"자의 정확한 위치를 우리에게나 AI 모델에게나 절대 공개하지 않습니다."
+"관련성을 높이기 위해, 어느 도시에 있는지 AI 모델에 알려주세요. Duck.ai는 사용자의 정확한 위치를 우리에게나 AI 모델에게나 "
+"절대 공개하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -18805,8 +18476,7 @@ msgctxt ""
 msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
-msgstr ""
-"DuckDuckGo에 프롬프트 및 채팅 응답 공유하기(불법적이고 유해한 신고에 필요)"
+msgstr "DuckDuckGo에 프롬프트 및 채팅 응답 공유하기(불법적이고 유해한 신고에 필요)"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -18832,9 +18502,7 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Shield your online activity with our no-log, fast VPN. Simple to set up and "
 "easy to turn on and off anytime."
-msgstr ""
-"로그를 남기지 않는 빠른 VPN으로 온라인 활동을 보호하세요. 설정이 간편하고 언"
-"제든 쉽게 켜고 끌 수 있어요."
+msgstr "로그를 남기지 않는 빠른 VPN으로 온라인 활동을 보호하세요. 설정이 간편하고 언제든 쉽게 켜고 끌 수 있어요."
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -18852,7 +18520,7 @@ msgstr "구매"
 #. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
 msgctxt "Button in the merchandise logo modal (mobile)"
 msgid "Shop Now"
-msgstr ""
+msgstr "지금 구매"
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -19198,17 +18866,15 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
 msgstr ""
-"DuckDuckGo의 모든 검색은 항상 비공개라는 알림을 표시합니다. 이 기능을 끄면 알"
-"림을 숨기며 검색 개인정보에는 영향을 주지 않습니다."
+"DuckDuckGo의 모든 검색은 항상 비공개라는 알림을 표시합니다. 이 기능을 끄면 알림을 숨기며 검색 개인정보에는 영향을 주지 "
+"않습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
-msgstr ""
-"DuckDuckGo의 검색은 항상 보호 받는다는 알림을 표시합니다. 이 기능을 끄면 알림"
-"만 감춰지고, 검색 보호에는 영향이 가지 않습니다."
+msgstr "DuckDuckGo의 검색은 항상 보호 받는다는 알림을 표시합니다. 이 기능을 끄면 알림만 감춰지고, 검색 보호에는 영향이 가지 않습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19353,8 +19019,7 @@ msgstr "사이트 이름"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr ""
-"사이트 검색을 일시적으로 사용할 수 없습니다. 현재 문제를 해결하고 있습니다."
+msgstr "사이트 검색을 일시적으로 사용할 수 없습니다. 현재 문제를 해결하고 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19586,8 +19251,7 @@ msgctxt "Error message when an uploaded image cannot be decoded or processed"
 msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
-msgstr ""
-"업로드하신 이미지를 처리할 수 없습니다. 다른 이미지나 형식을 사용해 보세요."
+msgstr "업로드하신 이미지를 처리할 수 없습니다. 다른 이미지나 형식을 사용해 보세요."
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -19595,9 +19259,7 @@ msgctxt "Description for the wrong code error screen"
 msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
-msgstr ""
-"죄송합니다. 이 코드는 유효하지 않습니다. 코드를 정확하게 입력했거나 스캔했는"
-"지 확인하세요."
+msgstr "죄송합니다. 이 코드는 유효하지 않습니다. 코드를 정확하게 입력했거나 스캔했는지 확인하세요."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19611,9 +19273,7 @@ msgctxt "noresults"
 msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
-msgstr ""
-"죄송하지만 이 결과를 표시하는 동안 오류가 생겼습니다. 다시 시도하려면 %1$s여"
-"기를 클릭%2$s하세요."
+msgstr "죄송하지만 이 결과를 표시하는 동안 오류가 생겼습니다. 다시 시도하려면 %1$s여기를 클릭%2$s하세요."
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
@@ -19673,8 +19333,7 @@ msgstr "원문 지움"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr ""
-"원본이 너무 길어서 요약할 수 없습니다. 길이를 줄여서 다시 시도해 보세요."
+msgstr "원본이 너무 길어서 요약할 수 없습니다. 길이를 줄여서 다시 시도해 보세요."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -20023,9 +19682,7 @@ msgctxt "Description prompting subscription for higher limits"
 msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
-msgstr ""
-"DuckDuckGo를 구독해서 Duck.ai 한도를 높이거나, 나중에 돌아와서 이미지를 더 많"
-"이 만들어 보세요."
+msgstr "DuckDuckGo를 구독해서 Duck.ai 한도를 높이거나, 나중에 돌아와서 이미지를 더 많이 만들어 보세요."
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -20491,7 +20148,7 @@ msgctxt "Chat history with sync modal list item description"
 msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
-msgstr ""
+msgstr "Sync & Backup을 사용하면 더 많은 채팅을 저장하고 모든 기기에서 동기화할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20540,13 +20197,11 @@ msgid ""
 msgstr ""
 "동기화 복구 코드\n"
 "\n"
-"복구 코드를 사용하면 여러 장치에서 비밀번호, 자동 입력 데이터 및 Duck.ai 채팅"
-"을 동기화할 수 있으며, 장치에 액세스할 수 없는 경우 동기화된 데이터를 복구할 "
-"수 있습니다.\n"
+"복구 코드를 사용하면 여러 장치에서 비밀번호, 자동 입력 데이터 및 Duck.ai 채팅을 동기화할 수 있으며, 장치에 액세스할 수 없는 "
+"경우 동기화된 데이터를 복구할 수 있습니다.\n"
 "\n"
 "이 정보를 안전하게 보관하세요.\n"
-"이 코드에 액세스할 수 있는 모든 사람이 동기화된 데이터에 액세스할 수 있습니"
-"다.\n"
+"이 코드에 액세스할 수 있는 모든 사람이 동기화된 데이터에 액세스할 수 있습니다.\n"
 "\n"
 "%1$s\n"
 "\n"
@@ -20555,8 +20210,8 @@ msgstr ""
 "2. \"Sync & Backup\"를 선택한 다음, \"동기화된 데이터 복구\"를 선택합니다.\n"
 "3. 위 복구 코드를 복사하여 \"여기에 코드 붙여넣기\"에 붙여넣습니다.\n"
 "\n"
-"Sync & Backup이 활성화된 상태에서 DuckDuckGo 브라우저를 18개월 이상 사용하지 "
-"않으면 서버에서 데이터가 삭제되어 복원할 수 없습니다."
+"Sync & Backup이 활성화된 상태에서 DuckDuckGo 브라우저를 18개월 이상 사용하지 않으면 서버에서 데이터가 삭제되어 "
+"복원할 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -20610,7 +20265,7 @@ msgstr "모든 기기에서 채팅을 동기화하세요."
 #. Headline in sync-enabled chat history about modals explaining cross-device sync.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Sync your chats across all your devices"
-msgstr ""
+msgstr "모든 기기에서 채팅을 동기화하세요."
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -20694,9 +20349,7 @@ msgctxt "Product-tour success modal body - mobile variant"
 msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
-msgstr ""
-"어디서나 Duck.ai를 이용해 보세요. 어디서든 더 빠르게 이용할 수 있도록 무료 앱"
-"에 내장하세요."
+msgstr "어디서나 Duck.ai를 이용해 보세요. 어디서든 더 빠르게 이용할 수 있도록 무료 앱에 내장하세요."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20704,9 +20357,7 @@ msgctxt "Product-tour success modal body"
 msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
-msgstr ""
-"어디서나 Duck.ai를 이용해 보세요. 어디서 웹서핑을 하든 더 빠르게 이용할 수 있"
-"도록 무료 브라우저에 내장하세요."
+msgstr "어디서나 Duck.ai를 이용해 보세요. 어디서 웹서핑을 하든 더 빠르게 이용할 수 있도록 무료 브라우저에 내장하세요."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20950,9 +20601,8 @@ msgid ""
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
 msgstr ""
-"이는 사용자의 기기와 이 링크 뒤의 웹 페이지 사이에 전송되는 정보를 제삼자가 "
-"가로챌 위험이 높아짐을 의미합니다. 드문 경우이지만 비밀번호 또는 결제 세부 정"
-"보가 이에 포함됩니다."
+"이는 사용자의 기기와 이 링크 뒤의 웹 페이지 사이에 전송되는 정보를 제삼자가 가로챌 위험이 높아짐을 의미합니다. 드문 경우이지만 "
+"비밀번호 또는 결제 세부 정보가 이에 포함됩니다."
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -20960,9 +20610,7 @@ msgctxt "cloudsave"
 msgid ""
 "The Cloud Save bookmarklet allows any changes you make to your settings to "
 "automatically save in the cloud."
-msgstr ""
-"Cloud Save 북마클릿을 사용하면 설정에 대한 모든 변경 사항을 클라우드에 자동으"
-"로 저장할 수 있습니다."
+msgstr "Cloud Save 북마클릿을 사용하면 설정에 대한 모든 변경 사항을 클라우드에 자동으로 저장할 수 있습니다."
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -20991,8 +20639,7 @@ msgctxt "Second paragraph for the Sync & Backup intro screen"
 msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
-msgstr ""
-"암호화 키는 브라우저의 로컬 저장소에만 저장되며, 본인만 접근할 수 있습니다."
+msgstr "암호화 키는 브라우저의 로컬 저장소에만 저장되며, 본인만 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider deletes all chat data within 30 days.
@@ -21071,9 +20718,7 @@ msgctxt "Error message when there was an issue saving a chat to the browser"
 msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
-msgstr ""
-"이 채팅을 로컬에 저장하는 중 오류가 발생했습니다. 로컬 데이터 저장 공간이 활"
-"성화되어 있는지 브라우저 설정에서 확인하세요."
+msgstr "이 채팅을 로컬에 저장하는 중 오류가 발생했습니다. 로컬 데이터 저장 공간이 활성화되어 있는지 브라우저 설정에서 확인하세요."
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -21087,8 +20732,7 @@ msgctxt "noresults"
 msgid ""
 "There was still an error displaying the search results. Please wait a few "
 "minutes before you try again."
-msgstr ""
-"검색 결과를 표시하는 중에 오류가 발생했습니다. 몇 분 후 다시 시도해 주세요."
+msgstr "검색 결과를 표시하는 중에 오류가 발생했습니다. 몇 분 후 다시 시도해 주세요."
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
@@ -21107,9 +20751,8 @@ msgid ""
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
 msgstr ""
-"이 브라우저 권한은 숨겨진 추적기를 차단하고, 가능한 경우 연결을 암호화하고, "
-"DuckDuckGo를 기본 검색 엔진으로 설정하여 방문하는 웹사이트의 개인정보 보호를 "
-"강화하는 데 적용됩니다."
+"이 브라우저 권한은 숨겨진 추적기를 차단하고, 가능한 경우 연결을 암호화하고, DuckDuckGo를 기본 검색 엔진으로 설정하여 방문하는 "
+"웹사이트의 개인정보 보호를 강화하는 데 적용됩니다."
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -21146,9 +20789,7 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr ""
-"이 AI 모델은 더 이상 이용할 수 없습니다. 다른 모델로 새로 채팅을 시작해 보세"
-"요."
+msgstr "이 AI 모델은 더 이상 이용할 수 없습니다. 다른 모델로 새로 채팅을 시작해 보세요."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -21156,9 +20797,7 @@ msgctxt "AI Chat: Error message for when a model is deprecated"
 msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
-msgstr ""
-"이 AI 모델 버전은 더 이상 지원되지 않습니다. 이 모델의 최신 버전으로 새 채팅"
-"을 시작해 보세요."
+msgstr "이 AI 모델 버전은 더 이상 지원되지 않습니다. 이 모델의 최신 버전으로 새 채팅을 시작해 보세요."
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -21192,13 +20831,13 @@ msgctxt ""
 msgid ""
 "This chat and its generated images become public when you create and copy "
 "the link."
-msgstr ""
+msgstr "링크를 생성하고 복사하면 이 채팅과 생성된 이미지가 공개됩니다."
 
 # smartling.placeholder_format=C
 #. Explains that creating and copying a share link makes the selected chat content public.
 msgctxt "Share modal info bullet about public access"
 msgid "This chat becomes public when you create and copy the link."
-msgstr ""
+msgstr "링크를 생성하고 복사하면 이 채팅이 공개됩니다."
 
 # smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
@@ -21213,8 +20852,8 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"이 대화는 %2$s의 %3$s 모델을 사용하여 Duck.ai(%1$s)로 생성되었습니다. AI 채팅"
-"은 부정확하거나 공격적인 정보를 보여줄 수 있습니다(자세한 내용은 %4$s 참조)."
+"이 대화는 %2$s의 %3$s 모델을 사용하여 Duck.ai(%1$s)로 생성되었습니다. AI 채팅은 부정확하거나 공격적인 정보를 보여줄 "
+"수 있습니다(자세한 내용은 %4$s 참조)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21224,8 +20863,8 @@ msgid ""
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"이 대화는 여러 채팅 모델을 사용하여 Duck.ai(%1$s)로 생성되었습니다. AI 채팅"
-"은 부정확하거나 공격적인 정보를 보여줄 수 있습니다(자세한 내용은 %2$s 참조)."
+"이 대화는 여러 채팅 모델을 사용하여 Duck.ai(%1$s)로 생성되었습니다. AI 채팅은 부정확하거나 공격적인 정보를 보여줄 수 "
+"있습니다(자세한 내용은 %2$s 참조)."
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21234,8 +20873,8 @@ msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
 msgstr ""
-"이 대화는 Duck.ai 음성 채팅(%1$s)으로 생성되었습니다. AI가 부정확하거나 불쾌"
-"한 정보를 제공할 수 있습니다(자세한 내용은 %2$s 참고)."
+"이 대화는 Duck.ai 음성 채팅(%1$s)으로 생성되었습니다. AI가 부정확하거나 불쾌한 정보를 제공할 수 있습니다(자세한 내용은 "
+"%2$s 참고)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -21245,9 +20884,8 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"이 대화는 %2$s의 %3$s 모델을 사용하여 DuckDuckGo AI Chat(%1$s)으로 생성되었습"
-"니다. AI 채팅은 부정확하거나 공격적인 정보를 보여줄 수 있습니다(자세한 내용"
-"은 %4$s 참조)."
+"이 대화는 %2$s의 %3$s 모델을 사용하여 DuckDuckGo AI Chat(%1$s)으로 생성되었습니다. AI 채팅은 부정확하거나 "
+"공격적인 정보를 보여줄 수 있습니다(자세한 내용은 %4$s 참조)."
 
 # smartling.placeholder_format=C
 #. Renders to the right of the device name for the row that matches this device's id.
@@ -21263,9 +20901,7 @@ msgctxt ""
 msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
-msgstr ""
-"이 기기는 앞으로 다른 기기에서 동기화된 데이터에 접근할 수 없습니다. 마지막 "
-"채팅 %1$s개는 로컬 저장소에 남습니다."
+msgstr "이 기기는 앞으로 다른 기기에서 동기화된 데이터에 접근할 수 없습니다. 마지막 채팅 %1$s개는 로컬 저장소에 남습니다."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21336,16 +20972,14 @@ msgstr "이 이미지를 만들 수 없습니다."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr ""
-"이 이미지 유형은 지원되지 않으니 JPG, PNG, WebP, GIF 중 하나로 첨부하세요"
+msgstr "이 이미지 유형은 지원되지 않으니 JPG, PNG, WebP, GIF 중 하나로 첨부하세요"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr ""
-"이 이미지 유형은 지원되지 않으니 JPG, PNG, WebP, GIF 중 하나로 첨부하세요."
+msgstr "이 이미지 유형은 지원되지 않으니 JPG, PNG, WebP, GIF 중 하나로 첨부하세요."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -21364,9 +20998,7 @@ msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
-msgstr ""
-"샘플 채팅입니다. 메뉴(점 3개)를 열고 '고정'을 선택하여 채팅 목록 맨 위에 계"
-"속 표시되도록 하세요."
+msgstr "샘플 채팅입니다. 메뉴(점 3개)를 열고 '고정'을 선택하여 채팅 목록 맨 위에 계속 표시되도록 하세요."
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -21374,8 +21006,7 @@ msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
-msgstr ""
-"샘플 채팅입니다. 측면 메뉴에 있는 Fire Button을 사용하여 삭제해 보세요!"
+msgstr "샘플 채팅입니다. 측면 메뉴에 있는 Fire Button을 사용하여 삭제해 보세요!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -21395,9 +21026,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
-msgstr ""
-"이 모델 제공사는 이 채팅과 관련된 데이터를 30일 이내에 삭제합니다. 다른 모델 "
-"제공사는 데이터를 보유하지 않는 모델을 따릅니다."
+msgstr "이 모델 제공사는 이 채팅과 관련된 데이터를 30일 이내에 삭제합니다. 다른 모델 제공사는 데이터를 보유하지 않는 모델을 따릅니다."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -21405,9 +21034,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
-msgstr ""
-"이 모델 제공사는 이 채팅과 관련된 데이터를 저장하지 않습니다. 다른 모델 제공"
-"사는 데이터를 제한적으로 보유하는 모델을 따릅니다."
+msgstr "이 모델 제공사는 이 채팅과 관련된 데이터를 저장하지 않습니다. 다른 모델 제공사는 데이터를 제한적으로 보유하는 모델을 따릅니다."
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -21443,9 +21070,7 @@ msgctxt "First paragraph for the Sync & Backup intro screen"
 msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
-msgstr ""
-"이렇게 하면 채팅이 DuckDuckGo의 보안 서버에 종단간 암호화로 저장되며, 나중에 "
-"모든 브라우저에서 접근할 수 있습니다."
+msgstr "이렇게 하면 채팅이 DuckDuckGo의 보안 서버에 종단간 암호화로 저장되며, 나중에 모든 브라우저에서 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21453,9 +21078,7 @@ msgctxt "duckassist"
 msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
-msgstr ""
-"이 설정은 브라우저에 저장됩니다. 따라서 duckduckgo.com 브라우저 데이터를 지우"
-"면 AI 지원 답변이 다시 표시될 수 있습니다."
+msgstr "이 설정은 브라우저에 저장됩니다. 따라서 duckduckgo.com 브라우저 데이터를 지우면 AI 지원 답변이 다시 표시될 수 있습니다."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21465,9 +21088,8 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"이 설정은 브라우저에 저장됩니다. 따라서 duckduckgo.com 브라우저 데이터를 지우"
-"면 AI 지원 답변이 다시 표시될 수 있습니다. 하지만 AI 지원 답변이 절대 표시되"
-"지 않는 시작 페이지(%1$s)도 있습니다."
+"이 설정은 브라우저에 저장됩니다. 따라서 duckduckgo.com 브라우저 데이터를 지우면 AI 지원 답변이 다시 표시될 수 있습니다. "
+"하지만 AI 지원 답변이 절대 표시되지 않는 시작 페이지(%1$s)도 있습니다."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
@@ -21502,17 +21124,13 @@ msgstr "이 번역은 잘못되었습니다."
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"아직 현재 페이지에서는 이 동영상을 재생할 수 없습니다. %1$s에서 직접 시청할 "
-"수 있습니다."
+msgstr "아직 현재 페이지에서는 이 동영상을 재생할 수 없습니다. %1$s에서 직접 시청할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"이 웹사이트는 사용자를 안전하게 보호하고 통신을 암호화하는 HTTPS 프로토콜을 "
-"사용하지 않고 있습니다."
+msgstr "이 웹사이트는 사용자를 안전하게 보호하고 통신을 암호화하는 HTTPS 프로토콜을 사용하지 않고 있습니다."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21522,9 +21140,8 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"이렇게 하면 이 브라우저에서 Duck.ai 채팅이 모두 삭제되고 Sync & Backup 연결"
-"이 끊깁니다. Sync & Backup에 연결된 다른 브라우저에서는 계속 채팅을 볼 수 있"
-"습니다."
+"이렇게 하면 이 브라우저에서 Duck.ai 채팅이 모두 삭제되고 Sync & Backup 연결이 끊깁니다. Sync & Backup에 "
+"연결된 다른 브라우저에서는 계속 채팅을 볼 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -21532,9 +21149,7 @@ msgctxt "Body text for clear all recent chats confirmation modal"
 msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
-msgstr ""
-"이렇게 하면 고정된 채팅을 제외한 최근 채팅이 전부 삭제됩니다. 이 작업은 되돌"
-"릴 수 없습니다."
+msgstr "이렇게 하면 고정된 채팅을 제외한 최근 채팅이 전부 삭제됩니다. 이 작업은 되돌릴 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -21626,9 +21241,7 @@ msgstr "팁"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr ""
-"개인 정보를 추적하는 웹사이트가 지긋지긋하시다고요? %1$s저희가 도와드리겠습니"
-"다.%2$s"
+msgstr "개인 정보를 추적하는 웹사이트가 지긋지긋하시다고요? %1$s저희가 도와드리겠습니다.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -21673,9 +21286,7 @@ msgctxt "directions"
 msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
-msgstr ""
-"경로를 인쇄하려면 %1$s지도로 돌아가세요.%2$s원하는 경로를 선택하세요.%3$s인"
-"쇄 아이콘을 클릭하세요.%4$s"
+msgstr "경로를 인쇄하려면 %1$s지도로 돌아가세요.%2$s원하는 경로를 선택하세요.%3$s인쇄 아이콘을 클릭하세요.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -21685,9 +21296,8 @@ msgid ""
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
 msgstr ""
-"동기화된 데이터를 복원하려면 처음 Sync를 설치할 때 저장한 복구 코드가 필요합"
-"니다. 이 코드는 Sync를 설치할 때 원래 사용한 기기에 PDF로 저장되었을 수 있습"
-"니다."
+"동기화된 데이터를 복원하려면 처음 Sync를 설치할 때 저장한 복구 코드가 필요합니다. 이 코드는 Sync를 설치할 때 원래 사용한 "
+"기기에 PDF로 저장되었을 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -21695,18 +21305,14 @@ msgctxt "duckai_migration"
 msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
-msgstr ""
-"채팅 기록을 Duck.ai로 전송하려면 DuckDuckGo 브라우저를 최신 버전으로 업데이트"
-"하고 다시 시도하세요."
+msgstr "채팅 기록을 Duck.ai로 전송하려면 DuckDuckGo 브라우저를 최신 버전으로 업데이트하고 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "To use dictation, allow your browser to access the microphone in your system "
 "settings."
-msgstr ""
-"받아쓰기를 사용하려면 시스템 설정에서 브라우저가 마이크에 접근할 수 있도록 허"
-"용해 주세요."
+msgstr "받아쓰기를 사용하려면 시스템 설정에서 브라우저가 마이크에 접근할 수 있도록 허용해 주세요."
 
 # smartling.placeholder_format=C
 msgid "Today"
@@ -21728,15 +21334,13 @@ msgstr "오늘"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
-msgstr ""
+msgstr "전환하여 비공개 AI 채팅을 사용하거나 %1$s설정에서 비활성화%2$s하세요."
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
-msgstr ""
-"전환하여 비공개 AI 채팅을 사용해 보거나 %1$s %2$s 메뉴에서 비활성화하세요."
-"%3$s"
+msgstr "전환하여 비공개 AI 채팅을 사용해 보거나 %1$s %2$s 메뉴에서 비활성화하세요.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21909,9 +21513,7 @@ msgctxt "tracker_stats"
 msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
-msgstr ""
-"DuckDuckGo가 차단한 추적 시도가 여기에 표시됩니다. 얼마나 많은 시도가 차단되"
-"었는지 둘러보세요."
+msgstr "DuckDuckGo가 차단한 추적 시도가 여기에 표시됩니다. 얼마나 많은 시도가 차단되었는지 둘러보세요."
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -21958,9 +21560,7 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"'여기에서 가장 가까운 영화관에 어떻게 가나요?'라는 문장을 프랑스어로 번역해 "
-"주세요."
+msgstr "'여기에서 가장 가까운 영화관에 어떻게 가나요?'라는 문장을 프랑스어로 번역해 주세요."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -21968,9 +21568,7 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"'여기에서 가장 가까운 영화관에 어떻게 가나요?'라는 문장을 프랑스어로 번역해 "
-"주세요."
+msgstr "'여기에서 가장 가까운 영화관에 어떻게 가나요?'라는 문장을 프랑스어로 번역해 주세요."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -22356,9 +21954,7 @@ msgstr "위치를 수동으로 설정하세요."
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Try the %sDuckDuckGo Browser.%s Fast. Free. Private."
-msgstr ""
-"%1$sDuckDuckGo%2$s 브라우저를 사용해 보세요. 빠른 검색. 무료 제공. 개인 정보 "
-"보호."
+msgstr "%1$sDuckDuckGo%2$s 브라우저를 사용해 보세요. 빠른 검색. 무료 제공. 개인 정보 보호."
 
 # smartling.placeholder_format=C
 #. Link to a page where users can download the DuckDuckGo Browser for iOS or Android.
@@ -22450,8 +22046,8 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"AI 기능을 해제하고 싶으신가요? %1$sDuckDuckGo No AI%2$s 검색 확장 프로그램을 "
-"설치하면 설정을 기억시킬 수 있습니다. %3$s자세히 알아보세요%4$s"
+"AI 기능을 해제하고 싶으신가요? %1$sDuckDuckGo No AI%2$s 검색 확장 프로그램을 설치하면 설정을 기억시킬 수 "
+"있습니다. %3$s자세히 알아보세요%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -22460,8 +22056,8 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"AI 기능을 해제하고 하시나요? %1$sDuckDuckGo No AI%2$s 검색 확장 프로그램으로 "
-"전환하면 설정을 기억시킬 수 있습니다. %3$s자세히 알아보세요%4$s"
+"AI 기능을 해제하고 하시나요? %1$sDuckDuckGo No AI%2$s 검색 확장 프로그램으로 전환하면 설정을 기억시킬 수 "
+"있습니다. %3$s자세히 알아보세요%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -22661,9 +22257,7 @@ msgctxt "settings"
 msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
-msgstr ""
-"DuckAssist 답변이 생성되는 대로 입력합니다. 이 기능을 끄면 검색 시 답변이 표"
-"시되기까지 시간이 조금 지연될 수 있습니다."
+msgstr "DuckAssist 답변이 생성되는 대로 입력합니다. 이 기능을 끄면 검색 시 답변이 표시되기까지 시간이 조금 지연될 수 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -22792,30 +22386,24 @@ msgstr "장점과 단점 파악"
 msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
-msgstr ""
-"%1$s시작 페이지%2$s 항목에서 %3$s특정 페이지 열기%4$s를 클릭한 다음 %5$s페이"
-"지 설정%6$s을 클릭하세요."
+msgstr "%1$s시작 페이지%2$s 항목에서 %3$s특정 페이지 열기%4$s를 클릭한 다음 %5$s페이지 설정%6$s을 클릭하세요."
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
-msgstr ""
-"%1$s시작 페이지%2$s에서 %3$s홈페이지%4$s를 선택한 다음 https://duckduckgo.com"
-"을 입력하세요."
+msgstr "%1$s시작 페이지%2$s에서 %3$s홈페이지%4$s를 선택한 다음 https://duckduckgo.com을 입력하세요."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"%1$s다음으로 열기%2$s에서 %3$s특정 페이지(또는 여러 페이지)%4$s를 선택하세요."
+msgstr "%1$s다음으로 열기%2$s에서 %3$s특정 페이지(또는 여러 페이지)%4$s를 선택하세요."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"%1$s시작 페이지 > 홈페이지%2$s에서 https://duckduckgo.com을 입력하세요."
+msgstr "%1$s시작 페이지 > 홈페이지%2$s에서 https://duckduckgo.com을 입력하세요."
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22825,8 +22413,7 @@ msgstr "%1$s검색 설정%2$s에서 %3$sDuckDuckGo%4$s를 선택하세요."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr ""
-"%1$s주소창에서 다음을 사용하여 검색%2$s에서 %3$s새로 추가%4$s를 선택하세요."
+msgstr "%1$s주소창에서 다음을 사용하여 검색%2$s에서 %3$s새로 추가%4$s를 선택하세요."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -22838,8 +22425,7 @@ msgstr "%1$s검색%2$s 섹션에서, %3$s검색 엔진 관리...%4$s를 클릭�
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr ""
-"시작 페이지에서 %1$s특정 페이지 또는 페이지 모음 열기%2$s를 선택하세요."
+msgstr "시작 페이지에서 %1$s특정 페이지 또는 페이지 모음 열기%2$s를 선택하세요."
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -22922,9 +22508,7 @@ msgctxt "Description of the modal to upgrade to Pro"
 msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
-msgstr ""
-"Pro로 업그레이드하여 %1$s, 더 높은 AI 추론 및 Plus 요금제보다 2배 더 높은 사"
-"용 한도를 이용하세요."
+msgstr "Pro로 업그레이드하여 %1$s, 더 높은 AI 추론 및 Plus 요금제보다 2배 더 높은 사용 한도를 이용하세요."
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -23081,9 +22665,7 @@ msgctxt "Old app version banner component in Duck.ai"
 msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
-msgstr ""
-"DuckDuckGo 브라우저를 업데이트하여 Duck.ai에서 구독을 활성화하고 고급 모델을 "
-"이용하세요."
+msgstr "DuckDuckGo 브라우저를 업데이트하여 Duck.ai에서 구독을 활성화하고 고급 모델을 이용하세요."
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -23207,9 +22789,7 @@ msgctxt ""
 msgid ""
 "Upgrade to Pro to unlock 2x higher limits than Plus, or come back later to "
 "create more images."
-msgstr ""
-"Pro로 업그레이드해서 한도를 Plus의 2배로 높이거나, 나중에 돌아와서 이미지를 "
-"더 많이 만들어 보세요."
+msgstr "Pro로 업그레이드해서 한도를 Plus의 2배로 높이거나, 나중에 돌아와서 이미지를 더 많이 만들어 보세요."
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
@@ -23311,8 +22891,8 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"ChatGPT, Claude 등의 AI를 비공개로 사용하세요. 해커, 사기꾼, 기업으로부터 채"
-"팅을 보호하세요. 정보를 기밀로 유지하세요. 무료로. 계정이 없어도 괜찮습니다."
+"ChatGPT, Claude 등의 AI를 비공개로 사용하세요. 해커, 사기꾼, 기업으로부터 채팅을 보호하세요. 정보를 기밀로 유지하세요. "
+"무료로. 계정이 없어도 괜찮습니다."
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -23366,17 +22946,14 @@ msgctxt "Description for the joiner-device success screen"
 msgid ""
 "Use this code to restore your data if you lose access to your devices. Keep "
 "it safe."
-msgstr ""
-"기기에 접근할 수 없는 경우 이 코드를 사용하여 데이터를 복원하세요. 안전하게 "
-"보관하세요."
+msgstr "기기에 접근할 수 없는 경우 이 코드를 사용하여 데이터를 복원하세요. 안전하게 보관하세요."
 
 # smartling.placeholder_format=C
 #. First sentence of the recovery section. The 18-month inactivity notice is rendered by the component using DUCKCHAT_SYNC_RECOVERY_INACTIVITY_NOTICE so both surfaces stay consistent.
 msgctxt "Description for the recovery section inside Manage"
 msgid ""
 "Use this code to restore your saved chats if you lose access to your devices."
-msgstr ""
-"기기에 접근할 수 없는 경우 이 코드를 사용하여 저장된 채팅을 복원하세요."
+msgstr "기기에 접근할 수 없는 경우 이 코드를 사용하여 저장된 채팅을 복원하세요."
 
 # smartling.placeholder_format=C
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
@@ -23525,9 +23102,7 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr ""
-"광고 보기 시 DuckDuckGo에 의해 개인 정보가 보호됩니다. 광고 클릭은 마이크로소"
-"프트의 광고 네트워크에서 관리합니다."
+msgstr "광고 보기 시 DuckDuckGo에 의해 개인 정보가 보호됩니다. 광고 클릭은 마이크로소프트의 광고 네트워크에서 관리합니다."
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -23535,9 +23110,7 @@ msgctxt "Single Place Hotel Offers Module"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
-msgstr ""
-"광고 보기 시 DuckDuckGo에 의해 개인 정보가 보호됩니다. 광고 클릭은 "
-"TripAdvisor의 광고 네트워크에서 관리합니다."
+msgstr "광고 보기 시 DuckDuckGo에 의해 개인 정보가 보호됩니다. 광고 클릭은 TripAdvisor의 광고 네트워크에서 관리합니다."
 
 # smartling.placeholder_format=C
 #. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
@@ -23545,7 +23118,7 @@ msgctxt "Ads GDPR"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Yelp's ad network."
-msgstr ""
+msgstr "광고 보기 시 DuckDuckGo에 의해 개인 정보가 보호됩니다. 광고 클릭은 Yelp의 광고 네트워크에서 관리합니다."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -23572,9 +23145,7 @@ msgctxt "mobile promotion on desktop"
 msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
-msgstr ""
-"휴대전화 또는 태블릿에서 %1$sDuckDuckGo.com%2$s을 접속한 다음, 제공되는 설명"
-"을 따르세요."
+msgstr "휴대전화 또는 태블릿에서 %1$sDuckDuckGo.com%2$s을 접속한 다음, 제공되는 설명을 따르세요."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -23589,8 +23160,8 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"다른 브라우저에서 Duck.ai를 열고 %1$sDuck.ai 설정%2$s > %3$sSync & "
-"Backup%4$s > %5$s관리%6$s로 들어가 %7$s다른 기기와 동기화%8$s를 선택하세요."
+"다른 브라우저에서 Duck.ai를 열고 %1$sDuck.ai 설정%2$s > %3$sSync & Backup%4$s > "
+"%5$s관리%6$s로 들어가 %7$s다른 기기와 동기화%8$s를 선택하세요."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23600,9 +23171,8 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"다른 브라우저에서 Duck.ai를 방문하여 Duck.ai 설정을 여세요. Sync & Backup 아"
-"래에 있는 '켜기'를 선택하고 ''다른 기기와 동기화'를 선택하세요. 또는 복구 PDF"
-"에 있는 QR을 스캔하세요."
+"다른 브라우저에서 Duck.ai를 방문하여 Duck.ai 설정을 여세요. Sync & Backup 아래에 있는 '켜기'를 선택하고 "
+"''다른 기기와 동기화'를 선택하세요. 또는 복구 PDF에 있는 QR을 스캔하세요."
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -23612,9 +23182,8 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"다른 브라우저나 DuckDuckGo 앱에서 Duck.ai를 열고 %1$sDuck.ai 설정%2$s > "
-"%3$sSync & Backup%4$s > %5$s관리%6$s로 들어가 %7$s다른 기기와 동기화%8$s를 선"
-"택하세요."
+"다른 브라우저나 DuckDuckGo 앱에서 Duck.ai를 열고 %1$sDuck.ai 설정%2$s > %3$sSync & "
+"Backup%4$s > %5$s관리%6$s로 들어가 %7$s다른 기기와 동기화%8$s를 선택하세요."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23624,9 +23193,8 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"다른 브라우저나 DuckDuckGo 앱에서 Duck.ai를 방문하여 Duck.ai 설정을 여세요. "
-"Sync & Backup 아래에 있는 '켜기'를 선택하고 ''다른 기기와 동기화'를 선택하세"
-"요. 또는 복구 PDF에 있는 QR을 스캔하세요."
+"다른 브라우저나 DuckDuckGo 앱에서 Duck.ai를 방문하여 Duck.ai 설정을 여세요. Sync & Backup 아래에 있는 "
+"'켜기'를 선택하고 ''다른 기기와 동기화'를 선택하세요. 또는 복구 PDF에 있는 QR을 스캔하세요."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23678,8 +23246,7 @@ msgstr "음성 채팅이 끝났습니다"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr ""
-"당사는 음성 채팅 내용을 익명화하며, AI 모델 학습에 절대 사용하지 않습니다."
+msgstr "당사는 음성 채팅 내용을 익명화하며, AI 모델 학습에 절대 사용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -23822,9 +23389,7 @@ msgstr "Duck Player에서 보기"
 msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
-msgstr ""
-"Duck Player로 영상을 시청하면 YouTube 맞춤 광고가 차단되고 시청 내역에 따라 "
-"YouTube 추천 영상이 달라지지 않습니다."
+msgstr "Duck Player로 영상을 시청하면 YouTube 맞춤 광고가 차단되고 시청 내역에 따라 YouTube 추천 영상이 달라지지 않습니다."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -23844,9 +23409,8 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"여기서 영상을 시청하면 콘텐츠를 스트리밍해야 하기 때문에 해당 영상을 호스팅하"
-"는 웹사이트에서 사용자를 추적할 수 있습니다. DuckDuckGo는 동영상 대부분을 호"
-"스팅하는 YouTube와 무관한 독립적인 기업입니다."
+"여기서 영상을 시청하면 콘텐츠를 스트리밍해야 하기 때문에 해당 영상을 호스팅하는 웹사이트에서 사용자를 추적할 수 있습니다. "
+"DuckDuckGo는 동영상 대부분을 호스팅하는 YouTube와 무관한 독립적인 기업입니다."
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -23858,9 +23422,7 @@ msgstr "DuckDuckGo의 익명화"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr ""
-"더 정확한 결과를 보여드리기 위해 %1$s사용자의 위치%2$s를 익명화할 수 있습니"
-"다."
+msgstr "더 정확한 결과를 보여드리기 위해 %1$s사용자의 위치%2$s를 익명화할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -23872,8 +23434,8 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
-"문제는 눈에 보여야 고칠 수 있습니다. 유해하거나 불법적인 응답을 신고하려면 저"
-"희가 문제를 조사하고 해결할 수 있도록 이대화를 DuckDuckGo와 공유해 주세요."
+"문제는 눈에 보여야 고칠 수 있습니다. 유해하거나 불법적인 응답을 신고하려면 저희가 문제를 조사하고 해결할 수 있도록 이대화를 "
+"DuckDuckGo와 공유해 주세요."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -23885,9 +23447,8 @@ msgid ""
 "please share your prompt and response so we can investigate and address the "
 "issue."
 msgstr ""
-"문제는 눈에 보여야 고칠 수 있습니다. 유해하거나 불법적인 응답이 나온 경우, 저"
-"희가 문제를 조사하고 해결할 수 있도록 사용하신 프롬프트와 응답 내용을 보내서 "
-"신고해 주세요."
+"문제는 눈에 보여야 고칠 수 있습니다. 유해하거나 불법적인 응답이 나온 경우, 저희가 문제를 조사하고 해결할 수 있도록 사용하신 "
+"프롬프트와 응답 내용을 보내서 신고해 주세요."
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
@@ -23928,9 +23489,8 @@ msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
 msgstr ""
-"DuckDuckGo는 사용자의 개인정보를 저장하지 않습니다. DuckDuckGo는 사용자를 따"
-"라다니며 광고를 게재하지 않습니다. DuckDuckGo는 사용자를 추적하지 않습니다. "
-"절대."
+"DuckDuckGo는 사용자의 개인정보를 저장하지 않습니다. DuckDuckGo는 사용자를 따라다니며 광고를 게재하지 않습니다. "
+"DuckDuckGo는 사용자를 추적하지 않습니다. 절대."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23943,9 +23503,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr ""
-"DuckDuckGo는 사용자를 추적하지 않습니다. 따라서 오늘 다시 방문하게 된 계기를 "
-"알려주시면 도움이 될 것 같습니다."
+msgstr "DuckDuckGo는 사용자를 추적하지 않습니다. 따라서 오늘 다시 방문하게 된 계기를 알려주시면 도움이 될 것 같습니다."
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -23953,9 +23511,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
-msgstr ""
-"DuckDuckGo는 사용자를 추적하지 않습니다. 따라서 오늘 사용해보게 된 계기를 알"
-"려주시면 도움이 될 것 같습니다."
+msgstr "DuckDuckGo는 사용자를 추적하지 않습니다. 따라서 오늘 사용해보게 된 계기를 알려주시면 도움이 될 것 같습니다."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23966,9 +23522,7 @@ msgstr "DuckDuckGo는 절대로 사용자를 추적하지 않습니다."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr ""
-"DuckDuckGo는 사용자를 추적하지 않습니다. 그게 바로 우리의 개인정보 보호정책입"
-"니다."
+msgstr "DuckDuckGo는 사용자를 추적하지 않습니다. 그게 바로 우리의 개인정보 보호정책입니다."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -23997,24 +23551,19 @@ msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
 msgstr ""
-"DuckDuckGo는 사용자의 검색 기록을 저장하지 않습니다. 따라서 인터넷을 통해 사"
-"용자를 추적하는 광고주에게 판매할 수 있는 어떠한 정보도 보유하고 있지 않습니"
-"다."
+"DuckDuckGo는 사용자의 검색 기록을 저장하지 않습니다. 따라서 인터넷을 통해 사용자를 추적하는 광고주에게 판매할 수 있는 어떠한 "
+"정보도 보유하고 있지 않습니다."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr ""
-"DuckDuckGo는 개인정보 보호 모드 사용 여부에 관계없이 절대로 사용자를 추적하"
-"지 않습니다."
+msgstr "DuckDuckGo는 개인정보 보호 모드 사용 여부에 관계없이 절대로 사용자를 추적하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr ""
-"DuckDuckGo는 사용자를 추적하지 않습니다. 그게 바로 우리의 개인정보 보호정책입"
-"니다."
+msgstr "DuckDuckGo는 사용자를 추적하지 않습니다. 그게 바로 우리의 개인정보 보호정책입니다."
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -24028,9 +23577,7 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
-msgstr ""
-"데이터 브로커 사이트에서 개인정보를 찾아 삭제해 드립니다. VPN 등의 기능까지 "
-"함께 이용하세요."
+msgstr "데이터 브로커 사이트에서 개인정보를 찾아 삭제해 드립니다. VPN 등의 기능까지 함께 이용하세요."
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -24038,9 +23585,7 @@ msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
-msgstr ""
-"DuckDuckGo는 모든 AI 제공업체와 협약을 맺어 채팅 내용이 AI 학습에 사용되지 않"
-"도록 보장합니다."
+msgstr "DuckDuckGo는 모든 AI 제공업체와 협약을 맺어 채팅 내용이 AI 학습에 사용되지 않도록 보장합니다."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -24064,9 +23609,7 @@ msgstr "연결이 끊겼습니다. 메시지를 다시 보내 보세요."
 msgid ""
 "We make money from %sprivacy-respecting search ads%s, not by exploiting your "
 "data."
-msgstr ""
-"우리는 %1$s프라이버시를 존중하는 검색 광고%2$s로 돈을 벌고, 여러분의 데이터"
-"를 악용하지 않습니다."
+msgstr "우리는 %1$s프라이버시를 존중하는 검색 광고%2$s로 돈을 벌고, 여러분의 데이터를 악용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Message describing how DuckDuckGo users location access anonymously to provide better search results.
@@ -24074,9 +23617,7 @@ msgctxt "precise_user_location"
 msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
-msgstr ""
-"익명 위치는 사용자 주변의 더 정확한 결과를 제공하기 위해서만 사용되며, 언제든"
-"지 설정을 변경할 수 있습니다."
+msgstr "익명 위치는 사용자 주변의 더 정확한 결과를 제공하기 위해서만 사용되며, 언제든지 설정을 변경할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
@@ -24084,24 +23625,18 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
-msgstr ""
-"데이터 브로커 사이트에 있는 사용자의 개인정보를 정기적으로 스캔해서, 사용하"
-"기 쉬운 대시보드를 통해 진행 상황을 알려드립니다."
+msgstr "데이터 브로커 사이트에 있는 사용자의 개인정보를 정기적으로 스캔해서, 사용하기 쉬운 대시보드를 통해 진행 상황을 알려드립니다."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr ""
-"여러분이 익명으로 보내주시는 피드백을 바탕으로 DuckDuckGo를 모두가 사용하기 "
-"좋게 발전시킵니다."
+msgstr "여러분이 익명으로 보내주시는 피드백을 바탕으로 DuckDuckGo를 모두가 사용하기 좋게 발전시킵니다."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr ""
-"여러분의 검색 기록을 그 누구도 수집할 수 없게 차단합니다. 물론 DuckDuckGo도 "
-"포함해서 말이죠."
+msgstr "여러분의 검색 기록을 그 누구도 수집할 수 없게 차단합니다. 물론 DuckDuckGo도 포함해서 말이죠."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -24117,8 +23652,8 @@ msgid ""
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
 msgstr ""
-"DuckDuckGo는 이러한 의견을 참고하여 서비스를 개선합니다. 보내주신 제안은 %1$s"
-"의 재량에 따라 적용됩니다. 정정 사항이 결과에 바로 나타나지 않을 수 있습니다."
+"DuckDuckGo는 이러한 의견을 참고하여 서비스를 개선합니다. 보내주신 제안은 %1$s의 재량에 따라 적용됩니다. 정정 사항이 결과에 "
+"바로 나타나지 않을 수 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -24131,9 +23666,7 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
-msgstr ""
-"데이터 브로커 사이트에서 사용자의 이메일, 이름, 주소 등을 스캔해서 발견된 정"
-"보가 삭제되도록 도와드립니다."
+msgstr "데이터 브로커 사이트에서 사용자의 이메일, 이름, 주소 등을 스캔해서 발견된 정보가 삭제되도록 도와드립니다."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24141,9 +23674,7 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
-msgstr ""
-"현재 이 문제를 인지하고 해결책을 모색 중입니다. 이 오류가 계속되면 %1$s에 문"
-"의하세요."
+msgstr "현재 이 문제를 인지하고 해결책을 모색 중입니다. 이 오류가 계속되면 %1$s에 문의하세요."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -24151,9 +23682,7 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. Sometimes "
 "clearing your browser's cache can help."
-msgstr ""
-"현재 이 문제를 인지하고 해결책을 모색 중입니다. 브라우저 캐시를 삭제하면 문제"
-"가 해결되는 경우도 있습니다."
+msgstr "현재 이 문제를 인지하고 해결책을 모색 중입니다. 브라우저 캐시를 삭제하면 문제가 해결되는 경우도 있습니다."
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -24167,9 +23696,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr ""
-"불편을 드려서 죄송합니다. 사용자 여러분이 더 쾌적한 경험을 하실 수 있도록 노"
-"력 중입니다."
+msgstr "불편을 드려서 죄송합니다. 사용자 여러분이 더 쾌적한 경험을 하실 수 있도록 노력 중입니다."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -24177,9 +23704,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
-msgstr ""
-"Duck.ai 서비스를 업데이트했습니다. 변경 사항을 적용하려면 페이지를 새로 고치"
-"세요."
+msgstr "Duck.ai 서비스를 업데이트했습니다. 변경 사항을 적용하려면 페이지를 새로 고치세요."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -24287,8 +23812,7 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Weekly usage limit reached. You can keep chatting by using your monthly "
 "limit."
-msgstr ""
-"주간 사용 한도에 도달했습니다. 월 한도를 사용하여 채팅을 이어갈 수 있습니다."
+msgstr "주간 사용 한도에 도달했습니다. 월 한도를 사용하여 채팅을 이어갈 수 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -24302,8 +23826,8 @@ msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
 msgstr ""
-"Duck.ai에 오신 걸 환영합니다! 여기서 이루어지는 모든 채팅은 비공개로 진행되"
-"며, DuckDuckGo에 저장되거나 AI 모델 학습에 사용되지 않습니다."
+"Duck.ai에 오신 걸 환영합니다! 여기서 이루어지는 모든 채팅은 비공개로 진행되며, DuckDuckGo에 저장되거나 AI 모델 학습에 "
+"사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -24312,8 +23836,8 @@ msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat에 오신 것을 환영합니다! 여기서 이루어지는 모든 채팅은 비공"
-"개로 진행되며, DuckDuckGo에 저장되거나 AI 모델 학습에 사용되지 않습니다."
+"DuckDuckGo AI Chat에 오신 것을 환영합니다! 여기서 이루어지는 모든 채팅은 비공개로 진행되며, DuckDuckGo에 "
+"저장되거나 AI 모델 학습에 사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -24323,9 +23847,8 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat에 오신 것을 환영합니다! %1$s의 %2$s 모델로 작동하는 채팅 "
-"세션입니다. 여기서 이루어지는 모든 채팅은 비공개로 진행되며, DuckDuckGo에 저"
-"장되거나 AI 모델 학습에 사용되지 않습니다."
+"DuckDuckGo AI Chat에 오신 것을 환영합니다! %1$s의 %2$s 모델로 작동하는 채팅 세션입니다. 여기서 이루어지는 모든 "
+"채팅은 비공개로 진행되며, DuckDuckGo에 저장되거나 AI 모델 학습에 사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24398,9 +23921,7 @@ msgctxt "duckai_fatal_error"
 msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
-msgstr ""
-"정말 죄송하지만 Duck.ai를 불러오는 중 문제가 생긴 것 같습니다. 페이지를 새로"
-"고침해 보세요."
+msgstr "정말 죄송하지만 Duck.ai를 불러오는 중 문제가 생긴 것 같습니다. 페이지를 새로고침해 보세요."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -24434,9 +23955,7 @@ msgctxt "Full sentence for finding a better word"
 msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
-msgstr ""
-"“우리 정말 더 잘해야 합니다.”라는 문맥에서 '더 잘'이라는 단어의 대체어를 몇 "
-"개 알려 주세요."
+msgstr "“우리 정말 더 잘해야 합니다.”라는 문맥에서 '더 잘'이라는 단어의 대체어를 몇 개 알려 주세요."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -24461,10 +23980,9 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"Duck.ai를 사용하려고 할 때 DuckDuckGo 브라우저를 설치하면 어떤 점이 좋나요? "
-"DuckDuckGo 공식 출처만 참고하세요. 답변은 명료하게 섹션을 나누어 작성하고 제"
-"목을 답니다. Duck.ai 통합과 개인정보 보호에 중점을 두고, AI나 기술 관련 경험 "
-"유무에 관계 없이 누구나 이해하기 쉽도록 간단하게 설명하세요."
+"Duck.ai를 사용하려고 할 때 DuckDuckGo 브라우저를 설치하면 어떤 점이 좋나요? DuckDuckGo 공식 출처만 참고하세요. "
+"답변은 명료하게 섹션을 나누어 작성하고 제목을 답니다. Duck.ai 통합과 개인정보 보호에 중점을 두고, AI나 기술 관련 경험 유무에 "
+"관계 없이 누구나 이해하기 쉽도록 간단하게 설명하세요."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24699,8 +24217,7 @@ msgctxt "cloudsave"
 msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
-msgstr ""
-"Cloud Save 북마클릿이란 무엇이며 URL 매개변수 북마클릿과 어떻게 다른가요?"
+msgstr "Cloud Save 북마클릿이란 무엇이며 URL 매개변수 북마클릿과 어떻게 다른가요?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -24775,8 +24292,7 @@ msgstr "무엇에 대해 피드백을 주고 싶으세요?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"DuckDuckGo에서 시청하는 콘텐츠는 YouTube의 추천에 영향을 미치지 않습니다."
+msgstr "DuckDuckGo에서 시청하는 콘텐츠는 YouTube의 추천에 영향을 미치지 않습니다."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -24801,9 +24317,7 @@ msgctxt "Full sentence for identifying product brands"
 msgid ""
 "When buying an electric guitar for a beginner, what are the top product "
 "brands I should consider?"
-msgstr ""
-"초보자가 연주할 일렉트릭 기타를 살 때 가장 추천할 만한 브랜드에는 무엇이 있나"
-"요?"
+msgstr "초보자가 연주할 일렉트릭 기타를 살 때 가장 추천할 만한 브랜드에는 무엇이 있나요?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -25004,8 +24518,8 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
-"Duck.ai를 사용하면 채팅 내용이 익명화되며, AI 학습에 절대 사용되지 않습니다. "
-"'%1$s' 메뉴에서 언제든지 켜거나 끌 수 있습니다."
+"Duck.ai를 사용하면 채팅 내용이 익명화되며, AI 학습에 절대 사용되지 않습니다. '%1$s' 메뉴에서 언제든지 켜거나 끌 수 "
+"있습니다."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
@@ -25013,14 +24527,14 @@ msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, up to %s of your most recent chats will be saved on "
 "this device."
-msgstr ""
+msgstr "채팅 기록을 켜면 최근 채팅 최대 %1$s개가 이 기기에 저장됩니다."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline in the About Chat History modal.
 msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, your most recent chats will be saved on this device."
-msgstr ""
+msgstr "채팅 기록을 켜면 최근 채팅이 이 기기에 저장됩니다."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -25034,9 +24548,7 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
-msgstr ""
-"사용자의 기기에서 직접 작동하여 데이터 브로커 사이트에 있는 사용자의 이메일, "
-"이름, 주소 등의 정보를 삭제해 드립니다."
+msgstr "사용자의 기기에서 직접 작동하여 데이터 브로커 사이트에 있는 사용자의 이메일, 이름, 주소 등의 정보를 삭제해 드립니다."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25303,9 +24815,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"%1$s 모델과 채팅 중입니다. AI 채팅은 부정확하거나 불쾌한 정보를 표시할 수 있"
-"습니다."
+msgstr "%1$s 모델과 채팅 중입니다. AI 채팅은 부정확하거나 불쾌한 정보를 표시할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -25313,9 +24823,7 @@ msgctxt "noresults"
 msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
-msgstr ""
-"%1$s 또는 %2$s 검색 단축키를 사용하여 DuckDuckGo에서 다른 검색 엔진으로 직접 "
-"검색할 수 있습니다."
+msgstr "%1$s 또는 %2$s 검색 단축키를 사용하여 DuckDuckGo에서 다른 검색 엔진으로 직접 검색할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -25328,8 +24836,7 @@ msgstr "%1$s에서 DuckDuckGo AI Chat에 바로 접속할 수 있습니다."
 msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
-msgstr ""
-"%1$s검색 설정%2$s에서 언제든 %3$s 작동 방식을 변경하거나 해제할 수 있습니다."
+msgstr "%1$s검색 설정%2$s에서 언제든 %3$s 작동 방식을 변경하거나 해제할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -25337,22 +24844,17 @@ msgctxt "duckassist"
 msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
-msgstr ""
-"%1$s검색 설정%2$s에서 언제든 Assist의 작동 방식을 변경하거나 해제할 수 있습니"
-"다."
+msgstr "%1$s검색 설정%2$s에서 언제든 Assist의 작동 방식을 변경하거나 해제할 수 있습니다."
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
-msgstr ""
-"%1$sDuck.ai%2$s를 사용해 질문에 대한 답을 찾거나 글을 요약할 수도 있습니다."
+msgstr "%1$sDuck.ai%2$s를 사용해 질문에 대한 답을 찾거나 글을 요약할 수도 있습니다."
 
 # smartling.placeholder_format=C
 msgid ""
 "You can also use %sDuckDuckGo AI Chat%s to answer questions or summarize "
 "text."
-msgstr ""
-"%1$sDuckDuckGo AI Chat%2$s을 사용해 질문에 대한 답을 찾거나 글을 요약할 수도 "
-"있습니다."
+msgstr "%1$sDuckDuckGo AI Chat%2$s을 사용해 질문에 대한 답을 찾거나 글을 요약할 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach more text selections than are allowed. Placeholder is the maximum number of text selections. E.g. You can attach up to 5 text selections.
@@ -25365,9 +24867,7 @@ msgstr "텍스트 선택은 %1$s개까지 첨부할 수 있습니다."
 msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
-msgstr ""
-"%1$sSearch Settings%2$s에서 검색 Assist가 표시되는 빈도를 변경하거나 해제할 "
-"수 있습니다."
+msgstr "%1$sSearch Settings%2$s에서 검색 Assist가 표시되는 빈도를 변경하거나 해제할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -25387,9 +24887,7 @@ msgctxt "cloudsave"
 msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
-msgstr ""
-"다른 암호로 설정을 저장하여 암호를 변경할 수 있으며, 필요한 경우 첫 번째 세트"
-"를 삭제할 수도 있습니다."
+msgstr "다른 암호로 설정을 저장하여 암호를 변경할 수 있으며, 필요한 경우 첫 번째 세트를 삭제할 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -25418,8 +24916,7 @@ msgstr "월 한도를 사용하여 채팅을 이어갈 수 있습니다."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"이제 이 기기에 최근 채팅을 최대 100개 저장할 수 있습니다. 마음껏 채팅하세요!"
+msgstr "이제 이 기기에 최근 채팅을 최대 100개 저장할 수 있습니다. 마음껏 채팅하세요!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -25482,9 +24979,7 @@ msgctxt "Organic result context menu"
 msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
-msgstr ""
-"차단할 수 있는 사이트는 최대 %1$s개입니다. %2$s 사이트를 차단하려면 다른 사이"
-"트 차단을 먼저 해제해야 합니다."
+msgstr "차단할 수 있는 사이트는 최대 %1$s개입니다. %2$s 사이트를 차단하려면 다른 사이트 차단을 먼저 해제해야 합니다."
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -25547,9 +25042,7 @@ msgctxt "Description of the post-upgrade success modal"
 msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
-msgstr ""
-"이제 %1$s, 더 뛰어난 AI 추론, Plus보다 2배 높은 사용량 한도를 경험할 수 있습"
-"니다."
+msgstr "이제 %1$s, 더 뛰어난 AI 추론, Plus보다 2배 높은 사용량 한도를 경험할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -25558,8 +25051,8 @@ msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
 msgstr ""
-"이제 고급 AI 모델을 이용하실 수 있습니다. DuckDuckGo 브라우저에서 VPN과 각종 "
-"DuckDuckGo 구독 보호 기능을 이용할 수 있습니다."
+"이제 고급 AI 모델을 이용하실 수 있습니다. DuckDuckGo 브라우저에서 VPN과 각종 DuckDuckGo 구독 보호 기능을 이용할 "
+"수 있습니다."
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -25581,9 +25074,8 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"이 브라우저에서 저장된 대화에 더 이상 액세스할 수 없습니다. 마지막 30개의 채"
-"팅은 로컬 저장소에 계속 남습니다. 암호화된 서버에서 채팅이 삭제되지는 않습니"
-"다."
+"이 브라우저에서 저장된 대화에 더 이상 액세스할 수 없습니다. 마지막 30개의 채팅은 로컬 저장소에 계속 남습니다. 암호화된 서버에서 "
+"채팅이 삭제되지는 않습니다."
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -25593,9 +25085,8 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"이 브라우저에서 저장된 대화에 더 이상 액세스할 수 없습니다. 마지막 30개의 채"
-"팅은 로컬 저장소에 계속 남습니다. 암호화된 서버에서 채팅이 삭제되지는 않습니"
-"다."
+"이 브라우저에서 저장된 대화에 더 이상 액세스할 수 없습니다. 마지막 30개의 채팅은 로컬 저장소에 계속 남습니다. 암호화된 서버에서 "
+"채팅이 삭제되지는 않습니다."
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -25623,8 +25114,8 @@ msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
 msgstr ""
-"이제 Chrome에서 비공개로 검색할 수 있습니다. Chrome 대신 DuckDuckGo 앱도 사용"
-"해 보세요. 이미 설치되어 있으며 다음과 같은 기능이 제공됩니다."
+"이제 Chrome에서 비공개로 검색할 수 있습니다. Chrome 대신 DuckDuckGo 앱도 사용해 보세요. 이미 설치되어 있으며 "
+"다음과 같은 기능이 제공됩니다."
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -25636,9 +25127,7 @@ msgstr "이제 개인정보 보호를 받으며 검색할 수 있습니다!"
 msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
-msgstr ""
-"현재 개인정보 보호 모드로 검색하고 있습니다. %1$s보안을 더욱 강화할 수 있는 "
-"팁을 알아보세요."
+msgstr "현재 개인정보 보호 모드로 검색하고 있습니다. %1$s보안을 더욱 강화할 수 있는 팁을 알아보세요."
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -25714,9 +25203,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"첨부 파일이 있는 Duck.ai 채팅의 Sync & Backup 저장 공간이 부족합니다. 동기화"
-"를 재개하려면 가장 오래된 채팅 %1$s개를 삭제하세요. 고정된 채팅은 삭제되지 않"
-"습니다."
+"첨부 파일이 있는 Duck.ai 채팅의 Sync & Backup 저장 공간이 부족합니다. 동기화를 재개하려면 가장 오래된 채팅 "
+"%1$s개를 삭제하세요. 고정된 채팅은 삭제되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25726,9 +25214,8 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"Duck.ai 채팅용 Sync & Backup 저장 공간이 소진되었습니다. 동기화를 재개하려면 "
-"첨부 파일이 있는 채팅을 오래된 순으로 %1$s개 삭제하세요. 고정된 채팅은 삭제되"
-"지 않습니다."
+"Duck.ai 채팅용 Sync & Backup 저장 공간이 소진되었습니다. 동기화를 재개하려면 첨부 파일이 있는 채팅을 오래된 순으로 "
+"%1$s개 삭제하세요. 고정된 채팅은 삭제되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -25742,8 +25229,8 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"YouTube(Google 소유)에서는 익명으로 동영상을 시청할 수 없습니다. 따라서 여기"
-"서 YouTube 동영상을 시청하면 YouTube나 Google의 추적을 받게 됩니다."
+"YouTube(Google 소유)에서는 익명으로 동영상을 시청할 수 없습니다. 따라서 여기서 YouTube 동영상을 시청하면 "
+"YouTube나 Google의 추적을 받게 됩니다."
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -25802,8 +25289,7 @@ msgctxt "First body paragraph in the Delete Server Data confirmation modal"
 msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
-msgstr ""
-"백업이 DuckDuckGo 서버에서 삭제됩니다. 모든 기기의 동기화가 해제됩니다."
+msgstr "백업이 DuckDuckGo 서버에서 삭제됩니다. 모든 기기의 동기화가 해제됩니다."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25813,8 +25299,8 @@ msgid ""
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
 msgstr ""
-"백업이 DuckDuckGo 서버에서 삭제됩니다. 모든 기기의 동기화가 해제됩니다. 다음 "
-"브라우저에서는 최근 채팅 %1$s개가 로컬 저장소에 저장됩니다."
+"백업이 DuckDuckGo 서버에서 삭제됩니다. 모든 기기의 동기화가 해제됩니다. 다음 브라우저에서는 최근 채팅 %1$s개가 로컬 "
+"저장소에 저장됩니다."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -25824,8 +25310,8 @@ msgid ""
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
 msgstr ""
-"백업이 DuckDuckGo 서버에서 삭제됩니다. 모든 기기의 동기화가 해제됩니다. 다음 "
-"브라우저에서는 최근 채팅 100개가 로컬 저장소에 저장됩니다."
+"백업이 DuckDuckGo 서버에서 삭제됩니다. 모든 기기의 동기화가 해제됩니다. 다음 브라우저에서는 최근 채팅 100개가 로컬 저장소에 "
+"저장됩니다."
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -25849,18 +25335,14 @@ msgctxt "new tab page"
 msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
-msgstr ""
-"가장 많이 방문한 사이트 목록은 사용자의 브라우저에서 제공됩니다. DuckDuckGo"
-"는 절대 이 데이터에 접근할 수 없습니다."
+msgstr "가장 많이 방문한 사이트 목록은 사용자의 브라우저에서 제공됩니다. DuckDuckGo는 절대 이 데이터에 접근할 수 없습니다."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
-msgstr ""
-"브라우저는 가장 많이 방문한 사이트 목록을 제공합니다. DuckDuckGo는 이 데이터"
-"에 절대 액세스할 수 없습니다."
+msgstr "브라우저는 가장 많이 방문한 사이트 목록을 제공합니다. DuckDuckGo는 이 데이터에 절대 액세스할 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -25868,9 +25350,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"%1$s 서비스와의 채팅은 비공개입니다. AI 채팅은 부정확하거나 불쾌한 정보를 표"
-"시할 수 있습니다."
+msgstr "%1$s 서비스와의 채팅은 비공개입니다. AI 채팅은 부정확하거나 불쾌한 정보를 표시할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -25895,36 +25375,28 @@ msgstr "사용자의 채팅은 비공개로 처리되며 AI 모델 훈련에 사
 msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"내 채팅은 비공개이며 당사는 이 내용을 익명화하고, AI 모델 훈련에 사용하지 않"
-"습니다."
+msgstr "내 채팅은 비공개이며 당사는 이 내용을 익명화하고, AI 모델 훈련에 사용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
 msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"내 채팅은 비공개이며 당사는 이 내용을 익명화하고, AI 모델 훈련에 사용하지 않"
-"습니다."
+msgstr "내 채팅은 비공개이며 당사는 이 내용을 익명화하고, AI 모델 훈련에 사용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
 msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
-msgstr ""
-"내 채팅은 비공개이며 당사는 이 내용을 저장하지 않고, AI 모델 훈련에도 사용하"
-"지 않습니다."
+msgstr "내 채팅은 비공개이며 당사는 이 내용을 저장하지 않고, AI 모델 훈련에도 사용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
 msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
-msgstr ""
-"내 채팅은 비공개이며 당사는 이 내용을 저장하지 않고, AI 모델 훈련에도 사용하"
-"지 않습니다."
+msgstr "내 채팅은 비공개이며 당사는 이 내용을 저장하지 않고, AI 모델 훈련에도 사용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -25939,8 +25411,8 @@ msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
 msgstr ""
-"내 채팅은 여전히 비공개입니다. Duck.ai는 이 내용을 익명화하고, AI 모델 훈련"
-"에 사용하지 않습니다. 채팅 기록을 보관하는 방법은 다음과 같습니다."
+"내 채팅은 여전히 비공개입니다. Duck.ai는 이 내용을 익명화하고, AI 모델 훈련에 사용하지 않습니다. 채팅 기록을 보관하는 방법은 "
+"다음과 같습니다."
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -25979,9 +25451,7 @@ msgctxt "newsletter email collection"
 msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
-msgstr ""
-"사용자의 이메일은 공유되지 않으며 %1$s비공개 검색에도 사용되지 않습니다. "
-"[%2$s메시지 예시%3$s]"
+msgstr "사용자의 이메일은 공유되지 않으며 %1$s비공개 검색에도 사용되지 않습니다. [%2$s메시지 예시%3$s]"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -26024,10 +25494,9 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"사용자의 암호는 %1$sSHA-2%2$s라고 알려진 보안 해시 알고리즘을 사용해 512비트 "
-"키를 생성합니다. 키와 연관된 설정 파일만 브라우저 외부로 전송됩니다. "
-"DuckDuckGo는 해당 키를 파일 이름으로 사용하여 설정 파일을 저장하며, 사용자의 "
-"암호를 절대 알 수 없습니다."
+"사용자의 암호는 %1$sSHA-2%2$s라고 알려진 보안 해시 알고리즘을 사용해 512비트 키를 생성합니다. 키와 연관된 설정 파일만 "
+"브라우저 외부로 전송됩니다. DuckDuckGo는 해당 키를 파일 이름으로 사용하여 설정 파일을 저장하며, 사용자의 암호를 절대 알 수 "
+"없습니다."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -26042,9 +25511,8 @@ msgid ""
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
 msgstr ""
-"DuckDuckGo 서버를 통해 프롬프트가 전달되며 개인 정보를 식별할 수 있는 메타데"
-"이터는 제거됩니다. 따라서 모델 제공사는 대화를 특정 사용자에 연결할 수 없습니"
-"다."
+"DuckDuckGo 서버를 통해 프롬프트가 전달되며 개인 정보를 식별할 수 있는 메타데이터는 제거됩니다. 따라서 모델 제공사는 대화를 "
+"특정 사용자에 연결할 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -26089,8 +25557,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
-"설정이 저장되지만 쿠키를 삭제하면 초기화됩니다. 설정을 영구적으로 적용하려면 "
-"%1$sDuckDuckGo No AI%2$s 확장 프로그램을 사용 설정하세요."
+"설정이 저장되지만 쿠키를 삭제하면 초기화됩니다. 설정을 영구적으로 적용하려면 %1$sDuckDuckGo No AI%2$s 확장 프로그램을 "
+"사용 설정하세요."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -26099,8 +25567,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"설정이 저장되지만 쿠키를 삭제하면 초기화됩니다. 설정을 영구적으로 적용하려면 "
-"%1$sDuckDuckGo No AI%2$s 확장 프로그램을 설치하세요. %3$s자세히 알아보기%4$s"
+"설정이 저장되지만 쿠키를 삭제하면 초기화됩니다. 설정을 영구적으로 적용하려면 %1$sDuckDuckGo No AI%2$s 확장 프로그램을 "
+"설치하세요. %3$s자세히 알아보기%4$s"
 
 # smartling.placeholder_format=C
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
@@ -26120,9 +25588,8 @@ msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
 msgstr ""
-"이제 Chrome에서 개인 정보 노출 없이 검색할 수 있습니다. Chrome 대신 "
-"DuckDuckGo 브라우저를 이용해서 더 철저하게 보호받으세요. 이미 설치되어 있으"
-"며 다음 기능이 제공됩니다."
+"이제 Chrome에서 개인 정보 노출 없이 검색할 수 있습니다. Chrome 대신 DuckDuckGo 브라우저를 이용해서 더 철저하게 "
+"보호받으세요. 이미 설치되어 있으며 다음 기능이 제공됩니다."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -26138,9 +25605,7 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
-msgstr ""
-"이 대화에서 채팅 길이 한도에 도달했습니다. 계속 진행하려면 Fire Button을 눌"
-"러 이 대화를 지우세요."
+msgstr "이 대화에서 채팅 길이 한도에 도달했습니다. 계속 진행하려면 Fire Button을 눌러 이 대화를 지우세요."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -26148,8 +25613,7 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Start a new "
 "chat to continue."
-msgstr ""
-"이 대화에서 채팅 길이 한도에 도달했습니다. 계속하려면 새 채팅을 시작해."
+msgstr "이 대화에서 채팅 길이 한도에 도달했습니다. 계속하려면 새 채팅을 시작해."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -26163,9 +25627,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr ""
-"하루에 보낼 수 있는 메시지 개수 한도에 도달했습니다. 이 채팅은 내일 계속하세"
-"요."
+msgstr "하루에 보낼 수 있는 메시지 개수 한도에 도달했습니다. 이 채팅은 내일 계속하세요."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -26399,7 +25861,7 @@ msgstr "분"
 #. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the chat options menu button"
 msgid "menu"
-msgstr ""
+msgstr "메뉴"
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.
@@ -26473,9 +25935,7 @@ msgstr "공식 웹사이트"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr ""
-"또는 원하는 색상 코드를 직접 입력하세요. 예: %1$s (%2$s(은)는 인코딩된 %3$s "
-"문자입니다)"
+msgstr "또는 원하는 색상 코드를 직접 입력하세요. 예: %1$s (%2$s(은)는 인코딩된 %3$s 문자입니다)"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/ku/LC_MESSAGES/duckduckgo.po
+++ b/locales/ku/LC_MESSAGES/duckduckgo.po
@@ -983,6 +983,11 @@ msgstr "Derbarê Me"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1086,6 +1091,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "Reklam gumanbar e"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "DuckDuckGo tevlî bike"
@@ -1107,6 +1124,24 @@ msgstr "DuckDuckGo tevlî bike wekî motora lêgerînê"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "DuckDuckGo tevlî %s bike"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1145,6 +1180,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1216,6 +1265,11 @@ msgstr "Pêvek"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1461,6 +1515,11 @@ msgstr "Hemû reng"
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2828,6 +2887,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3230,9 +3296,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3248,6 +3324,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4521,6 +4604,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr "Encama Heyî"
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4805,6 +4893,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5143,6 +5236,11 @@ msgstr "Heya heyayê paşguh bike"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6050,6 +6148,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6230,6 +6333,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6900,6 +7008,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7318,6 +7431,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8306,6 +8424,11 @@ msgid "How is it anonymous?"
 msgstr "Çawa nenas e?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9485,6 +9608,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11224,6 +11352,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "BAŞ E, min fêm kir!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12943,6 +13076,11 @@ msgstr "Daneyên xwe li ser hemû amûran biparêze."
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -13049,6 +13187,11 @@ msgstr "Baran"
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -14042,6 +14185,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14201,6 +14349,13 @@ msgstr "Bigere"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15130,6 +15285,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16473,6 +16633,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16553,6 +16720,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -17022,6 +17194,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17427,6 +17613,11 @@ msgstr "Îro"
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18901,6 +19092,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -20078,6 +20276,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21179,6 +21390,11 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "m"
 msgstr "x"
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.
 msgctxt "Aria label for the menu button"

--- a/locales/kw_GB/LC_MESSAGES/duckduckgo.po
+++ b/locales/kw_GB/LC_MESSAGES/duckduckgo.po
@@ -979,6 +979,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1082,6 +1087,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Keworra DuckDuckGo"
@@ -1100,6 +1117,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1139,6 +1174,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1210,6 +1259,11 @@ msgstr "Keworransow"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1454,6 +1508,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2801,6 +2860,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3201,9 +3267,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3219,6 +3295,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4476,6 +4559,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4760,6 +4848,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5098,6 +5191,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -5994,6 +6092,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6171,6 +6274,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6836,6 +6944,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7254,6 +7367,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8236,6 +8354,11 @@ msgid "How is it anonymous?"
 msgstr "Fatel yw dihanow?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9391,6 +9514,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11128,6 +11256,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12828,6 +12961,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12934,6 +13072,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13922,6 +14065,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14077,6 +14225,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -14992,6 +15147,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16331,6 +16491,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16411,6 +16578,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16871,6 +17043,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17273,6 +17459,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18735,6 +18926,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19884,6 +20082,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20966,6 +21177,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/ky_KG/LC_MESSAGES/duckduckgo.po
+++ b/locales/ky_KG/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr ""
@@ -1099,6 +1116,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr "Кошумчалар"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1453,6 +1507,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2800,6 +2859,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3200,9 +3266,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3218,6 +3294,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4475,6 +4558,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4759,6 +4847,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5097,6 +5190,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -5993,6 +6091,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6170,6 +6273,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6835,6 +6943,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7253,6 +7366,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8235,6 +8353,11 @@ msgid "How is it anonymous?"
 msgstr "Кандайча анонимдүү?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9388,6 +9511,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11125,6 +11253,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12825,6 +12958,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12931,6 +13069,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13919,6 +14062,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14074,6 +14222,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -14989,6 +15144,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16328,6 +16488,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16408,6 +16575,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16868,6 +17040,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17270,6 +17456,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18732,6 +18923,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19881,6 +20079,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20963,6 +21174,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/ln_CD/LC_MESSAGES/duckduckgo.po
+++ b/locales/ln_CD/LC_MESSAGES/duckduckgo.po
@@ -979,6 +979,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1082,6 +1087,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr ""
@@ -1100,6 +1117,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1139,6 +1174,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1210,6 +1259,11 @@ msgstr "Ebakisi"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1454,6 +1508,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2801,6 +2860,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3201,9 +3267,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3219,6 +3295,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4476,6 +4559,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4760,6 +4848,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5098,6 +5191,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -5994,6 +6092,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6171,6 +6274,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6836,6 +6944,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7254,6 +7367,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8236,6 +8354,11 @@ msgid "How is it anonymous?"
 msgstr ""
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9389,6 +9512,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11126,6 +11254,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12826,6 +12959,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12932,6 +13070,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13920,6 +14063,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14075,6 +14223,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -14990,6 +15145,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16329,6 +16489,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16409,6 +16576,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16869,6 +17041,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17271,6 +17457,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18733,6 +18924,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19882,6 +20080,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20964,6 +21175,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/lt_LT/LC_MESSAGES/duckduckgo.po
+++ b/locales/lt_LT/LC_MESSAGES/duckduckgo.po
@@ -2,16 +2,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: lt_LT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"(n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -381,8 +380,7 @@ msgstr "%1$s išnaudota"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
-"%1$s išnaudoja limitus iki 2–5 kartų greičiau nei baziniai modeliai %2$s"
+msgstr "%1$s išnaudoja limitus iki 2–5 kartų greičiau nei baziniai modeliai %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -518,8 +516,7 @@ msgstr ""
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr ""
-"%1$sSužinok daugiau%2$s, kaip pokalbiai saugomi privačiai tavo įrenginyje."
+msgstr "%1$sSužinok daugiau%2$s, kaip pokalbiai saugomi privačiai tavo įrenginyje."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -955,16 +952,14 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"Pasirodė nauja „AI Chat“ versija! Jei nori tęsti, atnaujink šį puslapį."
+msgstr "Pasirodė nauja „AI Chat“ versija! Jei nori tęsti, atnaujink šį puslapį."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"Pasirodė nauja „Duck.ai“ versija! Jei norite tęsti, atnaujinkite šį puslapį."
+msgstr "Pasirodė nauja „Duck.ai“ versija! Jei norite tęsti, atnaujinkite šį puslapį."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1220,7 +1215,7 @@ msgstr "Apie mūsų reklamas"
 #. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
 msgctxt "Modal header for chat history with sync information"
 msgid "About Chat History with Sync & Backup"
-msgstr ""
+msgstr "Apie pokalbių istoriją naudojant „Sync & Backup“"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
@@ -1355,7 +1350,7 @@ msgstr "Reklama yra įtartina"
 #. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
 msgctxt "Button to open menu for attaching images or page context to AI chat"
 msgid "Add"
-msgstr ""
+msgstr "Pridėti"
 
 # smartling.placeholder_format=C
 #. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
@@ -1363,7 +1358,7 @@ msgctxt ""
 "Primary button that attaches the tabs the user checked in the tab picker "
 "dialog"
 msgid "Add"
-msgstr ""
+msgstr "Pridėti"
 
 # smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
@@ -1398,13 +1393,13 @@ msgstr "Pridėti „DuckDuckGo“ prie %1$s"
 msgctxt ""
 "Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
 msgid "Add File"
-msgstr ""
+msgstr "Pridėti failą"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
 msgid "Add Image"
-msgstr ""
+msgstr "Pridėti vaizdą"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
@@ -1412,7 +1407,7 @@ msgctxt ""
 "Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
 "item)"
 msgid "Add Image or File"
-msgstr ""
+msgstr "Pridėti vaizdą ar failą"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1465,7 +1460,7 @@ msgctxt ""
 "Open the tab picker to attach browser tab content to the AI chat message "
 "(attach dropdown menu item)"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Pridėti korteles"
 
 # smartling.placeholder_format=C
 #. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
@@ -1473,7 +1468,7 @@ msgctxt ""
 "Title and accessible name of the tab-picker dialog opened from the attach "
 "dropdown menu"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Pridėti korteles"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1564,7 +1559,7 @@ msgstr "Atliekami baigiamieji veiksmai"
 #. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
 msgctxt "Aria label for the additional instructions textarea"
 msgid "Additional instructions"
-msgstr ""
+msgstr "Papildomos instrukcijos"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1710,8 +1705,7 @@ msgstr "Kai atsisiųsi ir atidarysi, spustelėk %1$sĮdiegti%2$s"
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr ""
-"Kai atsisiųsi, surask plėtinio failą ir du kartus jį spustelėk, kad įdiegtum"
+msgstr "Kai atsisiųsi, surask plėtinio failą ir du kartus jį spustelėk, kad įdiegtum"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1872,7 +1866,7 @@ msgstr "Viskas atlikta!"
 #. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the read-only textarea listing all AI instructions"
 msgid "All instructions"
-msgstr ""
+msgstr "Visos instrukcijos"
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -1966,8 +1960,7 @@ msgstr "Leisti anonimiškai peržiūrėti šio pokalbio failus?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Leisti privatumo paisančius skelbimus „DuckDuckGo Private Search“ paieškoje"
+msgstr "Leisti privatumo paisančius skelbimus „DuckDuckGo Private Search“ paieškoje"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2019,8 +2012,7 @@ msgstr "Jau sinchronizuota."
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Also search privately on your iPad, iPhone, or Android!"
-msgstr ""
-"Taip pat ieškok privačiai savo „iPad“, „iPhone“ arba „Android“ įrenginyje!"
+msgstr "Taip pat ieškok privačiai savo „iPad“, „iPhone“ arba „Android“ įrenginyje!"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -2680,8 +2672,7 @@ msgstr "Automatinis atsakymas"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr ""
-"Automatiškai generuojama pagal išvardytus šaltinius. Gali būti netikslumų."
+msgstr "Automatiškai generuojama pagal išvardytus šaltinius. Gali būti netikslumų."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -3587,7 +3578,7 @@ msgctxt ""
 "Secondary button that dismisses the tab picker dialog without attaching "
 "anything"
 msgid "Cancel"
-msgstr ""
+msgstr "Atšaukti"
 
 # smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
@@ -3843,8 +3834,7 @@ msgstr "Pakeičia fono spalvą visoje svetainėje"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr ""
-"Pakeičia žymeklio, modulių ir išskleidžiamųjų meniu rezultatų fono spalvą"
+msgstr "Pakeičia žymeklio, modulių ir išskleidžiamųjų meniu rezultatų fono spalvą"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -4085,7 +4075,7 @@ msgstr "Pokalbio atsakymas įžeidžiantis"
 #. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
 msgctxt "Chat history about modal list item headline"
 msgid "Chat storage varies by browser"
-msgstr ""
+msgstr "Skirtingose naršyklėse pokalbiai saugomi skirtingai"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4097,7 +4087,7 @@ msgstr "Kalbėkite su „%1$s“"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Chat with popular AI models, anonymized by us."
-msgstr ""
+msgstr "Kalbėk su populiariais DI modeliais, kuriuos anoniminame mes."
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4124,6 +4114,8 @@ msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
 msgstr ""
+"Pokalbiai patikimai saugomi „DuckDuckGo“ serveryje naudojant ištisinį "
+"šifravimą. Savo duomenis matai tik tu. Jų nematome net mes."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4173,9 +4165,9 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"Pokalbiai su %1$s paslaugų teikėjui visiškai nematomi, tačiau visus į Duck."
-"ai įkeltus failus anonimiškai peržiūri turinio moderavimo paslaugų teikėjas, "
-"ieškantis tokio turinio: %2$s."
+"Pokalbiai su %1$s paslaugų teikėjui visiškai nematomi, tačiau visus į "
+"Duck.ai įkeltus failus anonimiškai peržiūri turinio moderavimo paslaugų "
+"teikėjas, ieškantis tokio turinio: %2$s."
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -4645,8 +4637,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr ""
-"Dešiniojoje šoninėje juostoje spustelėk %1$sPrivatumas ir Paslaugos%2$s."
+msgstr "Dešiniojoje šoninėje juostoje spustelėk %1$sPrivatumas ir Paslaugos%2$s."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -4673,8 +4664,7 @@ msgstr "Išskleidžiamajame meniu spustelėk %1$sNustatymai%2$s."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Spustelėk %1$sNaudoti dabartinius puslapius%2$s, tada %3$s– „Gerai%4$s."
+msgstr "Spustelėk %1$sNaudoti dabartinius puslapius%2$s, tada %3$s– „Gerai%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4741,8 +4731,7 @@ msgstr "Paieškos juostoje spustelėk %1$sdidinamąjį stiklą%2$s"
 # smartling.placeholder_format=C
 #. Tells users what icon to click in their browser to change their default search engine.
 msgid "Click on the magnifying glass in the search box at the top right"
-msgstr ""
-"Viršuje dešinėje esančiame paieškos langelyje spustelėk didinamąjį stiklą"
+msgstr "Viršuje dešinėje esančiame paieškos langelyje spustelėk didinamąjį stiklą"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -5438,8 +5427,7 @@ msgstr "Kopijuoti"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"Nukopijuok ir įklijuok %1$sabout:preferences#search%2$s į adreso juostą"
+msgstr "Nukopijuok ir įklijuok %1$sabout:preferences#search%2$s į adreso juostą"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5730,7 +5718,7 @@ msgstr "Dabartinė serija"
 #. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
 msgctxt "Suffix label indicating a tab is the currently active browser tab"
 msgid "Current Tab"
-msgstr ""
+msgstr "Dabartinė kortelė"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
@@ -6084,7 +6072,7 @@ msgstr "Trinti senesnius nei 30 dienų pokalbius"
 #. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
 msgctxt "Button text in the modal for deleting all recent chats"
 msgid "Delete Chats and Shared Links"
-msgstr ""
+msgstr "Ištrinti pokalbius ir bendrinamas nuorodas"
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6308,8 +6296,7 @@ msgstr "Diktavimas „Duck.ai“"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr ""
-"Diktavimą mes anonimizuojame ir niekada nenaudojame DI modeliams mokyti."
+msgstr "Diktavimą mes anonimizuojame ir niekada nenaudojame DI modeliams mokyti."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6502,7 +6489,7 @@ msgstr "Atsisakyti reklamos"
 #. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the close button on the survey banner"
 msgid "Dismiss survey"
-msgstr ""
+msgstr "Atmesti apklausą"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7267,8 +7254,8 @@ msgid ""
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
 "„DuckDuckGo AI Chat“ yra privati dirbtiniu intelektu pagrįsta pokalbių "
-"paslauga, kuri šiuo metu palaiko pokalbių modelius „%1$s“ „%2$s“ ir "
-"„%3$s“ „%4$s“."
+"paslauga, kuri šiuo metu palaiko pokalbių modelius „%1$s“ „%2$s“ ir „%3$s“ "
+"„%4$s“."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7278,8 +7265,8 @@ msgid ""
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
 "„DuckDuckGo AI Chat“ yra privati dirbtiniu intelektu pagrįsta pokalbių "
-"paslauga, kuri šiuo metu palaiko pokalbių modelius „%1$s“ „%2$s“ ir "
-"„%3$s“ „%4$s“."
+"paslauga, kuri šiuo metu palaiko pokalbių modelius „%1$s“ „%2$s“ ir „%3$s“ "
+"„%4$s“."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -7315,8 +7302,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"„DuckDuckGo DI Chat“ laikinai nepasiekiamas. Bandykite dar kartą vėliau."
+msgstr "„DuckDuckGo DI Chat“ laikinai nepasiekiamas. Bandykite dar kartą vėliau."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7476,8 +7462,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"„DuckDuckGo“ anonimina tavo pokalbius. Jei spusteli „%1$s“, sutinki su „Duck."
-"ai“ %2$s."
+"„DuckDuckGo“ anonimina tavo pokalbius. Jei spusteli „%1$s“, sutinki su "
+"„Duck.ai“ %2$s."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7628,9 +7614,9 @@ msgid ""
 "characters long."
 msgstr ""
 "Kiekvieną kartą, kai paprašai pasiūlyti slaptafrazę, naudojame didelį "
-"atsitiktinių žodžių sąrašą iš „DuckDuckGo“ serverių. Naršyklėje parenkame 4–"
-"5 atsitiktinius žodžius iš sąrašo užtikrindami, kad slaptafrazė būtų bent 18–"
-"20 simbolių ilgio."
+"atsitiktinių žodžių sąrašą iš „DuckDuckGo“ serverių. Naršyklėje parenkame "
+"4–5 atsitiktinius žodžius iš sąrašo užtikrindami, kad slaptafrazė būtų bent "
+"18–20 simbolių ilgio."
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7687,7 +7673,7 @@ msgstr "Redaguoti užklausą"
 #. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the message-editing text area"
 msgid "Edit message"
-msgstr ""
+msgstr "Redaguoti žinutę"
 
 # smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
@@ -7917,7 +7903,7 @@ msgstr "Užšifruotas modelis"
 #. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
 msgctxt "Share modal info bullet about encryption"
 msgid "Encrypted so DuckDuckGo can't read your chat."
-msgstr ""
+msgstr "Užšifruota, kad „DuckDuckGo“ negalėtų perskaityti tavo pokalbio."
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -7975,15 +7961,13 @@ msgstr "Ar tau patinka „Duck.ai“?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr ""
-"Įsitikink, kad pasirinkta nustatymo „Vieta“ parinktis %1$s„Leisti“%2$s."
+msgstr "Įsitikink, kad pasirinkta nustatymo „Vieta“ parinktis %1$s„Leisti“%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr ""
-"Įsitikink, kad parinktis „Buvimo vietos nustatymo paslaugos“ %1$sįjungta%2$s."
+msgstr "Įsitikink, kad parinktis „Buvimo vietos nustatymo paslaugos“ %1$sįjungta%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
@@ -8131,8 +8115,7 @@ msgstr "Pusiaujo Gvinėja"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"Naršymo duomenis ištrinkite akimirksniu naudodami mūsų %1$s„Fire Button“%2$s"
+msgstr "Naršymo duomenis ištrinkite akimirksniu naudodami mūsų %1$s„Fire Button“%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -8238,8 +8221,7 @@ msgstr "Paprastais žodžiais paaiškink priimtą atsakymą."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr ""
-"Paaiškink pagrindines juodųjų skylių sąvokas vidurinės mokyklos lygmeniu."
+msgstr "Paaiškink pagrindines juodųjų skylių sąvokas vidurinės mokyklos lygmeniu."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -8317,8 +8299,7 @@ msgstr "Naršyti „Duck.ai“"
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
-msgstr ""
-"Susipažinkite su naujausiais „DuckDuckGo“ produktų ir funkcijų atnaujinimais."
+msgstr "Susipažinkite su naujausiais „DuckDuckGo“ produktų ir funkcijų atnaujinimais."
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8497,8 +8478,7 @@ msgstr ""
 msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
-msgstr ""
-"Keisk savo nustatymus žemiau. Tada, tiesiog nukopijuok kodą į savo svetainę."
+msgstr "Keisk savo nustatymus žemiau. Tada, tiesiog nukopijuok kodą į savo svetainę."
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8620,8 +8600,7 @@ msgstr "Finansų konsultantas"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr ""
-"Surask %1$sDuckDuckGo%2$s ir spustelėk%3$sNustatyti kaip numatytąjį%4$s"
+msgstr "Surask %1$sDuckDuckGo%2$s ir spustelėk%3$sNustatyti kaip numatytąjį%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8745,8 +8724,7 @@ msgstr ""
 #. Privacy reassurance and instructions intro.
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
-msgstr ""
-"Atlik šiuos veiksmus, kad perkeltum pokalbius į naująją „Duck.ai“ versiją"
+msgstr "Atlik šiuos veiksmus, kad perkeltum pokalbius į naująją „Duck.ai“ versiją"
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8757,7 +8735,7 @@ msgstr "Papildomas klausimas"
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
-msgstr ""
+msgstr "Tolesnės žinutės lieka privačios."
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8863,8 +8841,7 @@ msgstr "Nemokami ir privatūs pokalbiai, kuriuos anonimizuojame"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Nemokami ir privatūs pokalbiai, kuriuos anonimizuojame. Paskyros nereikia."
+msgstr "Nemokami ir privatūs pokalbiai, kuriuos anonimizuojame. Paskyros nereikia."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9272,14 +9249,13 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr ""
-"Gauk „DuckDuckGo VPN“, pažangųjį „Duck.ai“ ir „Identity Theft Restoration“."
+msgstr "Gauk „DuckDuckGo VPN“, pažangųjį „Duck.ai“ ir „Identity Theft Restoration“."
 
 # smartling.placeholder_format=C
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
 msgctxt "Tooltip on the header logo for sunglasses searches"
 msgid "Get DuckDuckGo sunglasses and other gear."
-msgstr ""
+msgstr "Įsigyk „DuckDuckGo“ akinius nuo saulės ir kitą atributiką."
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9338,8 +9314,7 @@ msgstr "Pradėti"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the Privacy Pro subscription.
 msgctxt "SERP footer content"
 msgid "Get a VPN + two more protections in one easy subscription."
-msgstr ""
-"Gaukite VPN ir dar dvi apsaugos priemones iš vienos paprastos prenumeratos."
+msgstr "Gaukite VPN ir dar dvi apsaugos priemones iš vienos paprastos prenumeratos."
 
 # smartling.placeholder_format=C
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
@@ -9431,8 +9406,7 @@ msgstr "Gauk didesnius naudojimo limitus su „DuckDuckGo“ prenumerata."
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
-msgstr ""
-"Atsisiųsk ir naudok mūsų naršyklę, kad niekada neprarastum savo nustatymų."
+msgstr "Atsisiųsk ir naudok mūsų naršyklę, kad niekada neprarastum savo nustatymų."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; shown in every market. 'No-log' means the VPN keeps no activity logs; 'advanced AI models' with 'higher chat limits' refer to Duck.ai; the VPN and other premium protections are bundled subscription features.
@@ -9467,8 +9441,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
-msgstr ""
-"Vienu atsisiuntimu nemokamai gauk sklandžią privatumo apsaugą naršyklėje:"
+msgstr "Vienu atsisiuntimu nemokamai gauk sklandžią privatumo apsaugą naršyklėje:"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -9505,8 +9478,8 @@ msgstr "Gauti programą"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"Gauk nemokamą „DuckDuckGo“ naršyklę, %1$skad blokuotum reklamas „YouTube“."
-"%2$s"
+"Gauk nemokamą „DuckDuckGo“ naršyklę, %1$skad blokuotum reklamas "
+"„YouTube“.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -10522,7 +10495,7 @@ msgstr "Kaip tai veikia"
 #. Headline in chat history about modals for the temporary encrypted server storage explanation.
 msgctxt "Chat history about modal list item headline"
 msgid "How it works"
-msgstr ""
+msgstr "Kaip tai veikia"
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -10703,8 +10676,7 @@ msgstr ""
 #. Option for feedback when the user needs more help or information on how to use the chat.
 msgctxt "Feedback option for difficulty in using chat"
 msgid "I need more help/info on how to use Chat"
-msgstr ""
-"Man reikia daugiau pagalbos / informacijos apie tai, kaip naudotis pokalbiu"
+msgstr "Man reikia daugiau pagalbos / informacijos apie tai, kaip naudotis pokalbiu"
 
 # smartling.placeholder_format=C
 msgid "IR Iran"
@@ -10937,8 +10909,7 @@ msgstr "Pagerink argumentus"
 msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
-msgstr ""
-"Pagerina rezultato skaitomumą atnaujintu URL formatu, išdėstymu ir spalva"
+msgstr "Pagerina rezultato skaitomumą atnaujintu URL formatu, išdėstymu ir spalva"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -11370,8 +11341,7 @@ msgstr "Ji greita, nemokama ir užtikrina dar daugiau apsaugos internete."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Leidžiu (labai retai) manęs klausti apie naudojimosi „DuckDuckGo“ patirtį"
+msgstr "Leidžiu (labai retai) manęs klausti apie naudojimosi „DuckDuckGo“ patirtį"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11889,8 +11859,7 @@ msgstr "Leidžia ieškoti anonimiškai su „DuckDuckGo“"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr ""
-"Leidžia perjungti tarp paieškos užklausų ir DI užklausų pateikimo „Duck.ai“"
+msgstr "Leidžia perjungti tarp paieškos užklausų ir DI užklausų pateikimo „Duck.ai“"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11972,7 +11941,7 @@ msgstr "Nuoroda baigia galioti po 7 dienų."
 #. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days. People can save a chat copy."
-msgstr ""
+msgstr "Nuoroda nebegalios po 7 dienų. Žmonės gali išsaugoti pokalbio kopiją."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11988,8 +11957,7 @@ msgstr "Nuorodos:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
-"Išvardyk įrankius, medžiagas ar išankstines sąlygas, kurių tam prireiks."
+msgstr "Išvardyk įrankius, medžiagas ar išankstines sąlygas, kurių tam prireiks."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12100,8 +12068,7 @@ msgstr "Įkeliama daugiau vaizdų slenkant"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr ""
-"Slenkant įkeliama daugiau Vaizdų, Vaizdo Įrašų ir Apsipirkimo rezultatų"
+msgstr "Slenkant įkeliama daugiau Vaizdų, Vaizdo Įrašų ir Apsipirkimo rezultatų"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -14095,7 +14062,7 @@ msgstr "Gerai, supratau!"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "OPTIONAL"
-msgstr ""
+msgstr "PASIRENKAMA"
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -14225,8 +14192,7 @@ msgstr "Omanas"
 #. http://i.imgur.com/zQWKLIm.png
 msgctxt "settings"
 msgid "Omits objectionable (mostly adult) material"
-msgstr ""
-"Praleidžiami nepageidaujami (daugiausia tik suaugusiesiems skirti) rezultatai"
+msgstr "Praleidžiami nepageidaujami (daugiausia tik suaugusiesiems skirti) rezultatai"
 
 # smartling.placeholder_format=C
 msgid "On"
@@ -14420,8 +14386,7 @@ msgstr "Atidaryti %1$s svetainę"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr ""
-"Atidarykite %1$sVieta%2$s ir įsitikinkite, kad vieta yra %3$sįjungta%4$s"
+msgstr "Atidarykite %1$sVieta%2$s ir įsitikinkite, kad vieta yra %3$sįjungta%4$s"
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -14590,8 +14555,7 @@ msgstr "Atidaryti skydelį „Kaip veikia Duck.ai“"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Atidarykite „Safari“ meniu ir pasirinkite %1$s„DuckDuckGo“ nustatymai...%2$s"
+msgstr "Atidarykite „Safari“ meniu ir pasirinkite %1$s„DuckDuckGo“ nustatymai...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -15418,8 +15382,7 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr ""
-"Aprašyk, kodėl šis pokalbio atsakymas neteisėtas ar žalingas. (Neprivaloma)"
+msgstr "Aprašyk, kodėl šis pokalbio atsakymas neteisėtas ar žalingas. (Neprivaloma)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -15607,8 +15570,7 @@ msgstr "Luktelk..."
 #. Tagline for the subscription promo shown in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Plus more premium features with a DuckDuckGo subscription."
-msgstr ""
-"„Plus“ – daugiau aukščiausios kokybės funkcijų su „DuckDuckGo“ prenumerata."
+msgstr "„Plus“ – daugiau aukščiausios kokybės funkcijų su „DuckDuckGo“ prenumerata."
 
 # smartling.placeholder_format=C
 #. A description to provide more detail on what Duck Player does (Duck Player is DDG's feature to watch youtube videos more privately)
@@ -16190,8 +16152,7 @@ msgstr "Paraginti mane"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"Paraginti mane naudoti apytikslę vietą, kad gaučiau tikslesnių rezultatų."
+msgstr "Paraginti mane naudoti apytikslę vietą, kad gaučiau tikslesnių rezultatų."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -16226,7 +16187,7 @@ msgstr "Apsaugotas"
 #. Headline in sync-enabled chat history about modals explaining encrypted server storage.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Protected with end-to-end encryption"
-msgstr ""
+msgstr "Apsaugota ištisiniu šifravimu"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -16365,7 +16326,7 @@ msgstr "Reitingai"
 #. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
 msgctxt "star rating on a product"
 msgid "Rated %s out of %s"
-msgstr ""
+msgstr "Įvertinta %1$s iš %2$s"
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17607,7 +17568,7 @@ msgstr "Išsaugok pokalbius visuose savo įrenginiuose."
 #. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
 msgctxt "Chat history about modal list item headline"
 msgid "Save your chats on this device"
-msgstr ""
+msgstr "Išsaugok savo pokalbius šiame įrenginyje"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
@@ -17784,8 +17745,7 @@ msgstr "Slink žemyn ir sąraše rask %1$ssavo naršyklę%2$s."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr ""
-"Slinkite žemyn iki %1$sDuckDuckGo%2$s ir leiskite jai naudoti jūsų vietovę."
+msgstr "Slinkite žemyn iki %1$sDuckDuckGo%2$s ir leiskite jai naudoti jūsų vietovę."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -17818,7 +17778,7 @@ msgctxt ""
 "Placeholder and accessibility label for the search input in the tab picker "
 "dialog"
 msgid "Search"
-msgstr ""
+msgstr "Ieškoti"
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18184,8 +18144,8 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"Saugok savo susirašinėjimus mūsų serveryje su ištisiniu (angl. <em>end-to-"
-"end</em>) šifravimu ir pasiek juos bet kuriame įrenginyje."
+"Saugok savo susirašinėjimus mūsų serveryje su ištisiniu (angl. "
+"<em>end-to-end</em>) šifravimu ir pasiek juos bet kuriame įrenginyje."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -18352,27 +18312,24 @@ msgstr "„Safari“ meniu pasirink %1$s„Šios svetainės nustatymas...“%2$s
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Pasirink %1$sPasirinktinis%2$s ir įvesties laukelyje įvesk %3$shttps://"
-"duckduckgo.com%4$s"
+"Pasirink %1$sPasirinktinis%2$s ir įvesties laukelyje įvesk "
+"%3$shttps://duckduckgo.com%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sPridėti kaip numatytąją%4$s!"
+msgstr "Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sPridėti kaip numatytąją%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sNustatyti kaip numatytąją%4$s"
+msgstr "Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sNustatyti kaip numatytąją%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sNustatyti kaip numatytąją%4$s."
+msgstr "Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sNustatyti kaip numatytąją%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -18386,8 +18343,7 @@ msgstr ""
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"Sąraše pasirinkite %1$sDuckDuckGo%2$s ir %3$sleiskite%4$s pasiekti vietą"
+msgstr "Sąraše pasirinkite %1$sDuckDuckGo%2$s ir %3$sleiskite%4$s pasiekti vietą"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18399,8 +18355,7 @@ msgstr "Paieškos teikėjų sąraše pasirink %1$s„DuckDuckGo“%2$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr ""
-"Pasirink %1$s„DuckDuckGo“%2$s skiltyje%3$sNumatytoji Paieškos Sistema%4$s"
+msgstr "Pasirink %1$s„DuckDuckGo“%2$s skiltyje%3$sNumatytoji Paieškos Sistema%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -18411,8 +18366,7 @@ msgstr "Pasirink %1$s„DuckDuckGo“%2$s!"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr ""
-"Išskleidžiamajame meniu pasirink %1$sRedaguoti Paieškos Sistemas...%2$s"
+msgstr "Išskleidžiamajame meniu pasirink %1$sRedaguoti Paieškos Sistemas...%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18486,8 +18440,7 @@ msgstr "Pasirink %1$sNustatymai%2$s, tuomet %3$sIšplėstiniai nustatymai%4$s"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr ""
-"Pasirink %1$sNustatymai%2$s, tuomet %3$sNumatytoji paieškos sistema%4$s"
+msgstr "Pasirink %1$sNustatymai%2$s, tuomet %3$sNumatytoji paieškos sistema%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -18509,8 +18462,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"Sąraše pasirinkite %1$ssavo naršyklę%2$s ir %3$sleiskite%4$s vietos prieigą"
+msgstr "Sąraše pasirinkite %1$ssavo naršyklę%2$s ir %3$sleiskite%4$s vietos prieigą"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18582,8 +18534,7 @@ msgstr "Pažymėtas tekstas iš %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr ""
-"Pasirinktas tekstas per ilgas. Bandykite dar kartą su trumpesniu pasirinkimu."
+msgstr "Pasirinktas tekstas per ilgas. Bandykite dar kartą su trumpesniu pasirinkimu."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -19006,7 +18957,7 @@ msgstr "Apsipirkti"
 #. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
 msgctxt "Button in the merchandise logo modal (mobile)"
 msgid "Shop Now"
-msgstr ""
+msgstr "Pirkti dabar"
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -19114,8 +19065,7 @@ msgstr "Rodyti „DuckAssist“ <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"Rodykite „DuckAssist“ dažniau. (Taip pat galite visiškai %1$sišjungti%2$s.)"
+msgstr "Rodykite „DuckAssist“ dažniau. (Taip pat galite visiškai %1$sišjungti%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -19298,8 +19248,7 @@ msgstr "Rodyk šoninę juostą"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
-"Rodyti nuoseklius patarimus, kaip geriausiai išnaudoti „ Duck.ai“ galimybes."
+msgstr "Rodyti nuoseklius patarimus, kaip geriausiai išnaudoti „ Duck.ai“ galimybes."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -19375,8 +19324,7 @@ msgstr "Rodomos horizontalios linijos ties rezultatų puslapio lūžiais"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr ""
-"Rodo nuorodas į instrukcijas, kaip pridėti „DuckDuckGo“ prie savo naršyklės"
+msgstr "Rodo nuorodas į instrukcijas, kaip pridėti „DuckDuckGo“ prie savo naršyklės"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -19443,8 +19391,7 @@ msgstr "Rodomas sveikinamasis pranešimas paieškos rezultatų viršuje"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Rodomas sveikinamasis pranešimas ES „Android“ nuostatų meniu naudotojams"
+msgstr "Rodomas sveikinamasis pranešimas ES „Android“ nuostatų meniu naudotojams"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -19786,8 +19733,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Atsiprašome, negalėjome pateikti tavo atsiliepimo. Bandyk dar kartą vėliau."
+msgstr "Atsiprašome, negalėjome pateikti tavo atsiliepimo. Bandyk dar kartą vėliau."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -20056,15 +20002,13 @@ msgstr ""
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Apsisaugok ir gauk informacijos užsisakęs mūsų privatumo naujienlaiškius."
+msgstr "Apsisaugok ir gauk informacijos užsisakęs mūsų privatumo naujienlaiškius."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Apsisaugok ir gauk informacijos užsisakęs mūsų privatumo naujienlaiškius."
+msgstr "Apsisaugok ir gauk informacijos užsisakęs mūsų privatumo naujienlaiškius."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -20102,14 +20046,12 @@ msgstr "Sustabdyti generavimą"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr ""
-"Užkirsk kelią paslėptoms stebėjimo priemonėms, slypinčioms kitose svetainėse."
+msgstr "Užkirsk kelią paslėptoms stebėjimo priemonėms, slypinčioms kitose svetainėse."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Sustabdyk daugumą paslėptų stebėjimo priemonių, slypinčių kitose svetainėse."
+msgstr "Sustabdyk daugumą paslėptų stebėjimo priemonių, slypinčių kitose svetainėse."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20282,8 +20224,7 @@ msgstr "Pasiūlyk tinklaraščio įrašo pavadinimą"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
-"Pasiūlyk susijusių straipsnių ar temų, kuriomis verta pasidomėti toliau."
+msgstr "Pasiūlyk susijusių straipsnių ar temų, kuriomis verta pasidomėti toliau."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -20672,6 +20613,8 @@ msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
 msgstr ""
+"„Sync & Backup“ išsaugo daugiau tavo pokalbių ir sinchronizuoja juos visuose "
+"įrenginiuose."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20793,7 +20736,7 @@ msgstr "Sinchronizuok pokalbius visuose savo įrenginiuose."
 #. Headline in sync-enabled chat history about modals explaining cross-device sync.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Sync your chats across all your devices"
-msgstr ""
+msgstr "Sinchronizuok pokalbius visuose savo įrenginiuose"
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21387,12 +21330,14 @@ msgid ""
 "This chat and its generated images become public when you create and copy "
 "the link."
 msgstr ""
+"Šis pokalbis ir jo sugeneruoti vaizdai tampa vieši, kai sukuri ir "
+"nukopijuoji nuorodą."
 
 # smartling.placeholder_format=C
 #. Explains that creating and copying a share link makes the selected chat content public.
 msgctxt "Share modal info bullet about public access"
 msgid "This chat becomes public when you create and copy the link."
-msgstr ""
+msgstr "Sukūrus ir nukopijavus nuorodą, šis pokalbis tampa viešas."
 
 # smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
@@ -21928,7 +21873,7 @@ msgstr "Šiandien"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
-msgstr ""
+msgstr "Perjunk į privatų DI pokalbį arba %1$sišjunk nuostatose%2$s."
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -22284,8 +22229,7 @@ msgstr "Pabandyk %1$s, kad daugiau nematytum tokių pranešimų."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Išbandyk %1$s – mūsų pirmąjį modelį be jokio matomumo paslaugų teikėjui."
+msgstr "Išbandyk %1$s – mūsų pirmąjį modelį be jokio matomumo paslaugų teikėjui."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -22487,8 +22431,7 @@ msgstr "Išbandyti nemokamai"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr ""
-"Išbandyk nemokamai! Saugus VPN, pažangus ir privatus DI, ir dar daugiau."
+msgstr "Išbandyk nemokamai! Saugus VPN, pažangus ir privatus DI, ir dar daugiau."
 
 # smartling.placeholder_format=C
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
@@ -22527,8 +22470,7 @@ msgstr "Išbandyk mūsų naršyklę,"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr ""
-"Išbandyk mūsų pradžios puslapį, kuriame niekada nerodomi šie pranešimai:"
+msgstr "Išbandyk mūsų pradžios puslapį, kuriame niekada nerodomi šie pranešimai:"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time; shown in the US. Invites the user to start a free trial of the paid subscription.
@@ -22799,8 +22741,7 @@ msgstr "Norėdami gauti tikslesnius rezultatus, įjunkite %1$sTiksli vieta%2$s"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr ""
-"Įjunkite „Duck Player“, kad galėtumėte žiūrėti „YouTube“ be tikslinių reklamų"
+msgstr "Įjunkite „Duck Player“, kad galėtumėte žiūrėti „YouTube“ be tikslinių reklamų"
 
 # smartling.placeholder_format=C
 #. Button that enables the Search/Duck.ai toggle.
@@ -22818,8 +22759,7 @@ msgstr "Kad rezultatai būtų tikslesni, įjunkite nustatymą „Tiksli vietovė
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr ""
-"Kad rezultatai būtų tikslesni, įjunkite nustatymą „Naudoti tikslią vietovę“."
+msgstr "Kad rezultatai būtų tikslesni, įjunkite nustatymą „Naudoti tikslią vietovę“."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -23024,8 +22964,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"Laukelyje %1$sPALEISTIS > Pradžios puslapis%2$s įvesk: https://duckduckgo.com"
+msgstr "Laukelyje %1$sPALEISTIS > Pradžios puslapis%2$s įvesk: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23035,15 +22974,13 @@ msgstr "Laukelyje %1$sPaieškos nustatymai%2$s pasirink %3$s„DuckDuckGo“%4$s
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr ""
-"Laukelyje %1$sIeškoti adreso juostoje su%2$s pasirink %3$sPridėti naują%4$s"
+msgstr "Laukelyje %1$sIeškoti adreso juostoje su%2$s pasirink %3$sPridėti naują%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr ""
-"Skiltyje %1$sIeškoti%2$s spustelėk %3$sValdyti paieškos sistemas...%4$s"
+msgstr "Skiltyje %1$sIeškoti%2$s spustelėk %3$sValdyti paieškos sistemas...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -23200,8 +23137,7 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr ""
-"Gauk prieigą prie galingesnių DI modelių su „DuckDuckGo“ prenumerata. %1$s"
+msgstr "Gauk prieigą prie galingesnių DI modelių su „DuckDuckGo“ prenumerata. %1$s"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -23769,6 +23705,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Yelp's ad network."
 msgstr ""
+"„DuckDuckGo“ užtikrina tavo privatumą, kai peržiūri skelbimus. Skelbimų "
+"paspaudimus valdo „Yelp“ skelbimų tinklas."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -23908,8 +23846,7 @@ msgstr "Balso pokalbis baigtas"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr ""
-"Balso pokalbius nuasmeniname ir niekada nenaudojame DI modeliams mokyti."
+msgstr "Balso pokalbius nuasmeniname ir niekada nenaudojame DI modeliams mokyti."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -24135,8 +24072,7 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"Negalime perskaityti pridėtų failų, nes bent vienas iš jų yra užšifruotas."
+msgstr "Negalime perskaityti pridėtų failų, nes bent vienas iš jų yra užšifruotas."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24238,8 +24174,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr ""
-"Nestebime tavęs, kai naudojiesi arba nesinaudoji privačiu naršymo režimu."
+msgstr "Nestebime tavęs, kai naudojiesi arba nesinaudoji privačiu naršymo režimu."
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
@@ -24556,9 +24491,9 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"Sveiki, čia – „DuckDuckGo AI Chat“! Šią pokalbių sesiją teikia "
-"„%1$s“ „%2$s“. Visi jūsų pokalbiai čia yra privatūs ir „DuckDuckGo“ jų "
-"niekada nesaugo ir nenaudoja DI modeliams mokyti."
+"Sveiki, čia – „DuckDuckGo AI Chat“! Šią pokalbių sesiją teikia „%1$s“ "
+"„%2$s“. Visi jūsų pokalbiai čia yra privatūs ir „DuckDuckGo“ jų niekada "
+"nesaugo ir nenaudoja DI modeliams mokyti."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24572,8 +24507,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai, it's time to import your chats"
-msgstr ""
-"Sveikiname išbandžius naująją „Duck.ai“ versiją, laikas importuoti pokalbius"
+msgstr "Sveikiname išbandžius naująją „Duck.ai“ versiją, laikas importuoti pokalbius"
 
 # smartling.placeholder_format=C
 #. Welcome message for new DuckDuckGo users.
@@ -24664,8 +24598,7 @@ msgstr "Į kokius veiksnius reikia atsižvelgti perkant kompiuterio monitorių?"
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr ""
-"Kokias lankytinas vietas Paryžiuje būtina pamatyti lankantis pirmą kartą?"
+msgstr "Kokias lankytinas vietas Paryžiuje būtina pamatyti lankantis pirmą kartą?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -24932,8 +24865,7 @@ msgstr "Kokia informacija yra išsaugoma?"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr ""
-"Kokių darbo pokalbio klausimų galima sulaukti pretenduojant į šias pareigas?"
+msgstr "Kokių darbo pokalbio klausimų galima sulaukti pretenduojant į šias pareigas?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -25018,8 +24950,7 @@ msgstr "Apie ką norėtum pateikti atsiliepimą?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"Tai, ką žiūrite „DuckDuckGo“, neturės įtakos jūsų rekomendacijoms „YouTube“."
+msgstr "Tai, ką žiūrite „DuckDuckGo“, neturės įtakos jūsų rekomendacijoms „YouTube“."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -25260,6 +25191,8 @@ msgid ""
 "With chat history on, up to %s of your most recent chats will be saved on "
 "this device."
 msgstr ""
+"Įjungus pokalbių istoriją, šiame įrenginyje bus išsaugota iki %1$s tavo "
+"naujausių pokalbių."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline in the About Chat History modal.
@@ -25267,6 +25200,8 @@ msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, your most recent chats will be saved on this device."
 msgstr ""
+"Įjungus pokalbių istoriją, šiame įrenginyje bus išsaugoti tavo naujausi "
+"pokalbiai."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -25530,8 +25465,7 @@ msgstr "Taip, naujas naudotojas!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr ""
-"Taip, mes pašaliname duomenis, kai baigi naudotis, ir jų nebegalima atkurti."
+msgstr "Taip, mes pašaliname duomenis, kai baigi naudotis, ir jų nebegalima atkurti."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -25938,8 +25872,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr ""
-"Šiuo metu pasiekėte maksimalų pranešimų skaičių. Bandykite dar kartą vėliau."
+msgstr "Šiuo metu pasiekėte maksimalų pranešimų skaičių. Bandykite dar kartą vėliau."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -26025,8 +25958,7 @@ msgstr ""
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr ""
-"Tavo „Duck.ai“ pokalbiai sinchronizuojami naudojant ištisinį šifravimą."
+msgstr "Tavo „Duck.ai“ pokalbiai sinchronizuojami naudojant ištisinį šifravimą."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -26157,16 +26089,14 @@ msgstr ""
 msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"Jūsų pokalbiai yra privatūs, anonimizuoti ir nenaudojami DI modeliams mokyti."
+msgstr "Jūsų pokalbiai yra privatūs, anonimizuoti ir nenaudojami DI modeliams mokyti."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
 msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"Jūsų pokalbiai yra privatūs, anonimizuoti ir nenaudojami DI modeliams mokyti."
+msgstr "Jūsų pokalbiai yra privatūs, anonimizuoti ir nenaudojami DI modeliams mokyti."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -26520,8 +26450,7 @@ msgstr "sukurta %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"kūrėjas „DuckDuckGo“ – interneto apsauga, kuria kasdien pasitiki milijonai."
+msgstr "kūrėjas „DuckDuckGo“ – interneto apsauga, kuria kasdien pasitiki milijonai."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"
@@ -26666,7 +26595,7 @@ msgstr "min."
 #. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the chat options menu button"
 msgid "menu"
-msgstr ""
+msgstr "meniu"
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/lt_LT/LC_MESSAGES/duckduckgo.po
+++ b/locales/lt_LT/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: lt_LT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1217,6 +1217,12 @@ msgid "About our ads"
 msgstr "Apie mūsų reklamas"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1346,6 +1352,20 @@ msgid "Ad is suspicious"
 msgstr "Reklama yra įtartina"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Pridėti „DuckDuckGo“"
@@ -1372,6 +1392,27 @@ msgstr "Pridėti „DuckDuckGo“ kaip paieškos sistemą"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Pridėti „DuckDuckGo“ prie %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1417,6 +1458,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Pridėti puslapio turinio"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1502,6 +1559,12 @@ msgstr "Priedai"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Atliekami baigiamieji veiksmai"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1804,6 +1867,12 @@ msgstr "Visos spalvos"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Viskas atlikta!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3513,6 +3582,14 @@ msgid "Cancel"
 msgstr "Atšaukti"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4005,10 +4082,22 @@ msgid "Chat response is offensive"
 msgstr "Pokalbio atsakymas įžeidžiantis"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Kalbėkite su „%1$s“"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4027,6 +4116,14 @@ msgstr "Pokalbiai"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Pokalbiai"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5630,6 +5727,12 @@ msgid "Current Streak"
 msgstr "Dabartinė serija"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5976,6 +6079,12 @@ msgstr "Ištrinti pokalbius"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Trinti senesnius nei 30 dienų pokalbius"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6388,6 +6497,12 @@ msgstr "Atmesti visam laikui"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Atsisakyti reklamos"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7569,6 +7684,12 @@ msgid "Edit Prompt"
 msgstr "Redaguoti užklausą"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7791,6 +7912,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Užšifruotas modelis"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8627,6 +8754,12 @@ msgid "Follow-up question"
 msgstr "Papildomas klausimas"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9141,6 +9274,12 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
 "Gauk „DuckDuckGo VPN“, pažangųjį „Duck.ai“ ir „Identity Theft Restoration“."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10378,6 +10517,12 @@ msgstr "Kaip tai anonimiška?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Kaip tai veikia"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11822,6 +11967,12 @@ msgstr "Laimėtos užribio grumtynės"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "Nuoroda baigia galioti po 7 dienų."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13939,6 +14090,12 @@ msgstr "Gerai"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "Gerai, supratau!"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16066,6 +16223,12 @@ msgid "Protected"
 msgstr "Apsaugotas"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Apsauga. Privatumas. Ramybės jausmas."
@@ -16197,6 +16360,12 @@ msgstr "Lietus"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Reitingai"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17435,6 +17604,12 @@ msgid "Save your chats across all your devices."
 msgstr "Išsaugok pokalbius visuose savo įrenginiuose."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17636,6 +17811,14 @@ msgstr "Paieška"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Paieška"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18818,6 +19001,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Apsipirkti"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20477,6 +20666,14 @@ msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr "„Sync & Backup“ duomenų negalima atkurti po 18 mėnesių neaktyvumo."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20591,6 +20788,12 @@ msgstr "Sinchronizuok su netoliese esančiu įrenginiu."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Sinchronizuok pokalbius visuose savo įrenginiuose."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21176,6 +21379,22 @@ msgid "This Week"
 msgstr "Ši savaitė"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21704,6 +21923,12 @@ msgstr "Šiandien"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Šiandien"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23538,6 +23763,14 @@ msgstr ""
 "„TripAdvisor“ skelbimų tinklas."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Mergelių salos"
 
@@ -25021,6 +25254,21 @@ msgstr ""
 "„%1$s“."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26413,6 +26661,12 @@ msgstr "min."
 msgctxt "published date for videos"
 msgid "m"
 msgstr "min."
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/lv_LV/LC_MESSAGES/duckduckgo.po
+++ b/locales/lv_LV/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: lv_LV\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1219,6 +1219,12 @@ msgid "About our ads"
 msgstr "Par mūsu reklāmām"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1348,6 +1354,20 @@ msgid "Ad is suspicious"
 msgstr "Reklāma ir aizdomīga"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Pievienot DuckDuckGo"
@@ -1374,6 +1394,27 @@ msgstr "Pievienot DuckDuckGo kā meklētājprogrammu"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Pievienot DuckDuckGo savam %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1419,6 +1460,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Pievienot lapas saturu"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1504,6 +1561,12 @@ msgstr "Paplašinājumi"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Apdares pieskārienu pievienošana"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1808,6 +1871,12 @@ msgstr "Visas krāsas"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Viss pabeigts!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3519,6 +3588,14 @@ msgid "Cancel"
 msgstr "Atcelt"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4012,10 +4089,22 @@ msgid "Chat response is offensive"
 msgstr "Tērzēšanas atbilde ir aizskaroša"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Tērzē ar %1$s"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4034,6 +4123,14 @@ msgstr "Sarakstes"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Sarakstes"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5643,6 +5740,12 @@ msgid "Current Streak"
 msgstr "Pašreizējā sērija"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5991,6 +6094,12 @@ msgstr "Dzēst tērzēšanas sarunas"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Dzēst tērzēšanas sarunas, kas vecākas par 30 dienām"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6407,6 +6516,12 @@ msgstr "Vairs nerādīt"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Noraidīt akciju"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7587,6 +7702,12 @@ msgid "Edit Prompt"
 msgstr "Rediģēt uzvedni"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7809,6 +7930,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Šifrēts modelis"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8648,6 +8775,12 @@ msgid "Follow-up question"
 msgstr "Papildjautājums"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9164,6 +9297,12 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
 "Iegūsti DuckDuckGo VPN, padziļināto Duck.ai un Identity Theft Restoration."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10399,6 +10538,12 @@ msgstr "Kā tiek nodrošināta anonimitāte?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Kā tas darbojas"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11848,6 +11993,12 @@ msgstr "Uzvarētās līnijas"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "Saites derīguma termiņš beigsies pēc 7 dienām."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13970,6 +14121,12 @@ msgstr "Labi"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "Labi, sapratu!"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16100,6 +16257,12 @@ msgid "Protected"
 msgstr "Aizsargāts"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Aizsardzība. Privātums. Sirds miers."
@@ -16231,6 +16394,12 @@ msgstr "Lietus"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Rangs"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17471,6 +17640,12 @@ msgid "Save your chats across all your devices."
 msgstr "Saglabā savas sarunas visās savās ierīcēs."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17674,6 +17849,14 @@ msgstr "Meklēt"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Meklēt"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18854,6 +19037,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Veikals"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20505,6 +20694,14 @@ msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr "Sync & Backup datus nevar atgūt pēc 18 mēnešu neaktivitātes."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20618,6 +20815,12 @@ msgstr "Sinhronizē ar tuvumā esošu ierīci."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Sinhronizē tērzēšanas sarunas visās savās ierīcēs."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21201,6 +21404,22 @@ msgid "This Week"
 msgstr "Šonedēļ"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21730,6 +21949,12 @@ msgstr "Šodien"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Šodien"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23559,6 +23784,14 @@ msgstr ""
 "TripAdvisor reklāmu tīkls."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Virdžīnu Salas"
 
@@ -25039,6 +25272,21 @@ msgstr ""
 "izmantotas MI apmācībai. Ieslēdz vai izslēdz to jebkurā laikā izvēlnē '%1$s'."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26440,6 +26688,12 @@ msgstr "min."
 msgctxt "published date for videos"
 msgid "m"
 msgstr "min."
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/lv_LV/LC_MESSAGES/duckduckgo.po
+++ b/locales/lv_LV/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: lv_LV\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -380,8 +380,7 @@ msgstr "%1$s izmantots"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
-"%1$s patērē lietojuma limitu līdz pat 2–5 reizes ātrāk nekā pamatmodeļi %2$s"
+msgstr "%1$s patērē lietojuma limitu līdz pat 2–5 reizes ātrāk nekā pamatmodeļi %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -957,16 +956,14 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"Ir pieejama jauna AI Chat versija! Lūdzu, atsvaidzini šo lapu, lai turpinātu."
+msgstr "Ir pieejama jauna AI Chat versija! Lūdzu, atsvaidzini šo lapu, lai turpinātu."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"Ir pieejama jauna Duck.ai versija! Lai turpinātu, lūdzu, atsvaidzini šo lapu."
+msgstr "Ir pieejama jauna Duck.ai versija! Lai turpinātu, lūdzu, atsvaidzini šo lapu."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1222,7 +1219,7 @@ msgstr "Par mūsu reklāmām"
 #. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
 msgctxt "Modal header for chat history with sync information"
 msgid "About Chat History with Sync & Backup"
-msgstr ""
+msgstr "Par tērzēšanas vēsturi ar Sync & Backup"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
@@ -1357,7 +1354,7 @@ msgstr "Reklāma ir aizdomīga"
 #. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
 msgctxt "Button to open menu for attaching images or page context to AI chat"
 msgid "Add"
-msgstr ""
+msgstr "Pievienot"
 
 # smartling.placeholder_format=C
 #. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
@@ -1365,7 +1362,7 @@ msgctxt ""
 "Primary button that attaches the tabs the user checked in the tab picker "
 "dialog"
 msgid "Add"
-msgstr ""
+msgstr "Pievienot"
 
 # smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
@@ -1400,13 +1397,13 @@ msgstr "Pievienot DuckDuckGo savam %1$s"
 msgctxt ""
 "Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
 msgid "Add File"
-msgstr ""
+msgstr "Pievienot failu"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
 msgid "Add Image"
-msgstr ""
+msgstr "Pievienot attēlu"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
@@ -1414,7 +1411,7 @@ msgctxt ""
 "Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
 "item)"
 msgid "Add Image or File"
-msgstr ""
+msgstr "Pievienot attēlu vai failu"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1467,7 +1464,7 @@ msgctxt ""
 "Open the tab picker to attach browser tab content to the AI chat message "
 "(attach dropdown menu item)"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Pievienot cilnes"
 
 # smartling.placeholder_format=C
 #. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
@@ -1475,7 +1472,7 @@ msgctxt ""
 "Title and accessible name of the tab-picker dialog opened from the attach "
 "dropdown menu"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Pievienot cilnes"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1566,7 +1563,7 @@ msgstr "Apdares pieskārienu pievienošana"
 #. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
 msgctxt "Aria label for the additional instructions textarea"
 msgid "Additional instructions"
-msgstr ""
+msgstr "Papildu norādījumi"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1659,8 +1656,8 @@ msgctxt ""
 msgid ""
 "Advanced models can reach usage limits 2–5x sooner than other models. %s"
 msgstr ""
-"Izmantojot jaudīgākus modeļus, lietošanas ierobežojumu var sasniegt 2–"
-"5 reizes ātrāk nekā ar citiem modeļiem. %1$s"
+"Izmantojot jaudīgākus modeļus, lietošanas ierobežojumu var sasniegt "
+"2–5 reizes ātrāk nekā ar citiem modeļiem. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
@@ -1835,8 +1832,7 @@ msgstr "Visas tērzēšanas sarunas ir %1$s"
 #. Disclaimer text shown below chat input. %s is replaced with a clickable underlined 'private' link that opens the privacy protection modal.
 msgctxt "Disclaimer below chat input in Duck.ai"
 msgid "All chats are %s. AI can make mistakes."
-msgstr ""
-"Visas tērzēšanas sarunas ir %1$s. Mākslīgais intelekts var pieļaut kļūdas."
+msgstr "Visas tērzēšanas sarunas ir %1$s. Mākslīgais intelekts var pieļaut kļūdas."
 
 # smartling.placeholder_format=C
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
@@ -1876,7 +1872,7 @@ msgstr "Viss pabeigts!"
 #. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the read-only textarea listing all AI instructions"
 msgid "All instructions"
-msgstr ""
+msgstr "Visi norādījumi"
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2303,8 +2299,7 @@ msgstr "Vai tu joprojām esi tur?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"Vai tiešām vēlies notīrīt visas tērzēšanas sarunas? Šo darbību nevar atsaukt."
+msgstr "Vai tiešām vēlies notīrīt visas tērzēšanas sarunas? Šo darbību nevar atsaukt."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2316,8 +2311,7 @@ msgstr "Vai tiešām vēlies notīrīt šo sarunu un sākt jaunu?"
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
 msgctxt "Body text for delete chat confirmation modal"
 msgid "Are you sure you want to delete this chat? This cannot be undone."
-msgstr ""
-"Vai tiešām vēlies izdzēst šo tērzēšanas sarunu? Šo darbību nevar atsaukt."
+msgstr "Vai tiešām vēlies izdzēst šo tērzēšanas sarunu? Šo darbību nevar atsaukt."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable chat history, with a warning that it will also delete currently saved chats including pinned chats.
@@ -3520,8 +3514,7 @@ msgstr "Kamerūna"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr ""
-"Vai vari izveidot dažas vienkāršas receptes ar vistu, brokoļiem un rīsiem?"
+msgstr "Vai vari izveidot dažas vienkāršas receptes ar vistu, brokoļiem un rīsiem?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3593,7 +3586,7 @@ msgctxt ""
 "Secondary button that dismisses the tab picker dialog without attaching "
 "anything"
 msgid "Cancel"
-msgstr ""
+msgstr "Atcelt"
 
 # smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
@@ -3849,8 +3842,7 @@ msgstr "Maina fona krāsu visā vietnē"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr ""
-"Maina rezultātu fona krāsu zem kursora, moduļos un nolaižamajās izvēlnēs"
+msgstr "Maina rezultātu fona krāsu zem kursora, moduļos un nolaižamajās izvēlnēs"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -3983,8 +3975,8 @@ msgstr ""
 "ar trešo pušu mākslīgā intelekta tērzēšanas modeļiem, kas atbalsta OpenAI, "
 "Anthropic un citus rīkus. Izslēdzot šo iestatījumu tiks paslēptas tērzēšanas "
 "pogas un saites DuckDuckGo Search platformā. Taču tu joprojām vari piekļūt "
-"tērzēšanai, ja šis iestatījums ir izslēgts, apmeklējot %1$shttps://duck."
-"ai%2$s tieši."
+"tērzēšanai, ja šis iestatījums ir izslēgts, apmeklējot "
+"%1$shttps://duck.ai%2$s tieši."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4092,7 +4084,7 @@ msgstr "Tērzēšanas atbilde ir aizskaroša"
 #. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
 msgctxt "Chat history about modal list item headline"
 msgid "Chat storage varies by browser"
-msgstr ""
+msgstr "Tērzēšanas krātuve atšķiras atkarībā no pārlūka"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4104,7 +4096,7 @@ msgstr "Tērzē ar %1$s"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Chat with popular AI models, anonymized by us."
-msgstr ""
+msgstr "Tērzē ar mūsu anonimizētiem populāriem MI modeļiem."
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4131,6 +4123,8 @@ msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
 msgstr ""
+"Tērzēšanas sarunas tiek droši glabātas DuckDuckGo serverī ar pilnīgu "
+"šifrēšanu. Neviens, izņemot tevi, nevar redzēt tavus datus, pat ne mēs."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4618,8 +4612,7 @@ msgstr "Nospied %1$sAtļaut%2$s, pēc tam %3$sPievienot%4$s."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Click %sChange Search Settings%s in the drop down"
-msgstr ""
-"Nolaižamajā izvēlnē noklikšķini uz %1$sMainīt meklēšanas iestatījumus%2$s"
+msgstr "Nolaižamajā izvēlnē noklikšķini uz %1$sMainīt meklēšanas iestatījumus%2$s"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -4720,8 +4713,7 @@ msgstr "Sānjoslā noklikšķini uz %1$sPārlūks%2$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on %sChange Search Settings%s in the dropdown menu"
-msgstr ""
-"Nolaižamajā izvēlnē noklikšķini uz %1$sMainīt meklēšanas iestatījumus%2$s"
+msgstr "Nolaižamajā izvēlnē noklikšķini uz %1$sMainīt meklēšanas iestatījumus%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -4741,8 +4733,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sTools icon%s in the top-right of the browser"
-msgstr ""
-"Pārlūkprogrammas augšējā labajā stūrī noklikšķini uz %1$sRīku ikonas%2$s"
+msgstr "Pārlūkprogrammas augšējā labajā stūrī noklikšķini uz %1$sRīku ikonas%2$s"
 
 #  Firefox default search engine instruction
 # smartling.placeholder_format=C
@@ -4871,8 +4862,7 @@ msgstr "Noklikšķini uz palielināmā stikla ikonas meklēšanas lodziņā"
 #. Tells users what icon to click in order to make DuckDuckGo the default engine in their browser.
 msgid ""
 "Click the magnifying glass in the search box (at the top of the browser)"
-msgstr ""
-"Noklikšķini uz palielināmā stikla meklēšanas lodziņā (parlūka augšdaļā)"
+msgstr "Noklikšķini uz palielināmā stikla meklēšanas lodziņā (parlūka augšdaļā)"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -5332,8 +5322,7 @@ msgstr "Turpināt bloķēt reklāmas"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
-"Turpini nesenās tērzēšanas sarunas šeit. Vai arī dzēs tās ar Fire Button."
+msgstr "Turpini nesenās tērzēšanas sarunas šeit. Vai arī dzēs tās ar Fire Button."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5557,8 +5546,7 @@ msgstr "Kostarika"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr ""
-"Nevarēja ielādēt tavu atkopšanas kodu. Lūdzu, aizver šo un mēģini vēlreiz."
+msgstr "Nevarēja ielādēt tavu atkopšanas kodu. Lūdzu, aizver šo un mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5743,7 +5731,7 @@ msgstr "Pašreizējā sērija"
 #. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
 msgctxt "Suffix label indicating a tab is the currently active browser tab"
 msgid "Current Tab"
-msgstr ""
+msgstr "Pašreizējā cilne"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
@@ -6099,7 +6087,7 @@ msgstr "Dzēst tērzēšanas sarunas, kas vecākas par 30 dienām"
 #. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
 msgctxt "Button text in the modal for deleting all recent chats"
 msgid "Delete Chats and Shared Links"
-msgstr ""
+msgstr "Dzēst sarunas un kopīgotās saites"
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6426,8 +6414,7 @@ msgstr "Atspējot un atvienot"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr ""
-"Vai atspējot tērzēšanas vēsturi un pārtraukt savienojumu ar Sync & Backup?"
+msgstr "Vai atspējot tērzēšanas vēsturi un pārtraukt savienojumu ar Sync & Backup?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6521,7 +6508,7 @@ msgstr "Noraidīt akciju"
 #. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the close button on the survey banner"
 msgid "Dismiss survey"
-msgstr ""
+msgstr "Nerādīt aptauju"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6634,8 +6621,7 @@ msgstr "Neredzi DuckDuckGo sarakstā?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr ""
-"Neredzi to? %1$s%2$s%3$sNoklikšķini šeit, lai lejupielādētu vēlreiz%4$s"
+msgstr "Neredzi to? %1$s%2$s%3$sNoklikšķini šeit, lai lejupielādētu vēlreiz%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -7059,8 +7045,7 @@ msgstr ""
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr ""
-"Duck.ai uz laiku nav pieejams. Lūdzu, atsvaidzini lapu un mēģini vēlreiz."
+msgstr "Duck.ai uz laiku nav pieejams. Lūdzu, atsvaidzini lapu un mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7075,8 +7060,8 @@ msgid ""
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 "Duck.ai ļauj tev privāti tērzēt ar populāriem MI modeļiem. Atspējošana "
-"paslēpj Duck.ai pogas un saites, taču tu joprojām vari apmeklēt %1$sduck."
-"ai%2$s tieši."
+"paslēpj Duck.ai pogas un saites, taču tu joprojām vari apmeklēt "
+"%1$sduck.ai%2$s tieši."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7146,8 +7131,7 @@ msgstr "Duck.ai atjaunināts!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.ai vislabāk darbojas mūsu privātajā un bezmaksas DuckDuckGo lietotnē!"
+msgstr "Duck.ai vislabāk darbojas mūsu privātajā un bezmaksas DuckDuckGo lietotnē!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7705,7 +7689,7 @@ msgstr "Rediģēt uzvedni"
 #. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the message-editing text area"
 msgid "Edit message"
-msgstr ""
+msgstr "Rediģēt ziņojumu"
 
 # smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
@@ -7724,8 +7708,7 @@ msgstr "Rediģē attēlu..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr ""
-"Rediģējot savu ziņu, tiks dzēsta zemāk esošā atbilde un izveidota jauna."
+msgstr "Rediģējot savu ziņu, tiks dzēsta zemāk esošā atbilde un izveidota jauna."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7935,7 +7918,7 @@ msgstr "Šifrēts modelis"
 #. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
 msgctxt "Share modal info bullet about encryption"
 msgid "Encrypted so DuckDuckGo can't read your chat."
-msgstr ""
+msgstr "Šifrēts – DuckDuckGo nevar izlasīt tavu tērzēšanu."
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8053,15 +8036,13 @@ msgstr ""
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access"
-msgstr ""
-"Pārliecinies, vai pārlūkprogrammai ir atļauta piekļuve atrašanās vietai"
+msgstr "Pārliecinies, vai pārlūkprogrammai ir atļauta piekļuve atrašanās vietai"
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr ""
-"Pārliecinies, vai pārlūkprogrammai ir atļauta piekļuve atrašanās vietai."
+msgstr "Pārliecinies, vai pārlūkprogrammai ir atļauta piekļuve atrašanās vietai."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -8155,8 +8136,7 @@ msgstr "Ekvatoriālā Gvineja"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"Ātri izdzēs savus pārlūkošanas datus, izmantojot mūsu %1$sFire Button%2$s"
+msgstr "Ātri izdzēs savus pārlūkošanas datus, izmantojot mūsu %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -8262,8 +8242,7 @@ msgstr "Izskaidro pieņemto atbildi vienkāršā valodā."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr ""
-"Paskaidro man pamatjēdzienus par melnajiem caurumiem vidusskolas līmenī."
+msgstr "Paskaidro man pamatjēdzienus par melnajiem caurumiem vidusskolas līmenī."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -8500,8 +8479,7 @@ msgstr "Atsauksme sekmīgi iesniegta"
 msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
-msgstr ""
-"Tavas atsauksmes tieši ietekmē mūsu produktu atjauninājumus un uzlabojumus."
+msgstr "Tavas atsauksmes tieši ietekmē mūsu produktu atjauninājumus un uzlabojumus."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8642,8 +8620,7 @@ msgstr "Finanšu konsultants"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr ""
-"Atrodi %1$sDuckDuckGo%2$s un noklikšķini uz%3$sPadarīt par noklusējumu%4$s"
+msgstr "Atrodi %1$sDuckDuckGo%2$s un noklikšķini uz%3$sPadarīt par noklusējumu%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8778,7 +8755,7 @@ msgstr "Papildjautājums"
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
-msgstr ""
+msgstr "Papildjautājumi paliek privāti."
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -9000,9 +8977,9 @@ msgid ""
 "strong>."
 msgstr ""
 "Mac datorā lietotnes izvēlnes joslā izvēlies <strong>DuckDuckGo</strong> "
-"&gt; <strong>Check for Updates...</strong> (&quot;Meklēt atjauninājumus..."
-"&quot;) un tad <strong>Install Update</strong> (&quot;Instalēt "
-"atjauninājumu&quot;)."
+"&gt; <strong>Check for Updates...</strong> (&quot;Meklēt "
+"atjauninājumus...&quot;) un tad <strong>Install Update</strong> "
+"(&quot;Instalēt atjauninājumu&quot;)."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9295,14 +9272,13 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr ""
-"Iegūsti DuckDuckGo VPN, padziļināto Duck.ai un Identity Theft Restoration."
+msgstr "Iegūsti DuckDuckGo VPN, padziļināto Duck.ai un Identity Theft Restoration."
 
 # smartling.placeholder_format=C
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
 msgctxt "Tooltip on the header logo for sunglasses searches"
 msgid "Get DuckDuckGo sunglasses and other gear."
-msgstr ""
+msgstr "Iegūsti DuckDuckGo saulesbrilles un citu aprīkojumu."
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9525,8 +9501,7 @@ msgstr "Iegūt lietotni"
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
-msgstr ""
-"Iegūsti bezmaksas pārlūku DuckDuckGo, %1$slai bloķētu reklāmas YouTube.%2$s"
+msgstr "Iegūsti bezmaksas pārlūku DuckDuckGo, %1$slai bloķētu reklāmas YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9638,8 +9613,7 @@ msgstr ""
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr ""
-"Atver sadaļas %1$sPrivātums un drošība > Atrašanās vietas pakalpojumi%2$s"
+msgstr "Atver sadaļas %1$sPrivātums un drošība > Atrašanās vietas pakalpojumi%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -10312,8 +10286,8 @@ msgstr "Slēp savu e-pasta adresi"
 msgctxt "settings"
 msgid "Hides search term from being shown in browser tab/history"
 msgstr ""
-"Nodrošina, ka meklētais vienums netiek parādīts pārlūkprogrammas cilnē/"
-"vēsturē"
+"Nodrošina, ka meklētais vienums netiek parādīts pārlūkprogrammas "
+"cilnē/vēsturē"
 
 # smartling.placeholder_format=C
 #. The highest stock price in a day
@@ -10543,7 +10517,7 @@ msgstr "Kā tas darbojas"
 #. Headline in chat history about modals for the temporary encrypted server storage explanation.
 msgctxt "Chat history about modal list item headline"
 msgid "How it works"
-msgstr ""
+msgstr "Kā tas darbojas"
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -10567,8 +10541,7 @@ msgstr "Cik daudz tu vēlies, lai parādītos MI atbalstītas atbildes?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr ""
-"Cik daudz no saviem dienas un nedēļas limitiem tu esi līdz šim izmantojis."
+msgstr "Cik daudz no saviem dienas un nedēļas limitiem tu esi līdz šim izmantojis."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10725,8 +10698,7 @@ msgstr ""
 #. Option for feedback when the user needs more help or information on how to use the chat.
 msgctxt "Feedback option for difficulty in using chat"
 msgid "I need more help/info on how to use Chat"
-msgstr ""
-"Man ir nepieciešama papildu palīdzība/informācija par tērzēšanas izmantošanu"
+msgstr "Man ir nepieciešama papildu palīdzība/informācija par tērzēšanas izmantošanu"
 
 # smartling.placeholder_format=C
 msgid "IR Iran"
@@ -10813,8 +10785,7 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"Ja tu tiešām vēlies mūs atbalstīt, %1$spalīdzi popularizēt DuckDuckGo%2$s"
+msgstr "Ja tu tiešām vēlies mūs atbalstīt, %1$spalīdzi popularizēt DuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10832,8 +10803,7 @@ msgstr ""
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
-msgstr ""
-"Ja vēlies, nospied Sākuma lapu pie Jauna loga un Jaunas cilnes (atvērt ar)."
+msgstr "Ja vēlies, nospied Sākuma lapu pie Jauna loga un Jaunas cilnes (atvērt ar)."
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -11391,8 +11361,7 @@ msgstr "Tas varētu aizņemt dažas minūtes"
 #. Body text of a card that promotes installing the DuckDuckGo desktop browser.
 msgctxt "new tab page"
 msgid "It's fast, free, and gives you even more online protection."
-msgstr ""
-"Tas ir ātrs, bezmaksas un sniedz tev vēl lielāku aizsardzību tiešsaistē."
+msgstr "Tas ir ātrs, bezmaksas un sniedz tev vēl lielāku aizsardzību tiešsaistē."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -11999,6 +11968,8 @@ msgstr "Saites derīguma termiņš beigsies pēc 7 dienām."
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
+"Saites derīguma termiņš beigsies pēc 7 dienām. Cilvēki var saglabāt "
+"tērzēšanas kopiju."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -12907,8 +12878,7 @@ msgstr "Tu esi sasniedzis mēneša limitu"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Sasniegts mēneša lietošanas limits. Tu varēsi turpināt šo tērzēšanu pēc %1$s."
+msgstr "Sasniegts mēneša lietošanas limits. Tu varēsi turpināt šo tērzēšanu pēc %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -13810,8 +13780,7 @@ msgstr "Tikai meklēšana – bez izsekošanas un mērķētas reklāmas!"
 #. Refers to how web searches on DuckDuckGo aren't tracked.
 msgctxt "homepage onboarding"
 msgid "No tracking, no ad targeting, just searching."
-msgstr ""
-"Tikai meklēšana, bez izsekošanas, bez reklāmas mērķauditorijas atlases."
+msgstr "Tikai meklēšana, bez izsekošanas, bez reklāmas mērķauditorijas atlases."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search. The placeholder is the user's search term. For example: 'No videos found for 'bad dogs''
@@ -14126,7 +14095,7 @@ msgstr "Labi, sapratu!"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "OPTIONAL"
-msgstr ""
+msgstr "NEOBLIGĀTI"
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -14474,8 +14443,7 @@ msgstr "Atver %1$sIestatījumi%2$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open 'Location', and ensure location is %senabled%s."
-msgstr ""
-"Atver opciju “Atrašanās vieta” un pārliecinies, ka tā ir %1$siespējota%2$s."
+msgstr "Atver opciju “Atrašanās vieta” un pārliecinies, ka tā ir %1$siespējota%2$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -15427,8 +15395,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr ""
-"Lūdzu, izpildi uzdevumu, lai apstiprinātu, ka šo vaicājumu veic cilvēks."
+msgstr "Lūdzu, izpildi uzdevumu, lai apstiprinātu, ka šo vaicājumu veic cilvēks."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -15436,8 +15403,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr ""
-"Lūdzu, izpildi šo uzdevumu, lai apstiprinātu, ka meklēšanu veic cilvēks."
+msgstr "Lūdzu, izpildi šo uzdevumu, lai apstiprinātu, ka meklēšanu veic cilvēks."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -15648,8 +15614,7 @@ msgstr "Plus vēl citas premium funkcijas ar DuckDuckGo abonementu."
 msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
-msgstr ""
-"Turklāt tas, ko tu skaties Duck Player, neietekmē tavus ieteikumus YouTube."
+msgstr "Turklāt tas, ko tu skaties Duck Player, neietekmē tavus ieteikumus YouTube."
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -16242,8 +16207,7 @@ msgstr "Aizsargā savus datus meklēšanas un pārlūkošanas laikā."
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
-msgstr ""
-"Aizsargā savus datus, meklējot, pārlūkojot un izmantojot mākslīgo intelektu."
+msgstr "Aizsargā savus datus, meklējot, pārlūkojot un izmantojot mākslīgo intelektu."
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -16260,7 +16224,7 @@ msgstr "Aizsargāts"
 #. Headline in sync-enabled chat history about modals explaining encrypted server storage.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Protected with end-to-end encryption"
-msgstr ""
+msgstr "Aizsargāts ar pilnīgu šifrēšanu"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -16399,7 +16363,7 @@ msgstr "Rangs"
 #. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
 msgctxt "star rating on a product"
 msgid "Rated %s out of %s"
-msgstr ""
+msgstr "Vērtējums: %1$s no %2$s"
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -16877,8 +16841,7 @@ msgstr "Atcerēties manu izvēli"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Atcerēties manu izvēli (to var mainīt sadaļā %1$s%2$s%3$sIestatījumi%4$s)"
+msgstr "Atcerēties manu izvēli (to var mainīt sadaļā %1$s%2$s%3$sIestatījumi%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -17643,7 +17606,7 @@ msgstr "Saglabā savas sarunas visās savās ierīcēs."
 #. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
 msgctxt "Chat history about modal list item headline"
 msgid "Save your chats on this device"
-msgstr ""
+msgstr "Saglabā savas sarunas šajā ierīcē"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
@@ -17822,8 +17785,7 @@ msgstr "Ritini uz leju un sarakstā atrodi %1$ssavu pārlūkprogrammu%2$s."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr ""
-"Ritini uz leju līdz %1$sDuckDuckGo%2$s un ļauj izmantot savu atrašanās vietu."
+msgstr "Ritini uz leju līdz %1$sDuckDuckGo%2$s un ļauj izmantot savu atrašanās vietu."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -17856,7 +17818,7 @@ msgctxt ""
 "Placeholder and accessibility label for the search input in the tab picker "
 "dialog"
 msgid "Search"
-msgstr ""
+msgstr "Meklēt"
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18355,8 +18317,7 @@ msgstr "Apskati dažus no mūsu pēdējiem atjauninājumiem"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr ""
-"Apskati %1$sURL parametru uzziņas lapa%2$s, lai iegūtu vairāk informācijas."
+msgstr "Apskati %1$sURL parametru uzziņas lapa%2$s, lai iegūtu vairāk informācijas."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -18390,20 +18351,18 @@ msgstr "Safari izvēlnē atlasi %1$s“Šīs vietnes iestatījumi...”%2$s."
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Atlasi %1$sPielāgots%2$s un ievades laukā raksti %3$shttps://duckduckgo."
-"com%4$s"
+"Atlasi %1$sPielāgots%2$s un ievades laukā raksti "
+"%3$shttps://duckduckgo.com%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Atlasi %1$sDuckDuckGo%2$s un noklikšķini uz %3$sPievienot kā noklusējumu%4$s!"
+msgstr "Atlasi %1$sDuckDuckGo%2$s un noklikšķini uz %3$sPievienot kā noklusējumu%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"Atlasi %1$sDuckDuckGo%2$s un noklikšķini uz %3$sIestatīt kā noklusējumu%4$s"
+msgstr "Atlasi %1$sDuckDuckGo%2$s un noklikšķini uz %3$sIestatīt kā noklusējumu%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -18415,8 +18374,7 @@ msgstr "Atlasi %1$sDuckDuckGo%2$s un nospied %3$sIestatīt kā noklusējumu%4$s.
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr ""
-"Noklusējuma meklētājprogrammas nolaižamajā izvēlnē atlasi %1$sDuckDuckGo%2$s"
+msgstr "Noklusējuma meklētājprogrammas nolaižamajā izvēlnē atlasi %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
@@ -18436,8 +18394,7 @@ msgstr "Meklēšanas pakalpojumu sniedzēju sarakstā atlasi %1$sDuckDuckGo%2$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr ""
-"Sadaļā%3$sNoklusējuma meklētājprogramma%4$s izvēlies %1$sDuckDuckGo%2$s"
+msgstr "Sadaļā%3$sNoklusējuma meklētājprogramma%4$s izvēlies %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -18470,8 +18427,7 @@ msgstr ""
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
-msgstr ""
-"Atver %1$sOpera > Preferences%2$s (Mac) vai %3$sOpera > Opcijas%4$s (Windows)"
+msgstr "Atver %1$sOpera > Preferences%2$s (Mac) vai %3$sOpera > Opcijas%4$s (Windows)"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -19042,7 +18998,7 @@ msgstr "Veikals"
 #. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
 msgctxt "Button in the merchandise logo modal (mobile)"
 msgid "Shop Now"
-msgstr ""
+msgstr "Iepirkties tagad"
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -19408,8 +19364,7 @@ msgstr "Parāda horizontālas līnijas rezultātu lapu pārtraukumos"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr ""
-"Parāda saites uz instrukcijām, kā pievienot DuckDuckGo savai pārlūkprogrammai"
+msgstr "Parāda saites uz instrukcijām, kā pievienot DuckDuckGo savai pārlūkprogrammai"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -19430,8 +19385,7 @@ msgstr "Ik pa laikam rāda atgādinājumus par DuckDuckGo pievienošanu pārlūk
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Ik pa laikam rāda atgādinājumus par DuckDuckGo pievienošanu tavām ierīcēm"
+msgstr "Ik pa laikam rāda atgādinājumus par DuckDuckGo pievienošanu tavām ierīcēm"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19707,15 +19661,13 @@ msgstr "Ielādējot šo kopīgoto tērzēšanu, radās kļūda."
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr ""
-"Kaut kas nogāja greizi, mēģinot saglabāt serverī, lūdzu, mēģini vēlreiz."
+msgstr "Kaut kas nogāja greizi, mēģinot saglabāt serverī, lūdzu, mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr ""
-"Kaut kas nogāja greizi, iespējojot Sync & Backup. Lūdzu, mēģini vēlreiz."
+msgstr "Kaut kas nogāja greizi, iespējojot Sync & Backup. Lūdzu, mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -19802,8 +19754,8 @@ msgstr ""
 msgid ""
 "Sorry, we couldn't generate a richer answer. You can try asking Duck.ai."
 msgstr ""
-"Atvaino, mēs nevarējām sniegt plašāku atbildi. Tu vari mēģināt jautāt Duck."
-"ai."
+"Atvaino, mēs nevarējām sniegt plašāku atbildi. Tu vari mēģināt jautāt "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and that they could try to refresh the page to resolve the error. Placeholders are for markup, please ignore.
@@ -19819,8 +19771,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Diemžēl mums neizdevās iesniegt tavu atsauksmi. Lūdzu, mēģini vēlreiz vēlāk."
+msgstr "Diemžēl mums neizdevās iesniegt tavu atsauksmi. Lūdzu, mēģini vēlreiz vēlāk."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -20081,22 +20032,19 @@ msgstr "Paliec DuckDuckGo platformā"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr ""
-"Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
+msgstr "Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
+msgstr "Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
+msgstr "Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -20298,8 +20246,7 @@ msgctxt "Full sentence for composing a card"
 msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
-msgstr ""
-"Iesaki frāzi, ko uzrakstīt uz kartītes kādam, kurš atveseļojas pēc operācijas"
+msgstr "Iesaki frāzi, ko uzrakstīt uz kartītes kādam, kurš atveseļojas pēc operācijas"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
@@ -20700,6 +20647,8 @@ msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
 msgstr ""
+"Sync & Backup saglabā vairāk tavu tērzēšanas sarunu un sinhronizē tās visās "
+"tavās ierīcēs."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20820,7 +20769,7 @@ msgstr "Sinhronizē tērzēšanas sarunas visās savās ierīcēs."
 #. Headline in sync-enabled chat history about modals explaining cross-device sync.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Sync your chats across all your devices"
-msgstr ""
+msgstr "Sinhronizē tērzēšanas sarunas visās savās ierīcēs"
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -20939,8 +20888,7 @@ msgstr "Esi noteicējs pār saviem personīgajiem datiem!"
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr ""
-"Aizpildi šo anonīmo aptauju, lai mēs uzzinātu, kā varam uzlabot Duck.ai."
+msgstr "Aizpildi šo anonīmo aptauju, lai mēs uzzinātu, kā varam uzlabot Duck.ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -21412,12 +21360,14 @@ msgid ""
 "This chat and its generated images become public when you create and copy "
 "the link."
 msgstr ""
+"Šī tērzēšana un tās veidotie attēli kļūs publiski pieejami, kad izveidosi un "
+"nokopēsi saiti."
 
 # smartling.placeholder_format=C
 #. Explains that creating and copying a share link makes the selected chat content public.
 msgctxt "Share modal info bullet about public access"
 msgid "This chat becomes public when you create and copy the link."
-msgstr ""
+msgstr "Šī tērzēšana kļūst publiska, kad tu izveido un nokopē saiti."
 
 # smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
@@ -21954,7 +21904,7 @@ msgstr "Šodien"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
-msgstr ""
+msgstr "Pārslēdzies uz privātu MI tērzēšanu vai %1$sizslēdz to iestatījumos%2$s."
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -22010,8 +21960,7 @@ msgstr "Pārāk daudz reklāmu"
 #. Displayed when the user has sent too many requests in a short period of time.
 msgctxt "Error message for rate limit"
 msgid "Too many requests. Please take a short break and try again."
-msgstr ""
-"Pārāk daudz pieprasījumu. Lūdzu, paņem nelielu pārtraukumu un mēģini vēlreiz."
+msgstr "Pārāk daudz pieprasījumu. Lūdzu, paņem nelielu pārtraukumu un mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -22452,8 +22401,7 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Lai iegūtu precīzākus rezultātus, pamēģini iespējot anonīmu atrašanās vietu."
+msgstr "Lai iegūtu precīzākus rezultātus, pamēģini iespējot anonīmu atrašanās vietu."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
@@ -22844,8 +22792,7 @@ msgstr "Lai iegūtu precīzākus rezultātus, ieslēdz “Precīza atrašanās v
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr ""
-"Lai iegūtu precīzākus rezultātus, ieslēdz “Izmantot precīzu atrašanās vietu”."
+msgstr "Lai iegūtu precīzākus rezultātus, ieslēdz “Izmantot precīzu atrašanās vietu”."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -22996,8 +22943,7 @@ msgstr "Nevar iesniegt atsauksmi"
 #. Message shown to the user when the voice chat failed to establish a connection, and they should try again later.
 msgctxt "voice chat"
 msgid "Unable to connect to voice chat, please try again later."
-msgstr ""
-"Nevar izveidot savienojumu ar balss tērzēšanu. Lūdzu, vēlāk mēģini vēlreiz. "
+msgstr "Nevar izveidot savienojumu ar balss tērzēšanu. Lūdzu, vēlāk mēģini vēlreiz. "
 
 # smartling.placeholder_format=C
 #. Message shown to the user when there was an issue connecting to their microphone.
@@ -23038,8 +22984,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Sadaļā %1$sPie palaišanas%2$s atlasi %3$sMājaslapa%4$s un ievadi: https://"
-"duckduckgo.com"
+"Sadaļā %1$sPie palaišanas%2$s atlasi %3$sMājaslapa%4$s un ievadi: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -23065,15 +23011,13 @@ msgstr "Zem %1$sMeklēt adreses joslā ar%2$s nospied %3$sPievienot jaunu%4$s"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr ""
-"Zem %1$sMeklēt%2$s sekcijas nospied %3$sPārvaldīt meklējumprogrammas...%4$s"
+msgstr "Zem %1$sMeklēt%2$s sekcijas nospied %3$sPārvaldīt meklējumprogrammas...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr ""
-"Sadaļā \"Pie palaišanas\" atlasi %1$sAtvērt noteiktu lapu vai lapu kopu%2$s"
+msgstr "Sadaļā \"Pie palaišanas\" atlasi %1$sAtvērt noteiktu lapu vai lapu kopu%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -23181,8 +23125,7 @@ msgstr "Atbloķē ar DuckDuckGo abonementu"
 msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
-msgstr ""
-"Atbloķē uzlabotus MI modeļus un augstākas robežas ar DuckDuckGo abonementu"
+msgstr "Atbloķē uzlabotus MI modeļus un augstākas robežas ar DuckDuckGo abonementu"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -23625,8 +23568,7 @@ msgstr ""
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
 msgctxt "DuckChat location prompt"
 msgid "Use your approximate location for more accurate results?"
-msgstr ""
-"Vai izmantot aptuveno atrašanās vietu, lai iegūtu precīzākus rezultātus?"
+msgstr "Vai izmantot aptuveno atrašanās vietu, lai iegūtu precīzākus rezultātus?"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes before every user message in the downloaded file, indicating which message it is out of the total number of messages. Example: 'User prompt 3 of 5'
@@ -23790,6 +23732,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Yelp's ad network."
 msgstr ""
+"Reklāmu skatīšanu aizsargā DuckDuckGo privātums. Reklāmu klikšķus pārvalda "
+"Yelp reklāmu tīkls."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -23873,8 +23817,8 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"Apmeklē Duck.ai citā pārlūkprogrammā vai DuckDuckGo lietotnē un atver Duck."
-"ai iestatījumus. Sadaļā “Sync & Backup” izvēlies “Ieslēgt” un tad "
+"Apmeklē Duck.ai citā pārlūkprogrammā vai DuckDuckGo lietotnē un atver "
+"Duck.ai iestatījumus. Sadaļā “Sync & Backup” izvēlies “Ieslēgt” un tad "
 "“Sinhronizēt ar citu ierīci”. Vai arī noskenē kvadrātkodu savā atkopšanas "
 "PDF failā."
 
@@ -24156,8 +24100,7 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"Mēs nevaram nolasīt pievienotos failus, jo vismaz viens no tiem ir šifrēts."
+msgstr "Mēs nevaram nolasīt pievienotos failus, jo vismaz viens no tiem ir šifrēts."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24173,8 +24116,7 @@ msgstr "Mēs neglabājam lietotājvārdus un personu identificējošu informāci
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr ""
-"Mēs neuzglabājam tavu personisko informāciju un neizsekojam tevi. Nekad."
+msgstr "Mēs neuzglabājam tavu personisko informāciju un neizsekojam tevi. Nekad."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24307,8 +24249,7 @@ msgstr "Mēs zaudējām savienojumu, lūdzu, vēlāk mēģini vēlreiz."
 #. We store chats for 15 minutes in the BE. If the user tries to fetch it after the 15 minutes elapsed or if we had an issue saving it we show them this error message so they can re-submit their prompt.
 msgctxt "AI Chat: Error message for unsaved or expired chats saved in sync"
 msgid "We lost the connection. Please try sending your message again."
-msgstr ""
-"Mēs pazaudējām savienojumu. Lūdzu, mēģini nosūtīt savu ziņojumu vēlreiz."
+msgstr "Mēs pazaudējām savienojumu. Lūdzu, mēģini nosūtīt savu ziņojumu vēlreiz."
 
 # smartling.placeholder_format=C
 #. Message asking the user to disable their ad blocker, with a link to how our ads don't track you. The placeholders are for the start and end tags of that link (e.g. <a href="%">, </a>)
@@ -24350,8 +24291,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr ""
-"Mēs neļaujam nevienam piekļūt tavai meklēšanas vēsturei – to nevaram arī mēs."
+msgstr "Mēs neļaujam nevienam piekļūt tavai meklēšanas vēsturei – to nevaram arī mēs."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -24586,8 +24526,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"Laipni lūdzam jaunajā Duck.ai! Tagad vari importēt lejupielādētās sarakstes."
+msgstr "Laipni lūdzam jaunajā Duck.ai! Tagad vari importēt lejupielādētās sarakstes."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -25038,8 +24977,7 @@ msgstr "Par ko tu vēlētos sniegt atsauksmes?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"Tas, ko skaties DuckDuckGo, neietekmēs tavus ieteikumus pakalpojumā YouTube."
+msgstr "Tas, ko skaties DuckDuckGo, neietekmēs tavus ieteikumus pakalpojumā YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -25129,8 +25067,7 @@ msgstr "Kas mēs esam"
 #. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
-msgstr ""
-"Kas ir galvenie aktieri un filmēšanas grupa, un ar ko vēl viņi ir pazīstami?"
+msgstr "Kas ir galvenie aktieri un filmēšanas grupa, un ar ko vēl viņi ir pazīstami?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -25278,6 +25215,8 @@ msgid ""
 "With chat history on, up to %s of your most recent chats will be saved on "
 "this device."
 msgstr ""
+"Kad ir ieslēgta tērzēšanas vēsture, šajā ierīcē tiks saglabāts līdz pat %1$s "
+"tavām jaunākajām tērzēšanas sarunām."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline in the About Chat History modal.
@@ -25285,6 +25224,8 @@ msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, your most recent chats will be saved on this device."
 msgstr ""
+"Kad tērzēšanas vēsture būs ieslēgta, jaunākās tērzēšanas sarunas tiks "
+"saglabātas šajā ierīcē."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -25548,8 +25489,7 @@ msgstr "Jā, jauns lietotājs!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr ""
-"Jā, mēs izmetam datus, kad tu beidz ar tiem darboties, un tos nevar atgūt."
+msgstr "Jā, mēs izmetam datus, kad tu beidz ar tiem darboties, un tos nevar atgūt."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -25646,8 +25586,7 @@ msgstr "Tu vari mainīt to jebkurā laikā sadaļā %1$sMeklēšanas iestatījum
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr ""
-"Tu varēsi turpināt šo tērzēšanu, kad tavs limits tiks atiestatīts (%1$s)."
+msgstr "Tu varēsi turpināt šo tērzēšanu, kad tavs limits tiks atiestatīts (%1$s)."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -25686,8 +25625,7 @@ msgstr "Tu vari turpināt tērzēt, izmantojot savu mēneša limitu."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Tagad šajā ierīcē vari saglabāt līdz pat 100 tērzēšanas sarunām. Tērzē!"
+msgstr "Tagad šajā ierīcē vari saglabāt līdz pat 100 tērzēšanas sarunām. Tērzē!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -25868,8 +25806,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr ""
-"Tu vairs neredzēsi šo ziņojumu, ja vien nenotīrīsi pārlūkprogrammas datus."
+msgstr "Tu vairs neredzēsi šo ziņojumu, ja vien nenotīrīsi pārlūkprogrammas datus."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -25978,8 +25915,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"Tu esi sasniedzis diktēšanas lietošanas ierobežojumu. Mēģini vēlreiz vēlāk."
+msgstr "Tu esi sasniedzis diktēšanas lietošanas ierobežojumu. Mēģini vēlreiz vēlāk."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -26038,16 +25974,14 @@ msgctxt ""
 msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
-msgstr ""
-"Tavas %1$s jaunākās tērzēšanas būs pieejamas lokālajā krātuvē šajos pārlūkos:"
+msgstr "Tavas %1$s jaunākās tērzēšanas būs pieejamas lokālajā krātuvē šajos pārlūkos:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr ""
-"Tavas Duck.ai tērzēšanas tiek sinhronizētas, izmantojot pilnīgu šifrēšanu."
+msgstr "Tavas Duck.ai tērzēšanas tiek sinhronizētas, izmantojot pilnīgu šifrēšanu."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -26169,8 +26103,7 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr ""
-"Tava tērzēšana ir privāta, un tā nekad netiek izmantota MI modeļu apmācībai"
+msgstr "Tava tērzēšana ir privāta, un tā nekad netiek izmantota MI modeļu apmācībai"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -26462,8 +26395,7 @@ msgstr ""
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr ""
-"Tu esi sasniedzis balss tērzēšanas ierobežojumu. Lūdzu, vēlāk mēģini vēlreiz."
+msgstr "Tu esi sasniedzis balss tērzēšanas ierobežojumu. Lūdzu, vēlāk mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -26693,7 +26625,7 @@ msgstr "min."
 #. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the chat options menu button"
 msgid "menu"
-msgstr ""
+msgstr "Izvēlne"
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.
@@ -26767,8 +26699,7 @@ msgstr "oficiālā vietne"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr ""
-"vai uzraksti krāsas kodu pats, piemēram, %1$s (%2$s ir %3$s zīmes kods)."
+msgstr "vai uzraksti krāsas kodu pats, piemēram, %1$s (%2$s ir %3$s zīmes kods)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/ml_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/ml_IN/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: ml_IN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1207,6 +1207,12 @@ msgid "About our ads"
 msgstr "ഞങ്ങളുടെ പരസ്യങ്ങളെക്കുറിച്ച്"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1336,6 +1342,20 @@ msgid "Ad is suspicious"
 msgstr "സംശയാസ്പദമായ പരസ്യം"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "DuckDuckGo-യെ ചേർക്കുക"
@@ -1362,6 +1382,27 @@ msgstr "ഒരു തിരയൽ എഞ്ചിനായി DuckDuckGo ചേ�
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "%1$s-ലേക്ക് DuckDuckGo ചേർക്കുക"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1407,6 +1448,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "പേജ് ഉള്ളടക്കം ചേർക്കുക"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1492,6 +1549,12 @@ msgstr "ആഡ്-ഓണുകള്‍"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "അവസാന മിനുക്കുപണികൾ ചേർക്കുന്നു"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1795,6 +1858,12 @@ msgstr "എല്ലാ നിറങ്ങളും"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "എല്ലാം പൂർത്തിയായി!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3501,6 +3570,14 @@ msgid "Cancel"
 msgstr "റദ്ദാക്കുക"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3993,10 +4070,22 @@ msgid "Chat response is offensive"
 msgstr "ചാറ്റ് പ്രതികരണം കുറ്റകരമാണ്"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "%1$s-നൊപ്പം ചാറ്റ് ചെയ്യുക"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4015,6 +4104,14 @@ msgstr "ചാറ്റുകൾ"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "ചാറ്റുകൾ"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5609,6 +5706,12 @@ msgid "Current Streak"
 msgstr "നിലവിലെ സ്ട്രീക്ക്"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5953,6 +6056,12 @@ msgstr "ചാറ്റുകൾ ഇല്ലാതാക്കുക"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "30 ദിവസത്തിലധികം പഴക്കമുള്ള ചാറ്റുകൾ ഇല്ലാതാക്കുക"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6366,6 +6475,12 @@ msgstr "എന്നേക്കുമായി നിരസിക്കുക"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "പ്രൊമോഷൻ ഒഴിവാക്കുക"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7534,6 +7649,12 @@ msgid "Edit Prompt"
 msgstr "പ്രോംപ്റ്റ് എഡിറ്റ് ചെയ്യുക"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7756,6 +7877,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "എൻക്രിപ്റ്റ് ചെയ്ത മോഡൽ"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8585,6 +8712,12 @@ msgid "Follow-up question"
 msgstr "ഫോളോ-അപ്പ് ചോദ്യം"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9096,6 +9229,12 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
 "DuckDuckGo VPN, നൂതന Duck.ai, കൂടാതെ Identity Theft Restoration എന്നിവ നേടൂ."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10323,6 +10462,12 @@ msgstr "എങ്ങനെയാണ് ഇത് അജ്ഞാതമാവു�
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "ഇത് എങ്ങനെ പ്രവർത്തിക്കുന്നു"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11768,6 +11913,12 @@ msgstr "നേടിയ ലൈനൗട്ടുകൾ"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "ലിങ്ക് 7 ദിവസത്തിനുള്ളിൽ കാലഹരണപ്പെടുന്നു."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13885,6 +14036,12 @@ msgstr "ശരി"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "ശരി, കിട്ടി!"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16007,6 +16164,12 @@ msgid "Protected"
 msgstr "സംരക്ഷിതം"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "സംരക്ഷണം. സ്വകാര്യത. മനസ്സമാധാനം."
@@ -16138,6 +16301,12 @@ msgstr "മഴ"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "റാങ്കിംഗുകൾ"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17371,6 +17540,12 @@ msgid "Save your chats across all your devices."
 msgstr "നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിലും നിങ്ങളുടെ ചാറ്റുകൾ സംരക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17572,6 +17747,14 @@ msgstr "തിരയുക"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "തിരയുക"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18748,6 +18931,12 @@ msgstr "ഷിഫ്റ്റ്+എന്റർ"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "ഷോപ്പ് ചെയ്യുക"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20396,6 +20585,14 @@ msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr "Sync & Backup ഡാറ്റ 18 മാസത്തെ നിഷ്‌ക്രിയത്വത്തിന് ശേഷം വീണ്ടെടുക്കാൻ കഴിയില്ല."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20509,6 +20706,12 @@ msgstr "അടുത്തുള്ള ഒരു ഉപകരണവുമായ�
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിലും ചാറ്റുകൾ സമന്വയിപ്പിക്കുക."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21085,6 +21288,22 @@ msgid "This Week"
 msgstr "ഈ ആഴ്ച"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21605,6 +21824,12 @@ msgstr "ഇന്ന്"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "ഇന്ന്"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23428,6 +23653,14 @@ msgstr ""
 "നിയന്ത്രിക്കുന്നത് TripAdvisor ന്റെ പരസ്യ ശൃംഖലയാണ്."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "വിർജിൻ ദ്വീപുകൾ"
 
@@ -24902,6 +25135,21 @@ msgstr ""
 "ചെയ്യാം."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26293,6 +26541,12 @@ msgstr "മാ"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "മാ"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/ml_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/ml_IN/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: ml_IN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -190,8 +190,9 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"Pro-യുടെ ഒപ്പം മാത്രമേ %1$s ലഭ്യമാകൂ. ചാറ്റ് തുടരാൻ ഈ ബ്രൗസറിൽ നിങ്ങളുടെ DuckDuckGo "
-"സബ്‌സ്‌ക്രിപ്‌ഷൻ വീണ്ടും അപ്‌ഗ്രേഡ് ചെയ്യുക, അല്ലെങ്കിൽ Plus അല്ലെങ്കിൽ സൗജന്യ മോഡലിലേക്ക് മാറുക."
+"Pro-യുടെ ഒപ്പം മാത്രമേ %1$s ലഭ്യമാകൂ. ചാറ്റ് തുടരാൻ ഈ ബ്രൗസറിൽ നിങ്ങളുടെ "
+"DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷൻ വീണ്ടും അപ്‌ഗ്രേഡ് ചെയ്യുക, അല്ലെങ്കിൽ Plus "
+"അല്ലെങ്കിൽ സൗജന്യ മോഡലിലേക്ക് മാറുക."
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -201,8 +202,9 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"Pro-യുടെ ഒപ്പം മാത്രമേ %1$s ലഭ്യമാകൂ. ചാറ്റ് തുടരാൻ ഈ ബ്രൗസറിൽ നിങ്ങളുടെ DuckDuckGo "
-"സബ്‌സ്‌ക്രിപ്‌ഷൻ വീണ്ടും അപ്‌ഗ്രേഡ് ചെയ്യുക, അല്ലെങ്കിൽ Plus അല്ലെങ്കിൽ സൗജന്യ മോഡലിലേക്ക് മാറുക."
+"Pro-യുടെ ഒപ്പം മാത്രമേ %1$s ലഭ്യമാകൂ. ചാറ്റ് തുടരാൻ ഈ ബ്രൗസറിൽ നിങ്ങളുടെ "
+"DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷൻ വീണ്ടും അപ്‌ഗ്രേഡ് ചെയ്യുക, അല്ലെങ്കിൽ Plus "
+"അല്ലെങ്കിൽ സൗജന്യ മോഡലിലേക്ക് മാറുക."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -218,8 +220,9 @@ msgid ""
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
 msgstr ""
-"%1$s DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷനോടൊപ്പം മാത്രമേ ലഭ്യമാകൂ. ഈ ബ്രൗസറിൽ ചാറ്റ് തുടരാൻ, നിങ്ങളുടെ "
-"സബ്സ്ക്രിപ്ഷൻ വീണ്ടും സജീവമാക്കുക, അല്ലെങ്കിൽ ഒരു സൗജന്യ മോഡലിലേക്ക് മാറുക."
+"%1$s DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷനോടൊപ്പം മാത്രമേ ലഭ്യമാകൂ. ഈ ബ്രൗസറിൽ ചാറ്റ് "
+"തുടരാൻ, നിങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ വീണ്ടും സജീവമാക്കുക, അല്ലെങ്കിൽ ഒരു സൗജന്യ "
+"മോഡലിലേക്ക് മാറുക."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -228,8 +231,8 @@ msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
 msgstr ""
-"%1$s താൽക്കാലികമായി ലഭ്യമല്ല. ദയവായി മറ്റൊരു മോഡലിലേക്ക് മാറുക അല്ലെങ്കിൽ പിന്നീട് വീണ്ടും "
-"ശ്രമിക്കുക."
+"%1$s താൽക്കാലികമായി ലഭ്യമല്ല. ദയവായി മറ്റൊരു മോഡലിലേക്ക് മാറുക അല്ലെങ്കിൽ "
+"പിന്നീട് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -306,7 +309,8 @@ msgstr "%1$s റാങ്കിംഗുകൾ ഇതുവരെ ലഭ്യ�
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
 msgstr ""
-"%1$s അടിസ്ഥാന മോഡലുകളേക്കാൾ 2 മുതൽ 5 മടങ്ങ് വരെ വേഗത്തിൽ ഉപയോഗ പരിധികളിൽ എത്തുന്നു. %2$s"
+"%1$s അടിസ്ഥാന മോഡലുകളേക്കാൾ 2 മുതൽ 5 മടങ്ങ് വരെ വേഗത്തിൽ ഉപയോഗ പരിധികളിൽ "
+"എത്തുന്നു. %2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -327,9 +331,9 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$s ഒരു വിശ്വസനീയമായ നിർവഹണ അന്തരീക്ഷത്തിൽ പ്രവർത്തിക്കുന്നു. മോഡൽ ദാതാവിന് പോലും "
-"നിങ്ങളുടെ പ്രോംപ്റ്റുകളോ മോഡലിന്റെ പ്രതികരണങ്ങളോ കാണാനോ ഈ ചാറ്റ് അവരുടെ സെർവറുകളിൽ "
-"സംരക്ഷിക്കാനോ കഴിയില്ല എന്നാണ്."
+"%1$s ഒരു വിശ്വസനീയമായ നിർവഹണ അന്തരീക്ഷത്തിൽ പ്രവർത്തിക്കുന്നു. മോഡൽ ദാതാവിന് "
+"പോലും നിങ്ങളുടെ പ്രോംപ്റ്റുകളോ മോഡലിന്റെ പ്രതികരണങ്ങളോ കാണാനോ ഈ ചാറ്റ് "
+"അവരുടെ സെർവറുകളിൽ സംരക്ഷിക്കാനോ കഴിയില്ല എന്നാണ്."
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -415,8 +419,8 @@ msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
 msgstr ""
-"%1$s %2$s ദിവസങ്ങൾക്കുള്ളിൽ (%3$s) Duck.ai ഉപേക്ഷിച്ച് പോകും. അതിനുശേഷം, ഈ ചാറ്റ് "
-"തുടരുന്നതിന് നിങ്ങൾക്ക് മോഡലുകൾ മാറ്റാം."
+"%1$s %2$s ദിവസങ്ങൾക്കുള്ളിൽ (%3$s) Duck.ai ഉപേക്ഷിച്ച് പോകും. അതിനുശേഷം, ഈ "
+"ചാറ്റ് തുടരുന്നതിന് നിങ്ങൾക്ക് മോഡലുകൾ മാറ്റാം."
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -427,8 +431,8 @@ msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
 msgstr ""
-"%1$s 1 ദിവസം കൊണ്ട് Duck.ai വിടുന്നതായിരിക്കും (%2$s). അതിനുശേഷം, ഈ ചാറ്റ് തുടരുന്നതിന് "
-"നിങ്ങൾക്ക് മോഡലുകൾ മാറ്റാം."
+"%1$s 1 ദിവസം കൊണ്ട് Duck.ai വിടുന്നതായിരിക്കും (%2$s). അതിനുശേഷം, ഈ ചാറ്റ് "
+"തുടരുന്നതിന് നിങ്ങൾക്ക് മോഡലുകൾ മാറ്റാം."
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -441,8 +445,8 @@ msgstr "%1$s വാക്കുകൾ"
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$s%2$sചേർക്കുക%3$s ക്ലിക്ക് ചെയ്യുക %4$sഅനുവദിക്കുക%5$s ചെക്ക് ചെയ്യുക, തുടർന്ന് "
-"%6$sശരി%7$s ക്ലിക്ക് ചെയ്യുക"
+"%1$s%2$sചേർക്കുക%3$s ക്ലിക്ക് ചെയ്യുക %4$sഅനുവദിക്കുക%5$s ചെക്ക് ചെയ്യുക, "
+"തുടർന്ന് %6$sശരി%7$s ക്ലിക്ക് ചെയ്യുക"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -450,8 +454,8 @@ msgstr ""
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$s%2$sഅനുവദിക്കുക%3$s ക്ലിക്ക് ചെയ്യുക%4$sചേർക്കുക%5$s ക്ലിക്ക് ചെയ്യുക%6$sഅനുവദിക്കുക%7$s "
-"ശരിയിടുക, തുടർന്ന് %8$sശരി%9$s ക്ലിക്ക് ചെയ്യുക"
+"%1$s%2$sഅനുവദിക്കുക%3$s ക്ലിക്ക് ചെയ്യുക%4$sചേർക്കുക%5$s ക്ലിക്ക് "
+"ചെയ്യുക%6$sഅനുവദിക്കുക%7$s ശരിയിടുക, തുടർന്ന് %8$sശരി%9$s ക്ലിക്ക് ചെയ്യുക"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -461,8 +465,9 @@ msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
 msgstr ""
-"%1$s%2$sഇൻസ്റ്റാളേഷനിലേക്ക് തുടരുക%3$s ക്ലിക്ക് ചെയ്യുക %4$sചേർക്കുക%5$s ക്ലിക്ക് "
-"ചെയ്യുക%6$sഅനുവദിക്കുക%7$s അടയാളപ്പെടുത്തുക, തുടർന്ന് %8$sശരി%9$s ക്ലിക്ക് ചെയ്യുക"
+"%1$s%2$sഇൻസ്റ്റാളേഷനിലേക്ക് തുടരുക%3$s ക്ലിക്ക് ചെയ്യുക %4$sചേർക്കുക%5$s "
+"ക്ലിക്ക് ചെയ്യുക%6$sഅനുവദിക്കുക%7$s അടയാളപ്പെടുത്തുക, തുടർന്ന് %8$sശരി%9$s "
+"ക്ലിക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -471,8 +476,8 @@ msgid ""
 "%sClick here%s to try again, if you think there should be results for this "
 "search."
 msgstr ""
-"വീണ്ടും ശ്രമിക്കാൻ %1$sഇവിടെ അമർത്തുക%2$s, ഈ തിരയലിന് ഫലങ്ങൾ ഉണ്ടായിരിക്കണമെന്ന് നിങ്ങൾ "
-"കരുതുന്നുണ്ടെങ്കിൽ."
+"വീണ്ടും ശ്രമിക്കാൻ %1$sഇവിടെ അമർത്തുക%2$s, ഈ തിരയലിന് ഫലങ്ങൾ "
+"ഉണ്ടായിരിക്കണമെന്ന് നിങ്ങൾ കരുതുന്നുണ്ടെങ്കിൽ."
 
 # smartling.placeholder_format=C
 #. Header for a page with information about sharing DuckDuckGo.
@@ -491,7 +496,8 @@ msgstr "%1$sകൂടുതലറിയുക%2$s ."
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
-"%1$sനിങ്ങളുടെ ലൊക്കേഷൻ ഞങ്ങൾ സ്വകാര്യമായി സൂക്ഷിക്കുന്നത് എങ്ങനെയെന്ന് മനസ്സിലാക്കുക%2$s."
+"%1$sനിങ്ങളുടെ ലൊക്കേഷൻ ഞങ്ങൾ സ്വകാര്യമായി സൂക്ഷിക്കുന്നത് എങ്ങനെയെന്ന് "
+"മനസ്സിലാക്കുക%2$s."
 
 # smartling.placeholder_format=C
 #. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
@@ -506,16 +512,16 @@ msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
 msgstr ""
-"DuckDuckGo-യുടെ സെർവറിൽ ചാറ്റുകൾ എങ്ങനെ സ്വകാര്യമായി സൂക്ഷിക്കപ്പെടുന്നു എന്നതിനെക്കുറിച്ച് "
-"%1$sകൂടുതൽ അറിയുക%2$s."
+"DuckDuckGo-യുടെ സെർവറിൽ ചാറ്റുകൾ എങ്ങനെ സ്വകാര്യമായി സൂക്ഷിക്കപ്പെടുന്നു "
+"എന്നതിനെക്കുറിച്ച് %1$sകൂടുതൽ അറിയുക%2$s."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
 msgstr ""
-"ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ എങ്ങനെ സ്വകാര്യമായി സൂക്ഷിക്കപ്പെടുന്നു എന്നതിനെക്കുറിച്ച് "
-"%1$sകൂടുതൽ അറിയുക%2$s."
+"ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ എങ്ങനെ സ്വകാര്യമായി സൂക്ഷിക്കപ്പെടുന്നു "
+"എന്നതിനെക്കുറിച്ച് %1$sകൂടുതൽ അറിയുക%2$s."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -528,7 +534,8 @@ msgstr "ഹോം സ്ക്രീനിൽ DuckDuckGo ആപ്പ് ഐക�
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
 msgstr ""
-"%1$sക്ഷമിക്കണം!%2$s%3$sഎന്തോ കുഴപ്പം സംഭവിച്ചു. ദയവായി %4$sപുതുക്കി%5$s വീണ്ടും ശ്രമിക്കുക."
+"%1$sക്ഷമിക്കണം!%2$s%3$sഎന്തോ കുഴപ്പം സംഭവിച്ചു. ദയവായി %4$sപുതുക്കി%5$s "
+"വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -886,7 +893,9 @@ msgstr "6 മണിക്കൂർ ഉപയോഗ പരിധി കഴിഞ�
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "6-hour usage limit reached. You can keep chatting by using your daily limit."
-msgstr "6 മണിക്കൂർ ഉപയോഗ പരിധി കഴിഞ്ഞു. നിങ്ങളുടെ ദൈനംദിന പരിധി ഉപയോഗിച്ച് ചാറ്റ് തുടരാം."
+msgstr ""
+"6 മണിക്കൂർ ഉപയോഗ പരിധി കഴിഞ്ഞു. നിങ്ങളുടെ ദൈനംദിന പരിധി ഉപയോഗിച്ച് ചാറ്റ് "
+"തുടരാം."
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes abbreviation
@@ -940,8 +949,8 @@ msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
 msgstr ""
-"ഒരു നെറ്റ്‌വർക്ക് പ്രശ്‌നം Search Assist ഉത്തരം സൃഷ്ടിക്കുന്നതിനെ തടയുന്നു. നിങ്ങളുടെ കണക്ഷൻ "
-"പരിശോധിച്ച് വീണ്ടും ശ്രമിക്കുക."
+"ഒരു നെറ്റ്‌വർക്ക് പ്രശ്‌നം Search Assist ഉത്തരം സൃഷ്ടിക്കുന്നതിനെ തടയുന്നു. "
+"നിങ്ങളുടെ കണക്ഷൻ പരിശോധിച്ച് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
@@ -999,10 +1008,10 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"3കക്ഷി AI Chat മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ AI Chat നിങ്ങളെ അനുവദിക്കുന്നു. ഇത് "
-"ഓഫാക്കുന്നത് DuckDuckGo Search-ലെ AI Chat സവിശേഷത മറയ്ക്കും. %1$sduckduckgo.com/"
-"aichat%2$s സന്ദർശിച്ച് ഈ ക്രമീകരണം ഓഫ് ചെയ്യുമ്പോഴും നിങ്ങൾക്ക് AI Chat ആക്സസ് ചെയ്യാൻ "
-"കഴിയും."
+"3കക്ഷി AI Chat മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ AI Chat നിങ്ങളെ "
+"അനുവദിക്കുന്നു. ഇത് ഓഫാക്കുന്നത് DuckDuckGo Search-ലെ AI Chat സവിശേഷത "
+"മറയ്ക്കും. %1$sduckduckgo.com/aichat%2$s സന്ദർശിച്ച് ഈ ക്രമീകരണം ഓഫ് "
+"ചെയ്യുമ്പോഴും നിങ്ങൾക്ക് AI Chat ആക്സസ് ചെയ്യാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1063,10 +1072,11 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"AI- സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ നിലവിൽ ഫോളോ-അപ്പ് ചോദ്യങ്ങളെ നേരിട്ട് പിന്തുണയ്ക്കുന്നില്ല. "
-"എന്നിരുന്നാലും, ഞങ്ങൾ ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്കായി %1$sDuck.ai%2$s വാഗ്ദാനം ചെയ്യുകയും "
-"പലപ്പോഴും ലിങ്ക് ചെയ്യുകയും ചെയ്യുന്നു, ഇത് OpenAI, Anthropic തുടങ്ങിയവയിൽ നിന്നുള്ള ചാറ്റ് "
-"മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഞങ്ങളുടെ സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
+"AI- സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ നിലവിൽ ഫോളോ-അപ്പ് ചോദ്യങ്ങളെ നേരിട്ട് "
+"പിന്തുണയ്ക്കുന്നില്ല. എന്നിരുന്നാലും, ഞങ്ങൾ ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്കായി "
+"%1$sDuck.ai%2$s വാഗ്ദാനം ചെയ്യുകയും പലപ്പോഴും ലിങ്ക് ചെയ്യുകയും ചെയ്യുന്നു, "
+"ഇത് OpenAI, Anthropic തുടങ്ങിയവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ "
+"പിന്തുണയ്ക്കുന്ന ഞങ്ങളുടെ സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1210,7 +1220,7 @@ msgstr "ഞങ്ങളുടെ പരസ്യങ്ങളെക്കുറ�
 #. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
 msgctxt "Modal header for chat history with sync information"
 msgid "About Chat History with Sync & Backup"
-msgstr ""
+msgstr "Sync & Backup ഉപയോഗിച്ചുള്ള ചാറ്റ് ചരിത്രത്തെക്കുറിച്ച്"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
@@ -1257,8 +1267,8 @@ msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
 msgstr ""
-"ചാറ്റ് തുടരാൻ നിങ്ങളുടെ %1$s ഈ ബ്രൗസറിൽ വീണ്ടും സജീവമാക്കുക, അല്ലെങ്കിൽ ഒരു സൗജന്യ "
-"മോഡലിലേക്ക് മാറുക."
+"ചാറ്റ് തുടരാൻ നിങ്ങളുടെ %1$s ഈ ബ്രൗസറിൽ വീണ്ടും സജീവമാക്കുക, അല്ലെങ്കിൽ ഒരു "
+"സൗജന്യ മോഡലിലേക്ക് മാറുക."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1294,8 +1304,8 @@ msgstr "പരസ്യം"
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
 msgstr ""
-"%1$s-ൻ്റെ പരസ്യ നെറ്റ്വർക്കുകൾ ആണ് പരസ്യ ക്ലിക്കുകൾ കൈകാര്യം ചെയ്യുന്നത്, അവ നിങ്ങളെ "
-"തിരിച്ചറിയാൻ ഉപയോഗിക്കപ്പെടാറില്ല."
+"%1$s-ൻ്റെ പരസ്യ നെറ്റ്വർക്കുകൾ ആണ് പരസ്യ ക്ലിക്കുകൾ കൈകാര്യം ചെയ്യുന്നത്, അവ "
+"നിങ്ങളെ തിരിച്ചറിയാൻ ഉപയോഗിക്കപ്പെടാറില്ല."
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
@@ -1303,8 +1313,8 @@ msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
 msgstr ""
-"പരസ്യ ക്ലിക്കുകൾ നിയന്ത്രിക്കുന്നത് Microsoft-ന്റെ പരസ്യ ശൃംഖലയാണ്, നിങ്ങളെ പ്രൊഫൈൽ "
-"ചെയ്യുന്നതിനായി അവ ഉപയോഗിക്കപ്പെടുന്നില്ല."
+"പരസ്യ ക്ലിക്കുകൾ നിയന്ത്രിക്കുന്നത് Microsoft-ന്റെ പരസ്യ ശൃംഖലയാണ്, നിങ്ങളെ "
+"പ്രൊഫൈൽ ചെയ്യുന്നതിനായി അവ ഉപയോഗിക്കപ്പെടുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1345,7 +1355,7 @@ msgstr "സംശയാസ്പദമായ പരസ്യം"
 #. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
 msgctxt "Button to open menu for attaching images or page context to AI chat"
 msgid "Add"
-msgstr ""
+msgstr "ചേർക്കുക"
 
 # smartling.placeholder_format=C
 #. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
@@ -1353,7 +1363,7 @@ msgctxt ""
 "Primary button that attaches the tabs the user checked in the tab picker "
 "dialog"
 msgid "Add"
-msgstr ""
+msgstr "ചേർക്കുക"
 
 # smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
@@ -1369,8 +1379,8 @@ msgstr "DuckDuckGo എക്സ്റ്റൻഷൻ ചേർക്കുക"
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
 msgstr ""
-"ഒരു ഡൗൺ ലോഡിനൊപ്പം സൗജന്യമായി നിങ്ങളുടെ ബ്രൗസറിലേക്ക് DuckDuckGo Privacy Essentials "
-"ചേർക്കുക:"
+"ഒരു ഡൗൺ ലോഡിനൊപ്പം സൗജന്യമായി നിങ്ങളുടെ ബ്രൗസറിലേക്ക് DuckDuckGo Privacy "
+"Essentials ചേർക്കുക:"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1388,13 +1398,13 @@ msgstr "%1$s-ലേക്ക് DuckDuckGo ചേർക്കുക"
 msgctxt ""
 "Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
 msgid "Add File"
-msgstr ""
+msgstr "ഫയൽ ചേർക്കുക"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
 msgid "Add Image"
-msgstr ""
+msgstr "ഇമേജ് ചേർക്കുക"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
@@ -1402,7 +1412,7 @@ msgctxt ""
 "Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
 "item)"
 msgid "Add Image or File"
-msgstr ""
+msgstr "ഇമേജോ ഫയലോ ചേർക്കുക"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1455,7 +1465,7 @@ msgctxt ""
 "Open the tab picker to attach browser tab content to the AI chat message "
 "(attach dropdown menu item)"
 msgid "Add Tabs"
-msgstr ""
+msgstr "ടാബുകൾ ചേർക്കുക"
 
 # smartling.placeholder_format=C
 #. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
@@ -1463,7 +1473,7 @@ msgctxt ""
 "Title and accessible name of the tab-picker dialog opened from the attach "
 "dropdown menu"
 msgid "Add Tabs"
-msgstr ""
+msgstr "ടാബുകൾ ചേർക്കുക"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1554,7 +1564,7 @@ msgstr "അവസാന മിനുക്കുപണികൾ ചേർക്�
 #. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
 msgctxt "Aria label for the additional instructions textarea"
 msgid "Additional instructions"
-msgstr ""
+msgstr "അധിക നിർദ്ദേശങ്ങൾ"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1647,8 +1657,8 @@ msgctxt ""
 msgid ""
 "Advanced models can reach usage limits 2–5x sooner than other models. %s"
 msgstr ""
-"നൂതന മോഡലുകൾക്ക് മറ്റ് മോഡലുകളേക്കാൾ 2 മുതൽ 5 മടങ്ങ് വരെ വേഗത്തിൽ ഉപയോഗ പരിധിയിൽ "
-"എത്തിച്ചേരാൻ കഴിഞ്ഞേക്കാം. %1$s"
+"നൂതന മോഡലുകൾക്ക് മറ്റ് മോഡലുകളേക്കാൾ 2 മുതൽ 5 മടങ്ങ് വരെ വേഗത്തിൽ ഉപയോഗ "
+"പരിധിയിൽ എത്തിച്ചേരാൻ കഴിഞ്ഞേക്കാം. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
@@ -1657,8 +1667,8 @@ msgctxt ""
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
 msgstr ""
-"നൂതന മോഡലുകൾക്ക് മറ്റ് മോഡലുകളേക്കാൾ 2-5 മടങ്ങ് വേഗത്തിൽ പരിധികൾ ഉപയോഗിക്കാൻ കഴിഞ്ഞേക്കാം. "
-"%1$s"
+"നൂതന മോഡലുകൾക്ക് മറ്റ് മോഡലുകളേക്കാൾ 2-5 മടങ്ങ് വേഗത്തിൽ പരിധികൾ ഉപയോഗിക്കാൻ "
+"കഴിഞ്ഞേക്കാം. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1694,15 +1704,17 @@ msgstr "ആഫ്രികാൻസ്"
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid "After it downloads and opens, click %sInstall%s"
-msgstr "ഇത് ഡൗൺലോഡ് ചെയ്ത് തുറന്ന ശേഷം %1$sഇൻസ്റ്റാൾ ചെയ്യുക%2$s എന്നതിൽ ക്ലിക്ക് ചെയ്യുക"
+msgstr ""
+"ഇത് ഡൗൺലോഡ് ചെയ്ത് തുറന്ന ശേഷം %1$sഇൻസ്റ്റാൾ ചെയ്യുക%2$s എന്നതിൽ ക്ലിക്ക് "
+"ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
 msgstr ""
-"അത് ഡൗൺലോഡ് ചെയ്ത ശേഷം, എക്സ്റ്റൻഷൻ ഫയൽ കണ്ടെത്തി, ഇൻസ്റ്റാൾ ചെയ്യാൻ അത് ഡബിൾ ക്ലിക്ക് "
-"ചെയ്യുക"
+"അത് ഡൗൺലോഡ് ചെയ്ത ശേഷം, എക്സ്റ്റൻഷൻ ഫയൽ കണ്ടെത്തി, ഇൻസ്റ്റാൾ ചെയ്യാൻ അത് "
+"ഡബിൾ ക്ലിക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1838,8 +1850,9 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
-"എല്ലാ ചാറ്റുകളും DuckDuckGo അജ്ഞാതമാക്കുന്നു, കൂടാതെ നിങ്ങളുടെ സംഭാഷണങ്ങൾ DuckDuckGo "
-"അല്ലെങ്കിൽ മോഡൽ ദാതാക്കൾ ചാറ്റ് മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല"
+"എല്ലാ ചാറ്റുകളും DuckDuckGo അജ്ഞാതമാക്കുന്നു, കൂടാതെ നിങ്ങളുടെ സംഭാഷണങ്ങൾ "
+"DuckDuckGo അല്ലെങ്കിൽ മോഡൽ ദാതാക്കൾ ചാറ്റ് മോഡലുകളെ പരിശീലിപ്പിക്കാൻ "
+"ഉപയോഗിക്കുന്നില്ല"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1863,7 +1876,7 @@ msgstr "എല്ലാം പൂർത്തിയായി!"
 #. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the read-only textarea listing all AI instructions"
 msgid "All instructions"
-msgstr ""
+msgstr "എല്ലാ നിർദ്ദേശങ്ങളും"
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -1878,8 +1891,8 @@ msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
 msgstr ""
-"നിങ്ങളുടെ സംഭാഷണങ്ങൾ ഉപയോഗിച്ച് അവരുടെ AI പരിശീലിപ്പിക്കാൻ എല്ലാ മോഡൽ ദാതാക്കളെയും "
-"അനുവദിക്കില്ല."
+"നിങ്ങളുടെ സംഭാഷണങ്ങൾ ഉപയോഗിച്ച് അവരുടെ AI പരിശീലിപ്പിക്കാൻ എല്ലാ മോഡൽ "
+"ദാതാക്കളെയും അനുവദിക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1894,8 +1907,8 @@ msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
 msgstr ""
-"AI ദാതാവിന് ഒരു ചാറ്റ് അയയ്ക്കുന്നതിന് മുമ്പ് എല്ലാ വ്യക്തിഗത മെറ്റാഡാറ്റയും (ഉദാഹരണത്തിന്, "
-"നിങ്ങളുടെ IP വിലാസം) നീക്കംചെയ്യപ്പെടുന്നു."
+"AI ദാതാവിന് ഒരു ചാറ്റ് അയയ്ക്കുന്നതിന് മുമ്പ് എല്ലാ വ്യക്തിഗത മെറ്റാഡാറ്റയും "
+"(ഉദാഹരണത്തിന്, നിങ്ങളുടെ IP വിലാസം) നീക്കംചെയ്യപ്പെടുന്നു."
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1934,7 +1947,8 @@ msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
 msgstr ""
-"വോയ്സ് ചാറ്റ് ഉപയോഗിക്കാൻ സിസ്റ്റം ക്രമീകരണങ്ങളിൽ DuckDuckGo മൈക്രോഫോൺ ആക്സസ് അനുവദിക്കുക."
+"വോയ്സ് ചാറ്റ് ഉപയോഗിക്കാൻ സിസ്റ്റം ക്രമീകരണങ്ങളിൽ DuckDuckGo മൈക്രോഫോൺ "
+"ആക്സസ് അനുവദിക്കുക."
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1966,10 +1980,11 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"പ്രസക്തമായ പ്രോംപ്റ്റുകൾക്കുള്ള പ്രതികരണങ്ങൾ മെച്ചപ്പെടുത്താൻ വെബിൽ തിരയാൻ %1$s-നെ "
-"അനുവദിക്കുന്നു. പരിമിതമായ ഡാറ്റ നിലനിർത്തൽ ഉള്ള ഒരു സെർച്ച് എഞ്ചിനിലേക്ക് മാത്രമേ AI സൃഷ്ടിച്ച "
-"ചോദ്യങ്ങൾ അയയ്ക്കൂ. %2$s ഉള്ള പ്രോംപ്റ്റുകൾക്കും പ്രതികരണങ്ങൾക്കും ഇപ്പോഴും %3$sദാതാവിന്റെ "
-"ദൃശ്യപരത പൂജ്യം ആണ്%4$s."
+"പ്രസക്തമായ പ്രോംപ്റ്റുകൾക്കുള്ള പ്രതികരണങ്ങൾ മെച്ചപ്പെടുത്താൻ വെബിൽ തിരയാൻ "
+"%1$s-നെ അനുവദിക്കുന്നു. പരിമിതമായ ഡാറ്റ നിലനിർത്തൽ ഉള്ള ഒരു സെർച്ച് "
+"എഞ്ചിനിലേക്ക് മാത്രമേ AI സൃഷ്ടിച്ച ചോദ്യങ്ങൾ അയയ്ക്കൂ. %2$s ഉള്ള "
+"പ്രോംപ്റ്റുകൾക്കും പ്രതികരണങ്ങൾക്കും ഇപ്പോഴും %3$sദാതാവിന്റെ ദൃശ്യപരത പൂജ്യം "
+"ആണ്%4$s."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2116,8 +2131,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"%1$s, %2$s, കൂടാതെ ഓപ്പൺ സോഴ്സ് %3$s, %4$s ഉൾപ്പെടെയുള്ള ജനപ്രിയ AI മോഡലുകളിലേക്കുള്ള "
-"അജ്ഞാത ആക്സസ്."
+"%1$s, %2$s, കൂടാതെ ഓപ്പൺ സോഴ്സ് %3$s, %4$s ഉൾപ്പെടെയുള്ള ജനപ്രിയ AI "
+"മോഡലുകളിലേക്കുള്ള അജ്ഞാത ആക്സസ്."
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -2126,8 +2141,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"%1$s, %2$s, കൂടാതെ ഓപ്പൺ സോഴ്സ് %3$s, %4$s ഉൾപ്പെടെയുള്ള ജനപ്രിയ AI മോഡലുകളിലേക്കുള്ള "
-"അജ്ഞാത ആക്സസ്."
+"%1$s, %2$s, കൂടാതെ ഓപ്പൺ സോഴ്സ് %3$s, %4$s ഉൾപ്പെടെയുള്ള ജനപ്രിയ AI "
+"മോഡലുകളിലേക്കുള്ള അജ്ഞാത ആക്സസ്."
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -2141,8 +2156,9 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
-"വെബ് ഉള്ളടക്കത്തെ അടിസ്ഥാനമാക്കി തിരയൽ അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കുന്നു. ഇത് "
-"എത്ര തവണ പ്രത്യക്ഷപ്പെടണമെന്ന് തിരഞ്ഞെടുക്കുക, അല്ലെങ്കിൽ പൂർണ്ണമായും പ്രവർത്തനരഹിതമാക്കുക."
+"വെബ് ഉള്ളടക്കത്തെ അടിസ്ഥാനമാക്കി തിരയൽ അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ "
+"സൃഷ്ടിക്കുന്നു. ഇത് എത്ര തവണ പ്രത്യക്ഷപ്പെടണമെന്ന് തിരഞ്ഞെടുക്കുക, "
+"അല്ലെങ്കിൽ പൂർണ്ണമായും പ്രവർത്തനരഹിതമാക്കുക."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2310,8 +2326,8 @@ msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
 msgstr ""
-"ചരിത്രം പ്രവർത്തനരഹിതമാക്കണമെന്ന് നിങ്ങൾക്ക് ഉറപ്പാണോ? ഇത് പിൻ ചെയ്ത ചാറ്റുകൾ ഉൾപ്പെടെ എല്ലാ "
-"ചാറ്റുകളും ഇല്ലാതാക്കും."
+"ചരിത്രം പ്രവർത്തനരഹിതമാക്കണമെന്ന് നിങ്ങൾക്ക് ഉറപ്പാണോ? ഇത് പിൻ ചെയ്ത "
+"ചാറ്റുകൾ ഉൾപ്പെടെ എല്ലാ ചാറ്റുകളും ഇല്ലാതാക്കും."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2320,8 +2336,8 @@ msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
 msgstr ""
-"സമീപകാല ചാറ്റുകൾ പ്രവർത്തനരഹിതമാക്കണമെന്ന് നിങ്ങൾക്ക് ഉറപ്പാണോ? നിലവിൽ സേവ് ചെയ്ത സമീപകാല "
-"ചാറ്റുകളും ഇത് ഇല്ലാതാക്കും."
+"സമീപകാല ചാറ്റുകൾ പ്രവർത്തനരഹിതമാക്കണമെന്ന് നിങ്ങൾക്ക് ഉറപ്പാണോ? നിലവിൽ സേവ് "
+"ചെയ്ത സമീപകാല ചാറ്റുകളും ഇത് ഇല്ലാതാക്കും."
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2359,8 +2375,9 @@ msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
 msgstr ""
-"ഞങ്ങളുടെ സ്വകാര്യത നയം അനുസരിച്ച്, ഞങ്ങൾ നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾ ഒന്നും ശേഖരിക്കുകയോ "
-"പങ്കുവയ്ക്കുകയോ ചെയ്യില്ല. ഈ സ്വകാര്യതാ പരിരക്ഷ എല്ലാം നിങ്ങളുടെ ഉപകരണത്തിൽ സംഭവിക്കുന്നു."
+"ഞങ്ങളുടെ സ്വകാര്യത നയം അനുസരിച്ച്, ഞങ്ങൾ നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾ ഒന്നും "
+"ശേഖരിക്കുകയോ പങ്കുവയ്ക്കുകയോ ചെയ്യില്ല. ഈ സ്വകാര്യതാ പരിരക്ഷ എല്ലാം "
+"നിങ്ങളുടെ ഉപകരണത്തിൽ സംഭവിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2502,13 +2519,15 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"പ്രസക്തമായ വെബ് ഉള്ളടക്കം സംഗ്രഹിച്ച് ചില തിരയലുകൾക്ക് AI സഹായത്തോടെ ഉത്തരങ്ങൾ അജ്ഞാതമായി "
-"സൃഷ്ടിക്കാൻ Assist-ന് കഴിയും. Assist എത്ര തവണ പ്രത്യക്ഷപ്പെടണമെന്ന് നിങ്ങൾക്ക് തിരഞ്ഞെടുക്കാം: "
-"ഒരിക്കലും ഇല്ല (തിരയൽ ഫലങ്ങളിൽ നിന്ന് Assist UI പൂർണ്ണമായും നീക്കം ചെയ്യുന്നു), ആവശ്യാനുസരണം "
-"(നിങ്ങൾ Assist ബട്ടൺ ക്ലിക്ക് ചെയ്താൽ മാത്രമേ AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ കാണിക്കൂ), ചിലപ്പോൾ "
-"(വളരെ പ്രസക്തമാകുമ്പോൾ മാത്രമേ AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ കാണിക്കൂ), ഇടയ്ക്കിടെ (വിശാലമായ "
-"തിരയൽ ശ്രേണികളിൽ കൂടുതൽ പതിവായി കാണിക്കുന്നു). ഇപ്പോൾ, AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ യു.എസ്. "
-"(ഇംഗ്ലീഷ്) മേഖലയിൽ മാത്രമേ ലഭ്യമാകൂ."
+"പ്രസക്തമായ വെബ് ഉള്ളടക്കം സംഗ്രഹിച്ച് ചില തിരയലുകൾക്ക് AI സഹായത്തോടെ "
+"ഉത്തരങ്ങൾ അജ്ഞാതമായി സൃഷ്ടിക്കാൻ Assist-ന് കഴിയും. Assist എത്ര തവണ "
+"പ്രത്യക്ഷപ്പെടണമെന്ന് നിങ്ങൾക്ക് തിരഞ്ഞെടുക്കാം: ഒരിക്കലും ഇല്ല (തിരയൽ "
+"ഫലങ്ങളിൽ നിന്ന് Assist UI പൂർണ്ണമായും നീക്കം ചെയ്യുന്നു), ആവശ്യാനുസരണം "
+"(നിങ്ങൾ Assist ബട്ടൺ ക്ലിക്ക് ചെയ്താൽ മാത്രമേ AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ "
+"കാണിക്കൂ), ചിലപ്പോൾ (വളരെ പ്രസക്തമാകുമ്പോൾ മാത്രമേ AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ "
+"കാണിക്കൂ), ഇടയ്ക്കിടെ (വിശാലമായ തിരയൽ ശ്രേണികളിൽ കൂടുതൽ പതിവായി "
+"കാണിക്കുന്നു). ഇപ്പോൾ, AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ യു.എസ്. (ഇംഗ്ലീഷ്) മേഖലയിൽ "
+"മാത്രമേ ലഭ്യമാകൂ."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2520,13 +2539,14 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു ഓപ്ഷണൽ സവിശേഷതയാണ് Assist, അതിന് തിരയൽ അന്വേഷണങ്ങൾക്ക് "
-"അജ്ഞാതമായി AI സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. ഇത് ചെയ്യുന്നതിന്, പ്രസക്തമായ "
-"ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും തുടർന്ന് കണ്ടെത്തിയ പ്രസക്തമായ വിവരങ്ങളെ "
-"അടിസ്ഥാനമാക്കി ഒരു ഹ്രസ്വമായ ഉത്തരം സൃഷ്ടിക്കുന്നതിന് AI- പിന്തുണയ്ക്കുന്ന സ്വഭാവിക ഭാഷ "
-"സാങ്കേതികവിദ്യ ഉപയോഗിക്കുകയും ചെയ്യുന്നു. ഉദ്ധരിച്ച ഉറവിടങ്ങളിൽ നിന്ന് പ്രതികരണങ്ങൾ സ്വയം "
-"സൃഷ്ടിക്കപ്പെട്ടതാണെന്നും%2$s വെബ് ക്രൗളിങ്ങിനെ %1$sഅടിസ്ഥാനമാക്കിയുള്ളതാണെന്നും ഓർമ്മിക്കേണ്ടത് "
-"പ്രധാനമാണ്."
+"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു ഓപ്ഷണൽ സവിശേഷതയാണ് Assist, അതിന് തിരയൽ "
+"അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി AI സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. "
+"ഇത് ചെയ്യുന്നതിന്, പ്രസക്തമായ ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും "
+"തുടർന്ന് കണ്ടെത്തിയ പ്രസക്തമായ വിവരങ്ങളെ അടിസ്ഥാനമാക്കി ഒരു ഹ്രസ്വമായ ഉത്തരം "
+"സൃഷ്ടിക്കുന്നതിന് AI- പിന്തുണയ്ക്കുന്ന സ്വഭാവിക ഭാഷ സാങ്കേതികവിദ്യ "
+"ഉപയോഗിക്കുകയും ചെയ്യുന്നു. ഉദ്ധരിച്ച ഉറവിടങ്ങളിൽ നിന്ന് പ്രതികരണങ്ങൾ സ്വയം "
+"സൃഷ്ടിക്കപ്പെട്ടതാണെന്നും%2$s വെബ് ക്രൗളിങ്ങിനെ "
+"%1$sഅടിസ്ഥാനമാക്കിയുള്ളതാണെന്നും ഓർമ്മിക്കേണ്ടത് പ്രധാനമാണ്."
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2552,8 +2572,9 @@ msgid ""
 "At the café, airport, or hotel, DuckDuckGo VPN encrypts your connection and "
 "hides your IP address on Wi-Fi."
 msgstr ""
-"കഫേയിലോ വിമാനത്താവളത്തിലോ ഹോട്ടലിലോ ആയിരിക്കുമ്പോൾ, DuckDuckGo VPN നിങ്ങളുടെ കണക്ഷൻ "
-"എൻക്രിപ്റ്റ് ചെയ്യുകയും Wi-Fi-യിൽ നിങ്ങളുടെ IP വിലാസം മറയ്ക്കുകയും ചെയ്യുന്നു."
+"കഫേയിലോ വിമാനത്താവളത്തിലോ ഹോട്ടലിലോ ആയിരിക്കുമ്പോൾ, DuckDuckGo VPN നിങ്ങളുടെ "
+"കണക്ഷൻ എൻക്രിപ്റ്റ് ചെയ്യുകയും Wi-Fi-യിൽ നിങ്ങളുടെ IP വിലാസം മറയ്ക്കുകയും "
+"ചെയ്യുന്നു."
 
 # smartling.placeholder_format=C
 #. In the context of the National Hockey League (NHL), label for teams belonging to the Atlantic division
@@ -2669,15 +2690,16 @@ msgstr "സ്വയമേവയുള്ള-ഉത്തരം"
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
 msgstr ""
-"ലിസ്റ്റ് ചെയ്ത ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കി യാന്ത്രികമായി സൃഷ്ടിച്ചത്. അപാകതകൾ അടങ്ങിയിരിക്കാം."
+"ലിസ്റ്റ് ചെയ്ത ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കി യാന്ത്രികമായി സൃഷ്ടിച്ചത്. അപാകതകൾ "
+"അടങ്ങിയിരിക്കാം."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
 msgstr ""
-"ലിസ്റ്റ് ചെയ്ത ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കി യാന്ത്രികമായി സൃഷ്ടിച്ചത്. പ്രതികരണങ്ങളിൽ അപാകതകൾ "
-"അടങ്ങിയിരിക്കാം."
+"ലിസ്റ്റ് ചെയ്ത ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കി യാന്ത്രികമായി സൃഷ്ടിച്ചത്. "
+"പ്രതികരണങ്ങളിൽ അപാകതകൾ അടങ്ങിയിരിക്കാം."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
@@ -2702,9 +2724,9 @@ msgid ""
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
 msgstr ""
-"പ്രസക്തമായ തിരയലുകൾക്കായി സ്വയമേവ Assist കാണിക്കുന്നു. Assist-ന് അജ്ഞാതമായി തിരയാനും ചില "
-"സെർച്ചുകൾക്ക് മറുപടിയായി വിവരങ്ങൾ സംഗ്രഹിക്കാനും കഴിയും. ഇപ്പോൾ, ഇംഗ്ലീഷ് പ്രദേശങ്ങളിൽ "
-"മാത്രമേ Assist ലഭ്യമാകൂ."
+"പ്രസക്തമായ തിരയലുകൾക്കായി സ്വയമേവ Assist കാണിക്കുന്നു. Assist-ന് അജ്ഞാതമായി "
+"തിരയാനും ചില സെർച്ചുകൾക്ക് മറുപടിയായി വിവരങ്ങൾ സംഗ്രഹിക്കാനും കഴിയും. "
+"ഇപ്പോൾ, ഇംഗ്ലീഷ് പ്രദേശങ്ങളിൽ മാത്രമേ Assist ലഭ്യമാകൂ."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2713,16 +2735,17 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"പ്രസക്തമായ തിരയലുകൾക്കായി സ്വയമേവ DuckAssist കാണിക്കുന്നു. DuckAssist-ന് അജ്ഞാതമായി "
-"തിരയാനും ചില തിരയലുകൾക്ക് മറുപടിയായി വിവരങ്ങൾ സംഗ്രഹിക്കാനും കഴിയും. ഇപ്പോൾ, ഇംഗ്ലീഷ് "
-"പ്രദേശങ്ങളിൽ മാത്രമേ DuckAssist ലഭ്യമാകൂ."
+"പ്രസക്തമായ തിരയലുകൾക്കായി സ്വയമേവ DuckAssist കാണിക്കുന്നു. DuckAssist-ന് "
+"അജ്ഞാതമായി തിരയാനും ചില തിരയലുകൾക്ക് മറുപടിയായി വിവരങ്ങൾ സംഗ്രഹിക്കാനും "
+"കഴിയും. ഇപ്പോൾ, ഇംഗ്ലീഷ് പ്രദേശങ്ങളിൽ മാത്രമേ DuckAssist ലഭ്യമാകൂ."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Autoplay short, silent video previews when you hover over video results."
 msgstr ""
-"വീഡിയോ ഫലങ്ങളിൽ ഹോവർ ചെയ്യുമ്പോൾ ചെറുതും നിശബ്‌ദവുമായ വീഡിയോ പ്രിവ്യൂകൾ സ്വയമേവ പ്ലേ ചെയ്യുക."
+"വീഡിയോ ഫലങ്ങളിൽ ഹോവർ ചെയ്യുമ്പോൾ ചെറുതും നിശബ്‌ദവുമായ വീഡിയോ പ്രിവ്യൂകൾ "
+"സ്വയമേവ പ്ലേ ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Title for the menu listing free/degraded models available after the advanced-model usage limit has been reached.
@@ -2754,7 +2777,9 @@ msgstr "ശരാശരി വോളിയം"
 #. Warning text shown below the chat input when the user has attached files, advising them not to upload files from untrusted sources.
 msgctxt "Disclaimer below chat input in Duck.ai when files are attached"
 msgid "Avoid uploading files from sources you don't trust."
-msgstr "നിങ്ങൾ വിശ്വസിക്കാത്ത ഉറവിടങ്ങളിൽ നിന്ന് ഫയലുകൾ അപ്‌ലോഡ് ചെയ്യുന്നത് ഒഴിവാക്കുക."
+msgstr ""
+"നിങ്ങൾ വിശ്വസിക്കാത്ത ഉറവിടങ്ങളിൽ നിന്ന് ഫയലുകൾ അപ്‌ലോഡ് ചെയ്യുന്നത് "
+"ഒഴിവാക്കുക."
 
 # smartling.placeholder_format=C
 #. Indicates the Win-Loss record of a team when playing away
@@ -2922,8 +2947,9 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
-"ഈ റിപ്പോർട്ട് സൂക്ഷിക്കുന്നതിന് മുമ്പ്, പേരുകൾ, ഇമെയിൽ വിലാസങ്ങൾ, തിരിച്ചറിയൽ മെറ്റാഡാറ്റ "
-"എന്നിവ പോലുള്ള PII നീക്കം ചെയ്തുകൊണ്ട് DuckDuckGo നിങ്ങളുടെ സംഭാഷണം അജ്ഞാതമാക്കും."
+"ഈ റിപ്പോർട്ട് സൂക്ഷിക്കുന്നതിന് മുമ്പ്, പേരുകൾ, ഇമെയിൽ വിലാസങ്ങൾ, "
+"തിരിച്ചറിയൽ മെറ്റാഡാറ്റ എന്നിവ പോലുള്ള PII നീക്കം ചെയ്തുകൊണ്ട് DuckDuckGo "
+"നിങ്ങളുടെ സംഭാഷണം അജ്ഞാതമാക്കും."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3053,8 +3079,8 @@ msgid ""
 "Block harmful sites, hide your IP address, plus get more premium protections "
 "with our subscription."
 msgstr ""
-"ഉപദ്രവകരമായ സൈറ്റുകൾ തടയുക, നിങ്ങളുടെ IP വിലാസം മറയ്ക്കുക, കൂടാതെ ഞങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ വഴി "
-"കൂടുതൽ പ്രീമിയം പരിരക്ഷകൾ നേടുക."
+"ഉപദ്രവകരമായ സൈറ്റുകൾ തടയുക, നിങ്ങളുടെ IP വിലാസം മറയ്ക്കുക, കൂടാതെ ഞങ്ങളുടെ "
+"സബ്സ്ക്രിപ്ഷൻ വഴി കൂടുതൽ പ്രീമിയം പരിരക്ഷകൾ നേടുക."
 
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
@@ -3314,18 +3340,18 @@ msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"ഞങ്ങൾ സ്വകാര്യത പരിരക്ഷണം ചേർക്കുമ്പോൾ പതിവുപോലെ ബ്രൗസ് ചെയ്യുക. ഞങ്ങളുടെ തിരയൽ എഞ്ചിൻ, "
-"ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ എന്നിവ ഒറ്റ %1$s%2$s വിപുലീകരണത്തിലേക്ക്%3$s ഞങ്ങൾ "
-"ഒരുമിച്ചുചേർത്തു."
+"ഞങ്ങൾ സ്വകാര്യത പരിരക്ഷണം ചേർക്കുമ്പോൾ പതിവുപോലെ ബ്രൗസ് ചെയ്യുക. ഞങ്ങളുടെ "
+"തിരയൽ എഞ്ചിൻ, ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ എന്നിവ ഒറ്റ %1$s%2$s "
+"വിപുലീകരണത്തിലേക്ക്%3$s ഞങ്ങൾ ഒരുമിച്ചുചേർത്തു."
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"സാധാരണപോലെ ബ്രൗസ് ചെയ്യുക, ബാക്കി കാര്യങ്ങൾ ഞങ്ങൾ നോക്കിക്കൊള്ളാം. ഞങ്ങളുടെ തിരയൽ എഞ്ചിൻ, "
-"ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ എന്നിവ ഒറ്റ %1$s%2$s വിപുലീകരണത്തിലേക്ക്%3$s ഞങ്ങൾ "
-"ഒരുമിച്ചുചേർത്തു."
+"സാധാരണപോലെ ബ്രൗസ് ചെയ്യുക, ബാക്കി കാര്യങ്ങൾ ഞങ്ങൾ നോക്കിക്കൊള്ളാം. ഞങ്ങളുടെ "
+"തിരയൽ എഞ്ചിൻ, ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ എന്നിവ ഒറ്റ %1$s%2$s "
+"വിപുലീകരണത്തിലേക്ക്%3$s ഞങ്ങൾ ഒരുമിച്ചുചേർത്തു."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3333,9 +3359,9 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"സാധാരണപോലെ ബ്രൗസ് ചെയ്യുക, ബാക്കി കാര്യങ്ങൾ ഞങ്ങൾ നോക്കിക്കൊള്ളാം. %1$sപ്രധാന "
-"ബ്രൗസറുകൾക്കായുള്ള%2$s private search, ട്രാക്കർ ബ്ലോക്കിംഗ്, സൈറ്റ് എൻക്രിപ്ഷൻ എന്നിവ "
-"മൊത്തത്തിൽ ഒറ്റ ഡൗൺലോഡിൽ നേടുക."
+"സാധാരണപോലെ ബ്രൗസ് ചെയ്യുക, ബാക്കി കാര്യങ്ങൾ ഞങ്ങൾ നോക്കിക്കൊള്ളാം. "
+"%1$sപ്രധാന ബ്രൗസറുകൾക്കായുള്ള%2$s private search, ട്രാക്കർ ബ്ലോക്കിംഗ്, "
+"സൈറ്റ് എൻക്രിപ്ഷൻ എന്നിവ മൊത്തത്തിൽ ഒറ്റ ഡൗൺലോഡിൽ നേടുക."
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3421,7 +3447,9 @@ msgstr "'%1$s' ക്ലിക്ക് ചെയ്യുക വഴി, നി�
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr "“%1$s” ക്ലിക്ക് ചെയ്യുന്നതിലൂടെ നീ Duck.ai-യുടെ %2$s ഉം %3$s ഉം അംഗീകരിക്കുന്നു."
+msgstr ""
+"“%1$s” ക്ലിക്ക് ചെയ്യുന്നതിലൂടെ നീ Duck.ai-യുടെ %2$s ഉം %3$s ഉം "
+"അംഗീകരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3442,10 +3470,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"സ്വതവേ, വ്യക്തിഗതമല്ലാത്ത ബ്രൗസർ കുക്കികളിലാണ് (നിങ്ങളുടെ ബ്രൗസറിൽ), ക്രമീകരണം "
-"സൂക്ഷിച്ചിരിക്കുന്നത്. നിങ്ങളുടെ ക്രമീകരണം കൂടുതൽ സ്ഥിരമായ ഒരു വിധത്തിൽ സംഭരിക്കാൻ (ക്ലൗഡിലെ "
-"ഒരു റിമോട്ട് സെർവറിൽ), നിങ്ങൾക്ക് അജ്ഞാത Cloud Save ഉപയോഗിക്കാൻ കഴിയും. വ്യക്തിപരമായി "
-"തിരിച്ചറിയാൻ കഴിയുന്ന വിവരങ്ങളൊന്നും ക്ലൗഡിൽ സംഭരിക്കില്ല, നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും "
+"സ്വതവേ, വ്യക്തിഗതമല്ലാത്ത ബ്രൗസർ കുക്കികളിലാണ് (നിങ്ങളുടെ ബ്രൗസറിൽ), "
+"ക്രമീകരണം സൂക്ഷിച്ചിരിക്കുന്നത്. നിങ്ങളുടെ ക്രമീകരണം കൂടുതൽ സ്ഥിരമായ ഒരു "
+"വിധത്തിൽ സംഭരിക്കാൻ (ക്ലൗഡിലെ ഒരു റിമോട്ട് സെർവറിൽ), നിങ്ങൾക്ക് അജ്ഞാത "
+"Cloud Save ഉപയോഗിക്കാൻ കഴിയും. വ്യക്തിപരമായി തിരിച്ചറിയാൻ കഴിയുന്ന "
+"വിവരങ്ങളൊന്നും ക്ലൗഡിൽ സംഭരിക്കില്ല, നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും "
 "നിങ്ങളുടെ ബ്രൗസറിൽ നിന്ന് പുറത്തുപോകില്ല."
 
 # smartling.placeholder_format=C
@@ -3454,8 +3483,9 @@ msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"ഡിക്ടേഷന്‍ പ്രവര്‍ത്തനക്ഷമമാക്കുന്നതിലൂടെ, ഈ സവിശേഷത ഉപയോഗിക്കുന്നതിനായി നിങ്ങളുടെ ശബ്ദ ഡാറ്റ "
-"OpenAI-ലേക്ക് അയയ്ക്കുന്നതിന് നിങ്ങൾ സമ്മതം നൽകുന്നു. ആരംഭിക്കുന്നതിന് മുമ്പ് ഞങ്ങളുടെ %1$s കാണൂ."
+"ഡിക്ടേഷന്‍ പ്രവര്‍ത്തനക്ഷമമാക്കുന്നതിലൂടെ, ഈ സവിശേഷത ഉപയോഗിക്കുന്നതിനായി "
+"നിങ്ങളുടെ ശബ്ദ ഡാറ്റ OpenAI-ലേക്ക് അയയ്ക്കുന്നതിന് നിങ്ങൾ സമ്മതം നൽകുന്നു. "
+"ആരംഭിക്കുന്നതിന് മുമ്പ് ഞങ്ങളുടെ %1$s കാണൂ."
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3464,9 +3494,9 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"വോയ്സ് ചാറ്റ് പ്രവർത്തനക്ഷമമാക്കുന്നതിലൂടെ, ഈ സവിശേഷത ഉപയോഗിക്കുന്നതിനായി നിങ്ങളുടെ വോയ്സ് "
-"ഡാറ്റ OpenAI-ലേക്ക് അയയ്ക്കുന്നതിന് നിങ്ങൾ സമ്മതം നൽകുന്നു. ആരംഭിക്കുന്നതിന് മുമ്പ് ഞങ്ങളുടെ %1$s "
-"കാണൂ."
+"വോയ്സ് ചാറ്റ് പ്രവർത്തനക്ഷമമാക്കുന്നതിലൂടെ, ഈ സവിശേഷത ഉപയോഗിക്കുന്നതിനായി "
+"നിങ്ങളുടെ വോയ്സ് ഡാറ്റ OpenAI-ലേക്ക് അയയ്ക്കുന്നതിന് നിങ്ങൾ സമ്മതം നൽകുന്നു. "
+"ആരംഭിക്കുന്നതിന് മുമ്പ് ഞങ്ങളുടെ %1$s കാണൂ."
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3502,8 +3532,8 @@ msgstr "കാമറൂൺ"
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
 msgstr ""
-"കോഴിയിറച്ചി, ബ്രോക്കോളി, അരി എന്നിവ ഉപയോഗിച്ച് നിങ്ങൾക്ക് ഏതാനും ലളിതമായ പാചകക്കുറിപ്പുകൾ "
-"സൃഷ്ടിക്കാൻ കഴിയുമോ?"
+"കോഴിയിറച്ചി, ബ്രോക്കോളി, അരി എന്നിവ ഉപയോഗിച്ച് നിങ്ങൾക്ക് ഏതാനും ലളിതമായ "
+"പാചകക്കുറിപ്പുകൾ സൃഷ്ടിക്കാൻ കഴിയുമോ?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3575,7 +3605,7 @@ msgctxt ""
 "Secondary button that dismisses the tab picker dialog without attaching "
 "anything"
 msgid "Cancel"
-msgstr ""
+msgstr "റദ്ദാക്കുക"
 
 # smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
@@ -3813,7 +3843,8 @@ msgstr "ഫലങ്ങളുടെ URL-കൾ എങ്ങനെ പ്രദ�
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
 msgstr ""
-"നിങ്ങൾ സ്ക്രോൾ ചെയ്യുമ്പോൾ ശീർഷകം എങ്ങനെ പ്രദർശിപ്പിക്കുന്നു എന്നതും അതിന്റെ പെരുമാറ്റവും മാറുന്നു"
+"നിങ്ങൾ സ്ക്രോൾ ചെയ്യുമ്പോൾ ശീർഷകം എങ്ങനെ പ്രദർശിപ്പിക്കുന്നു എന്നതും അതിന്റെ "
+"പെരുമാറ്റവും മാറുന്നു"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3832,13 +3863,17 @@ msgstr "മുഴുവൻ സൈറ്റിലും പശ്ചാത്ത�
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr "ഹോവർ, മൊഡ്യൂളുകൾ, ഡ്രോപ്പ്ഡൗൺ മെനുകൾ എന്നിവയിലെ ഫലങ്ങളുടെ പശ്ചാത്തല നിറം മാറ്റുന്നു"
+msgstr ""
+"ഹോവർ, മൊഡ്യൂളുകൾ, ഡ്രോപ്പ്ഡൗൺ മെനുകൾ എന്നിവയിലെ ഫലങ്ങളുടെ പശ്ചാത്തല നിറം "
+"മാറ്റുന്നു"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
 msgctxt "settings"
 msgid "Changes the background color when hovering over a result"
-msgstr "ഫലങ്ങളുടെ മുകളില്‍ കൂടി മൗസ് ചലിപ്പിക്കുമ്പോള്‍ പശ്ചാത്തലത്തിന്റെ നിറം മാറ്റുന്നു"
+msgstr ""
+"ഫലങ്ങളുടെ മുകളില്‍ കൂടി മൗസ് ചലിപ്പിക്കുമ്പോള്‍ പശ്ചാത്തലത്തിന്റെ നിറം "
+"മാറ്റുന്നു"
 
 # smartling.placeholder_format=C
 #. Description of a setting managing the color of search result snippet text.
@@ -3961,10 +3996,11 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"നിങ്ങൾക്ക് മൂന്നാം കക്ഷി AI ചാറ്റ് മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ ചാറ്റ് (Duck.ai "
-"സേവനം വഴി) നിങ്ങളെ അനുവദിക്കുന്നു, ഇത് OpenAI, Anthropic തുടങ്ങിയ മോഡലുകളെ പിന്തുണയ്ക്കുന്നു. "
-"ഈ ക്രമീകരണം ഓഫാക്കുന്നത് DuckDuckGo Search-ൽ ചാറ്റ് ബട്ടണുകളും ലിങ്കുകളും മറയ്ക്കും. "
-"എന്നിരുന്നാലും, %1$shttps://duck.ai%2$s സന്ദർശിച്ച് ഈ ക്രമീകരണം ഓഫ് ആയിരിക്കുമ്പോഴും "
+"നിങ്ങൾക്ക് മൂന്നാം കക്ഷി AI ചാറ്റ് മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ "
+"ചാറ്റ് (Duck.ai സേവനം വഴി) നിങ്ങളെ അനുവദിക്കുന്നു, ഇത് OpenAI, Anthropic "
+"തുടങ്ങിയ മോഡലുകളെ പിന്തുണയ്ക്കുന്നു. ഈ ക്രമീകരണം ഓഫാക്കുന്നത് DuckDuckGo "
+"Search-ൽ ചാറ്റ് ബട്ടണുകളും ലിങ്കുകളും മറയ്ക്കും. എന്നിരുന്നാലും, "
+"%1$shttps://duck.ai%2$s സന്ദർശിച്ച് ഈ ക്രമീകരണം ഓഫ് ആയിരിക്കുമ്പോഴും "
 "നിങ്ങൾക്ക് ചാറ്റ് ആക്സസ് ചെയ്യാൻ കഴിയും. നേരിട്ട്."
 
 # smartling.placeholder_format=C
@@ -4021,8 +4057,8 @@ msgstr "സ്വകാര്യമായി ചാറ്റ് ചെയ്യ�
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
 msgstr ""
-"ഞങ്ങളുടെ സൗജന്യ ബ്രൗസറിൽ തന്നെയുള്ള Duck.ai ഉപയോഗിച്ച് ഏത് വെബ്‌സൈറ്റിലും സ്വകാര്യമായി ചാറ്റ് "
-"ചെയ്യുക."
+"ഞങ്ങളുടെ സൗജന്യ ബ്രൗസറിൽ തന്നെയുള്ള Duck.ai ഉപയോഗിച്ച് ഏത് വെബ്‌സൈറ്റിലും "
+"സ്വകാര്യമായി ചാറ്റ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
@@ -4030,8 +4066,8 @@ msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
 msgstr ""
-"ഞങ്ങളുടെ സൗജന്യ ബ്രൗസറിലെ Duck.ai സൈഡ്‌ബാർ ഉപയോഗിച്ച് ഏത് വെബ്‌സൈറ്റിലും സ്വകാര്യമായി ചാറ്റ് "
-"ചെയ്യുക."
+"ഞങ്ങളുടെ സൗജന്യ ബ്രൗസറിലെ Duck.ai സൈഡ്‌ബാർ ഉപയോഗിച്ച് ഏത് വെബ്‌സൈറ്റിലും "
+"സ്വകാര്യമായി ചാറ്റ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4073,7 +4109,7 @@ msgstr "ചാറ്റ് പ്രതികരണം കുറ്റകരമ�
 #. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
 msgctxt "Chat history about modal list item headline"
 msgid "Chat storage varies by browser"
-msgstr ""
+msgstr "ബ്രൗസർ അനുസരിച്ച് ചാറ്റ് സംഭരണം വ്യത്യാസപ്പെടുന്നു"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4085,7 +4121,7 @@ msgstr "%1$s-നൊപ്പം ചാറ്റ് ചെയ്യുക"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Chat with popular AI models, anonymized by us."
-msgstr ""
+msgstr "ഞങ്ങൾ അജ്ഞാതമാക്കിയ ജനപ്രിയ AI മോഡലുകളുമായി ചാറ്റ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4112,6 +4148,9 @@ msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
 msgstr ""
+"ചാറ്റുകൾ DuckDuckGo-യുടെ സെർവറിൽ എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷനോടെ സുരക്ഷിതമായി "
+"സംഭരിച്ചിരിക്കുന്നു. നിങ്ങൾക്കല്ലാതെ മറ്റാർക്കും നിങ്ങളുടെ ഡാറ്റ കാണാൻ "
+"കഴിയില്ല, ഞങ്ങൾക്ക് പോലും."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4120,9 +4159,9 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"ചാറ്റുകൾ DuckDuckGo സെർവറുകളിലോ വിദൂര സെർവറുകളിലോ സംഭരിക്കുന്നതിന് പകരം നിങ്ങളുടെ "
-"ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിക്കുന്നു. ചാറ്റ് ചരിത്രം പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്ത "
-"ചാറ്റുകൾ നീക്കം ചെയ്യും."
+"ചാറ്റുകൾ DuckDuckGo സെർവറുകളിലോ വിദൂര സെർവറുകളിലോ സംഭരിക്കുന്നതിന് പകരം "
+"നിങ്ങളുടെ ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിക്കുന്നു. ചാറ്റ് ചരിത്രം "
+"പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്ത ചാറ്റുകൾ നീക്കം ചെയ്യും."
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -4134,11 +4173,13 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ തന്നെ സംഭരിക്കപ്പെടുന്നു. പുതിയ പ്രോംപ്റ്റുകളും പ്രതികരണങ്ങളും "
-"അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് താൽക്കാലികമായി ഒരു DuckDuckGo സെർവറിൽ സംഭരിക്കും, ഇത് "
-"നിങ്ങളുടെ ഇന്റർനെറ്റ് കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് വീണ്ടെടുക്കാൻ സഹായിക്കും. ചാറ്റ് ചരിത്രം "
-"പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്‌ത ചാറ്റുകൾ ഇല്ലാതാക്കുകയും പുതിയ പ്രോംപ്റ്റുകളുടെയും "
-"പ്രതികരണങ്ങളുടെയും താൽക്കാലിക സ്റ്റോറേജ് പ്രവർത്തനരഹിതമാക്കുകയും ചെയ്യും."
+"ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ തന്നെ സംഭരിക്കപ്പെടുന്നു. പുതിയ "
+"പ്രോംപ്റ്റുകളും പ്രതികരണങ്ങളും അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് "
+"താൽക്കാലികമായി ഒരു DuckDuckGo സെർവറിൽ സംഭരിക്കും, ഇത് നിങ്ങളുടെ ഇന്റർനെറ്റ് "
+"കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് വീണ്ടെടുക്കാൻ സഹായിക്കും. ചാറ്റ് ചരിത്രം "
+"പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്‌ത ചാറ്റുകൾ ഇല്ലാതാക്കുകയും പുതിയ "
+"പ്രോംപ്റ്റുകളുടെയും പ്രതികരണങ്ങളുടെയും താൽക്കാലിക സ്റ്റോറേജ് "
+"പ്രവർത്തനരഹിതമാക്കുകയും ചെയ്യും."
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -4161,8 +4202,9 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"%1$s ഉപയോഗിച്ചുള്ള ചാറ്റുകൾക്ക് ദാതാവിന്റെ ദൃശ്യപരതയില്ല, എന്നാൽ Duck.ai-ൽ അപ്‌ലോഡ് ചെയ്യുന്ന "
-"എല്ലാ ഫയലുകളും %2$s-നായി ഒരു ഉള്ളടക്ക മോഡറേഷൻ ദാതാവ് അജ്ഞാതമായി പരിശോധിക്കുന്നു."
+"%1$s ഉപയോഗിച്ചുള്ള ചാറ്റുകൾക്ക് ദാതാവിന്റെ ദൃശ്യപരതയില്ല, എന്നാൽ Duck.ai-ൽ "
+"അപ്‌ലോഡ് ചെയ്യുന്ന എല്ലാ ഫയലുകളും %2$s-നായി ഒരു ഉള്ളടക്ക മോഡറേഷൻ ദാതാവ് "
+"അജ്ഞാതമായി പരിശോധിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -4170,8 +4212,8 @@ msgctxt "Sync file storage inline disclaimer body"
 msgid ""
 "Chats with attachments have stopped syncing. Free up storage to resume Sync."
 msgstr ""
-"അറ്റാച്ചുമെന്റുകളുള്ള ചാറ്റുകൾ സമന്വയിപ്പിക്കുന്നത് നിർത്തിയിരിക്കുന്നു. സമന്വയം പുനരാരംഭിക്കാൻ "
-"സംഭരണ സ്ഥലം ശൂന്യമാക്കുക."
+"അറ്റാച്ചുമെന്റുകളുള്ള ചാറ്റുകൾ സമന്വയിപ്പിക്കുന്നത് നിർത്തിയിരിക്കുന്നു. "
+"സമന്വയം പുനരാരംഭിക്കാൻ സംഭരണ സ്ഥലം ശൂന്യമാക്കുക."
 
 # smartling.placeholder_format=C
 #. Message shown when we have no data from upstream to display
@@ -4224,7 +4266,9 @@ msgstr "സ്പെല്ലിംഗ് പരിശോധിക്കുക"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr "ഈ തടസ്സത്തിനെക്കുറിച്ചുള്ള അപ്ഡേറ്റുകൾക്കായി DuckDuckGo സബ് റെഡ്ഡിറ്റ് പരിശോധിക്കുക."
+msgstr ""
+"ഈ തടസ്സത്തിനെക്കുറിച്ചുള്ള അപ്ഡേറ്റുകൾക്കായി DuckDuckGo സബ് റെഡ്ഡിറ്റ് "
+"പരിശോധിക്കുക."
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4295,7 +4339,9 @@ msgstr "%1$s , %2$s എന്നിവ ഉൾപ്പെടെ AI മോഡല�
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr "നിങ്ങളുടെ സ്വകാര്യത പരിരക്ഷിക്കുന്നത് തുടരാൻ %1$sനിലനിർത്തുക%2$s തിരഞ്ഞെടുക്കുക."
+msgstr ""
+"നിങ്ങളുടെ സ്വകാര്യത പരിരക്ഷിക്കുന്നത് തുടരാൻ %1$sനിലനിർത്തുക%2$s "
+"തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -4327,8 +4373,8 @@ msgid ""
 "Choose from 40+ server locations worldwide to help block harmful sites and "
 "scams."
 msgstr ""
-"ഉപദ്രവകരമായ സൈറ്റുകളെയും തട്ടിപ്പുകളെയും തടയാൻ ലോകമെമ്പാടുമുള്ള 40-ലധികം സെർവർ "
-"ലൊക്കേഷനുകളിൽ നിന്ന് തിരഞ്ഞെടുക്കുക."
+"ഉപദ്രവകരമായ സൈറ്റുകളെയും തട്ടിപ്പുകളെയും തടയാൻ ലോകമെമ്പാടുമുള്ള 40-ലധികം "
+"സെർവർ ലൊക്കേഷനുകളിൽ നിന്ന് തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. The title of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -4346,8 +4392,8 @@ msgctxt "settings"
 msgid ""
 "Choose which app to use when you need directions for a location search result"
 msgstr ""
-"നിങ്ങൾക്ക് ഒരു ലൊക്കേഷൻ തിരയൽ ഫലത്തിനായി നിർദ്ദേശങ്ങൾ ആവശ്യമുള്ളപ്പോൾ ഏത് ആപ്പ് "
-"ഉപയോഗിക്കണമെന്ന് തിരഞ്ഞെടുക്കുക"
+"നിങ്ങൾക്ക് ഒരു ലൊക്കേഷൻ തിരയൽ ഫലത്തിനായി നിർദ്ദേശങ്ങൾ ആവശ്യമുള്ളപ്പോൾ ഏത് "
+"ആപ്പ് ഉപയോഗിക്കണമെന്ന് തിരഞ്ഞെടുക്കുക"
 
 # smartling.placeholder_format=C
 #. Accessible label for the citations popover dialog in Duck.ai chat responses.
@@ -4528,9 +4574,9 @@ msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
-"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് ചാറ്റുകൾ ഇല്ലാതാക്കും. ചില ബ്രൗസറുകൾ അടുത്തിടെ നടന്ന ചാറ്റുകൾ "
-"അനിശ്ചിതകാലം സൂക്ഷിക്കുകയോ AI Chat ഉപയോഗം ഇല്ലാത്ത 7 ദിവസങ്ങൾക്ക് ശേഷം യാന്ത്രികമായി "
-"ഇല്ലാതാക്കുകയോ ചെയ്തേക്കാം."
+"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് ചാറ്റുകൾ ഇല്ലാതാക്കും. ചില ബ്രൗസറുകൾ അടുത്തിടെ "
+"നടന്ന ചാറ്റുകൾ അനിശ്ചിതകാലം സൂക്ഷിക്കുകയോ AI Chat ഉപയോഗം ഇല്ലാത്ത 7 "
+"ദിവസങ്ങൾക്ക് ശേഷം യാന്ത്രികമായി ഇല്ലാതാക്കുകയോ ചെയ്തേക്കാം."
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4540,9 +4586,10 @@ msgid ""
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
 msgstr ""
-"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് സമീപകാല ചാറ്റുകൾ ഇല്ലാതാക്കും. സമീപകാല ചാറ്റുകൾ Duck.ai "
-"ഉപയോഗിക്കാതെ 7 ദിവസത്തിനുശേഷം അനിശ്ചിതകാലം സൂക്ഷിക്കപ്പെടുകയോ യാന്ത്രികമായി ഇല്ലാതാക്കുകയോ "
-"ചെയ്യാം. നിങ്ങളുടെ ബ്രൗസറിനെ ആശ്രയിച്ചിരിക്കുന്നു."
+"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് സമീപകാല ചാറ്റുകൾ ഇല്ലാതാക്കും. സമീപകാല ചാറ്റുകൾ "
+"Duck.ai ഉപയോഗിക്കാതെ 7 ദിവസത്തിനുശേഷം അനിശ്ചിതകാലം സൂക്ഷിക്കപ്പെടുകയോ "
+"യാന്ത്രികമായി ഇല്ലാതാക്കുകയോ ചെയ്യാം. നിങ്ങളുടെ ബ്രൗസറിനെ "
+"ആശ്രയിച്ചിരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4551,8 +4598,8 @@ msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
 msgstr ""
-"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് നിങ്ങൾ തടഞ്ഞ സൈറ്റുകളെ റീസെറ്റ് ചെയ്യും. നിങ്ങളുടെ ബ്ലോക്ക് ലിസ്റ്റ് "
-"ശാശ്വതമായി ഞങ്ങളുടെ സൗജന്യ"
+"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് നിങ്ങൾ തടഞ്ഞ സൈറ്റുകളെ റീസെറ്റ് ചെയ്യും. "
+"നിങ്ങളുടെ ബ്ലോക്ക് ലിസ്റ്റ് ശാശ്വതമായി ഞങ്ങളുടെ സൗജന്യ"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4561,9 +4608,10 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"ഒരു വിഷയത്തിൽ കൂടുതൽ ആഴത്തിൽ പോകാൻ \"കൂടുതൽ\" ക്ലിക്ക് ചെയ്യുക, കൂടാതെ %1$sDuck.ai%2$s "
-"വഴി ഫോളോ-അപ്പ് ചോദ്യങ്ങൾ ചോദിക്കൂ OpenAI, Anthropic എന്നിവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ "
-"പിന്തുണയ്ക്കുന്ന ഞങ്ങളുടെ സ്വകാര്യ AI ചാറ്റ് സേവനം."
+"ഒരു വിഷയത്തിൽ കൂടുതൽ ആഴത്തിൽ പോകാൻ \"കൂടുതൽ\" ക്ലിക്ക് ചെയ്യുക, കൂടാതെ "
+"%1$sDuck.ai%2$s വഴി ഫോളോ-അപ്പ് ചോദ്യങ്ങൾ ചോദിക്കൂ OpenAI, Anthropic "
+"എന്നിവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഞങ്ങളുടെ സ്വകാര്യ AI "
+"ചാറ്റ് സേവനം."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4622,7 +4670,9 @@ msgstr "DuckDuckGo എക്സ്റ്റൻഷൻ ഡൗൺലോഡ് ച�
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr "DuckDuckGo Safari എക്സ്റ്റൻഷൻ ഡൗൺലോഡ് ചെയ്യാൻ %1$sതുറക്കുക%2$s ക്ലിക്ക് ചെയ്യുക"
+msgstr ""
+"DuckDuckGo Safari എക്സ്റ്റൻഷൻ ഡൗൺലോഡ് ചെയ്യാൻ %1$sതുറക്കുക%2$s ക്ലിക്ക് "
+"ചെയ്യുക"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4639,8 +4689,8 @@ msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
 msgstr ""
-"മുകളിലെ മെനുവിലെ %1$sSafari%2$s ക്ലിക്ക് ചെയ്യുക (Windows-ൽ, മുകളിൽ വലതുവശത്തുള്ള "
-"%3$sഗിയേഴ്സ് ഐക്കൺ%4$s ക്ലിക്ക് ചെയ്യുക)"
+"മുകളിലെ മെനുവിലെ %1$sSafari%2$s ക്ലിക്ക് ചെയ്യുക (Windows-ൽ, മുകളിൽ "
+"വലതുവശത്തുള്ള %3$sഗിയേഴ്സ് ഐക്കൺ%4$s ക്ലിക്ക് ചെയ്യുക)"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4658,7 +4708,8 @@ msgstr "ഡ്രോപ്പ്ഡൗണിൽ %1$sക്രമീകരണം%
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
 msgstr ""
-"%1$sനിലവിലുള്ള പേജുകൾ ഉപയോഗിക്കുക%2$s ക്ലിക്ക് ചെയ്യുക, തുടർന്ന് %3$sശരി ക്ലിക്ക് ചെയ്യുക%4$s."
+"%1$sനിലവിലുള്ള പേജുകൾ ഉപയോഗിക്കുക%2$s ക്ലിക്ക് ചെയ്യുക, തുടർന്ന് %3$sശരി "
+"ക്ലിക്ക് ചെയ്യുക%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4671,7 +4722,8 @@ msgstr "%1$sഉവ്വ്%2$s ക്ലിക്ക് ചെയ്യുക"
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
 msgstr ""
-"(മുകളിൽ വലത്), Chrome ടൂൾബാറിലെ %1$sക്രമീകരണം/ഹാംബർഗർ ഐക്കൺ %2$s ക്ലിക്ക് ചെയ്യുക."
+"(മുകളിൽ വലത്), Chrome ടൂൾബാറിലെ %1$sക്രമീകരണം/ഹാംബർഗർ ഐക്കൺ %2$s ക്ലിക്ക് "
+"ചെയ്യുക."
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4733,9 +4785,10 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
 msgstr ""
-"%1$sഎൻ്റെ ഡാറ്റ ഇല്ലാതാക്കുക%2$s ക്ലിക്ക് ചെയ്യുക അല്ലെങ്കിൽ ടാപ്പ് ചെയ്യുക. ഇത് ക്ലൗഡിൽ നിന്ന് "
-"ഡാറ്റ നീക്കംചെയ്യുന്നു, എന്നാൽ നിങ്ങൾ %3$sഎല്ലാ തിരയൽ ക്രമീകരണവും പുനഃക്രമീകരിക്കുക%4$s "
-"ക്ലിക്ക്/ടാപ്പ് ചെയ്യുന്നതുവരെ ഇത് നിങ്ങളുടെ ബ്രൗസറിൽ തുടരും."
+"%1$sഎൻ്റെ ഡാറ്റ ഇല്ലാതാക്കുക%2$s ക്ലിക്ക് ചെയ്യുക അല്ലെങ്കിൽ ടാപ്പ് ചെയ്യുക. "
+"ഇത് ക്ലൗഡിൽ നിന്ന് ഡാറ്റ നീക്കംചെയ്യുന്നു, എന്നാൽ നിങ്ങൾ %3$sഎല്ലാ തിരയൽ "
+"ക്രമീകരണവും പുനഃക്രമീകരിക്കുക%4$s ക്ലിക്ക്/ടാപ്പ് ചെയ്യുന്നതുവരെ ഇത് "
+"നിങ്ങളുടെ ബ്രൗസറിൽ തുടരും."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4746,9 +4799,10 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
 msgstr ""
-"%1$sഎന്റെ ഡാറ്റ ഇല്ലാതാക്കുക%2$s ക്ലിക്ക് ചെയ്യുക അല്ലെങ്കിൽ ടാപ്പ് ചെയ്യുക. ഇത് ക്ലൗഡിൽ നിന്ന് "
-"ഡാറ്റ നീക്കംചെയ്യുന്നു, എന്നാൽ നിങ്ങൾ %3$sഎല്ലാ ക്രമീകരണവും പുനഃക്രമീകരിക്കുക%4$s ക്ലിക്ക്/"
-"ടാപ്പ് ചെയ്യുന്നതുവരെ ഇത് നിങ്ങളുടെ ബ്രൗസറിൽ തുടരും."
+"%1$sഎന്റെ ഡാറ്റ ഇല്ലാതാക്കുക%2$s ക്ലിക്ക് ചെയ്യുക അല്ലെങ്കിൽ ടാപ്പ് ചെയ്യുക. "
+"ഇത് ക്ലൗഡിൽ നിന്ന് ഡാറ്റ നീക്കംചെയ്യുന്നു, എന്നാൽ നിങ്ങൾ %3$sഎല്ലാ "
+"ക്രമീകരണവും പുനഃക്രമീകരിക്കുക%4$s ക്ലിക്ക്/ടാപ്പ് ചെയ്യുന്നതുവരെ ഇത് "
+"നിങ്ങളുടെ ബ്രൗസറിൽ തുടരും."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4817,8 +4871,8 @@ msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
 msgstr ""
-"%1$sവിലാസ ബാറിൽ ഉപയോഗിച്ചിരിക്കുന്ന തിരയൽ എഞ്ചിന്%2$s സമീപമുള്ള ഡ്രോപ്പ്ഡൗൺ മെനുവിൽ "
-"ക്ലിക്ക് ചെയ്ത്, %3$sDuckDuckGo%4$s തിരഞ്ഞെടുക്കുക."
+"%1$sവിലാസ ബാറിൽ ഉപയോഗിച്ചിരിക്കുന്ന തിരയൽ എഞ്ചിന്%2$s സമീപമുള്ള ഡ്രോപ്പ്ഡൗൺ "
+"മെനുവിൽ ക്ലിക്ക് ചെയ്ത്, %3$sDuckDuckGo%4$s തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
@@ -4826,8 +4880,8 @@ msgid ""
 "Click the icon of the ad blocker extension. It's usually in the upper right "
 "hand corner of your browser."
 msgstr ""
-"Ad blocker എക്സ്റ്റൻഷന്റെ ഐക്കണിൽ ക്ലിക്ക് ചെയ്യുക. ഇത് സാധാരണയായി നിങ്ങളുടെ ബ്രൗസറിന്റെ "
-"മുകളിൽ വലത് കോണിലായിരിക്കും."
+"Ad blocker എക്സ്റ്റൻഷന്റെ ഐക്കണിൽ ക്ലിക്ക് ചെയ്യുക. ഇത് സാധാരണയായി നിങ്ങളുടെ "
+"ബ്രൗസറിന്റെ മുകളിൽ വലത് കോണിലായിരിക്കും."
 
 #  Safari default search engine instruction
 # smartling.placeholder_format=C
@@ -5028,8 +5082,8 @@ msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
 msgstr ""
-"Cloud Save പാസ്‌ഫ്രെയ്സ് നൽകുക വഴി നിങ്ങളുടെ ക്രമീകരണം സ്ഥിരമായി സംരക്ഷിക്കാൻ അനുവദിക്കും. "
-"ഇത് തീർത്തും ഓപ്ഷണല്‍ ആണ്."
+"Cloud Save പാസ്‌ഫ്രെയ്സ് നൽകുക വഴി നിങ്ങളുടെ ക്രമീകരണം സ്ഥിരമായി "
+"സംരക്ഷിക്കാൻ അനുവദിക്കും. ഇത് തീർത്തും ഓപ്ഷണല്‍ ആണ്."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -5300,7 +5354,9 @@ msgstr "പരസ്യങ്ങൾ തടയുന്നത് തുടരു�
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr "സമീപകാല ചാറ്റുകൾ ഇവിടെ തുടരുക. അല്ലെങ്കിൽ Fire Button ഉപയോഗിച്ച് അവ ഇല്ലാതാക്കുക."
+msgstr ""
+"സമീപകാല ചാറ്റുകൾ ഇവിടെ തുടരുക. അല്ലെങ്കിൽ Fire Button ഉപയോഗിച്ച് അവ "
+"ഇല്ലാതാക്കുക."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5471,8 +5527,9 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
-"മറ്റൊരു ഉപകരണത്തിൽ നിന്ന് കോഡ് പകർത്തുക. %1$sDuck.ai ക്രമീകരണങ്ങൾ › ചാറ്റുകൾ › Sync & "
-"Backup › മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%2$s എന്നതിലേക്ക് പോയി വീണ്ടും ശ്രമിക്കുക."
+"മറ്റൊരു ഉപകരണത്തിൽ നിന്ന് കോഡ് പകർത്തുക. %1$sDuck.ai ക്രമീകരണങ്ങൾ › ചാറ്റുകൾ "
+"› Sync & Backup › മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%2$s എന്നതിലേക്ക് പോയി "
+"വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5524,7 +5581,9 @@ msgstr "കോസ്റ്റാ റിക്ക"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr "നിങ്ങളുടെ റിക്കവറി കോഡ് ലോഡ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി ഇത് അടച്ച് വീണ്ടും ശ്രമിക്കു."
+msgstr ""
+"നിങ്ങളുടെ റിക്കവറി കോഡ് ലോഡ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി ഇത് അടച്ച് വീണ്ടും "
+"ശ്രമിക്കു."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5625,8 +5684,8 @@ msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
 msgstr ""
-"ഒരു ലിങ്ക് നിർമ്മിക്കുന്നത് ചാറ്റിന്റെ ഒരു പകർപ്പ് ഉണ്ടാക്കുന്നു, അത് തുറക്കുന്ന ആർക്കും അത് കാണാൻ "
-"കഴിയും."
+"ഒരു ലിങ്ക് നിർമ്മിക്കുന്നത് ചാറ്റിന്റെ ഒരു പകർപ്പ് ഉണ്ടാക്കുന്നു, അത് "
+"തുറക്കുന്ന ആർക്കും അത് കാണാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5709,7 +5768,7 @@ msgstr "നിലവിലെ സ്ട്രീക്ക്"
 #. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
 msgctxt "Suffix label indicating a tab is the currently active browser tab"
 msgid "Current Tab"
-msgstr ""
+msgstr "നിലവിലെ ടാബ്"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
@@ -5871,7 +5930,9 @@ msgstr "ദൈനംദിന ഉപയോഗ പരിധി കവിഞ്ഞ
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Daily usage limit reached. You can keep chatting by using your weekly limit."
-msgstr "ദൈനംദിന ഉപയോഗ പരിധി കവിഞ്ഞു. നിങ്ങൾക്ക് പ്രതിവാര പരിധി ഉപയോഗിച്ച് ചാറ്റ് തുടരാം."
+msgstr ""
+"ദൈനംദിന ഉപയോഗ പരിധി കവിഞ്ഞു. നിങ്ങൾക്ക് പ്രതിവാര പരിധി ഉപയോഗിച്ച് ചാറ്റ് "
+"തുടരാം."
 
 # smartling.placeholder_format=C
 #. The name of the Danish language
@@ -6061,7 +6122,7 @@ msgstr "30 ദിവസത്തിലധികം പഴക്കമുള്�
 #. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
 msgctxt "Button text in the modal for deleting all recent chats"
 msgid "Delete Chats and Shared Links"
-msgstr ""
+msgstr "ചാറ്റുകളും പങ്കിട്ട ലിങ്കുകളും ഇല്ലാതാക്കുക"
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6153,7 +6214,9 @@ msgstr "സംഭരണ സ്ഥലം ശൂന്യമാക്കാൻ ഏ
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr "സ്റ്റോറേജ് ഒഴിവാക്കാൻ അറ്റാച്ച്മെന്റുകളുള്ള ഏറ്റവും പഴയ ചാറ്റുകൾ ഇല്ലാതാക്കണോ?"
+msgstr ""
+"സ്റ്റോറേജ് ഒഴിവാക്കാൻ അറ്റാച്ച്മെന്റുകളുള്ള ഏറ്റവും പഴയ ചാറ്റുകൾ "
+"ഇല്ലാതാക്കണോ?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
@@ -6188,8 +6251,9 @@ msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
 msgstr ""
-"ഒരു ലിങ്ക് ഇല്ലാതാക്കുന്നത് അത് പ്രവർത്തിക്കുന്നത് തടയുന്നു. ഇത് തുറന്ന് തങ്ങളുടെ ചാറ്റുകളിലേക്ക് "
-"സംഭാഷണം ചേർത്ത ആളുകളുടെ പക്കൽ അവരുടെ സ്വന്തം പകർപ്പ് ഉണ്ടായിരിക്കും."
+"ഒരു ലിങ്ക് ഇല്ലാതാക്കുന്നത് അത് പ്രവർത്തിക്കുന്നത് തടയുന്നു. ഇത് തുറന്ന് "
+"തങ്ങളുടെ ചാറ്റുകളിലേക്ക് സംഭാഷണം ചേർത്ത ആളുകളുടെ പക്കൽ അവരുടെ സ്വന്തം "
+"പകർപ്പ് ഉണ്ടായിരിക്കും."
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6286,8 +6350,8 @@ msgstr "Duck.ai-യിലെ ഡിക്റ്റേഷൻ"
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
 msgstr ""
-"ഡിക്റ്റേഷൻ നമ്മൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു, മാത്രമല്ല AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഒരിക്കലും "
-"ഉപയോഗിക്കാറില്ല."
+"ഡിക്റ്റേഷൻ നമ്മൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു, മാത്രമല്ല AI മോഡലുകളെ "
+"പരിശീലിപ്പിക്കാൻ ഒരിക്കലും ഉപയോഗിക്കാറില്ല."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6305,8 +6369,9 @@ msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
 msgstr ""
-"നിങ്ങളുടെ സംസാരം ടെക്സ്റ്റാക്കി മാറ്റുന്നതിനായി ഡിക്റ്റേഷൻ ഒരു OpenAI മോഡൽ ഉപയോഗിക്കുന്നു, "
-"അതിനാൽ നിങ്ങൾക്ക് ടൈപ്പ് ചെയ്യാതെ തന്നെ Duck.ai-യിൽ ചാറ്റ് ചെയ്യാൻ സാധിക്കും."
+"നിങ്ങളുടെ സംസാരം ടെക്സ്റ്റാക്കി മാറ്റുന്നതിനായി ഡിക്റ്റേഷൻ ഒരു OpenAI മോഡൽ "
+"ഉപയോഗിക്കുന്നു, അതിനാൽ നിങ്ങൾക്ക് ടൈപ്പ് ചെയ്യാതെ തന്നെ Duck.ai-യിൽ ചാറ്റ് "
+"ചെയ്യാൻ സാധിക്കും."
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6480,7 +6545,7 @@ msgstr "പ്രൊമോഷൻ ഒഴിവാക്കുക"
 #. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the close button on the survey banner"
 msgid "Dismiss survey"
-msgstr ""
+msgstr "സർവേ നിരസിക്കുക"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6593,7 +6658,9 @@ msgstr "പട്ടികയിൽ DuckDuckGo കാണുന്നില്ല
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr "അത് കാണുന്നില്ലേ? %1$s%2$s%3$sവീണ്ടും ഡൗൺലോഡ് ചെയ്യാൻ ഇവിടെ ക്ലിക്ക് ചെയ്യുക%4$s"
+msgstr ""
+"അത് കാണുന്നില്ലേ? %1$s%2$s%3$sവീണ്ടും ഡൗൺലോഡ് ചെയ്യാൻ ഇവിടെ ക്ലിക്ക് "
+"ചെയ്യുക%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6631,8 +6698,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
-"AI വേണ്ടേ? %1$snoai.duckduckgo.com%2$s AI ഫീച്ചറുകളൊന്നും നൽകുന്നില്ല, AI ചിത്രങ്ങൾ "
-"ഫിൽട്ടർ ചെയ്ത് ഒഴിവാക്കിയിരിക്കുന്നു. %3$sകൂടുതലറിയുക%4$s"
+"AI വേണ്ടേ? %1$snoai.duckduckgo.com%2$s AI ഫീച്ചറുകളൊന്നും നൽകുന്നില്ല, AI "
+"ചിത്രങ്ങൾ ഫിൽട്ടർ ചെയ്ത് ഒഴിവാക്കിയിരിക്കുന്നു. %3$sകൂടുതലറിയുക%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6758,8 +6825,8 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for "
 "ceiling fan repair services."
 msgstr ""
-"സീലിംഗ് ഫാൻ അറ്റകുറ്റപ്പണി സേവനങ്ങൾക്കായി ഒരു ക്വൊട്ടേഷൻ അഭ്യർത്ഥിച്ച് ഒരു വെണ്ടറിന് "
-"സംക്ഷിപ്തവും വിശദവുമായ ഒരു ഇമെയിൽ തയ്യാറാക്കുക."
+"സീലിംഗ് ഫാൻ അറ്റകുറ്റപ്പണി സേവനങ്ങൾക്കായി ഒരു ക്വൊട്ടേഷൻ അഭ്യർത്ഥിച്ച് ഒരു "
+"വെണ്ടറിന് സംക്ഷിപ്തവും വിശദവുമായ ഒരു ഇമെയിൽ തയ്യാറാക്കുക."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion asking for an email draft to a vendor requesting a quote for home refrigerator repair services.
@@ -6768,8 +6835,8 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
 msgstr ""
-"വീട്ടിലെ റഫ്രിജറേറ്റർ അറ്റകുറ്റപ്പണി സേവനങ്ങൾക്കായി ഒരു ക്വൊട്ടേഷൻ അഭ്യർത്ഥിച്ച് ഒരു വെണ്ടർക്ക് "
-"സംക്ഷിപ്തവും വിശദവുമായ ഒരു ഇമെയിൽ തയ്യാറാക്കുക."
+"വീട്ടിലെ റഫ്രിജറേറ്റർ അറ്റകുറ്റപ്പണി സേവനങ്ങൾക്കായി ഒരു ക്വൊട്ടേഷൻ "
+"അഭ്യർത്ഥിച്ച് ഒരു വെണ്ടർക്ക് സംക്ഷിപ്തവും വിശദവുമായ ഒരു ഇമെയിൽ തയ്യാറാക്കുക."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -6790,8 +6857,8 @@ msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
 msgstr ""
-"എന്റെ വരാനിരിക്കുന്ന പാർട്ടിയിലേക്ക് ആളുകളെ ക്ഷണിക്കുന്ന ഒരു സോഷ്യൽ മീഡിയ പോസ്റ്റിന് കുറച്ച് "
-"ഓപ്ഷനുകൾ ഡ്രാഫ്റ്റ് ചെയ്യുക."
+"എന്റെ വരാനിരിക്കുന്ന പാർട്ടിയിലേക്ക് ആളുകളെ ക്ഷണിക്കുന്ന ഒരു സോഷ്യൽ മീഡിയ "
+"പോസ്റ്റിന് കുറച്ച് ഓപ്ഷനുകൾ ഡ്രാഫ്റ്റ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6800,8 +6867,8 @@ msgid ""
 "Draft a few options for a title of a post I’m writing about strategies to "
 "increase team collaboration."
 msgstr ""
-"ടീം സഹകരണം വർദ്ധിപ്പിക്കുന്നതിനുള്ള തന്ത്രങ്ങളെക്കുറിച്ച് ഞാൻ എഴുതുന്ന ഒരു പോസ്റ്റിന്റെ "
-"തലക്കെട്ടിനായി കുറച്ച് ഓപ്ഷനുകൾ തയ്യാറാക്കുക."
+"ടീം സഹകരണം വർദ്ധിപ്പിക്കുന്നതിനുള്ള തന്ത്രങ്ങളെക്കുറിച്ച് ഞാൻ എഴുതുന്ന ഒരു "
+"പോസ്റ്റിന്റെ തലക്കെട്ടിനായി കുറച്ച് ഓപ്ഷനുകൾ തയ്യാറാക്കുക."
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for drafting a social media post.
@@ -6871,7 +6938,9 @@ msgstr "നിങ്ങളുടെ ഫോട്ടോകളോ PDF ഫയലു
 # smartling.placeholder_format=C
 #. A title explaining what Duck Player (DDG's feature to watch youtube videos more privately) does
 msgid "Duck Player lets you watch YouTube without targeted ads"
-msgstr "ലക്ഷ്യമിട്ടുള്ള പരസ്യങ്ങളില്ലാതെ YouTube കാണാൻ Duck Player നിങ്ങളെ അനുവദിക്കുന്നു"
+msgstr ""
+"ലക്ഷ്യമിട്ടുള്ള പരസ്യങ്ങളില്ലാതെ YouTube കാണാൻ Duck Player നിങ്ങളെ "
+"അനുവദിക്കുന്നു"
 
 # smartling.placeholder_format=C
 #. This is the DDG version of "Google it", meaning "search it".
@@ -6933,9 +7002,10 @@ msgid ""
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
 msgstr ""
-"നിങ്ങൾ കാണുന്ന പേജിനെക്കുറിച്ചുള്ള ചോദ്യങ്ങൾക്ക് ഇപ്പോൾ Duck.ai-യ്ക്ക് ഉത്തരം നൽകാൻ "
-"സഹായിക്കാനാവും. ക്രമീകരണങ്ങളിൽ പേജുകൾ സ്വയമേവ അറ്റാച്ച് ചെയ്യാൻ നിങ്ങൾ "
-"തിരഞ്ഞെടുക്കുന്നില്ലെങ്കിൽ മാത്രമേ അത് അറ്റാച്ചുചെയ്യുമ്പോൾ പേജ് ഉള്ളടക്കം ഉൾപ്പെടുത്തൂ."
+"നിങ്ങൾ കാണുന്ന പേജിനെക്കുറിച്ചുള്ള ചോദ്യങ്ങൾക്ക് ഇപ്പോൾ Duck.ai-യ്ക്ക് "
+"ഉത്തരം നൽകാൻ സഹായിക്കാനാവും. ക്രമീകരണങ്ങളിൽ പേജുകൾ സ്വയമേവ അറ്റാച്ച് ചെയ്യാൻ "
+"നിങ്ങൾ തിരഞ്ഞെടുക്കുന്നില്ലെങ്കിൽ മാത്രമേ അത് അറ്റാച്ചുചെയ്യുമ്പോൾ പേജ് "
+"ഉള്ളടക്കം ഉൾപ്പെടുത്തൂ."
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6945,9 +7015,9 @@ msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ സംരക്ഷിക്കാനായി Duck.ai-ക്ക് ലോക്കൽ സ്റ്റോറേജ് ആക്‌സസ് ചെയ്യാൻ കഴിയില്ല. "
-"നിങ്ങളുടെ ബ്രൗസർ ക്രമീകരണങ്ങൾ പരിശോധിക്കുകയോ ഏതെങ്കിലും എക്സ്റ്റൻഷനുകൾ പ്രവർത്തനരഹിതമാക്കുകയോ "
-"ചെയ്ത് വീണ്ടും ശ്രമിക്കുക."
+"നിങ്ങളുടെ ചാറ്റുകൾ സംരക്ഷിക്കാനായി Duck.ai-ക്ക് ലോക്കൽ സ്റ്റോറേജ് ആക്‌സസ് "
+"ചെയ്യാൻ കഴിയില്ല. നിങ്ങളുടെ ബ്രൗസർ ക്രമീകരണങ്ങൾ പരിശോധിക്കുകയോ ഏതെങ്കിലും "
+"എക്സ്റ്റൻഷനുകൾ പ്രവർത്തനരഹിതമാക്കുകയോ ചെയ്ത് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6956,14 +7026,16 @@ msgid ""
 "Duck.ai has reached the maximum number of messages for one day. Please "
 "continue this chat tomorrow."
 msgstr ""
-"ഒരു ദിവസത്തേക്കുള്ള പരമാവധി സന്ദേശങ്ങളുടെ എണ്ണത്തിൽ Duck.ai എത്തിച്ചേർന്നു. ദയവായി നാളെ ഈ "
-"ചാറ്റ് തുടരുക."
+"ഒരു ദിവസത്തേക്കുള്ള പരമാവധി സന്ദേശങ്ങളുടെ എണ്ണത്തിൽ Duck.ai എത്തിച്ചേർന്നു. "
+"ദയവായി നാളെ ഈ ചാറ്റ് തുടരുക."
 
 # smartling.placeholder_format=C
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "ഞങ്ങളുടെ സ്വകാര്യവും സൗജന്യവുമായ DuckDuckGo ബ്രൗസറിൽ Duck.ai ആണ് ഏറ്റവും മികച്ചത്!"
+msgstr ""
+"ഞങ്ങളുടെ സ്വകാര്യവും സൗജന്യവുമായ DuckDuckGo ബ്രൗസറിൽ Duck.ai ആണ് ഏറ്റവും "
+"മികച്ചത്!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6973,8 +7045,9 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
-"Duck.ai നിർമ്മിച്ചത് DuckDuckGo ആണ്. തങ്ങളുടെ സ്വകാര്യ വിവരങ്ങളുടെ നിയന്ത്രണം തിരികെ "
-"നേടാൻ ആഗ്രഹിക്കുന്ന ഏതൊരാൾക്കും വേണ്ടിയുള്ള ഒരു സ്വതന്ത്ര ഓൺലൈൻ സംരക്ഷണ കമ്പനിയാണ് ഞങ്ങൾ."
+"Duck.ai നിർമ്മിച്ചത് DuckDuckGo ആണ്. തങ്ങളുടെ സ്വകാര്യ വിവരങ്ങളുടെ "
+"നിയന്ത്രണം തിരികെ നേടാൻ ആഗ്രഹിക്കുന്ന ഏതൊരാൾക്കും വേണ്ടിയുള്ള ഒരു സ്വതന്ത്ര "
+"ഓൺലൈൻ സംരക്ഷണ കമ്പനിയാണ് ഞങ്ങൾ."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6989,8 +7062,8 @@ msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
 msgstr ""
-"Duck.ai ഇപ്പോഴും ഒരു DuckDuckGo ഉൽപ്പന്നമാണ്, പക്ഷേ ഇനി വെബിൽ ഓർമ്മിക്കാൻ എളുപ്പമുള്ള ഒരു "
-"വിലാസം ലഭിക്കും: https://duck.ai"
+"Duck.ai ഇപ്പോഴും ഒരു DuckDuckGo ഉൽപ്പന്നമാണ്, പക്ഷേ ഇനി വെബിൽ ഓർമ്മിക്കാൻ "
+"എളുപ്പമുള്ള ഒരു വിലാസം ലഭിക്കും: https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -7005,8 +7078,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai താൽക്കാലികമായി ലഭ്യമല്ല. ഇത് നിലനിൽക്കുകയാണെങ്കിൽ, ദയവായി ഈ %1$s അജ്ഞാത കോഡ് "
-"%2$s എന്നതിലേക്ക് ഇമെയിൽ ചെയ്യുക"
+"Duck.ai താൽക്കാലികമായി ലഭ്യമല്ല. ഇത് നിലനിൽക്കുകയാണെങ്കിൽ, ദയവായി ഈ %1$s "
+"അജ്ഞാത കോഡ് %2$s എന്നതിലേക്ക് ഇമെയിൽ ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7027,9 +7100,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"ജനപ്രിയ AI മോഡലുകളുമായി സ്വകാര്യമായി ചാറ്റ് ചെയ്യാൻ Duck.ai നിങ്ങളെ അനുവദിക്കുന്നു. ഇത് "
-"പ്രവർത്തനരഹിതമാക്കുന്നത് Duck.ai ബട്ടണുകളും ലിങ്കുകളും മറയ്ക്കും, എന്നാൽ നിങ്ങൾക്ക് ഇപ്പോഴും "
-"%1$sduck.ai%2$s സന്ദർശിക്കാം നേരിട്ട്."
+"ജനപ്രിയ AI മോഡലുകളുമായി സ്വകാര്യമായി ചാറ്റ് ചെയ്യാൻ Duck.ai നിങ്ങളെ "
+"അനുവദിക്കുന്നു. ഇത് പ്രവർത്തനരഹിതമാക്കുന്നത് Duck.ai ബട്ടണുകളും ലിങ്കുകളും "
+"മറയ്ക്കും, എന്നാൽ നിങ്ങൾക്ക് ഇപ്പോഴും %1$sduck.ai%2$s സന്ദർശിക്കാം നേരിട്ട്."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7040,11 +7113,12 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"OpenAI, Anthropic, കൂടാതെ മറ്റുള്ളവയിൽ നിന്നുമുള്ള മോഡലുകൾ ഉൾപ്പെടെ മൂന്നാം കക്ഷി AI ചാറ്റ് "
-"മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ Duck.ai നിങ്ങളെ അനുവദിക്കുന്നു. ഈ ക്രമീകരണം "
-"ഓഫാക്കുന്നത് DuckDuckGo Search-ലെ Duck.ai ബട്ടണുകളും ലിങ്കുകളും മറയ്ക്കും. എന്നിരുന്നാലും, ഈ "
-"ക്രമീകരണം ഓഫ് ആയിരിക്കുമ്പോൾ %1$shttps://duck.ai%2$s സന്ദർശിച്ച് നിങ്ങൾക്ക് Duck.ai "
-"ആക്സസ് ചെയ്യാൻ കഴിയും. നേരിട്ട്."
+"OpenAI, Anthropic, കൂടാതെ മറ്റുള്ളവയിൽ നിന്നുമുള്ള മോഡലുകൾ ഉൾപ്പെടെ മൂന്നാം "
+"കക്ഷി AI ചാറ്റ് മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ Duck.ai നിങ്ങളെ "
+"അനുവദിക്കുന്നു. ഈ ക്രമീകരണം ഓഫാക്കുന്നത് DuckDuckGo Search-ലെ Duck.ai "
+"ബട്ടണുകളും ലിങ്കുകളും മറയ്ക്കും. എന്നിരുന്നാലും, ഈ ക്രമീകരണം ഓഫ് "
+"ആയിരിക്കുമ്പോൾ %1$shttps://duck.ai%2$s സന്ദർശിച്ച് നിങ്ങൾക്ക് Duck.ai ആക്സസ് "
+"ചെയ്യാൻ കഴിയും. നേരിട്ട്."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -7059,15 +7133,16 @@ msgid ""
 "Duck.ai might have lost your recent chats. You can still use Duck.ai as "
 "usual."
 msgstr ""
-"Duck.ai-ക്ക് നിങ്ങളുടെ അടുത്തിടെ നടന്ന ചാറ്റുകൾ നഷ്ടപ്പെട്ടിരിക്കാം. നിങ്ങൾക്ക് ഇപ്പോഴും "
-"പതിവുപോലെ Duck.ai ഉപയോഗിക്കാം."
+"Duck.ai-ക്ക് നിങ്ങളുടെ അടുത്തിടെ നടന്ന ചാറ്റുകൾ നഷ്ടപ്പെട്ടിരിക്കാം. "
+"നിങ്ങൾക്ക് ഇപ്പോഴും പതിവുപോലെ Duck.ai ഉപയോഗിക്കാം."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai now can read and analyze PDFs. Give it a try!"
 msgstr ""
-"Duck.ai-ക്ക് ഇപ്പോൾ PDF-കൾ വായിക്കാനും വിശകലനം ചെയ്യാനും കഴിയും. ഒന്ന് പരീക്ഷിച്ചു നോക്കൂ!"
+"Duck.ai-ക്ക് ഇപ്പോൾ PDF-കൾ വായിക്കാനും വിശകലനം ചെയ്യാനും കഴിയും. ഒന്ന് "
+"പരീക്ഷിച്ചു നോക്കൂ!"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown above the chat input only when coming from a DuckAssist grounded response into ungrounded models.
@@ -7075,14 +7150,16 @@ msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
 msgstr ""
-"Duck.ai പ്രതികരണങ്ങൾ പ്രത്യേക ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കിയുള്ളതല്ല, അല്ലെങ്കിൽ കൃത്യതയ്ക്കായി "
-"പരിശോധിച്ചിട്ടുമില്ല."
+"Duck.ai പ്രതികരണങ്ങൾ പ്രത്യേക ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കിയുള്ളതല്ല, അല്ലെങ്കിൽ "
+"കൃത്യതയ്ക്കായി പരിശോധിച്ചിട്ടുമില്ല."
 
 # smartling.placeholder_format=C
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
-msgstr "Anthropic, OpenAI, കൂടാതെ മറ്റുള്ളവയിൽ നിന്നുമുള്ള മോഡലുകളെ Duck.ai പിന്തുണയ്ക്കുന്നു."
+msgstr ""
+"Anthropic, OpenAI, കൂടാതെ മറ്റുള്ളവയിൽ നിന്നുമുള്ള മോഡലുകളെ Duck.ai "
+"പിന്തുണയ്ക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -7101,8 +7178,8 @@ msgstr "Duck.ai അപ്ഗ്രേഡ് ചെയ്തു!"
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
 msgstr ""
-"Duck.ai ഏറ്റവും മികച്ച രീതിയിൽ പ്രവർത്തിക്കുന്നത് ഞങ്ങളുടെ സ്വകാര്യവും സൗജന്യവുമായ "
-"DuckDuckGo ആപ്പിലാണ്!"
+"Duck.ai ഏറ്റവും മികച്ച രീതിയിൽ പ്രവർത്തിക്കുന്നത് ഞങ്ങളുടെ സ്വകാര്യവും "
+"സൗജന്യവുമായ DuckDuckGo ആപ്പിലാണ്!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7112,9 +7189,10 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, സ്വകാര്യ AI ചാറ്റ്ബോട്ട്, സൗജന്യ AI ചാറ്റ്, അജ്ഞാത AI ചാറ്റ്, "
-"സൈൻ അപ്പ് ആവശ്യമില്ലാത്ത AI ചാറ്റ്, OpenAI, ആന്ത്രോപിക്, ലാമ, മിസ്ട്രൽ, ഓപ്പൺ സോഴ്‌സ് AI "
-"മോഡലുകൾ, സ്വകാര്യത കേന്ദ്രീകരിച്ചുള്ള AI, അക്കൗണ്ടില്ലാത്ത AI ചാറ്റ്"
+"Duck.ai, DuckDuckGo AI, സ്വകാര്യ AI ചാറ്റ്ബോട്ട്, സൗജന്യ AI ചാറ്റ്, അജ്ഞാത "
+"AI ചാറ്റ്, സൈൻ അപ്പ് ആവശ്യമില്ലാത്ത AI ചാറ്റ്, OpenAI, ആന്ത്രോപിക്, ലാമ, "
+"മിസ്ട്രൽ, ഓപ്പൺ സോഴ്‌സ് AI മോഡലുകൾ, സ്വകാര്യത കേന്ദ്രീകരിച്ചുള്ള AI, "
+"അക്കൗണ്ടില്ലാത്ത AI ചാറ്റ്"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7142,11 +7220,12 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"DuckAssist-ന് അജ്ഞാതമായി തിരയാനും ചില search-കൾക്ക് മറുപടിയായി വിവരങ്ങൾ സംഗ്രഹിക്കാനും "
-"കഴിയും. DuckAssist എത്ര തവണ ദൃശ്യമാകാൻ ആഗ്രഹിക്കുന്നുവെന്ന് നിങ്ങൾക്ക് തിരഞ്ഞെടുക്കാം: "
-"ഒരിക്കലുമില്ല (Search ഫലങ്ങളിൽ നിന്ന് DuckAssist UI പൂർണ്ണമായും നീക്കംചെയ്യുന്നു), ഓൺ-"
-"ഡിമാൻഡ് (നിങ്ങൾ അസിസ്റ്റ് ബട്ടൺ ക്ലിക്ക് ചെയ്താൽ മാത്രം കാണിക്കുന്നു), ചിലപ്പോൾ (വളരെ "
-"പ്രസക്തമാകുമ്പോൾ മാത്രം കാണിക്കുക), ഇടയ്ക്കിടെ (വിശാലമായ Search-കളിൽ കൂടുതൽ പതിവായി "
+"DuckAssist-ന് അജ്ഞാതമായി തിരയാനും ചില search-കൾക്ക് മറുപടിയായി വിവരങ്ങൾ "
+"സംഗ്രഹിക്കാനും കഴിയും. DuckAssist എത്ര തവണ ദൃശ്യമാകാൻ ആഗ്രഹിക്കുന്നുവെന്ന് "
+"നിങ്ങൾക്ക് തിരഞ്ഞെടുക്കാം: ഒരിക്കലുമില്ല (Search ഫലങ്ങളിൽ നിന്ന് DuckAssist "
+"UI പൂർണ്ണമായും നീക്കംചെയ്യുന്നു), ഓൺ-ഡിമാൻഡ് (നിങ്ങൾ അസിസ്റ്റ് ബട്ടൺ "
+"ക്ലിക്ക് ചെയ്താൽ മാത്രം കാണിക്കുന്നു), ചിലപ്പോൾ (വളരെ പ്രസക്തമാകുമ്പോൾ "
+"മാത്രം കാണിക്കുക), ഇടയ്ക്കിടെ (വിശാലമായ Search-കളിൽ കൂടുതൽ പതിവായി "
 "കാണിക്കുന്നു). ഇപ്പോൾ, DuckAssist യുഎസ് (ഇംഗ്ലീഷ്) മേഖലയിൽ മാത്രമേ ലഭ്യമാകൂ."
 
 # smartling.placeholder_format=C
@@ -7156,9 +7235,10 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist-ന് ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാൻ കഴിയില്ല, എന്നിരുന്നാലും, ഞങ്ങൾ "
-"%1$sDuckDuckGo AI Chat%2$s വാഗ്ദാനം ചെയ്യുന്നു, ഇത് OpenAI, Anthropic തുടങ്ങിയവയിൽ "
-"നിന്നുള്ള ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
+"DuckAssist-ന് ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാൻ കഴിയില്ല, "
+"എന്നിരുന്നാലും, ഞങ്ങൾ %1$sDuckDuckGo AI Chat%2$s വാഗ്ദാനം ചെയ്യുന്നു, ഇത് "
+"OpenAI, Anthropic തുടങ്ങിയവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന "
+"ഒരു സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7167,9 +7247,10 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist-ന് ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാൻ കഴിയില്ല, എന്നിരുന്നാലും, ഞങ്ങൾ "
-"DuckDuckGo %1$sAI Chat%2$s എന്നിവയും വാഗ്ദാനം ചെയ്യുന്നു, ഇത് OpenAI, Anthropic "
-"എന്നിവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
+"DuckAssist-ന് ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാൻ കഴിയില്ല, "
+"എന്നിരുന്നാലും, ഞങ്ങൾ DuckDuckGo %1$sAI Chat%2$s എന്നിവയും വാഗ്ദാനം "
+"ചെയ്യുന്നു, ഇത് OpenAI, Anthropic എന്നിവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ "
+"പിന്തുണയ്ക്കുന്ന ഒരു സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7181,12 +7262,13 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു പുതിയ സവിശേഷതയാണ് DuckAssist, അതിന് തിരയൽ അന്വേഷണങ്ങൾക്ക് "
-"അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. ഇതിനായി, പ്രസക്തമായ ഉള്ളടക്കത്തിനായി "
-"വിക്കിപീഡിയയെയും അനുബന്ധ സൈറ്റുകളെയും സ്കാൻ ചെയ്യുകയും തുടർന്ന് ആ വിവരങ്ങളുടെ സംഗ്രഹം "
-"സൃഷ്ടിക്കാൻ AI-പിന്തുണയുള്ള സ്വാഭാവിക ഭാഷാ സാങ്കേതികവിദ്യ ഉപയോഗിക്കുകയും ചെയ്യുന്നു. അതിന്റെ "
-"പ്രതികരണങ്ങൾ നിലവിൽ വിക്കിപീഡിയയെയും അനുബന്ധ ഉള്ളടക്കത്തെയും അടിസ്ഥാനമാക്കിയുള്ളതാണെന്നും "
-"കൃത്യത പരിശോധിച്ചിട്ടില്ലെന്നതും ശ്രദ്ധിക്കുക."
+"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു പുതിയ സവിശേഷതയാണ് DuckAssist, അതിന് തിരയൽ "
+"അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. ഇതിനായി, പ്രസക്തമായ "
+"ഉള്ളടക്കത്തിനായി വിക്കിപീഡിയയെയും അനുബന്ധ സൈറ്റുകളെയും സ്കാൻ ചെയ്യുകയും "
+"തുടർന്ന് ആ വിവരങ്ങളുടെ സംഗ്രഹം സൃഷ്ടിക്കാൻ AI-പിന്തുണയുള്ള സ്വാഭാവിക ഭാഷാ "
+"സാങ്കേതികവിദ്യ ഉപയോഗിക്കുകയും ചെയ്യുന്നു. അതിന്റെ പ്രതികരണങ്ങൾ നിലവിൽ "
+"വിക്കിപീഡിയയെയും അനുബന്ധ ഉള്ളടക്കത്തെയും അടിസ്ഥാനമാക്കിയുള്ളതാണെന്നും കൃത്യത "
+"പരിശോധിച്ചിട്ടില്ലെന്നതും ശ്രദ്ധിക്കുക."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7200,14 +7282,16 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു പുതിയ ഓപ്ഷണൽ സവിശേഷതയാണ് DuckAssist, അതിന് തിരയൽ "
-"അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. ഇത് ചെയ്യുന്നതിന്, പ്രസക്തമായ "
-"ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും തുടർന്ന് കണ്ടെത്തിയ പ്രസക്തമായ വിവരങ്ങളെ "
-"അടിസ്ഥാനമാക്കി ഒരു ഹ്രസ്വമായ ഉത്തരം സൃഷ്ടിക്കുന്നതിന് AI- പിന്തുണയ്ക്കുന്ന സ്വഭാവിക ഭാഷ "
-"സാങ്കേതികവിദ്യ ഉപയോഗിക്കുകയും ചെയ്യുന്നു. DuckAssist പ്രതികരണങ്ങൾ എല്ലായ്പ്പോഴും ഒന്നോ രണ്ടോ "
-"ഉറവിടങ്ങളിലേക്ക് നേരിട്ട് ലിങ്ക് ചെയ്യുന്നു, ഉത്തരം എവിടെ നിന്ന് വന്നുവെന്ന് ഉദ്ധരിക്കുന്നു, അതിനാൽ "
-"നിങ്ങൾക്ക് എളുപ്പത്തിൽ കൂടുതൽ വിശദമായ വിവരങ്ങൾ നേടാനാവും. ഉദ്ധരിച്ച ഉറവിടങ്ങളിൽ നിന്ന് "
-"പ്രതികരണങ്ങൾ സ്വയം സൃഷ്ടിക്കപ്പെട്ടതാണെന്നും%2$s വെബ് ക്രൗളിങ്ങിനെ "
+"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു പുതിയ ഓപ്ഷണൽ സവിശേഷതയാണ് DuckAssist, അതിന് "
+"തിരയൽ അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. ഇത് "
+"ചെയ്യുന്നതിന്, പ്രസക്തമായ ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും "
+"തുടർന്ന് കണ്ടെത്തിയ പ്രസക്തമായ വിവരങ്ങളെ അടിസ്ഥാനമാക്കി ഒരു ഹ്രസ്വമായ ഉത്തരം "
+"സൃഷ്ടിക്കുന്നതിന് AI- പിന്തുണയ്ക്കുന്ന സ്വഭാവിക ഭാഷ സാങ്കേതികവിദ്യ "
+"ഉപയോഗിക്കുകയും ചെയ്യുന്നു. DuckAssist പ്രതികരണങ്ങൾ എല്ലായ്പ്പോഴും ഒന്നോ "
+"രണ്ടോ ഉറവിടങ്ങളിലേക്ക് നേരിട്ട് ലിങ്ക് ചെയ്യുന്നു, ഉത്തരം എവിടെ നിന്ന് "
+"വന്നുവെന്ന് ഉദ്ധരിക്കുന്നു, അതിനാൽ നിങ്ങൾക്ക് എളുപ്പത്തിൽ കൂടുതൽ വിശദമായ "
+"വിവരങ്ങൾ നേടാനാവും. ഉദ്ധരിച്ച ഉറവിടങ്ങളിൽ നിന്ന് പ്രതികരണങ്ങൾ സ്വയം "
+"സൃഷ്ടിക്കപ്പെട്ടതാണെന്നും%2$s വെബ് ക്രൗളിങ്ങിനെ "
 "%1$sഅടിസ്ഥാനമാക്കിയുള്ളതാണെന്നും ഓർമ്മിക്കേണ്ടത് പ്രധാനമാണ്."
 
 # smartling.placeholder_format=C
@@ -7226,8 +7310,8 @@ msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
 msgstr ""
-"DuckDuckGo AI Chat ഒരു ദിവസത്തേക്ക് പരമാവധി മെസേജുകള് എത്തിയിട്ടുണ്ട്. ദയവായി നാളെ ഈ "
-"ചാറ്റ് തുടരുക."
+"DuckDuckGo AI Chat ഒരു ദിവസത്തേക്ക് പരമാവധി മെസേജുകള് എത്തിയിട്ടുണ്ട്. "
+"ദയവായി നാളെ ഈ ചാറ്റ് തുടരുക."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7236,8 +7320,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"നിലവിൽ %1$sന്റെ %2$s, %3$sന്റെ %4$s ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു സ്വകാര്യ AI "
-"പ്രവർത്തിപ്പിക്കുന്ന ചാറ്റ് സേവനമാണ് DuckDuckGo AI Chat."
+"നിലവിൽ %1$sന്റെ %2$s, %3$sന്റെ %4$s ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു "
+"സ്വകാര്യ AI പ്രവർത്തിപ്പിക്കുന്ന ചാറ്റ് സേവനമാണ് DuckDuckGo AI Chat."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7246,8 +7330,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"നിലവിൽ %1$sന്റെ %2$s, %3$sന്റെ %4$s ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു സ്വകാര്യ AI "
-"പ്രവർത്തിപ്പിക്കുന്ന ചാറ്റ് സേവനമാണ് DuckDuckGo AI Chat."
+"നിലവിൽ %1$sന്റെ %2$s, %3$sന്റെ %4$s ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു "
+"സ്വകാര്യ AI പ്രവർത്തിപ്പിക്കുന്ന ചാറ്റ് സേവനമാണ് DuckDuckGo AI Chat."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -7256,8 +7340,8 @@ msgid ""
 "DuckDuckGo AI Chat is in Beta, it may display inaccurate or offensive "
 "information."
 msgstr ""
-"DuckDuckGo AI Chat ബീറ്റയിലാണുള്ളത്, ഇത് കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ "
-"പ്രദർശിപ്പിച്ചേക്കാം."
+"DuckDuckGo AI Chat ബീറ്റയിലാണുള്ളത്, ഇത് കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ "
+"വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം."
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat making it unavailable, and asking the user to send an email with a specific code if the error persists. E.g. 'DuckDuckGo AI Chat is temporarily unavailable. If this persists, please email this anonymous code abcdefg12345 to aichat-error@duckduckgo.com'
@@ -7266,8 +7350,8 @@ msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
 msgstr ""
-"DuckDuckGo AI Chat താൽക്കാലികമായി ലഭ്യമല്ല. ഇത് നിലനിൽക്കുകയാണെങ്കിൽ, ദയവായി ഈ "
-"അജ്ഞാത കോഡ് %1$s %2$s എന്നതിലേക്ക് ഇമെയിൽ ചെയ്യുക"
+"DuckDuckGo AI Chat താൽക്കാലികമായി ലഭ്യമല്ല. ഇത് നിലനിൽക്കുകയാണെങ്കിൽ, ദയവായി "
+"ഈ അജ്ഞാത കോഡ് %1$s %2$s എന്നതിലേക്ക് ഇമെയിൽ ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7431,8 +7515,9 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"പേരുകൾ, ഇമെയിൽ വിലാസങ്ങൾ, ഫോൺ നമ്പറുകൾ, തിരിച്ചറിയൽ മെറ്റാഡാറ്റ എന്നിവ പോലുള്ള PII "
-"സ്വയമേവ നീക്കം ചെയ്തുകൊണ്ട് DuckDuckGo ഈ റിപ്പോർട്ടുകൾ അജ്ഞാതമാക്കുന്നു."
+"പേരുകൾ, ഇമെയിൽ വിലാസങ്ങൾ, ഫോൺ നമ്പറുകൾ, തിരിച്ചറിയൽ മെറ്റാഡാറ്റ എന്നിവ "
+"പോലുള്ള PII സ്വയമേവ നീക്കം ചെയ്തുകൊണ്ട് DuckDuckGo ഈ റിപ്പോർട്ടുകൾ "
+"അജ്ഞാതമാക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -7440,8 +7525,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo നിങ്ങളുടെ ചാറ്റുകൾ അജ്ഞാതമാക്കുന്നു. '%1$s' ക്ലിക്ക് ചെയ്യുക വഴി, നിങ്ങൾ Duck.ai-"
-"യുടെ %2$s സമ്മതിക്കുന്നു."
+"DuckDuckGo നിങ്ങളുടെ ചാറ്റുകൾ അജ്ഞാതമാക്കുന്നു. '%1$s' ക്ലിക്ക് ചെയ്യുക വഴി, "
+"നിങ്ങൾ Duck.ai-യുടെ %2$s സമ്മതിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7450,8 +7535,8 @@ msgctxt ""
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
 msgstr ""
-"DuckDuckGo നിങ്ങളുടെ ചാറ്റുകൾ അജ്ഞാതമാക്കുന്നു. '%1$s' ക്ലിക്ക് ചെയ്യുക വഴി, നിങ്ങൾ ഞങ്ങളുടെ "
-"%2$s-നെ അംഗീകരിക്കുന്നു."
+"DuckDuckGo നിങ്ങളുടെ ചാറ്റുകൾ അജ്ഞാതമാക്കുന്നു. '%1$s' ക്ലിക്ക് ചെയ്യുക വഴി, "
+"നിങ്ങൾ ഞങ്ങളുടെ %2$s-നെ അംഗീകരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7460,9 +7545,9 @@ msgid ""
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
 msgstr ""
-"മറ്റ് വെബ്‌സൈറ്റുകളിൽ ഇടയ്ക്കിടെ നിങ്ങളെ ട്രാക്ക് ചെയ്യാൻ ശ്രമിക്കുന്ന Google, Facebook പോലുള്ള "
-"കമ്പനികളിൽ നിന്നുള്ള ട്രാക്കറുകൾ ഉൾപ്പെടെ, നിങ്ങൾ സന്ദർശിക്കുന്ന വെബ്‌സൈറ്റുകളിലെ ട്രാക്കറുകളെ "
-"DuckDuckGo തടയുന്നു."
+"മറ്റ് വെബ്‌സൈറ്റുകളിൽ ഇടയ്ക്കിടെ നിങ്ങളെ ട്രാക്ക് ചെയ്യാൻ ശ്രമിക്കുന്ന "
+"Google, Facebook പോലുള്ള കമ്പനികളിൽ നിന്നുള്ള ട്രാക്കറുകൾ ഉൾപ്പെടെ, നിങ്ങൾ "
+"സന്ദർശിക്കുന്ന വെബ്‌സൈറ്റുകളിലെ ട്രാക്കറുകളെ DuckDuckGo തടയുന്നു."
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7474,12 +7559,13 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"ഡിസൈൻ പ്രകാരം DuckDuckGo സ്വകാര്യമാണ്. നിങ്ങൾ ലൊക്കേഷൻ പ്രവർത്തനക്ഷമമാക്കുമ്പോൾ, നിങ്ങളുടെ "
-"ലോക്കൽ ഉപകരണത്തിൽ മാത്രം അത് സംഭരിക്കപ്പെടുന്നു. നിങ്ങൾ തിരയുമ്പോൾ, നിങ്ങളുടെ ഉപകരണം അത് "
-"ഞങ്ങൾക്ക് അയയ്ക്കുന്നു, ആ തിരയലിനായുള്ള ഫലങ്ങൾ മെച്ചപ്പെടുത്തുന്നതിന് ഞങ്ങൾ അത് ഉപയോഗിക്കുന്നു, "
-"തുടർന്ന് നിങ്ങൾ അജ്ഞാതമായി തുടരുന്ന തരത്തിൽ ഞങ്ങൾ അത് ഉടനടി ഉപേക്ഷിച്ചുകളയുന്നു. %1$sനിങ്ങളുടെ "
-"സ്വകാര്യത പരിരക്ഷിക്കുന്നതിന് ഞങ്ങൾ ഈ സാങ്കേതികവിദ്യ രൂപകൽപ്പന ചെയ്തത് എങ്ങനെയെന്ന് കൂടുതൽ "
-"അറിയുക%2$s."
+"ഡിസൈൻ പ്രകാരം DuckDuckGo സ്വകാര്യമാണ്. നിങ്ങൾ ലൊക്കേഷൻ "
+"പ്രവർത്തനക്ഷമമാക്കുമ്പോൾ, നിങ്ങളുടെ ലോക്കൽ ഉപകരണത്തിൽ മാത്രം അത് "
+"സംഭരിക്കപ്പെടുന്നു. നിങ്ങൾ തിരയുമ്പോൾ, നിങ്ങളുടെ ഉപകരണം അത് ഞങ്ങൾക്ക് "
+"അയയ്ക്കുന്നു, ആ തിരയലിനായുള്ള ഫലങ്ങൾ മെച്ചപ്പെടുത്തുന്നതിന് ഞങ്ങൾ അത് "
+"ഉപയോഗിക്കുന്നു, തുടർന്ന് നിങ്ങൾ അജ്ഞാതമായി തുടരുന്ന തരത്തിൽ ഞങ്ങൾ അത് ഉടനടി "
+"ഉപേക്ഷിച്ചുകളയുന്നു. %1$sനിങ്ങളുടെ സ്വകാര്യത പരിരക്ഷിക്കുന്നതിന് ഞങ്ങൾ ഈ "
+"സാങ്കേതികവിദ്യ രൂപകൽപ്പന ചെയ്തത് എങ്ങനെയെന്ന് കൂടുതൽ അറിയുക%2$s."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -7499,8 +7585,9 @@ msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
 msgstr ""
-"നിങ്ങളുടെ ഏകദേശ ലൊക്കേഷൻ മാത്രമേ DuckDuckGo ഉപയോഗിക്കുകയുള്ളൂ. നിങ്ങൾക്ക് കൂടുതൽ ബന്ധമുള്ള, "
-"മികച്ച ഫലങ്ങൾ നൽകാൻ ഞങ്ങൾ ചെയ്യേണ്ടത് അതുമാത്രമാണ്. %1$sകൂടുതൽ അറിയുക%2$s."
+"നിങ്ങളുടെ ഏകദേശ ലൊക്കേഷൻ മാത്രമേ DuckDuckGo ഉപയോഗിക്കുകയുള്ളൂ. നിങ്ങൾക്ക് "
+"കൂടുതൽ ബന്ധമുള്ള, മികച്ച ഫലങ്ങൾ നൽകാൻ ഞങ്ങൾ ചെയ്യേണ്ടത് അതുമാത്രമാണ്. "
+"%1$sകൂടുതൽ അറിയുക%2$s."
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7592,10 +7679,11 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"ഓരോ തവണയും നിങ്ങൾ ഒരു പാസ്‌ഫ്രെയ്സ് നിർദേശം ആവശ്യപ്പെടുമ്പോൾ, DuckDuckGo സെർവറുകളിൽ നിന്ന് "
-"ക്രമരഹിതമായ പദങ്ങളുടെ ഒരു നീണ്ട പട്ടിക ഞങ്ങൾക്ക് ലഭിക്കും. പിന്നീട്, ബ്രൗസറിൽ, ആ പട്ടികയിൽ "
-"നിന്നും ഞങ്ങൾ 4-5 ക്രമരഹിതമായ പദങ്ങൾ തിരഞ്ഞെടുത്തുകൊണ്ട്, പാസ്‌ഫ്രെയ്സിന് കുറഞ്ഞത് 18-20 "
-"അക്ഷരങ്ങളെങ്കിലും ദൈർഘ്യമുണ്ടെന്ന് ഉറപ്പാക്കുന്നു."
+"ഓരോ തവണയും നിങ്ങൾ ഒരു പാസ്‌ഫ്രെയ്സ് നിർദേശം ആവശ്യപ്പെടുമ്പോൾ, DuckDuckGo "
+"സെർവറുകളിൽ നിന്ന് ക്രമരഹിതമായ പദങ്ങളുടെ ഒരു നീണ്ട പട്ടിക ഞങ്ങൾക്ക് ലഭിക്കും. "
+"പിന്നീട്, ബ്രൗസറിൽ, ആ പട്ടികയിൽ നിന്നും ഞങ്ങൾ 4-5 ക്രമരഹിതമായ പദങ്ങൾ "
+"തിരഞ്ഞെടുത്തുകൊണ്ട്, പാസ്‌ഫ്രെയ്സിന് കുറഞ്ഞത് 18-20 അക്ഷരങ്ങളെങ്കിലും "
+"ദൈർഘ്യമുണ്ടെന്ന് ഉറപ്പാക്കുന്നു."
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7652,7 +7740,7 @@ msgstr "പ്രോംപ്റ്റ് എഡിറ്റ് ചെയ്യ�
 #. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the message-editing text area"
 msgid "Edit message"
-msgstr ""
+msgstr "സന്ദേശം എഡിറ്റ് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
@@ -7672,8 +7760,8 @@ msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
 msgstr ""
-"നിങ്ങളുടെ സന്ദേശം എഡിറ്റ് ചെയ്യുന്നത് ചുവടെയുള്ള പ്രതികരണം നീക്കംചെയ്യുകയും പുതിയത് സൃഷ്ടിക്കുകയും "
-"ചെയ്യും."
+"നിങ്ങളുടെ സന്ദേശം എഡിറ്റ് ചെയ്യുന്നത് ചുവടെയുള്ള പ്രതികരണം നീക്കംചെയ്യുകയും "
+"പുതിയത് സൃഷ്ടിക്കുകയും ചെയ്യും."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7734,7 +7822,9 @@ msgstr "AI സവിശേഷതകൾ പ്രവർത്തനക്ഷമ�
 #. Text explaining how to enable the cloud save feature.
 msgctxt "cloudsave"
 msgid "Enable Cloud Save by entering your existing passphrase."
-msgstr "നിങ്ങളുടെ നിലവിലുള്ള പാസ്‌ഫ്രെയ്സ് ഉപയോഗിച്ച് Cloud Save പ്രവർത്തനക്ഷമമാക്കുക."
+msgstr ""
+"നിങ്ങളുടെ നിലവിലുള്ള പാസ്‌ഫ്രെയ്സ് ഉപയോഗിച്ച് Cloud Save "
+"പ്രവർത്തനക്ഷമമാക്കുക."
 
 # smartling.placeholder_format=C
 #. Primary button text in the dictation privacy consent modal to enable dictation.
@@ -7811,8 +7901,8 @@ msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
 msgstr ""
-"കൂടുതൽ കൃത്യമായ ഫലങ്ങൾക്കായി അജ്ഞാത ലൊക്കേഷൻ പ്രവർത്തനക്ഷമമാക്കുക. പിന്നീട് എപ്പോൾ "
-"വേണമെങ്കിലും നിങ്ങളുടെ മനസ്സ് മാറ്റാൻ കഴിയും."
+"കൂടുതൽ കൃത്യമായ ഫലങ്ങൾക്കായി അജ്ഞാത ലൊക്കേഷൻ പ്രവർത്തനക്ഷമമാക്കുക. പിന്നീട് "
+"എപ്പോൾ വേണമെങ്കിലും നിങ്ങളുടെ മനസ്സ് മാറ്റാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7857,8 +7947,9 @@ msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
 msgstr ""
-"അജ്ഞാത ലൊക്കേഷൻ പ്രവർത്തനക്ഷമമാക്കുന്നത് കൂടുതൽ കൃത്യമായ ഫലങ്ങൾ നൽകുന്നു, പക്ഷേ അപ്പോഴും നിങ്ങളുടെ "
-"തിരയലുകളും കൃത്യമായ ലൊക്കേഷനും DuckDuckGo-യിലേക്ക് സ്വകാര്യമായി സൂക്ഷിക്കുന്നു."
+"അജ്ഞാത ലൊക്കേഷൻ പ്രവർത്തനക്ഷമമാക്കുന്നത് കൂടുതൽ കൃത്യമായ ഫലങ്ങൾ നൽകുന്നു, "
+"പക്ഷേ അപ്പോഴും നിങ്ങളുടെ തിരയലുകളും കൃത്യമായ ലൊക്കേഷനും DuckDuckGo-യിലേക്ക് "
+"സ്വകാര്യമായി സൂക്ഷിക്കുന്നു."
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7883,6 +7974,8 @@ msgstr "എൻക്രിപ്റ്റ് ചെയ്ത മോഡൽ"
 msgctxt "Share modal info bullet about encryption"
 msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
+"DuckDuckGo-ക്ക് നിങ്ങളുടെ ചാറ്റ് വായിക്കാൻ കഴിയാത്തവിധം എൻക്രിപ്റ്റ് "
+"ചെയ്തിരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -7941,7 +8034,8 @@ msgstr "Duck.ai ആസ്വദിക്കുകയാണോ?"
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
 msgstr ""
-"'ലൊക്കേഷൻ' ക്രമീകരണത്തിനായി %1$s'അനുവദിക്കുക'%2$s തിരഞ്ഞെടുത്തിട്ടുണ്ടെന്ന് ഉറപ്പാക്കുക."
+"'ലൊക്കേഷൻ' ക്രമീകരണത്തിനായി %1$s'അനുവദിക്കുക'%2$s തിരഞ്ഞെടുത്തിട്ടുണ്ടെന്ന് "
+"ഉറപ്പാക്കുക."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -8027,8 +8121,8 @@ msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
 msgstr ""
-"ഒരു പുതിയ പാസ്‌ഫ്രെയ്സ് നൽകിയിട്ട്, %1$sക്രമീകരണം സംരക്ഷിക്കുക%2$s ക്ലിക്ക് ചെയ്യുക. ഇത് "
-"നിങ്ങളുടെ പുതിയ പാസ്‌ഫ്രെയ്സിന് കീഴിൽ ഡാറ്റ രക്ഷിക്കും."
+"ഒരു പുതിയ പാസ്‌ഫ്രെയ്സ് നൽകിയിട്ട്, %1$sക്രമീകരണം സംരക്ഷിക്കുക%2$s ക്ലിക്ക് "
+"ചെയ്യുക. ഇത് നിങ്ങളുടെ പുതിയ പാസ്‌ഫ്രെയ്സിന് കീഴിൽ ഡാറ്റ രക്ഷിക്കും."
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -8054,8 +8148,8 @@ msgstr "ടെക്‌സ്റ്റ് നൽകുക"
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
 msgstr ""
-"ഇനിപ്പറയുന്ന വിശദാംശങ്ങൾ നൽകുക: %1$s പേര് %2$s: DuckDuckGo%3$sURL%4$s: %5$sഅപരനാമം "
-"%6$s: ഡി%7$s"
+"ഇനിപ്പറയുന്ന വിശദാംശങ്ങൾ നൽകുക: %1$s പേര് %2$s: DuckDuckGo%3$sURL%4$s: "
+"%5$sഅപരനാമം %6$s: ഡി%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -8096,7 +8190,8 @@ msgstr "ഇക്വറ്റോറിയൽ ഗിനിയ"
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
 msgstr ""
-"ഞങ്ങളുടെ Fire Button ഉപയോഗിച്ച് ഒറ്റ ഫ്ലാഷിൽ നിങ്ങളുടെ ബ്രൗസിംഗ് ഡാറ്റ മായ്ക്കുക %1$s%2$s"
+"ഞങ്ങളുടെ Fire Button ഉപയോഗിച്ച് ഒറ്റ ഫ്ലാഷിൽ നിങ്ങളുടെ ബ്രൗസിംഗ് ഡാറ്റ "
+"മായ്ക്കുക %1$s%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -8156,7 +8251,9 @@ msgstr "മാപ്പ് വികസിപ്പിക്കുക"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr "സ്വകാര്യതയെ ശരിക്കും ശ്രദ്ധിക്കുന്നവർക്കായി വിദഗ്ദ്ധമായി രൂപകൽപ്പന ചെയ്ത ഉൽപ്പന്നങ്ങൾ."
+msgstr ""
+"സ്വകാര്യതയെ ശരിക്കും ശ്രദ്ധിക്കുന്നവർക്കായി വിദഗ്ദ്ധമായി രൂപകൽപ്പന ചെയ്ത "
+"ഉൽപ്പന്നങ്ങൾ."
 
 # smartling.placeholder_format=C
 #. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
@@ -8244,7 +8341,9 @@ msgstr "ഇത് ലളിതമായി വിശദീകരിക്കു�
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
-msgstr "ഈ റിപ്പോസിറ്ററി എന്താണ് ചെയ്യുന്നതെന്നും അത് എങ്ങനെ ഉപയോഗിക്കണമെന്നും വിശദീകരിക്കുക."
+msgstr ""
+"ഈ റിപ്പോസിറ്ററി എന്താണ് ചെയ്യുന്നതെന്നും അത് എങ്ങനെ ഉപയോഗിക്കണമെന്നും "
+"വിശദീകരിക്കുക."
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -8440,8 +8539,8 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
 msgstr ""
-"നിങ്ങളുടെ ഫീഡ്ബാക്ക് ഞങ്ങളുടെ ഉൽപ്പന്ന അപ്ഡേറ്റുകളെയും മെച്ചപ്പെടുത്തലുകളെയും നേരിട്ട് "
-"സ്വാധീനിക്കുന്നു."
+"നിങ്ങളുടെ ഫീഡ്ബാക്ക് ഞങ്ങളുടെ ഉൽപ്പന്ന അപ്ഡേറ്റുകളെയും "
+"മെച്ചപ്പെടുത്തലുകളെയും നേരിട്ട് സ്വാധീനിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8450,8 +8549,9 @@ msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
 msgstr ""
-"നിങ്ങളുടേത് പോലുള്ള ഫീഡ്ബാക്ക് ഞങ്ങളുടെ ഉൽപ്പന്ന അപ്ഡേറ്റുകളെയും മെച്ചപ്പെടുത്തലുകളെയും നേരിട്ട് "
-"സ്വാധീനിക്കുന്നു. നിങ്ങൾ പങ്കിട്ട പ്രശ്നവും പരിഹരിക്കാൻ ഞങ്ങൾക്ക് കഴിയുമെന്ന് പ്രതീക്ഷിക്കുന്നു."
+"നിങ്ങളുടേത് പോലുള്ള ഫീഡ്ബാക്ക് ഞങ്ങളുടെ ഉൽപ്പന്ന അപ്ഡേറ്റുകളെയും "
+"മെച്ചപ്പെടുത്തലുകളെയും നേരിട്ട് സ്വാധീനിക്കുന്നു. നിങ്ങൾ പങ്കിട്ട പ്രശ്നവും "
+"പരിഹരിക്കാൻ ഞങ്ങൾക്ക് കഴിയുമെന്ന് പ്രതീക്ഷിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -8459,8 +8559,8 @@ msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
 msgstr ""
-"ഇഷ്ട പ്രകാരം താഴെയുള്ള ക്രമീകരണം ക്രമപ്പെടുത്തുക. തുടർന്ന് കോഡ് താങ്കളുടെ സൈറ്റിലേക്കു പകർത്തി "
-"ഒട്ടിക്കുക"
+"ഇഷ്ട പ്രകാരം താഴെയുള്ള ക്രമീകരണം ക്രമപ്പെടുത്തുക. തുടർന്ന് കോഡ് താങ്കളുടെ "
+"സൈറ്റിലേക്കു പകർത്തി ഒട്ടിക്കുക"
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8544,15 +8644,16 @@ msgctxt "settings"
 msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
-"AI ഉപയോഗിച്ച് നിർമ്മിച്ച ചിത്രങ്ങൾ, ചിത്രങ്ങൾ തിരയുന്നതിൻ്റെ ഫലത്തിൽ നിന്ന് ഫിൽട്ടർ ചെയ്ത് "
-"ഒഴിവാക്കുന്നു. %1$sകൂടുതലറിയുക%2$s"
+"AI ഉപയോഗിച്ച് നിർമ്മിച്ച ചിത്രങ്ങൾ, ചിത്രങ്ങൾ തിരയുന്നതിൻ്റെ ഫലത്തിൽ നിന്ന് "
+"ഫിൽട്ടർ ചെയ്ത് ഒഴിവാക്കുന്നു. %1$sകൂടുതലറിയുക%2$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
 msgstr ""
-"ഇമേജ് തിരയൽ ഫലങ്ങളിൽ നിന്ന് അറിയപ്പെടുന്ന AI സ്പാം സൈറ്റുകൾ ഒഴിവാക്കുന്നു. %1$sകൂടുതലറിയുക%2$s"
+"ഇമേജ് തിരയൽ ഫലങ്ങളിൽ നിന്ന് അറിയപ്പെടുന്ന AI സ്പാം സൈറ്റുകൾ ഒഴിവാക്കുന്നു. "
+"%1$sകൂടുതലറിയുക%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8594,7 +8695,8 @@ msgstr "<b>%1$s</b> നിങ്ങളുടെ ഡൗൺലോഡുകൾ ഫ�
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
 msgstr ""
-"പ്രദർശിപ്പിച്ച പട്ടികയിൽ DuckDuckGo കണ്ടെത്തി %1$sഡിഫോൾട്ട് ആക്കുക%2$s എന്നത് ക്ലിക്ക് ചെയ്യുക"
+"പ്രദർശിപ്പിച്ച പട്ടികയിൽ DuckDuckGo കണ്ടെത്തി %1$sഡിഫോൾട്ട് ആക്കുക%2$s "
+"എന്നത് ക്ലിക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8632,8 +8734,8 @@ msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
 msgstr ""
-"നിങ്ങളോട് അടുത്തുള്ള ഫലങ്ങൾ കണ്ടെത്തുക. %1$sനിങ്ങളുടെ ലൊക്കേഷൻ സ്വകാര്യവും സുരക്ഷിതവും "
-"അജ്ഞാതവുമാണ്."
+"നിങ്ങളോട് അടുത്തുള്ള ഫലങ്ങൾ കണ്ടെത്തുക. %1$sനിങ്ങളുടെ ലൊക്കേഷൻ സ്വകാര്യവും "
+"സുരക്ഷിതവും അജ്ഞാതവുമാണ്."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8697,8 +8799,9 @@ msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
 msgstr ""
-"DuckDuckGo-യ്ക്കായി Ad blocker ഓഫാക്കാൻ നിർദ്ദേശങ്ങൾ പിന്തുടരുക. നിങ്ങൾ ഒരു മെനു ഓപ്ഷൻ "
-"തിരഞ്ഞെടുക്കുകയോ ഒരു ബട്ടൺ ക്ലിക്ക് ചെയ്യുകയോ ചെയ്യേണ്ടി വന്നേക്കാം."
+"DuckDuckGo-യ്ക്കായി Ad blocker ഓഫാക്കാൻ നിർദ്ദേശങ്ങൾ പിന്തുടരുക. നിങ്ങൾ ഒരു "
+"മെനു ഓപ്ഷൻ തിരഞ്ഞെടുക്കുകയോ ഒരു ബട്ടൺ ക്ലിക്ക് ചെയ്യുകയോ ചെയ്യേണ്ടി "
+"വന്നേക്കാം."
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8715,7 +8818,7 @@ msgstr "ഫോളോ-അപ്പ് ചോദ്യം"
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
-msgstr ""
+msgstr "ഫോളോ-അപ്പുകൾ സ്വകാര്യമായി തുടരുന്നു."
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8821,7 +8924,9 @@ msgstr "സൗജന്യവും സ്വകാര്യവുമായ ച�
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "സൗജന്യവും സ്വകാര്യവുമായ ചാറ്റുകൾ, ഞങ്ങൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു. അക്കൗണ്ട് ആവശ്യമില്ല."
+msgstr ""
+"സൗജന്യവും സ്വകാര്യവുമായ ചാറ്റുകൾ, ഞങ്ങൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു. അക്കൗണ്ട് "
+"ആവശ്യമില്ല."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8851,7 +8956,9 @@ msgstr "പങ്കിടലും വാണിജ്യപരമായി ഉ�
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr "നിങ്ങളുടെ ചാറ്റുകൾ ഇല്ലാതാക്കി സ്ഥലം ശൂന്യമാക്കുക. പിൻ ചെയ്ത ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
+msgstr ""
+"നിങ്ങളുടെ ചാറ്റുകൾ ഇല്ലാതാക്കി സ്ഥലം ശൂന്യമാക്കുക. പിൻ ചെയ്ത ചാറ്റുകൾ "
+"ഇല്ലാതാക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8932,9 +9039,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Mac-ലെ ആപ്പ് മെനു ബാറിൽ നിന്ന്, <strong>DuckDuckGo</strong> &gt; <strong>അപ്ഡേറ്റുകൾ "
-"പരിശോധിക്കുക...</strong>, തുടർന്ന് <strong>അപ്ഡേറ്റ് ഇൻസ്റ്റാൾ ചെയ്യുക</strong> "
-"തിരഞ്ഞെടുക്കുക."
+"Mac-ലെ ആപ്പ് മെനു ബാറിൽ നിന്ന്, <strong>DuckDuckGo</strong> &gt; "
+"<strong>അപ്ഡേറ്റുകൾ പരിശോധിക്കുക...</strong>, തുടർന്ന് <strong>അപ്ഡേറ്റ് "
+"ഇൻസ്റ്റാൾ ചെയ്യുക</strong> തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9220,21 +9327,20 @@ msgid ""
 "Get DuckDuckGo VPN, advanced Duck.ai, Personal Info Removal, and Identity "
 "Theft Restoration."
 msgstr ""
-"DuckDuckGo VPN, നൂതന Duck.ai എന്നിവ നേടൂ, Personal Info Removal, Identity Theft "
-"Restoration എന്നിവയും."
+"DuckDuckGo VPN, നൂതന Duck.ai എന്നിവ നേടൂ, Personal Info Removal, Identity "
+"Theft Restoration എന്നിവയും."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr ""
-"DuckDuckGo VPN, നൂതന Duck.ai, കൂടാതെ Identity Theft Restoration എന്നിവ നേടൂ."
+msgstr "DuckDuckGo VPN, നൂതന Duck.ai, കൂടാതെ Identity Theft Restoration എന്നിവ നേടൂ."
 
 # smartling.placeholder_format=C
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
 msgctxt "Tooltip on the header logo for sunglasses searches"
 msgid "Get DuckDuckGo sunglasses and other gear."
-msgstr ""
+msgstr "DuckDuckGo സൺഗ്ലാസുകളും മറ്റ് ഉൽപ്പന്നങ്ങളും നേടുക."
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9314,8 +9420,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, Personal Info Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"വേഗതയേറിയ, നോ-ലോഗ് VPN, ഓപ്ഷണൽ അഡ്വാൻസ്ഡ് AI ചാറ്റ്, Personal Info Removal, കൂടാതെ "
-"Identity Theft Restoration എന്നിവ നേടൂ."
+"വേഗതയേറിയ, നോ-ലോഗ് VPN, ഓപ്ഷണൽ അഡ്വാൻസ്ഡ് AI ചാറ്റ്, Personal Info Removal, "
+"കൂടാതെ Identity Theft Restoration എന്നിവ നേടൂ."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; 'advanced AI chat' refers to Duck.ai; Identity Theft Restoration is a bundled feature.
@@ -9324,8 +9430,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, and Identity Theft "
 "Restoration."
 msgstr ""
-"വേഗതയേറിയ, നോ-ലോഗ് VPN, ഓപ്ഷണലായ നൂതന AI ചാറ്റ്, കൂടാതെ Identity Theft Restoration "
-"നേടൂ."
+"വേഗതയേറിയ, നോ-ലോഗ് VPN, ഓപ്ഷണലായ നൂതന AI ചാറ്റ്, കൂടാതെ Identity Theft "
+"Restoration നേടൂ."
 
 # smartling.placeholder_format=C
 #. Description for the subscription modal where users can update their subscription to DuckDuckGo.
@@ -9334,8 +9440,9 @@ msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"ഞങ്ങളുടെ VPN-ഉം മറ്റ് പ്രീമിയം സ്വകാര്യതാ പരിരക്ഷകളും ഉൾപ്പെടുന്ന DuckDuckGo-യിലേക്ക് "
-"സബ്സ്ക്രൈബ് ചെയ്തുകൊണ്ട് Duck.ai-ലെ നൂതന AI മോഡലുകളിലേക്ക് ആക്സസ് നേടുക."
+"ഞങ്ങളുടെ VPN-ഉം മറ്റ് പ്രീമിയം സ്വകാര്യതാ പരിരക്ഷകളും ഉൾപ്പെടുന്ന "
+"DuckDuckGo-യിലേക്ക് സബ്സ്ക്രൈബ് ചെയ്തുകൊണ്ട് Duck.ai-ലെ നൂതന AI "
+"മോഡലുകളിലേക്ക് ആക്സസ് നേടുക."
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -9346,8 +9453,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"ഞങ്ങളുടെ VPN-ഉം മറ്റ് പ്രീമിയം സ്വകാര്യതാ പരിരക്ഷകളും ഉൾപ്പെടുന്ന DuckDuckGo സബ്സ്ക്രിപ്ഷൻ "
-"ഉപയോഗിച്ച് Duck.ai-ലെ നൂതന AI മോഡലുകളിലേക്ക് ആക്സസ് നേടുക."
+"ഞങ്ങളുടെ VPN-ഉം മറ്റ് പ്രീമിയം സ്വകാര്യതാ പരിരക്ഷകളും ഉൾപ്പെടുന്ന DuckDuckGo "
+"സബ്സ്ക്രിപ്ഷൻ ഉപയോഗിച്ച് Duck.ai-ലെ നൂതന AI മോഡലുകളിലേക്ക് ആക്സസ് നേടുക."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9391,8 +9498,9 @@ msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
 msgstr ""
-"ഞങ്ങളുടെ വേഗതയേറിയ നോ-ലോഗ് VPN, ഉയർന്ന ചാറ്റ് പരിധികളുള്ള നൂതന AI മോഡലുകളിലേക്കുള്ള ഓപ്ഷണൽ "
-"ആക്‌സസ്, കൂടാതെ കൂടുതൽ പ്രീമിയം പരിരക്ഷകൾ എന്നിവ നേടൂ."
+"ഞങ്ങളുടെ വേഗതയേറിയ നോ-ലോഗ് VPN, ഉയർന്ന ചാറ്റ് പരിധികളുള്ള നൂതന AI "
+"മോഡലുകളിലേക്കുള്ള ഓപ്ഷണൽ ആക്‌സസ്, കൂടാതെ കൂടുതൽ പ്രീമിയം പരിരക്ഷകൾ എന്നിവ "
+"നേടൂ."
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9401,8 +9509,8 @@ msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, Personal Information Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"ഞങ്ങളുടെ സുരക്ഷിതമായ, നോ-ലോഗ് VPN, നൂതന Duck.ai നേടൂ, Personal Information Removal, "
-"കൂടാതെ Identity Theft Restoration."
+"ഞങ്ങളുടെ സുരക്ഷിതമായ, നോ-ലോഗ് VPN, നൂതന Duck.ai നേടൂ, Personal Information "
+"Removal, കൂടാതെ Identity Theft Restoration."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
@@ -9410,14 +9518,15 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
-"ഞങ്ങളുടെ സുരക്ഷിതമായ, നോ-ലോഗ് VPN, നൂതന Duck.ai, കൂടാതെ Identity Theft Restoration "
-"എന്നിവ നേടൂ."
+"ഞങ്ങളുടെ സുരക്ഷിതമായ, നോ-ലോഗ് VPN, നൂതന Duck.ai, കൂടാതെ Identity Theft "
+"Restoration എന്നിവ നേടൂ."
 
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
 msgstr ""
-"ഒറ്റ ഡൗൺലോഡിൽ നിങ്ങളുടെ ബ്രൗസറിൽ തടസ്സമില്ലാത്ത സ്വകാര്യതാ പരിരക്ഷ സൗജന്യമായി നേടുക:"
+"ഒറ്റ ഡൗൺലോഡിൽ നിങ്ങളുടെ ബ്രൗസറിൽ തടസ്സമില്ലാത്ത സ്വകാര്യതാ പരിരക്ഷ "
+"സൗജന്യമായി നേടുക:"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -9513,8 +9622,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
 "നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s "
-"എന്നതിലേക്ക് പോയി, %3$sചാറ്റുകൾ › Sync & Backup › മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക › "
-"ടെക്സ്റ്റ് കോഡ് പകർത്തുക%4$sഎന്നതിലേക്ക് പോകുക"
+"എന്നതിലേക്ക് പോയി, %3$sചാറ്റുകൾ › Sync & Backup › മറ്റൊരു ഉപകരണവുമായി "
+"സമന്വയിപ്പിക്കുക › ടെക്സ്റ്റ് കോഡ് പകർത്തുക%4$sഎന്നതിലേക്ക് പോകുക"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9549,8 +9658,8 @@ msgid ""
 msgstr ""
 "നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s "
 "എന്നതിലേക്ക് പോയി %3$sചാറ്റുകൾ › Sync & Backup › മറ്റൊരു ഉപകരണവുമായി "
-"സമന്വയിപ്പിക്കുക%4$s എന്നതിലേക്ക് പോകുക. അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി PDF-ലെ QR സ്കാൻ "
-"ചെയ്യുക."
+"സമന്വയിപ്പിക്കുക%4$s എന്നതിലേക്ക് പോകുക. അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി "
+"PDF-ലെ QR സ്കാൻ ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Path to the pairing code on the other device. Bold segments are UI path labels.
@@ -9559,8 +9668,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
 msgstr ""
-"മറ്റൊരു ഉപകരണത്തിലെ %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s › %3$sചാറ്റുകൾ › Sync & Backup › "
-"മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%4$s എന്നതിലേക്ക് പോവുക."
+"മറ്റൊരു ഉപകരണത്തിലെ %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s › %3$sചാറ്റുകൾ › Sync & "
+"Backup › മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%4$s എന്നതിലേക്ക് പോവുക."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9575,8 +9684,8 @@ msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
 msgstr ""
-"%1$sക്രമീകരണം > സ്വകാര്യതയും സുരക്ഷയും > ലൊക്കേഷൻ സേവനങ്ങൾ%2$sഎന്നതിലേക്ക് പോയി "
-"\"ലൊക്കേഷൻ സേവനങ്ങൾ\" ഓണാക്കിയിട്ടുണ്ടെന്ന് ഉറപ്പാക്കുക."
+"%1$sക്രമീകരണം > സ്വകാര്യതയും സുരക്ഷയും > ലൊക്കേഷൻ സേവനങ്ങൾ%2$sഎന്നതിലേക്ക് "
+"പോയി \"ലൊക്കേഷൻ സേവനങ്ങൾ\" ഓണാക്കിയിട്ടുണ്ടെന്ന് ഉറപ്പാക്കുക."
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -9842,7 +9951,9 @@ msgstr "ഗ്വാട്ടിമാല"
 #. Text for a prompt suggestion for guiding through the basic steps of replacing a window wiper.
 msgctxt "Full sentence for learning a new skill"
 msgid "Guide me through the basic steps of replacing a window wiper."
-msgstr "ഒരു വിൻഡോ വൈപ്പർ മാറ്റിസ്ഥാപിക്കുന്നതിനുള്ള അടിസ്ഥാന ഘട്ടങ്ങളിലൂടെ എന്നെ നയിക്കുക."
+msgstr ""
+"ഒരു വിൻഡോ വൈപ്പർ മാറ്റിസ്ഥാപിക്കുന്നതിനുള്ള അടിസ്ഥാന ഘട്ടങ്ങളിലൂടെ എന്നെ "
+"നയിക്കുക."
 
 # smartling.placeholder_format=C
 msgid "Guinea"
@@ -10042,7 +10153,9 @@ msgstr "DuckDuckGo മെച്ചപ്പെടുത്താൻ ഞങ്ങ
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr "നിങ്ങളുടെ ഫീഡ്ബാക്ക് ഉപയോഗിച്ച് DuckDuckGo തിരയലുകൾ മെച്ചപ്പെടുത്താൻ ഞങ്ങളെ സഹായിക്കൂ"
+msgstr ""
+"നിങ്ങളുടെ ഫീഡ്ബാക്ക് ഉപയോഗിച്ച് DuckDuckGo തിരയലുകൾ മെച്ചപ്പെടുത്താൻ ഞങ്ങളെ "
+"സഹായിക്കൂ"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -10100,7 +10213,9 @@ msgstr "Duck ഭാഗത്ത് ചേരാൻ നിങ്ങളുടെ �
 #. Text description for the Spread card in the SERP footer
 msgctxt "footer_card"
 msgid "Help your friends and family take back their privacy!"
-msgstr "നിങ്ങളുടെ സുഹൃത്തുക്കളെയും കുടുംബാംഗങ്ങളെയും അവരുടെ സ്വകാര്യത വീണ്ടെടുക്കാൻ സഹായിക്കൂ!"
+msgstr ""
+"നിങ്ങളുടെ സുഹൃത്തുക്കളെയും കുടുംബാംഗങ്ങളെയും അവരുടെ സ്വകാര്യത വീണ്ടെടുക്കാൻ "
+"സഹായിക്കൂ!"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -10275,8 +10390,8 @@ msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
 msgstr ""
-"പ്രധാനപ്പെട്ട വിവരങ്ങൾ വേഗത്തിൽ കണ്ടെത്താൻ നിങ്ങളെ സഹായിക്കുന്നതിന് Search Assist "
-"ഉത്തരങ്ങളിൽ പ്രധാന വസ്തുതകൾ എടുത്തുകാണിക്കുന്നു."
+"പ്രധാനപ്പെട്ട വിവരങ്ങൾ വേഗത്തിൽ കണ്ടെത്താൻ നിങ്ങളെ സഹായിക്കുന്നതിന് Search "
+"Assist ഉത്തരങ്ങളിൽ പ്രധാന വസ്തുതകൾ എടുത്തുകാണിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -10303,8 +10418,9 @@ msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
 msgstr ""
-"DuckDuckGo പട്ടികയിലേക്ക് %3$sസംരക്ഷിക്കാൻ നിങ്ങളുടെ കീബോർഡിൽ %1$sമടങ്ങുക%2$s "
-"അമർത്തുക. %4$sതുടർന്ന് %5$sഡിഫോൾട്ട് ആക്കുക%6$s എന്നത് ക്ലിക്ക് ചെയ്യുക"
+"DuckDuckGo പട്ടികയിലേക്ക് %3$sസംരക്ഷിക്കാൻ നിങ്ങളുടെ കീബോർഡിൽ "
+"%1$sമടങ്ങുക%2$s അമർത്തുക. %4$sതുടർന്ന് %5$sഡിഫോൾട്ട് ആക്കുക%6$s എന്നത് "
+"ക്ലിക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -10318,8 +10434,8 @@ msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
 msgstr ""
-"ഹോൾഡ് ഓൺ! ഇത് തിരികെ മാറ്റുന്നത് DuckDuckGo വിപുലീകരണം പ്രവർത്തനരഹിതമാക്കും, നിങ്ങൾക്ക് "
-"ഞങ്ങളുടെ സ്വകാര്യതാ പരിരക്ഷണം നഷ്‌ടമാകും."
+"ഹോൾഡ് ഓൺ! ഇത് തിരികെ മാറ്റുന്നത് DuckDuckGo വിപുലീകരണം പ്രവർത്തനരഹിതമാക്കും, "
+"നിങ്ങൾക്ക് ഞങ്ങളുടെ സ്വകാര്യതാ പരിരക്ഷണം നഷ്‌ടമാകും."
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -10369,8 +10485,8 @@ msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
 msgstr ""
-"ഹോട്ടൽ പരസ്യ ക്ലിക്കുകൾ കൈകാര്യം ചെയ്യുന്നത് ട്രിപ്പ് അഡ്വൈസറിന്റെ പരസ്യ ശൃംഖലയാണ്, നിങ്ങളെ "
-"പ്രൊഫൈൽ ചെയ്യുന്നതിനായി അവ ഉപയോഗിക്കപ്പെടുന്നില്ല."
+"ഹോട്ടൽ പരസ്യ ക്ലിക്കുകൾ കൈകാര്യം ചെയ്യുന്നത് ട്രിപ്പ് അഡ്വൈസറിന്റെ പരസ്യ "
+"ശൃംഖലയാണ്, നിങ്ങളെ പ്രൊഫൈൽ ചെയ്യുന്നതിനായി അവ ഉപയോഗിക്കപ്പെടുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -10467,7 +10583,7 @@ msgstr "ഇത് എങ്ങനെ പ്രവർത്തിക്കുന�
 #. Headline in chat history about modals for the temporary encrypted server storage explanation.
 msgctxt "Chat history about modal list item headline"
 msgid "How it works"
-msgstr ""
+msgstr "ഇത് എങ്ങനെ പ്രവർത്തിക്കുന്നു"
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -10485,7 +10601,9 @@ msgstr "ഇത് എങ്ങനെ പ്രവർത്തിക്കുന�
 #. Header for the assist settings modal where the user can choose how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How much do you want AI-assisted answers to appear?"
-msgstr "നിങ്ങൾ എത്രത്തോളം AI- സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ ദൃശ്യമാകണമെന്നാണ് ആഗ്രഹിക്കുന്നത്?"
+msgstr ""
+"നിങ്ങൾ എത്രത്തോളം AI- സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ ദൃശ്യമാകണമെന്നാണ് "
+"ആഗ്രഹിക്കുന്നത്?"
 
 # smartling.placeholder_format=C
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
@@ -10518,8 +10636,8 @@ msgid ""
 "How should I tactfully approach a colleague about their constant pencil "
 "tapping and what should I say?"
 msgstr ""
-"അവരുടെ നിരന്തരമായ പെൻസിൽ ടാപ്പിംഗിനെക്കുറിച്ച് ഒരു സഹപ്രവർത്തകനെ എങ്ങനെ തന്ത്രപൂർവ്വം "
-"സമീപിക്കണം, ഞാൻ എന്താണ് പറയേണ്ടത്?"
+"അവരുടെ നിരന്തരമായ പെൻസിൽ ടാപ്പിംഗിനെക്കുറിച്ച് ഒരു സഹപ്രവർത്തകനെ എങ്ങനെ "
+"തന്ത്രപൂർവ്വം സമീപിക്കണം, ഞാൻ എന്താണ് പറയേണ്ടത്?"
 
 # smartling.placeholder_format=C
 #. The title for a feedback prompt that includes thumbs up and thumbs down buttons
@@ -10626,7 +10744,9 @@ msgstr "കൂടുതൽ വിൽപ്പനക്കാരിൽ നിന�
 #. Header above text explaining that passwords can't be recovered.
 msgctxt "cloudsave"
 msgid "I forgot my passphrase. Can you recover it?"
-msgstr "എന്റെ പാസ്‌ഫ്രെയ്സ് മറന്നു പോയി, നിങ്ങള്‍ക്ക് അത് വീണ്ടെടുക്കുവാന്‍ സാധിക്കുമോ?"
+msgstr ""
+"എന്റെ പാസ്‌ഫ്രെയ്സ് മറന്നു പോയി, നിങ്ങള്‍ക്ക് അത് വീണ്ടെടുക്കുവാന്‍ "
+"സാധിക്കുമോ?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user hits a chat limit.
@@ -10641,14 +10761,16 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"കാറ്റിൻ്റെ പേര് എന്ന പുസ്തകം എനിക്കിഷ്ടമാണ്. മറ്റു ചില നല്ല പുസ്തകങ്ങൾ/പരമ്പരകൾ ഏതൊക്കെയാണ് "
-"ഏറ്റവും ഇഷ്ടപ്പെടുന്നത്, എന്തുകൊണ്ട്?"
+"കാറ്റിൻ്റെ പേര് എന്ന പുസ്തകം എനിക്കിഷ്ടമാണ്. മറ്റു ചില നല്ല "
+"പുസ്തകങ്ങൾ/പരമ്പരകൾ ഏതൊക്കെയാണ് ഏറ്റവും ഇഷ്ടപ്പെടുന്നത്, എന്തുകൊണ്ട്?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
 msgctxt "Feedback option for difficulty in using chat"
 msgid "I need more help/info on how to use Chat"
-msgstr "ചാറ്റ് എങ്ങനെ ഉപയോഗിക്കാം എന്നതിനെക്കുറിച്ചുള്ള കൂടുതൽ സഹായം/വിവരങ്ങൾ എനിക്ക് ആവശ്യമാണ്"
+msgstr ""
+"ചാറ്റ് എങ്ങനെ ഉപയോഗിക്കാം എന്നതിനെക്കുറിച്ചുള്ള കൂടുതൽ സഹായം/വിവരങ്ങൾ "
+"എനിക്ക് ആവശ്യമാണ്"
 
 # smartling.placeholder_format=C
 msgid "IR Iran"
@@ -10677,8 +10799,9 @@ msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
 msgstr ""
-"ബ്രൗസർ ലൊക്കേഷൻ തുടർന്നും ലഭ്യമല്ലെങ്കിൽ, %1$sക്രമീകരണം > പൊതുവായത് > പുനഃക്രമീകരിക്കുക > "
-"'ലൊക്കേഷനും സ്വകാര്യതയും പുനഃക്രമീകരിക്കുക'%2$s എന്നതിലേക്ക് പോകുക."
+"ബ്രൗസർ ലൊക്കേഷൻ തുടർന്നും ലഭ്യമല്ലെങ്കിൽ, %1$sക്രമീകരണം > പൊതുവായത് > "
+"പുനഃക്രമീകരിക്കുക > 'ലൊക്കേഷനും സ്വകാര്യതയും പുനഃക്രമീകരിക്കുക'%2$s "
+"എന്നതിലേക്ക് പോകുക."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10688,9 +10811,9 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"ബ്രൗസർ ലൊക്കേഷൻ തുടർന്നും ലഭ്യമല്ലെങ്കിൽ, നിങ്ങളുടെ ബ്രൗസറിൽ ഇതിലേക്ക് പോകുക %1$s⋮ > മെനു > "
-"ക്രമീകരണം > സൈറ്റ് ക്രമീകരണം > ലൊക്കേഷൻ%2$s, തുടർന്ന് DuckDuckGo-യ്ക്ക് ലൊക്കേഷൻ ആക്സസ് "
-"അനുവദനീയമാണെന്ന് ഉറപ്പാക്കുക."
+"ബ്രൗസർ ലൊക്കേഷൻ തുടർന്നും ലഭ്യമല്ലെങ്കിൽ, നിങ്ങളുടെ ബ്രൗസറിൽ ഇതിലേക്ക് പോകുക "
+"%1$s⋮ > മെനു > ക്രമീകരണം > സൈറ്റ് ക്രമീകരണം > ലൊക്കേഷൻ%2$s, തുടർന്ന് "
+"DuckDuckGo-യ്ക്ക് ലൊക്കേഷൻ ആക്സസ് അനുവദനീയമാണെന്ന് ഉറപ്പാക്കുക."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10705,8 +10828,8 @@ msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
 msgstr ""
-"നിങ്ങൾ %1$sDuckDuckGo%2$s കാണുന്നില്ലെങ്കിൽ നിങ്ങൾ അത് %3$sമറ്റ് തിരയൽ എഞ്ചിനുകളുടെ%4$s "
-"പട്ടികയിലേക്ക് ചേർക്കേണ്ടതുണ്ട്"
+"നിങ്ങൾ %1$sDuckDuckGo%2$s കാണുന്നില്ലെങ്കിൽ നിങ്ങൾ അത് %3$sമറ്റ് തിരയൽ "
+"എഞ്ചിനുകളുടെ%4$s പട്ടികയിലേക്ക് ചേർക്കേണ്ടതുണ്ട്"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -10715,8 +10838,9 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"ഞങ്ങളുടെ ചാറ്റ് ദാതാക്കളെക്കുറിച്ചോ ഏതെങ്കിലും പ്രത്യേക ചാറ്റ് പ്രതികരണത്തെക്കുറിച്ചോ നിങ്ങൾക്ക് "
-"ആശങ്കയുണ്ടെങ്കിൽ, നിങ്ങൾക്ക് നേരിട്ട് %1$s, %2$s പിന്തുണാ പേജുകളിലേക്കും ബന്ധപ്പെടാം."
+"ഞങ്ങളുടെ ചാറ്റ് ദാതാക്കളെക്കുറിച്ചോ ഏതെങ്കിലും പ്രത്യേക ചാറ്റ് "
+"പ്രതികരണത്തെക്കുറിച്ചോ നിങ്ങൾക്ക് ആശങ്കയുണ്ടെങ്കിൽ, നിങ്ങൾക്ക് നേരിട്ട് "
+"%1$s, %2$s പിന്തുണാ പേജുകളിലേക്കും ബന്ധപ്പെടാം."
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10725,16 +10849,17 @@ msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെട്ടാൽ, നിങ്ങളുടെ സംരക്ഷിച്ച ചാറ്റുകൾ വീണ്ടെടുക്കാൻ "
-"ഈ കോഡ് ആവശ്യമായി വരും. ഈ കോഡ് നിങ്ങളുടെ ഉപകരണത്തിൽ ഒരു ടെക്സ്റ്റ് ഫയലായി സംരക്ഷിക്കാം."
+"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെട്ടാൽ, നിങ്ങളുടെ സംരക്ഷിച്ച "
+"ചാറ്റുകൾ വീണ്ടെടുക്കാൻ ഈ കോഡ് ആവശ്യമായി വരും. ഈ കോഡ് നിങ്ങളുടെ ഉപകരണത്തിൽ "
+"ഒരു ടെക്സ്റ്റ് ഫയലായി സംരക്ഷിക്കാം."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
 msgstr ""
-"നിങ്ങൾ ഇപ്പോഴും ഞങ്ങളെ പിന്തുണയ്ക്കാൻ ആഗ്രഹിക്കുന്നുണ്ടെങ്കിൽ, %1$sDuckDuckGo "
-"പ്രചരിപ്പിക്കുന്നതിനായി സഹായിക്കുക%2$s"
+"നിങ്ങൾ ഇപ്പോഴും ഞങ്ങളെ പിന്തുണയ്ക്കാൻ ആഗ്രഹിക്കുന്നുണ്ടെങ്കിൽ, "
+"%1$sDuckDuckGo പ്രചരിപ്പിക്കുന്നതിനായി സഹായിക്കുക%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10744,8 +10869,8 @@ msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
 msgstr ""
-"JavaScript ഇല്ലാതെ DuckDuckGo ഉപയോഗിക്കാൻ താൽപ്പര്യപ്പെടുന്നെങ്കിൽ, ഞങ്ങളുടെ %1$s "
-"അല്ലെങ്കിൽ %2$s പതിപ്പുകൾ ഉപയോഗിക്കുക."
+"JavaScript ഇല്ലാതെ DuckDuckGo ഉപയോഗിക്കാൻ താൽപ്പര്യപ്പെടുന്നെങ്കിൽ, ഞങ്ങളുടെ "
+"%1$s അല്ലെങ്കിൽ %2$s പതിപ്പുകൾ ഉപയോഗിക്കുക."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10753,8 +10878,8 @@ msgstr ""
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
 msgstr ""
-"നിങ്ങൾ ആഗ്രഹിക്കുന്നെങ്കിൽ, അടുത്ത പുതിയ ജാലകങ്ങൾക്കും പുതിയ ടാബുകൾക്കും അടുത്തുള്ള ഹോം പേജ് "
-"തിരഞ്ഞെടുക്കുക (ഇതിൽ തുറക്കുക)."
+"നിങ്ങൾ ആഗ്രഹിക്കുന്നെങ്കിൽ, അടുത്ത പുതിയ ജാലകങ്ങൾക്കും പുതിയ ടാബുകൾക്കും "
+"അടുത്തുള്ള ഹോം പേജ് തിരഞ്ഞെടുക്കുക (ഇതിൽ തുറക്കുക)."
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -10883,8 +11008,8 @@ msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
 msgstr ""
-"അപ്‌ഡേറ്റ് ചെയ്‌ത URL ഫോർമാറ്റ്, പ്ലേസ്‌മെന്റ്, നിറം എന്നിവ ഉപയോഗിച്ച് ഫലത്തിന്റെ വ്യക്തത "
-"മെച്ചപ്പെടുത്തുന്നു"
+"അപ്‌ഡേറ്റ് ചെയ്‌ത URL ഫോർമാറ്റ്, പ്ലേസ്‌മെന്റ്, നിറം എന്നിവ ഉപയോഗിച്ച് "
+"ഫലത്തിന്റെ വ്യക്തത മെച്ചപ്പെടുത്തുന്നു"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -10897,8 +11022,8 @@ msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
 msgstr ""
-"ചില പഴയ ബ്രൗസറുകളിൽ തിരയൽ ചോർച്ച തടയുന്നതിന് ഞങ്ങളുടെ സെർവറിലൂടെ നിങ്ങളുടെ ക്ലിക്കുകൾ "
-"റീഡയറക്റ്റ് ചെയ്യേണ്ടത് ആവശ്യമാണ്. %1$sകൂടുതൽ അറിയുക%2$s."
+"ചില പഴയ ബ്രൗസറുകളിൽ തിരയൽ ചോർച്ച തടയുന്നതിന് ഞങ്ങളുടെ സെർവറിലൂടെ നിങ്ങളുടെ "
+"ക്ലിക്കുകൾ റീഡയറക്റ്റ് ചെയ്യേണ്ടത് ആവശ്യമാണ്. %1$sകൂടുതൽ അറിയുക%2$s."
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -10909,8 +11034,8 @@ msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
 msgstr ""
-"DuckDuckGo ബ്രൗസറിൽ, ക്രമീകരണങ്ങൾ › Sync & Backup എന്നതിലേക്ക് പോയി, തുടർന്ന് \"മറ്റൊരു "
-"ഉപകരണവുമായി സമന്വയിപ്പിക്കുക\" തിരഞ്ഞെടുക്കുക."
+"DuckDuckGo ബ്രൗസറിൽ, ക്രമീകരണങ്ങൾ › Sync & Backup എന്നതിലേക്ക് പോയി, "
+"തുടർന്ന് \"മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക\" തിരഞ്ഞെടുക്കുക."
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -10925,8 +11050,9 @@ msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
 msgstr ""
-"സുതാര്യതയ്ക്കു വേണ്ടി ഈ ഡാറ്റകള്‍ എൻക്രിപ്റ്റ് ചെയ്തിട്ടില്ല: ഏതു തരം വിവരങ്ങളാണ് ഞങ്ങള്‍ ശേഖരിക്കുക "
-"എന്നത് നിങ്ങൾക്ക് വ്യക്തമായി പരിശോധിക്കാവുന്നതാണ്."
+"സുതാര്യതയ്ക്കു വേണ്ടി ഈ ഡാറ്റകള്‍ എൻക്രിപ്റ്റ് ചെയ്തിട്ടില്ല: ഏതു തരം "
+"വിവരങ്ങളാണ് ഞങ്ങള്‍ ശേഖരിക്കുക എന്നത് നിങ്ങൾക്ക് വ്യക്തമായി "
+"പരിശോധിക്കാവുന്നതാണ്."
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -11263,8 +11389,8 @@ msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
 msgstr ""
-"ഈ സ്ഥലം നല്ലതാണോ? അവലോകനങ്ങളെയും റേറ്റിംഗുകളെയും അടിസ്ഥാനമാക്കി ഇതിന്റെ പ്രശസ്തി "
-"സംഗ്രഹിക്കുക."
+"ഈ സ്ഥലം നല്ലതാണോ? അവലോകനങ്ങളെയും റേറ്റിംഗുകളെയും അടിസ്ഥാനമാക്കി ഇതിന്റെ "
+"പ്രശസ്തി സംഗ്രഹിക്കുക."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -11308,15 +11434,17 @@ msgstr "ഇതിന് ഏതാനും നിമിഷങ്ങൾ എടു
 #. Body text of a card that promotes installing the DuckDuckGo desktop browser.
 msgctxt "new tab page"
 msgid "It's fast, free, and gives you even more online protection."
-msgstr "ഇത് വേഗതയേറിയതും സൗജന്യവുമാണ്, കൂടാതെ നിങ്ങൾക്ക് കൂടുതൽ ഓൺലൈൻ സുരക്ഷയും നൽകുന്നു."
+msgstr ""
+"ഇത് വേഗതയേറിയതും സൗജന്യവുമാണ്, കൂടാതെ നിങ്ങൾക്ക് കൂടുതൽ ഓൺലൈൻ സുരക്ഷയും "
+"നൽകുന്നു."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
 msgstr ""
-"DuckDuckGo ഉപയോഗിച്ച എന്റെ അനുഭവത്തെക്കുറിച്ച് എന്നോട് (വളരെ അപൂർവമായി) ചോദിക്കുന്നതിൽ "
-"കുഴപ്പമില്ല"
+"DuckDuckGo ഉപയോഗിച്ച എന്റെ അനുഭവത്തെക്കുറിച്ച് എന്നോട് (വളരെ അപൂർവമായി) "
+"ചോദിക്കുന്നതിൽ കുഴപ്പമില്ല"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11335,10 +11463,10 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"ഇനങ്ങൾ നിങ്ങളുടെ തിരയൽ പദങ്ങളുടെ പ്രസക്തിയെ അടിസ്ഥാനമാക്കി റാങ്ക് ചെയ്ത്, Microsoft-ന്റെ "
-"പരസ്യ നെറ്റ്‌വർക്ക് വഴി ഡെലിവറി ചെയ്യുന്നു. ക്ലിക്കുകൾ നേരിട്ട് മർച്ചന്റ് ലാൻഡിംഗ് പേജുകളിലേക്ക് "
-"നയിക്കുന്നു, പരസ്യങ്ങളിൽ നിന്ന് വ്യത്യസ്തമായി ഈ ഫലങ്ങൾക്കായി DuckDuckGo-യ്ക്ക് പ്രതിഫലം "
-"ലഭിക്കുന്നില്ല."
+"ഇനങ്ങൾ നിങ്ങളുടെ തിരയൽ പദങ്ങളുടെ പ്രസക്തിയെ അടിസ്ഥാനമാക്കി റാങ്ക് ചെയ്ത്, "
+"Microsoft-ന്റെ പരസ്യ നെറ്റ്‌വർക്ക് വഴി ഡെലിവറി ചെയ്യുന്നു. ക്ലിക്കുകൾ "
+"നേരിട്ട് മർച്ചന്റ് ലാൻഡിംഗ് പേജുകളിലേക്ക് നയിക്കുന്നു, പരസ്യങ്ങളിൽ നിന്ന് "
+"വ്യത്യസ്തമായി ഈ ഫലങ്ങൾക്കായി DuckDuckGo-യ്ക്ക് പ്രതിഫലം ലഭിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -11347,8 +11475,8 @@ msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
 msgstr ""
-"10 ക്രമരഹിത പദങ്ങളും സംഖ്യകളും ഓര്‍മിക്കുന്നതിനെക്കാൾ എളുപ്പമാണ് 4-5 വാക്കുകൾ ഓർമിക്കുവാൻ, "
-"വളരെ അധികം സുരക്ഷിതവും."
+"10 ക്രമരഹിത പദങ്ങളും സംഖ്യകളും ഓര്‍മിക്കുന്നതിനെക്കാൾ എളുപ്പമാണ് 4-5 "
+"വാക്കുകൾ ഓർമിക്കുവാൻ, വളരെ അധികം സുരക്ഷിതവും."
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -11421,8 +11549,8 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Keep all your apps and online activity private on up to 5 devices at once."
 msgstr ""
-"ഒരേസമയം 5 ഉപകരണങ്ങളിൽ വരെ നിങ്ങളുടെ എല്ലാ ആപ്പുകളും ഓൺലൈൻ പ്രവർത്തനങ്ങളും സ്വകാര്യമായി "
-"സൂക്ഷിക്കുക."
+"ഒരേസമയം 5 ഉപകരണങ്ങളിൽ വരെ നിങ്ങളുടെ എല്ലാ ആപ്പുകളും ഓൺലൈൻ പ്രവർത്തനങ്ങളും "
+"സ്വകാര്യമായി സൂക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
 #. An instruction to state that a list of companies/trackers will be updated with continued use
@@ -11730,7 +11858,9 @@ msgstr "DuckDuckGo ക്രമീകരണങ്ങൾ എങ്ങനെ ക�
 #. Description of a page with more information about how anonymous location works.
 msgctxt "precise_user_location"
 msgid "Learn how we keep your location private"
-msgstr "നിങ്ങളുടെ ലൊക്കേഷൻ ഞങ്ങൾ സ്വകാര്യമായി സൂക്ഷിക്കുന്നത് എങ്ങനെയെന്ന് മനസ്സിലാക്കുക"
+msgstr ""
+"നിങ്ങളുടെ ലൊക്കേഷൻ ഞങ്ങൾ സ്വകാര്യമായി സൂക്ഷിക്കുന്നത് എങ്ങനെയെന്ന് "
+"മനസ്സിലാക്കുക"
 
 # smartling.placeholder_format=C
 #. Link text in the Usage section of Duck.ai settings that opens a help page explaining Duck.ai usage limits.
@@ -11772,7 +11902,9 @@ msgstr "ഇത് എങ്ങനെ പ്രവർത്തിക്കുന�
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
 msgid "Learn why reducing online tracking is important."
-msgstr "ഓൺലൈൻ ട്രാക്കിംഗ് കുറയ്ക്കുന്നത് പ്രധാനമായിരിക്കുന്നത് എന്തുകൊണ്ടാണെന്ന് അറിയുക."
+msgstr ""
+"ഓൺലൈൻ ട്രാക്കിംഗ് കുറയ്ക്കുന്നത് പ്രധാനമായിരിക്കുന്നത് എന്തുകൊണ്ടാണെന്ന് "
+"അറിയുക."
 
 # smartling.placeholder_format=C
 #. A link that takes users to a page where they can learn more about the dangers of online tracking.
@@ -11835,8 +11967,8 @@ msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
 msgstr ""
-"Duck.ai-ലേക്ക് തിരയൽ ചോദ്യങ്ങളും പ്രോംപ്റ്റുകളും സമർപ്പിക്കുന്നത് തമ്മിൽ മാറാൻ നിങ്ങളെ "
-"അനുവദിക്കുന്നു"
+"Duck.ai-ലേക്ക് തിരയൽ ചോദ്യങ്ങളും പ്രോംപ്റ്റുകളും സമർപ്പിക്കുന്നത് തമ്മിൽ "
+"മാറാൻ നിങ്ങളെ അനുവദിക്കുന്നു"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11894,7 +12026,9 @@ msgstr "ഈ ചാറ്റിനായി പരിമിതമായ ഡാറ
 #. Description of a setting managing the length of search result snippet text.
 msgctxt "settings"
 msgid "Limits the amount of descriptive content shown for results"
-msgstr "ഫലങ്ങൾക്കായി കാണിക്കുന്ന വിവരണാത്മക ഉള്ളടക്കത്തിന്റെ അളവ് പരിമിതപ്പെടുത്തുന്നു"
+msgstr ""
+"ഫലങ്ങൾക്കായി കാണിക്കുന്ന വിവരണാത്മക ഉള്ളടക്കത്തിന്റെ അളവ് "
+"പരിമിതപ്പെടുത്തുന്നു"
 
 # smartling.placeholder_format=C
 #. i.e. a type of image comprised of lines without gradiations in shade or hue
@@ -11919,6 +12053,8 @@ msgstr "ലിങ്ക് 7 ദിവസത്തിനുള്ളിൽ ക�
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
+"ലിങ്ക് 7 ദിവസത്തിനുള്ളിൽ കാലഹരണപ്പെടുന്നു. ആളുകൾക്ക് ചാറ്റിന്റെ ഒരു പകർപ്പ് "
+"സംരക്ഷിക്കാനാകും."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11935,7 +12071,8 @@ msgstr "ലിങ്കുകൾ:"
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
 msgstr ""
-"ഇതിന് എനിക്ക് ആവശ്യമായ ഉപകരണങ്ങൾ, സാമഗ്രികൾ, അല്ലെങ്കിൽ മുൻകൂർ ആവശ്യകതകൾ ലിസ്റ്റ് ചെയ്യുക."
+"ഇതിന് എനിക്ക് ആവശ്യമായ ഉപകരണങ്ങൾ, സാമഗ്രികൾ, അല്ലെങ്കിൽ മുൻകൂർ ആവശ്യകതകൾ "
+"ലിസ്റ്റ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12047,7 +12184,8 @@ msgstr "സ്ക്രോൾ ചെയ്യുമ്പോൾ കൂടുത�
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
 msgstr ""
-"സ്ക്രോൾ ചെയ്യുമ്പോൾ ഇമേജുകൾ, വീഡിയോകൾ, ഷോപ്പിംഗ് എന്നിവയിൽ കൂടുതൽ ഫലങ്ങൾ ലോഡ് ചെയ്യുന്നു"
+"സ്ക്രോൾ ചെയ്യുമ്പോൾ ഇമേജുകൾ, വീഡിയോകൾ, ഷോപ്പിംഗ് എന്നിവയിൽ കൂടുതൽ ഫലങ്ങൾ "
+"ലോഡ് ചെയ്യുന്നു"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -12234,7 +12372,8 @@ msgstr "എല്ലാ വാക്കുകളും അക്ഷരത്ത�
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
 msgstr ""
-"%1$s\"ഇതിനെ എന്റെ ഡിഫോൾട്ട് തിരയല്‍ ദാതാവാക്കുക\"%2$s എന്നത് തിരഞ്ഞെടുത്തുവെന്ന് ഉറപ്പാക്കുക"
+"%1$s\"ഇതിനെ എന്റെ ഡിഫോൾട്ട് തിരയല്‍ ദാതാവാക്കുക\"%2$s എന്നത് "
+"തിരഞ്ഞെടുത്തുവെന്ന് ഉറപ്പാക്കുക"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -12593,7 +12732,9 @@ msgstr "മൈക്രോനേഷ്യ"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr "മൈക്രോഫോൺ പ്രവേശനം നിഷേധിച്ചു. മൈക്രോഫോൺ ആക്‌സസ് അനുവദിച്ച് വീണ്ടും ശ്രമിക്കുക."
+msgstr ""
+"മൈക്രോഫോൺ പ്രവേശനം നിഷേധിച്ചു. മൈക്രോഫോൺ ആക്‌സസ് അനുവദിച്ച് വീണ്ടും "
+"ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -13377,10 +13518,11 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"പുതിയ പ്രോംപ്റ്റുകളും പ്രതികരണങ്ങളും അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് താൽക്കാലികമായി ഒരു "
-"DuckDuckGo സെർവറിൽ സംഭരിക്കും, ഇത് നിങ്ങളുടെ ഇന്റർനെറ്റ് കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് "
-"വീണ്ടെടുക്കാൻ സഹായിക്കും. ചാറ്റ് ചരിത്രം പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്‌ത ചാറ്റുകൾ "
-"ഇല്ലാതാക്കുകയും പുതിയ പ്രോംപ്റ്റുകളുടെയും പ്രതികരണങ്ങളുടെയും താൽക്കാലിക സ്റ്റോറേജ് "
+"പുതിയ പ്രോംപ്റ്റുകളും പ്രതികരണങ്ങളും അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് "
+"താൽക്കാലികമായി ഒരു DuckDuckGo സെർവറിൽ സംഭരിക്കും, ഇത് നിങ്ങളുടെ ഇന്റർനെറ്റ് "
+"കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് വീണ്ടെടുക്കാൻ സഹായിക്കും. ചാറ്റ് ചരിത്രം "
+"പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്‌ത ചാറ്റുകൾ ഇല്ലാതാക്കുകയും പുതിയ "
+"പ്രോംപ്റ്റുകളുടെയും പ്രതികരണങ്ങളുടെയും താൽക്കാലിക സ്റ്റോറേജ് "
 "പ്രവർത്തനരഹിതമാക്കുകയും ചെയ്യും."
 
 # smartling.placeholder_format=C
@@ -14041,7 +14183,7 @@ msgstr "ശരി, കിട്ടി!"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "OPTIONAL"
-msgstr ""
+msgstr "ഐച്ഛികം"
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -14219,8 +14361,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
 msgstr ""
-"മറ്റൊരു ഉപകരണത്തിൽ %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s › %3$sചാറ്റുകൾ › Sync & Backup › "
-"മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%4$sഎന്നതിലേക്ക് പോകുക"
+"മറ്റൊരു ഉപകരണത്തിൽ %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s › %3$sചാറ്റുകൾ › Sync & "
+"Backup › മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%4$sഎന്നതിലേക്ക് പോകുക"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14229,8 +14371,9 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
 msgstr ""
-"മറ്റൊരു ഉപകരണത്തിൽ %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s › %3$sചാറ്റുകൾ › Sync & Backup › "
-"മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%4$s എന്നതിലേക്ക് പോയി ഈ കോഡ് സ്കാൻ ചെയ്യുക:"
+"മറ്റൊരു ഉപകരണത്തിൽ %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s › %3$sചാറ്റുകൾ › Sync & "
+"Backup › മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%4$s എന്നതിലേക്ക് പോയി ഈ കോഡ് "
+"സ്കാൻ ചെയ്യുക:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14239,9 +14382,9 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
-"മറ്റൊരു ഉപകരണത്തിൽ %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s › %3$sചാറ്റുകൾ › Sync & Backup › "
-"മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%4$s എന്നതിലേക്ക് പോകുക. അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി "
-"PDF-ലെ QR സ്കാൻ ചെയ്യുക."
+"മറ്റൊരു ഉപകരണത്തിൽ %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s › %3$sചാറ്റുകൾ › Sync & "
+"Backup › മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%4$s എന്നതിലേക്ക് പോകുക. "
+"അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി PDF-ലെ QR സ്കാൻ ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14269,8 +14412,9 @@ msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
 msgstr ""
-"അറ്റാച്ച് ചെയ്തിരിക്കുന്ന ഫയലുകളിൽ ഒന്നിൽ ഞങ്ങൾ പിന്തുണയ്ക്കുന്നതിനേക്കാൾ കൂടുതൽ പേജുകളുണ്ട്. %1$s "
-"അല്ലെങ്കിൽ അതിൽ കുറവ് പേജുകളുള്ള ഫയലുകൾ അപ്‌ലോഡ് ചെയ്യുക."
+"അറ്റാച്ച് ചെയ്തിരിക്കുന്ന ഫയലുകളിൽ ഒന്നിൽ ഞങ്ങൾ പിന്തുണയ്ക്കുന്നതിനേക്കാൾ "
+"കൂടുതൽ പേജുകളുണ്ട്. %1$s അല്ലെങ്കിൽ അതിൽ കുറവ് പേജുകളുള്ള ഫയലുകൾ അപ്‌ലോഡ് "
+"ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -14313,8 +14457,8 @@ msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
 msgstr ""
-"ക്ഷമിക്കണം! ഈ ടെക്‌സ്റ്റ് വിവർത്തനം ചെയ്യുന്ന സമയത്ത് ഒരു അപ്രതീക്ഷിത പിശകുണ്ടായി. പിന്നീട് "
-"വീണ്ടും ശ്രമിക്കുക."
+"ക്ഷമിക്കണം! ഈ ടെക്‌സ്റ്റ് വിവർത്തനം ചെയ്യുന്ന സമയത്ത് ഒരു അപ്രതീക്ഷിത "
+"പിശകുണ്ടായി. പിന്നീട് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -14368,8 +14512,8 @@ msgstr "%1$s വെബ്‌സൈറ്റ് തുറക്കുക"
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
 msgstr ""
-"%1$s'ലൊക്കേഷൻ'%2$s തുറക്കുക, തുടര്‍ന്ന് ലൊക്കേഷൻ %3$sപ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന്%4$s "
-"ഉറപ്പാക്കുക"
+"%1$s'ലൊക്കേഷൻ'%2$s തുറക്കുക, തുടര്‍ന്ന് ലൊക്കേഷൻ "
+"%3$sപ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന്%4$s ഉറപ്പാക്കുക"
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -14390,7 +14534,8 @@ msgstr "%1$sക്രമീകരണം%2$s തുറക്കുക"
 msgctxt "precise_user_location"
 msgid "Open 'Location', and ensure location is %senabled%s."
 msgstr ""
-"'ലൊക്കേഷൻ' തുറക്കുക, തുടര്‍ന്ന് ലൊക്കേഷൻ %1$sപ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന്%2$s ഉറപ്പാക്കുക."
+"'ലൊക്കേഷൻ' തുറക്കുക, തുടര്‍ന്ന് ലൊക്കേഷൻ "
+"%1$sപ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന്%2$s ഉറപ്പാക്കുക."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -14539,7 +14684,9 @@ msgstr "How Duck.ai വർക്ക്സ് പാനൽ തുറക്കു�
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr "Safari മെനു തുറന്ന് %1$sDuckDuckGo എന്നതിനായുള്ള ക്രമീകരണങ്ങൾ%2$s തിരഞ്ഞെടുക്കുക..."
+msgstr ""
+"Safari മെനു തുറന്ന് %1$sDuckDuckGo എന്നതിനായുള്ള ക്രമീകരണങ്ങൾ%2$s "
+"തിരഞ്ഞെടുക്കുക..."
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14640,8 +14787,9 @@ msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
 msgstr ""
-"നിങ്ങൾ സ്വകാര്യ ബ്രൗസിംഗ് മോഡിൽ ആയിരിക്കുമ്പോൾ പോലും മറ്റ് തിരയൽ എഞ്ചിനുകൾ നിങ്ങളുടെ "
-"തിരയലുകളെ ട്രാക്ക് ചെയ്യുന്നു. ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല — കാലഘട്ടം"
+"നിങ്ങൾ സ്വകാര്യ ബ്രൗസിംഗ് മോഡിൽ ആയിരിക്കുമ്പോൾ പോലും മറ്റ് തിരയൽ എഞ്ചിനുകൾ "
+"നിങ്ങളുടെ തിരയലുകളെ ട്രാക്ക് ചെയ്യുന്നു. ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് "
+"ചെയ്യുന്നില്ല — കാലഘട്ടം"
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -14655,8 +14803,9 @@ msgid ""
 "Our fast, no-log VPN comes with smarter AI chats with higher limits, plus "
 "more premium protections. All in one subscription."
 msgstr ""
-"ഞങ്ങളുടെ വേഗതയേറിയ, നോ-ലോഗ് VPN-നൊപ്പം ഉയർന്ന പരിധികളുള്ള മികച്ച AI ചാറ്റുകളും കൂടുതൽ "
-"പ്രീമിയം പരിരക്ഷകളും ലഭിക്കുന്നു. എല്ലാം ഉൾപ്പെട്ട ഒരു സബ്‌സ്‌ക്രിപ്‌ഷൻ."
+"ഞങ്ങളുടെ വേഗതയേറിയ, നോ-ലോഗ് VPN-നൊപ്പം ഉയർന്ന പരിധികളുള്ള മികച്ച AI "
+"ചാറ്റുകളും കൂടുതൽ പ്രീമിയം പരിരക്ഷകളും ലഭിക്കുന്നു. എല്ലാം ഉൾപ്പെട്ട ഒരു "
+"സബ്‌സ്‌ക്രിപ്‌ഷൻ."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -14664,8 +14813,8 @@ msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
 msgstr ""
-"ഞങ്ങളുടെ സ്വകാര്യത നയം ലളിതമാണ്: ഞങ്ങൾ നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങളിൽ ഒന്നും ശേഖരിക്കുകയോ "
-"പങ്കുവയ്ക്കുകയോ ചെയ്യില്ല."
+"ഞങ്ങളുടെ സ്വകാര്യത നയം ലളിതമാണ്: ഞങ്ങൾ നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങളിൽ ഒന്നും "
+"ശേഖരിക്കുകയോ പങ്കുവയ്ക്കുകയോ ചെയ്യില്ല."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -14673,9 +14822,9 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"ഞങ്ങളുടെ തിരയൽ എഞ്ചിൻ, ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ തുടങ്ങിയവ ഉൾപ്പെടുത്തി "
-"മൊബൈലിനായുള്ള ഞങ്ങളുടെ സ്വകാര്യ ബ്രൗസർ ലഭിക്കുന്നു. %1$siOS, Android%2$s എന്നിവയിൽ "
-"ലഭ്യമാണ്."
+"ഞങ്ങളുടെ തിരയൽ എഞ്ചിൻ, ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ തുടങ്ങിയവ "
+"ഉൾപ്പെടുത്തി മൊബൈലിനായുള്ള ഞങ്ങളുടെ സ്വകാര്യ ബ്രൗസർ ലഭിക്കുന്നു. %1$siOS, "
+"Android%2$s എന്നിവയിൽ ലഭ്യമാണ്."
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14928,8 +15077,9 @@ msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
 msgstr ""
-"നിങ്ങളുടെ ഐപി വിലാസം, ബ്രൗസർ ഫിംഗർപ്രിന്റ് അല്ലെങ്കിൽ മറ്റേതെങ്കിലും വിവരങ്ങൾ ഞങ്ങൾ "
-"ഫയലുമായി ബന്ധപ്പെടുത്താത്തതിനാൽ പാസ്‌ഫ്രെയ്സുകൾ വീണ്ടെടുക്കാൻ കഴിയില്ല."
+"നിങ്ങളുടെ ഐപി വിലാസം, ബ്രൗസർ ഫിംഗർപ്രിന്റ് അല്ലെങ്കിൽ മറ്റേതെങ്കിലും "
+"വിവരങ്ങൾ ഞങ്ങൾ ഫയലുമായി ബന്ധപ്പെടുത്താത്തതിനാൽ പാസ്‌ഫ്രെയ്സുകൾ വീണ്ടെടുക്കാൻ "
+"കഴിയില്ല."
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -15085,8 +15235,9 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
-"Personal Information Removal നിങ്ങളുടെ വിവരങ്ങൾ വിൽക്കുന്ന ഡാറ്റ ബ്രോക്കർ സൈറ്റുകളിൽ അത് "
-"കണ്ടെത്തുന്നു. തുടർന്ന് അത് നിങ്ങൾക്കായി നീക്കം ചെയ്യാൻ ഞങ്ങൾ പ്രവർത്തിക്കുന്നു."
+"Personal Information Removal നിങ്ങളുടെ വിവരങ്ങൾ വിൽക്കുന്ന ഡാറ്റ ബ്രോക്കർ "
+"സൈറ്റുകളിൽ അത് കണ്ടെത്തുന്നു. തുടർന്ന് അത് നിങ്ങൾക്കായി നീക്കം ചെയ്യാൻ ഞങ്ങൾ "
+"പ്രവർത്തിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15157,9 +15308,10 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് AI സഹായമുള്ള ഉത്തരങ്ങൾ "
-"സ്വയമേവ പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും പലപ്പോഴും മികച്ച ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. "
-"അവ ഓഫാക്കാനും Assist ബട്ടൺ മറയ്ക്കാനും %1$sതിരയൽ ക്രമീകരണങ്ങൾ%2$s സന്ദർശിക്കുക."
+"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് AI "
+"സഹായമുള്ള ഉത്തരങ്ങൾ സ്വയമേവ പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും "
+"പലപ്പോഴും മികച്ച ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. അവ ഓഫാക്കാനും Assist ബട്ടൺ "
+"മറയ്ക്കാനും %1$sതിരയൽ ക്രമീകരണങ്ങൾ%2$s സന്ദർശിക്കുക."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15168,10 +15320,10 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് DuckAssist "
-"പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും പലപ്പോഴും മികച്ച ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. ഈ "
-"സവിശേഷത എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്ന് ക്രമീകരിക്കാനോ ഓഫ് ചെയ്യാനോ, %1$sDuckAssist "
-"ക്രമീകരണങ്ങൾ%2$sസന്ദർശിക്കുക."
+"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് "
+"DuckAssist പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും പലപ്പോഴും മികച്ച "
+"ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. ഈ സവിശേഷത എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്ന് "
+"ക്രമീകരിക്കാനോ ഓഫ് ചെയ്യാനോ, %1$sDuckAssist ക്രമീകരണങ്ങൾ%2$sസന്ദർശിക്കുക."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15181,9 +15333,10 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് DuckAssist സ്വയമേവ "
-"പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും പലപ്പോഴും മികച്ച ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. ഇത് "
-"ഓഫാക്കാനും അസിസ്റ്റ് ബട്ടൺ മറയ്ക്കാനും %1$sDuckAssist ക്രമീകരണം%2$s സന്ദർശിക്കുക."
+"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് "
+"DuckAssist സ്വയമേവ പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും പലപ്പോഴും "
+"മികച്ച ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. ഇത് ഓഫാക്കാനും അസിസ്റ്റ് ബട്ടൺ "
+"മറയ്ക്കാനും %1$sDuckAssist ക്രമീകരണം%2$s സന്ദർശിക്കുക."
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -15216,8 +15369,8 @@ msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
 msgstr ""
-"GPT-5 mini, Claude Haiku 4.5, Mistra തുടങ്ങിയ ജനപ്രിയ AI-കളുമായി ചാറ്റ് ചെയ്യാൻ "
-"തിരഞ്ഞെടുക്കുക."
+"GPT-5 mini, Claude Haiku 4.5, Mistra തുടങ്ങിയ ജനപ്രിയ AI-കളുമായി ചാറ്റ് "
+"ചെയ്യാൻ തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -15226,8 +15379,8 @@ msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, "
 "Mistral, etc."
 msgstr ""
-"GPT-5 mini, Claude Haiku 4.5, Mistral,   തുടങ്ങിയ ജനപ്രിയ AI-കളുമായി ചാറ്റ് ചെയ്യാൻ "
-"തിരഞ്ഞെടുക്കുക."
+"GPT-5 mini, Claude Haiku 4.5, Mistral,   തുടങ്ങിയ ജനപ്രിയ AI-കളുമായി ചാറ്റ് "
+"ചെയ്യാൻ തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. The description of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -15236,8 +15389,8 @@ msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
 msgstr ""
-"നിന്റെ ലക്ഷ്യസ്ഥാനത്തേക്ക് നാവിഗേറ്റ് ചെയ്യാൻ ഒരു സേവനം തിരഞ്ഞെടുക്കൂ. ബാഹ്യ ആപ്പുകൾക്ക് "
-"DuckDuckGo സംരക്ഷണങ്ങൾ ലഭ്യമല്ല."
+"നിന്റെ ലക്ഷ്യസ്ഥാനത്തേക്ക് നാവിഗേറ്റ് ചെയ്യാൻ ഒരു സേവനം തിരഞ്ഞെടുക്കൂ. ബാഹ്യ "
+"ആപ്പുകൾക്ക് DuckDuckGo സംരക്ഷണങ്ങൾ ലഭ്യമല്ല."
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -15250,8 +15403,8 @@ msgstr "ഒരു നിർദിഷ്ട പ്രശ്നം തിരഞ്
 msgid ""
 "Pick your ad blocker and follow the instructions to allow ads on DuckDuckGo."
 msgstr ""
-"നിങ്ങളുടെ പരസ്യ ബ്ലോക്കർ തിരഞ്ഞെടുക്കുക, DuckDuckGo-ൽ പരസ്യങ്ങൾ അനുവദിക്കാൻ നിർദ്ദേശങ്ങൾ "
-"പാലിക്കുക."
+"നിങ്ങളുടെ പരസ്യ ബ്ലോക്കർ തിരഞ്ഞെടുക്കുക, DuckDuckGo-ൽ പരസ്യങ്ങൾ അനുവദിക്കാൻ "
+"നിർദ്ദേശങ്ങൾ പാലിക്കുക."
 
 # smartling.placeholder_format=C
 #. Text for a button that pins a chat, as in it will it will add the chat to the pinned chats list.
@@ -15340,7 +15493,8 @@ msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
 msgstr ""
-"ഈ പ്രോംപ്റ്റ് നടത്തിയത് ഒരു മനുഷ്യനാണെന്ന് സ്ഥിരീകരിക്കാൻ ഇനിപ്പറയുന്ന ചലഞ്ച് പൂർത്തിയാക്കുക."
+"ഈ പ്രോംപ്റ്റ് നടത്തിയത് ഒരു മനുഷ്യനാണെന്ന് സ്ഥിരീകരിക്കാൻ ഇനിപ്പറയുന്ന "
+"ചലഞ്ച് പൂർത്തിയാക്കുക."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -15349,23 +15503,24 @@ msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
 msgstr ""
-"ഈ തിരയൽ നടത്തിയത് ഒരു മനുഷ്യനാണെന്ന് സ്ഥിരീകരിക്കാൻ ഇനിപ്പറയുന്ന വെല്ലുവിളി പൂർത്തിയാക്കുക."
+"ഈ തിരയൽ നടത്തിയത് ഒരു മനുഷ്യനാണെന്ന് സ്ഥിരീകരിക്കാൻ ഇനിപ്പറയുന്ന വെല്ലുവിളി "
+"പൂർത്തിയാക്കുക."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
 msgstr ""
-"ചാറ്റ് പ്രതികരണം ദോഷകരമോ നിയമവിരുദ്ധമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് ദയവായി വിശദീകരിക്കുക. "
-"(ഓപ്ഷണൽ)"
+"ചാറ്റ് പ്രതികരണം ദോഷകരമോ നിയമവിരുദ്ധമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് ദയവായി "
+"വിശദീകരിക്കുക. (ഓപ്ഷണൽ)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
-"ചാറ്റ് പ്രതികരണം നിയമവിരുദ്ധമോ ദോഷകരമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് ദയവായി വിശദീകരിക്കുക. "
-"(ഓപ്ഷണൽ)"
+"ചാറ്റ് പ്രതികരണം നിയമവിരുദ്ധമോ ദോഷകരമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് ദയവായി "
+"വിശദീകരിക്കുക. (ഓപ്ഷണൽ)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -15386,8 +15541,8 @@ msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
 msgstr ""
-"ദയവായി ശ്രദ്ധിക്കുക: ഏതെങ്കിലും മോഡലുമായി ഒരു പുതിയ ചാറ്റ് ആരംഭിക്കുന്നത് നിങ്ങളുടെ നിലവിലെ "
-"ചാറ്റ് സെഷൻ ഇല്ലാതാക്കും."
+"ദയവായി ശ്രദ്ധിക്കുക: ഏതെങ്കിലും മോഡലുമായി ഒരു പുതിയ ചാറ്റ് ആരംഭിക്കുന്നത് "
+"നിങ്ങളുടെ നിലവിലെ ചാറ്റ് സെഷൻ ഇല്ലാതാക്കും."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15396,8 +15551,9 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
-"നിങ്ങളുടെ പ്രോംപ്റ്റും പ്രശ്നമുള്ള ഔട്ട്പുട്ടും (ഏതെങ്കിലും വ്യക്തിഗത വിവരങ്ങൾ നീക്കം ചെയ്തത്) "
-"ഒട്ടിക്കുക, കൂടാതെ ഉള്ളടക്കം ദോഷകരമോ നിയമവിരുദ്ധമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് വിവരിക്കുക."
+"നിങ്ങളുടെ പ്രോംപ്റ്റും പ്രശ്നമുള്ള ഔട്ട്പുട്ടും (ഏതെങ്കിലും വ്യക്തിഗത "
+"വിവരങ്ങൾ നീക്കം ചെയ്തത്) ഒട്ടിക്കുക, കൂടാതെ ഉള്ളടക്കം ദോഷകരമോ നിയമവിരുദ്ധമോ "
+"ആകുന്നത് എന്തുകൊണ്ടെന്ന് വിവരിക്കുക."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15406,8 +15562,9 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
 msgstr ""
-"നിങ്ങളുടെ പ്രോംപ്റ്റും പ്രശ്നമുള്ള ഔട്ട്പുട്ടും (ഏതെങ്കിലും വ്യക്തിഗത വിവരങ്ങൾ നീക്കം ചെയ്തത്) "
-"ഒട്ടിക്കുക, കൂടാതെ ഉള്ളടക്കം നിയമവിരുദ്ധമോ ദോഷകരമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് വിവരിക്കുക."
+"നിങ്ങളുടെ പ്രോംപ്റ്റും പ്രശ്നമുള്ള ഔട്ട്പുട്ടും (ഏതെങ്കിലും വ്യക്തിഗത "
+"വിവരങ്ങൾ നീക്കം ചെയ്തത്) ഒട്ടിക്കുക, കൂടാതെ ഉള്ളടക്കം നിയമവിരുദ്ധമോ ദോഷകരമോ "
+"ആകുന്നത് എന്തുകൊണ്ടെന്ന് വിവരിക്കുക."
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -15560,7 +15717,8 @@ msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
 msgstr ""
-"കൂടാതെ, Duck Player-ൽ നിങ്ങൾ കാണുന്നത് YouTube-ലെ നിങ്ങളുടെ ശുപാർശകളെ സ്വാധീനിക്കുകയില്ല."
+"കൂടാതെ, Duck Player-ൽ നിങ്ങൾ കാണുന്നത് YouTube-ലെ നിങ്ങളുടെ ശുപാർശകളെ "
+"സ്വാധീനിക്കുകയില്ല."
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -15623,7 +15781,8 @@ msgstr "മോശം ഫോർമാറ്റിംഗ്"
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
 msgstr ""
-"ജനപ്രിയ AI മോഡലുകൾ ലഭ്യമാണ്. അക്കൗണ്ട് ആവശ്യമില്ല. ചാറ്റുകൾ ഞങ്ങൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു."
+"ജനപ്രിയ AI മോഡലുകൾ ലഭ്യമാണ്. അക്കൗണ്ട് ആവശ്യമില്ല. ചാറ്റുകൾ ഞങ്ങൾ "
+"അജ്ഞാതമാക്കിയിരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -16132,7 +16291,9 @@ msgstr "എന്നെ പ്രോംപ്റ്റ് ചെയ്യു�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr "സമീപത്തുള്ള ഫലങ്ങൾക്കായി എന്റെ ഏകദേശ ലൊക്കേഷൻ ഉപയോഗിക്കാൻ എന്നോട് നിർദേശിക്കുക."
+msgstr ""
+"സമീപത്തുള്ള ഫലങ്ങൾക്കായി എന്റെ ഏകദേശ ലൊക്കേഷൻ ഉപയോഗിക്കാൻ എന്നോട് "
+"നിർദേശിക്കുക."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -16150,7 +16311,9 @@ msgstr "നിങ്ങൾ തിരയുകയും ബ്രൗസ് ചെ
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
-msgstr "തിരയുമ്പോഴും, ബ്രൗസ് ചെയ്യുമ്പോഴും, AI ഉപയോഗിക്കുമ്പോഴും നിങ്ങളുടെ ഡാറ്റ സംരക്ഷിക്കുക."
+msgstr ""
+"തിരയുമ്പോഴും, ബ്രൗസ് ചെയ്യുമ്പോഴും, AI ഉപയോഗിക്കുമ്പോഴും നിങ്ങളുടെ ഡാറ്റ "
+"സംരക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -16167,7 +16330,7 @@ msgstr "സംരക്ഷിതം"
 #. Headline in sync-enabled chat history about modals explaining encrypted server storage.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Protected with end-to-end encryption"
-msgstr ""
+msgstr "എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് പരിരക്ഷിച്ചിരിക്കുന്നു"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -16181,8 +16344,8 @@ msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
 msgstr ""
-"ഇനിപ്പറയുന്ന വാചകം കൂടുതൽ സംക്ഷിപ്തമാക്കാൻ കുറച്ച് നിർദ്ദേശങ്ങൾ നൽകുക. [നിങ്ങളുടെ സ്വന്തം "
-"വാചകം ഇവിടെ ചേർക്കുക.]"
+"ഇനിപ്പറയുന്ന വാചകം കൂടുതൽ സംക്ഷിപ്തമാക്കാൻ കുറച്ച് നിർദ്ദേശങ്ങൾ നൽകുക. "
+"[നിങ്ങളുടെ സ്വന്തം വാചകം ഇവിടെ ചേർക്കുക.]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -16306,7 +16469,7 @@ msgstr "റാങ്കിംഗുകൾ"
 #. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
 msgctxt "star rating on a product"
 msgid "Rated %s out of %s"
-msgstr ""
+msgstr "%2$s-ൽ %1$s റേറ്റ് ചെയ്തു"
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -16406,14 +16569,16 @@ msgstr "സങ്കീർണ്ണമായ ചോദ്യങ്ങൾക്�
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
 msgstr ""
-"റീസണിംഗ് കൂടുതൽ സമഗ്രമാണ്, എന്നാൽ 2 മുതൽ 5 മടങ്ങ് വരെ വേഗത്തിൽ ഉപയോഗ പരിധിയിലെത്തുന്നു. "
-"%1$s"
+"റീസണിംഗ് കൂടുതൽ സമഗ്രമാണ്, എന്നാൽ 2 മുതൽ 5 മടങ്ങ് വരെ വേഗത്തിൽ ഉപയോഗ "
+"പരിധിയിലെത്തുന്നു. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr "റീസണിംഗ് കൂടുതൽ സമഗ്രമാണ്, എന്നാൽ പരിധികൾ 2-5 മടങ്ങ് വേഗത്തിൽ ഉപയോഗിക്കുന്നു. %1$s"
+msgstr ""
+"റീസണിംഗ് കൂടുതൽ സമഗ്രമാണ്, എന്നാൽ പരിധികൾ 2-5 മടങ്ങ് വേഗത്തിൽ "
+"ഉപയോഗിക്കുന്നു. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -16463,8 +16628,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"സമീപകാല ചാറ്റുകൾ DuckDuckGo സെർവറുകൾക്കോ മറ്റ് വിദൂര സെർവറുകൾക്കോ പകരം നിങ്ങളുടെ "
-"ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിച്ചിരിക്കുന്നു."
+"സമീപകാല ചാറ്റുകൾ DuckDuckGo സെർവറുകൾക്കോ മറ്റ് വിദൂര സെർവറുകൾക്കോ പകരം "
+"നിങ്ങളുടെ ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിച്ചിരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -16473,8 +16638,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"സമീപകാല ചാറ്റുകൾ DuckDuckGo സെർവറുൾക്കോ മറ്റ് വിദൂര സെർവറുകൾക്കോ പകരം നിങ്ങളുടെ "
-"ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിച്ചിരിക്കുന്നു."
+"സമീപകാല ചാറ്റുകൾ DuckDuckGo സെർവറുൾക്കോ മറ്റ് വിദൂര സെർവറുകൾക്കോ പകരം "
+"നിങ്ങളുടെ ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിച്ചിരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -16484,9 +16649,10 @@ msgid ""
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
 msgstr ""
-"സമീപകാല ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ തന്നെ സംഭരിച്ചിരിക്കുന്നു. പുതിയ പ്രോംപ്റ്റുകളും "
-"പ്രതികരണങ്ങളും അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് താൽക്കാലികമായി ഒരു DuckDuckGo സെർവറിൽ "
-"സംഭരിക്കും, ഇത് നിങ്ങളുടെ ഇന്റർനെറ്റ് കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് വീണ്ടെടുക്കാൻ സഹായിക്കും."
+"സമീപകാല ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ തന്നെ സംഭരിച്ചിരിക്കുന്നു. പുതിയ "
+"പ്രോംപ്റ്റുകളും പ്രതികരണങ്ങളും അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് "
+"താൽക്കാലികമായി ഒരു DuckDuckGo സെർവറിൽ സംഭരിക്കും, ഇത് നിങ്ങളുടെ ഇന്റർനെറ്റ് "
+"കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് വീണ്ടെടുക്കാൻ സഹായിക്കും."
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -16628,8 +16794,8 @@ msgid ""
 "Reduces extra space in and around results and reduces size of result title "
 "text"
 msgstr ""
-"ഫലങ്ങളിലും ചുറ്റുമുള്ള അധിക ഇടം കുറയ്ക്കുകയും ഫലമായുള്ള ശീർഷക ടെക്സ്റ്റിന്റെ വലുപ്പം കുറയ്ക്കുകയും "
-"ചെയ്യുന്നു"
+"ഫലങ്ങളിലും ചുറ്റുമുള്ള അധിക ഇടം കുറയ്ക്കുകയും ഫലമായുള്ള ശീർഷക ടെക്സ്റ്റിന്റെ "
+"വലുപ്പം കുറയ്ക്കുകയും ചെയ്യുന്നു"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'Refer to me as John'
@@ -16770,8 +16936,9 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"നിർദ്ദേശങ്ങൾ പാലിച്ച് DuckDuckGo വീണ്ടും ലോഡ് ചെയ്യുക, അല്ലെങ്കിൽ നിങ്ങളുടെ ബ്രൗസറിലെ "
-"&quot;റിഫ്രഷ്&quot; അല്ലെങ്കിൽ &quot;റീലോഡ്&quot; ബട്ടൺ ക്ലിക്ക് ചെയ്യുക."
+"നിർദ്ദേശങ്ങൾ പാലിച്ച് DuckDuckGo വീണ്ടും ലോഡ് ചെയ്യുക, അല്ലെങ്കിൽ നിങ്ങളുടെ "
+"ബ്രൗസറിലെ &quot;റിഫ്രഷ്&quot; അല്ലെങ്കിൽ &quot;റീലോഡ്&quot; ബട്ടൺ ക്ലിക്ക് "
+"ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16879,8 +17046,9 @@ msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
 msgstr ""
-"\"ചോദിക്കുക\" ബട്ടൺ നീക്കം ചെയ്യുന്നതിനാൽ പ്രസക്തമായ തിരയലുകളുടെ പ്രതികരണമായി ഉത്തരങ്ങൾ "
-"സ്വയമേവ ദൃശ്യമാകും. കാഷെ ചെയ്‌ത ഉത്തരങ്ങൾ എപ്പോഴും സ്വയമേവ പ്രദർശിപ്പിക്കും."
+"\"ചോദിക്കുക\" ബട്ടൺ നീക്കം ചെയ്യുന്നതിനാൽ പ്രസക്തമായ തിരയലുകളുടെ "
+"പ്രതികരണമായി ഉത്തരങ്ങൾ സ്വയമേവ ദൃശ്യമാകും. കാഷെ ചെയ്‌ത ഉത്തരങ്ങൾ എപ്പോഴും "
+"സ്വയമേവ പ്രദർശിപ്പിക്കും."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16888,8 +17056,9 @@ msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
 msgstr ""
-"\"ചോദിക്കുക\" ബട്ടൺ നീക്കം ചെയ്യുന്നതിനാൽ പ്രസക്തമായ തിരയലുകളുടെ പ്രതികരണമായി ഉത്തരങ്ങൾ "
-"സ്വയമേവ ദൃശ്യമാകും. കാഷെ ചെയ്ത ഉത്തരങ്ങൾ എപ്പോഴും സ്വയമേവ പ്രദർശിപ്പിക്കും."
+"\"ചോദിക്കുക\" ബട്ടൺ നീക്കം ചെയ്യുന്നതിനാൽ പ്രസക്തമായ തിരയലുകളുടെ "
+"പ്രതികരണമായി ഉത്തരങ്ങൾ സ്വയമേവ ദൃശ്യമാകും. കാഷെ ചെയ്ത ഉത്തരങ്ങൾ എപ്പോഴും "
+"സ്വയമേവ പ്രദർശിപ്പിക്കും."
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -16947,9 +17116,10 @@ msgid ""
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
 msgstr ""
-"റിപ്പോർട്ടുകൾ അജ്ഞാതമാണ്, ഞങ്ങളുടെ തിരയൽ സേവനം മെച്ചപ്പെടുത്താൻ സഹായിക്കുന്നതിന് അവ "
-"DuckDuckGo-ലേക്ക് അയയ്ക്കുന്നു. അവരുടെ സേവനങ്ങൾ മെച്ചപ്പെടുത്താൻ സഹായിക്കുന്നതിന് നിങ്ങളുടെ "
-"അജ്ഞാത ഫീഡ്ബാക്കും %1$s-ലേക്ക് അയയ്ക്കാറുണ്ട്."
+"റിപ്പോർട്ടുകൾ അജ്ഞാതമാണ്, ഞങ്ങളുടെ തിരയൽ സേവനം മെച്ചപ്പെടുത്താൻ "
+"സഹായിക്കുന്നതിന് അവ DuckDuckGo-ലേക്ക് അയയ്ക്കുന്നു. അവരുടെ സേവനങ്ങൾ "
+"മെച്ചപ്പെടുത്താൻ സഹായിക്കുന്നതിന് നിങ്ങളുടെ അജ്ഞാത ഫീഡ്ബാക്കും %1$s-ലേക്ക് "
+"അയയ്ക്കാറുണ്ട്."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16957,8 +17127,8 @@ msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo-ലേക്ക് അയയ്ക്കുന്ന റിപ്പോർട്ടുകൾ അജ്ഞാതമാണ്. നിങ്ങളുടെ ഫീഡ്ബാക്കിൽ വ്യക്തിപരമോ "
-"തിരിച്ചറിയുന്നതോ ആയ വിവരങ്ങളൊന്നും ഉൾപ്പെടുത്തരുത്."
+"DuckDuckGo-ലേക്ക് അയയ്ക്കുന്ന റിപ്പോർട്ടുകൾ അജ്ഞാതമാണ്. നിങ്ങളുടെ "
+"ഫീഡ്ബാക്കിൽ വ്യക്തിപരമോ തിരിച്ചറിയുന്നതോ ആയ വിവരങ്ങളൊന്നും ഉൾപ്പെടുത്തരുത്."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16967,9 +17137,10 @@ msgid ""
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo-ലേക്ക് അയച്ച റിപ്പോർട്ടുകളിൽ ഈ പേജ് ലോഡിനിടെ നിങ്ങൾ ഞങ്ങളോട് വിവർത്തനം "
-"ചെയ്യാൻ ആവശ്യപ്പെട്ട എല്ലാ വാചകങ്ങളും ഉൾപ്പെടുന്നു, അവ അജ്ഞാതവുമാണ്. നിങ്ങളുടെ ഫീഡ്ബാക്കിൽ "
-"വ്യക്തിപരമോ തിരിച്ചറിയുന്നതോ ആയ വിവരങ്ങളൊന്നും ഉൾപ്പെടുത്തരുത്."
+"DuckDuckGo-ലേക്ക് അയച്ച റിപ്പോർട്ടുകളിൽ ഈ പേജ് ലോഡിനിടെ നിങ്ങൾ ഞങ്ങളോട് "
+"വിവർത്തനം ചെയ്യാൻ ആവശ്യപ്പെട്ട എല്ലാ വാചകങ്ങളും ഉൾപ്പെടുന്നു, അവ "
+"അജ്ഞാതവുമാണ്. നിങ്ങളുടെ ഫീഡ്ബാക്കിൽ വ്യക്തിപരമോ തിരിച്ചറിയുന്നതോ ആയ "
+"വിവരങ്ങളൊന്നും ഉൾപ്പെടുത്തരുത്."
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -17061,9 +17232,10 @@ msgid ""
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
-"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, സാമ്പത്തിക, "
-"നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ ഉദ്ദേശിച്ചിട്ടില്ല. AI- "
-"സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ ഞങ്ങളുടെ %1$sസേവന നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
+"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, "
+"സാമ്പത്തിക, നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ "
+"ഉദ്ദേശിച്ചിട്ടില്ല. AI- സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ ഞങ്ങളുടെ %1$sസേവന "
+"നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -17072,9 +17244,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
 msgstr ""
-"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, സാമ്പത്തിക, "
-"നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ ഉദ്ദേശിച്ചിട്ടില്ല. DuckAssist "
-"ഞങ്ങളുടെ %1$sസേവന നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
+"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, "
+"സാമ്പത്തിക, നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ "
+"ഉദ്ദേശിച്ചിട്ടില്ല. DuckAssist ഞങ്ങളുടെ %1$sസേവന നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -17084,10 +17256,11 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, സാമ്പത്തിക, "
-"നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ ഉദ്ദേശിച്ചിട്ടില്ല. അവ വെബ് "
-"ഉള്ളടക്കത്തെ അടിസ്ഥാനമാക്കി സൃഷ്ടിക്കപ്പെട്ടതാണ്, കൂടാതെ കൃത്യതയില്ലായ്മകൾ ഉണ്ടാകാം. Search "
-"Assist ഞങ്ങളുടെ %1$sസേവന നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
+"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, "
+"സാമ്പത്തിക, നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ "
+"ഉദ്ദേശിച്ചിട്ടില്ല. അവ വെബ് ഉള്ളടക്കത്തെ അടിസ്ഥാനമാക്കി "
+"സൃഷ്ടിക്കപ്പെട്ടതാണ്, കൂടാതെ കൃത്യതയില്ലായ്മകൾ ഉണ്ടാകാം. Search Assist "
+"ഞങ്ങളുടെ %1$sസേവന നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -17164,8 +17337,8 @@ msgstr "ബ്ലോക്ക് ചെയ്‌ത സൈറ്റുകളി�
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
 msgstr ""
-"ഫലങ്ങളിൽ നിങ്ങളുടെ തടഞ്ഞ സൈറ്റുകൾ ഉൾപ്പെടുന്നില്ല, അവ നിങ്ങളുടെ %1$s-ൽ കൈകാര്യം ചെയ്യാൻ "
-"കഴിയും."
+"ഫലങ്ങളിൽ നിങ്ങളുടെ തടഞ്ഞ സൈറ്റുകൾ ഉൾപ്പെടുന്നില്ല, അവ നിങ്ങളുടെ %1$s-ൽ "
+"കൈകാര്യം ചെയ്യാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -17514,16 +17687,17 @@ msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
 msgstr ""
-"എൻക്രിപ്റ്റ് ചെയ്ത സ്റ്റോറേജ് ഉപയോഗിച്ച് കൂടുതൽ എന്ന ഓപ്ഷൻ ഉപയോഗിച്ച് നിങ്ങളുടെ ഏറ്റവും പുതിയ "
-"ചാറ്റുകളിൽ 30 എണ്ണം വരെ നിങ്ങളുടെ ഉപകരണത്തിൽ പ്രാദേശികമായി സംരക്ഷിക്കുക."
+"എൻക്രിപ്റ്റ് ചെയ്ത സ്റ്റോറേജ് ഉപയോഗിച്ച് കൂടുതൽ എന്ന ഓപ്ഷൻ ഉപയോഗിച്ച് "
+"നിങ്ങളുടെ ഏറ്റവും പുതിയ ചാറ്റുകളിൽ 30 എണ്ണം വരെ നിങ്ങളുടെ ഉപകരണത്തിൽ "
+"പ്രാദേശികമായി സംരക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
 msgctxt "Short description for Chat History feature on native DDG browsers"
 msgid "Save up to 30 of your most recent chats locally on your device."
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണത്തിൽ നിങ്ങളുടെ ഏറ്റവും പുതിയ ചാറ്റുകളിൽ 30 എണ്ണം വരെ പ്രാദേശികമായി "
-"സംരക്ഷിക്കുക."
+"നിങ്ങളുടെ ഉപകരണത്തിൽ നിങ്ങളുടെ ഏറ്റവും പുതിയ ചാറ്റുകളിൽ 30 എണ്ണം വരെ "
+"പ്രാദേശികമായി സംരക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
 #. Desktop/mobile intro modal body under the title per Sync Chats Figma (choose step).
@@ -17531,7 +17705,8 @@ msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് നിങ്ങളുടെ ഉപകരണങ്ങൾക്കിടയിൽ Duck.ai ചാറ്റുകൾ സംരക്ഷിക്കുക."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് നിങ്ങളുടെ ഉപകരണങ്ങൾക്കിടയിൽ Duck.ai "
+"ചാറ്റുകൾ സംരക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17543,7 +17718,7 @@ msgstr "നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങള�
 #. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
 msgctxt "Chat history about modal list item headline"
 msgid "Save your chats on this device"
-msgstr ""
+msgstr "ഈ ഉപകരണത്തിൽ നിങ്ങളുടെ ചാറ്റുകൾ സംരക്ഷിക്കുക"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
@@ -17677,13 +17852,17 @@ msgstr "സ്കോട്ട്ലൻഡ്"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Scroll down and click %sView advanced settings%s"
-msgstr "താഴോട്ട് സ്ക്രോൾ ചെയ്ത് %1$sവിപുലമായ ക്രമീകരണം കാണുക%2$s എന്നത് തിരഞ്ഞെടുക്കുക"
+msgstr ""
+"താഴോട്ട് സ്ക്രോൾ ചെയ്ത് %1$sവിപുലമായ ക്രമീകരണം കാണുക%2$s എന്നത് "
+"തിരഞ്ഞെടുക്കുക"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr "താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിപുലമായ ക്രമീകരണം കാണുക%2$s എന്നത് ക്ലിക്ക് ചെയ്യുക."
+msgstr ""
+"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിപുലമായ ക്രമീകരണം കാണുക%2$s എന്നത് ക്ലിക്ക് "
+"ചെയ്യുക."
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -17691,8 +17870,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
 msgstr ""
-"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിലാസ ബാറിൽ തിരയുക%2$s കണ്ടെത്തുക. %3$sമാറ്റുക%4$s (അല്ലെങ്കിൽ "
-"%5$sപുതിയത് ചേർക്കുക%6$s ക്ലിക്ക് ചെയ്യുക)"
+"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിലാസ ബാറിൽ തിരയുക%2$s കണ്ടെത്തുക. "
+"%3$sമാറ്റുക%4$s (അല്ലെങ്കിൽ %5$sപുതിയത് ചേർക്കുക%6$s ക്ലിക്ക് ചെയ്യുക)"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17701,8 +17880,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
 msgstr ""
-"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിലാസ ബാറിൽ തിരയുക%2$s കണ്ടെത്തുക. %3$sമാറ്റുക%4$s (അല്ലെങ്കിൽ "
-"%5$sപുതിയത് ചേർക്കുക%6$s ക്ലിക്ക് ചെയ്യുക)."
+"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിലാസ ബാറിൽ തിരയുക%2$s കണ്ടെത്തുക. "
+"%3$sമാറ്റുക%4$s (അല്ലെങ്കിൽ %5$sപുതിയത് ചേർക്കുക%6$s ക്ലിക്ക് ചെയ്യുക)."
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -17721,15 +17900,16 @@ msgstr "താഴേക്ക് സ്ക്രോൾ ചെയ്ത്, �
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
 msgstr ""
-"%1$sDuckDuckGo%2$s എന്നതിലേക്ക് താഴേക്ക് സ്ക്രോൾ ചെയ്ത് നിങ്ങളുടെ ലൊക്കേഷൻ ഉപയോഗിക്കാൻ "
-"അതിനെ അനുവദിക്കുക."
+"%1$sDuckDuckGo%2$s എന്നതിലേക്ക് താഴേക്ക് സ്ക്രോൾ ചെയ്ത് നിങ്ങളുടെ ലൊക്കേഷൻ "
+"ഉപയോഗിക്കാൻ അതിനെ അനുവദിക്കുക."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
 msgstr ""
-"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sസേവനങ്ങൾ%2$s വിഭാഗം എടുത്ത്, %3$sവിലാസ ബാർ%4$s ക്ലിക്ക് ചെയ്യുക."
+"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sസേവനങ്ങൾ%2$s വിഭാഗം എടുത്ത്, %3$sവിലാസ ബാർ%4$s "
+"ക്ലിക്ക് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -17754,7 +17934,7 @@ msgctxt ""
 "Placeholder and accessibility label for the search input in the tab picker "
 "dialog"
 msgid "Search"
-msgstr ""
+msgstr "തിരയുക"
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -17791,12 +17971,14 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist തിരയൽ ചോദ്യങ്ങൾക്കുള്ള ഉത്തരങ്ങൾ അജ്ഞാതമായി സൃഷ്ടിക്കുന്നു. ഇത് ചെയ്യുന്നതിന്, "
-"പ്രസക്തമായ ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും തുടർന്ന് AI ഉപയോഗിച്ച് ഒരു ഹ്രസ്വ ഉത്തരം "
-"സൃഷ്ടിക്കുകയും ചെയ്യുന്നു. നിങ്ങൾക്ക് ഇത് എത്ര തവണ പ്രത്യക്ഷപ്പെടണമെന്ന് തിരഞ്ഞെടുക്കാം: ഒരിക്കലും, "
-"ഓൺ-ഡിമാൻഡ് (Assist ക്ലിക്ക് ചെയ്യുമ്പോൾ മാത്രം), ചിലപ്പോൾ (വളരെ പ്രസക്തമാകുമ്പോൾ), "
-"അല്ലെങ്കിൽ പലപ്പോഴും (വിശാലമായ തിരയലുകളിൽ). ഈ സമയത്ത്, ഇംഗ്ലീഷ് സംസാരിക്കുന്ന പ്രദേശങ്ങളുടെ "
-"ഒരു ഭാഗത്ത് മാത്രമേ Search Assist ലഭ്യമാകൂ."
+"Search Assist തിരയൽ ചോദ്യങ്ങൾക്കുള്ള ഉത്തരങ്ങൾ അജ്ഞാതമായി സൃഷ്ടിക്കുന്നു. "
+"ഇത് ചെയ്യുന്നതിന്, പ്രസക്തമായ ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും "
+"തുടർന്ന് AI ഉപയോഗിച്ച് ഒരു ഹ്രസ്വ ഉത്തരം സൃഷ്ടിക്കുകയും ചെയ്യുന്നു. "
+"നിങ്ങൾക്ക് ഇത് എത്ര തവണ പ്രത്യക്ഷപ്പെടണമെന്ന് തിരഞ്ഞെടുക്കാം: ഒരിക്കലും, "
+"ഓൺ-ഡിമാൻഡ് (Assist ക്ലിക്ക് ചെയ്യുമ്പോൾ മാത്രം), ചിലപ്പോൾ (വളരെ "
+"പ്രസക്തമാകുമ്പോൾ), അല്ലെങ്കിൽ പലപ്പോഴും (വിശാലമായ തിരയലുകളിൽ). ഈ സമയത്ത്, "
+"ഇംഗ്ലീഷ് സംസാരിക്കുന്ന പ്രദേശങ്ങളുടെ ഒരു ഭാഗത്ത് മാത്രമേ Search Assist "
+"ലഭ്യമാകൂ."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -17804,8 +17986,8 @@ msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
 msgstr ""
-"ഈ ചോദ്യത്തിന് ഉത്തരം സൃഷ്ടിക്കുന്നതിന് വേണ്ടത്ര വിശ്വസനീയമായ വിവരങ്ങൾ Search Assist-ന് "
-"കണ്ടെത്താൻ കഴിഞ്ഞില്ല. മറ്റൊരു തിരയൽ ശ്രമിക്കുക."
+"ഈ ചോദ്യത്തിന് ഉത്തരം സൃഷ്ടിക്കുന്നതിന് വേണ്ടത്ര വിശ്വസനീയമായ വിവരങ്ങൾ Search "
+"Assist-ന് കണ്ടെത്താൻ കഴിഞ്ഞില്ല. മറ്റൊരു തിരയൽ ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -17814,9 +17996,10 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist എന്നത് തിരയൽ അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കുന്ന ഒരു ഓപ്ഷണൽ "
-"സവിശേഷതയാണ്. ഇത് ചെയ്യാൻ, പ്രസക്തമായ ഉള്ളടക്കത്തിനായി %1$sവെബ് സ്കാൻ%2$s ചെയ്യുകയും "
-"കണ്ടെത്തിയ വിവരങ്ങളെ അടിസ്ഥാനമാക്കി AI ഉപയോഗിച്ച് ഒരു ഹ്രസ്വമായ ഉത്തരം സൃഷ്ടിക്കുകയും ചെയ്യുന്നു."
+"Search Assist എന്നത് തിരയൽ അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ "
+"സൃഷ്ടിക്കുന്ന ഒരു ഓപ്ഷണൽ സവിശേഷതയാണ്. ഇത് ചെയ്യാൻ, പ്രസക്തമായ "
+"ഉള്ളടക്കത്തിനായി %1$sവെബ് സ്കാൻ%2$s ചെയ്യുകയും കണ്ടെത്തിയ വിവരങ്ങളെ "
+"അടിസ്ഥാനമാക്കി AI ഉപയോഗിച്ച് ഒരു ഹ്രസ്വമായ ഉത്തരം സൃഷ്ടിക്കുകയും ചെയ്യുന്നു."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -17937,8 +18120,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"%1$s ഷോർട്ട്കട്ടുകൾ ഉപയോഗിച്ച് മറ്റ് സൈറ്റുകൾ തിരയുക: ”!w ducks” എന്നതിനുള്ള തിരയൽ "
-"വിക്കിപീഡിയയിൽ “ducks” എന്നതിനായി നേരിട്ട് തിരയുന്നതാണ്."
+"%1$s ഷോർട്ട്കട്ടുകൾ ഉപയോഗിച്ച് മറ്റ് സൈറ്റുകൾ തിരയുക: ”!w ducks” എന്നതിനുള്ള "
+"തിരയൽ വിക്കിപീഡിയയിൽ “ducks” എന്നതിനായി നേരിട്ട് തിരയുന്നതാണ്."
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -17957,9 +18140,9 @@ msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
-"ഞങ്ങളുടെ ആപ്പ് അല്ലെങ്കിൽ എക്സ്റ്റന്‍ഷന്‍ ഉപയോഗിച്ച് സ്വകാര്യമായി തിരയുക, നിങ്ങളുടെ പ്രിയപ്പെട്ട "
-"ബ്രൗസറിലേക്ക് സ്വകാര്യ വെബ് തിരയൽ ചേർക്കുക, അല്ലെങ്കിൽ %1$sduckduckgo.com%2$s-ൽ നേരിട്ട് "
-"തിരയുക."
+"ഞങ്ങളുടെ ആപ്പ് അല്ലെങ്കിൽ എക്സ്റ്റന്‍ഷന്‍ ഉപയോഗിച്ച് സ്വകാര്യമായി തിരയുക, "
+"നിങ്ങളുടെ പ്രിയപ്പെട്ട ബ്രൗസറിലേക്ക് സ്വകാര്യ വെബ് തിരയൽ ചേർക്കുക, "
+"അല്ലെങ്കിൽ %1$sduckduckgo.com%2$s-ൽ നേരിട്ട് തിരയുക."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -17967,8 +18150,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"തിരയൽ അന്വേഷണങ്ങൾ URL-ൽ ഉൾപ്പെടുത്തിയിട്ടുണ്ട് (ഓഫാണെങ്കിൽ തിരയലുകൾ POST അഭ്യർത്ഥനകൾ "
-"ഉപയോഗിക്കും)"
+"തിരയൽ അന്വേഷണങ്ങൾ URL-ൽ ഉൾപ്പെടുത്തിയിട്ടുണ്ട് (ഓഫാണെങ്കിൽ തിരയലുകൾ POST "
+"അഭ്യർത്ഥനകൾ ഉപയോഗിക്കും)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -17980,10 +18163,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"തിരയൽ ക്രമീകരണങ്ങൾ വ്യക്തിഗതമല്ലാത്ത ബ്രൗസർ കുക്കികളിലും പ്രാദേശിക സംഭരണത്തിലും നിങ്ങളുടെ "
-"ബ്രൗസറിലും സൂക്ഷിച്ചിരിക്കുന്നു, എന്നാൽ ക്ലൗഡിലെ ഒരു വിദൂര സെർവറിൽ നിങ്ങളുടെ ക്രമീകരണങ്ങൾ "
-"അജ്ഞാതമായി സൂക്ഷിക്കാൻ Cloud Save ഉപയോഗിക്കാം. വ്യക്തിപരമായി തിരിച്ചറിയാൻ കഴിയുന്ന "
-"വിവരങ്ങളൊന്നും ക്ലൗഡിൽ സംഭരിക്കപ്പെടില്ല, നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും നിങ്ങളുടെ ബ്രൗസർ "
+"തിരയൽ ക്രമീകരണങ്ങൾ വ്യക്തിഗതമല്ലാത്ത ബ്രൗസർ കുക്കികളിലും പ്രാദേശിക "
+"സംഭരണത്തിലും നിങ്ങളുടെ ബ്രൗസറിലും സൂക്ഷിച്ചിരിക്കുന്നു, എന്നാൽ ക്ലൗഡിലെ ഒരു "
+"വിദൂര സെർവറിൽ നിങ്ങളുടെ ക്രമീകരണങ്ങൾ അജ്ഞാതമായി സൂക്ഷിക്കാൻ Cloud Save "
+"ഉപയോഗിക്കാം. വ്യക്തിപരമായി തിരിച്ചറിയാൻ കഴിയുന്ന വിവരങ്ങളൊന്നും ക്ലൗഡിൽ "
+"സംഭരിക്കപ്പെടില്ല, നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും നിങ്ങളുടെ ബ്രൗസർ "
 "വിട്ടുപോകില്ല."
 
 # smartling.placeholder_format=C
@@ -18079,7 +18263,8 @@ msgstr "രണ്ടാമതൊരു അഭിപ്രായം"
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
 msgstr ""
-"നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിലും ചാറ്റുകൾ സുരക്ഷിതമായി സംരക്ഷിക്കുകയും സമന്വയിപ്പിക്കുകയും ചെയ്യുക."
+"നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിലും ചാറ്റുകൾ സുരക്ഷിതമായി സംരക്ഷിക്കുകയും "
+"സമന്വയിപ്പിക്കുകയും ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18088,8 +18273,9 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ സുരക്ഷിതമായി "
-"സംഭരിച്ച്, അവ നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും ആക്സസ് ചെയ്യുക."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ "
+"സുരക്ഷിതമായി സംഭരിച്ച്, അവ നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും ആക്സസ് "
+"ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -18098,8 +18284,9 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ സുരക്ഷിതമായി "
-"സംഭരിച്ച്, അവ നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും ആക്സസ് ചെയ്യുക."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ "
+"സുരക്ഷിതമായി സംഭരിച്ച്, അവ നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും ആക്സസ് "
+"ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18108,8 +18295,9 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ സുരക്ഷിതമായി "
-"സംഭരിച്ച്, സിങ്ക് ചെയ്ത എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും അവ ആക്സസ് ചെയ്യുക."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ "
+"സുരക്ഷിതമായി സംഭരിച്ച്, സിങ്ക് ചെയ്ത എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും അവ ആക്സസ് "
+"ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18118,15 +18306,17 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് നിങ്ങളുടെ ചാറ്റുകൾ ഞങ്ങളുടെ സെർവറിൽ സുരക്ഷിതമായി "
-"സംഭരിക്കുക, നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും അവ ആക്സസ് ചെയ്യുക."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് നിങ്ങളുടെ ചാറ്റുകൾ ഞങ്ങളുടെ സെർവറിൽ "
+"സുരക്ഷിതമായി സംഭരിക്കുക, നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും അവ ആക്സസ് "
+"ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷനോടെ DuckDuckGo-യുടെ സെർവറിൽ സുരക്ഷിതമായി സംഭരിച്ചിരിക്കുന്നു."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷനോടെ DuckDuckGo-യുടെ സെർവറിൽ സുരക്ഷിതമായി "
+"സംഭരിച്ചിരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -18135,8 +18325,9 @@ msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷനോടെ DuckDuckGo-യുടെ സെർവറിൽ സുരക്ഷിതമായി സംഭരിച്ചിരിക്കുന്നു. "
-"നിനക്കല്ലാതെ മറ്റാർക്കും നിന്റെ ഡാറ്റ കാണാൻ കഴിയില്ല, ഞങ്ങൾക്ക് പോലും."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷനോടെ DuckDuckGo-യുടെ സെർവറിൽ സുരക്ഷിതമായി "
+"സംഭരിച്ചിരിക്കുന്നു. നിനക്കല്ലാതെ മറ്റാർക്കും നിന്റെ ഡാറ്റ കാണാൻ കഴിയില്ല, "
+"ഞങ്ങൾക്ക് പോലും."
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
@@ -18281,34 +18472,38 @@ msgstr "%1$s%2$s%3$s തിരഞ്ഞെടുക്കുക, തുടർന
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
 msgstr ""
-"Safari മെനുവിൽ നിന്ന് %1$s'ഈ വെബ്‌സൈറ്റിനായുള്ള ക്രമീകരണം...'%2$s എന്നത് തിരഞ്ഞെടുക്കുക."
+"Safari മെനുവിൽ നിന്ന് %1$s'ഈ വെബ്‌സൈറ്റിനായുള്ള ക്രമീകരണം...'%2$s എന്നത് "
+"തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"%1$sഇഷ്ടാനുസൃതമാക്കുക%2$s ഓപ്ഷൻ തിരഞ്ഞെടുത്ത ശേഷം %3$shttps://duckduckgo.com%4$s എന്ന് "
-"ഇൻപുട്ട് ഫീൽഡിൽ എന്റർ ചെയ്യുക"
+"%1$sഇഷ്ടാനുസൃതമാക്കുക%2$s ഓപ്ഷൻ തിരഞ്ഞെടുത്ത ശേഷം "
+"%3$shttps://duckduckgo.com%4$s എന്ന് ഇൻപുട്ട് ഫീൽഡിൽ എന്റർ ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
 msgstr ""
-"%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത ശേഷം %3$sഡിഫോൾട്ടായി ചേർക്കുക%4$s എന്നതിൽ ക്ലിക്ക് "
-"ചെയ്യുക!"
+"%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത ശേഷം %3$sഡിഫോൾട്ടായി ചേർക്കുക%4$s എന്നതിൽ "
+"ക്ലിക്ക് ചെയ്യുക!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr "%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് %3$sഡിഫോൾട്ടായി സജ്ജീകരിക്കുക%4$s ക്ലിക്ക് ചെയ്യുക"
+msgstr ""
+"%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് %3$sഡിഫോൾട്ടായി സജ്ജീകരിക്കുക%4$s ക്ലിക്ക് "
+"ചെയ്യുക"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
 msgstr ""
-"%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് %3$sഡിഫോൾട്ടായി സജ്ജീകരിക്കുക%4$s ക്ലിക്ക് ചെയ്യുക."
+"%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് %3$sഡിഫോൾട്ടായി സജ്ജീകരിക്കുക%4$s ക്ലിക്ക് "
+"ചെയ്യുക."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -18320,7 +18515,9 @@ msgstr "ഡിഫോൾട്ട് തിരയൽ എഞ്ചിൻ ഡ്ര
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr "ലിസ്റ്റിൽ %1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് ലൊക്കേഷൻ ആക്സസ് %4$sഅനുവദിക്കുക%3$s"
+msgstr ""
+"ലിസ്റ്റിൽ %1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് ലൊക്കേഷൻ ആക്സസ് "
+"%4$sഅനുവദിക്കുക%3$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18333,7 +18530,8 @@ msgstr "തിരയൽ ദാതാക്കളുടെ പട്ടികയ�
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
 msgstr ""
-"%3$sഡിഫോൾട്ട് തിരയൽ എഞ്ചിൻ%4$s വിഭാഗത്തിന് കീഴിൽ %1$sDuckDuckGo%2$s തിരഞ്ഞെടുക്കുക"
+"%3$sഡിഫോൾട്ട് തിരയൽ എഞ്ചിൻ%4$s വിഭാഗത്തിന് കീഴിൽ %1$sDuckDuckGo%2$s "
+"തിരഞ്ഞെടുക്കുക"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -18344,13 +18542,17 @@ msgstr "%1$sDuckDuckGo%2$s തിരഞ്ഞെടുക്കുക!"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr "ഡ്രോപ്പ്ഡൗണിൽ %1$sതിരയൽ എഞ്ചിനുകൾ എഡിറ്റ് ചെയ്യുക...%2$s എന്നത് തിരഞ്ഞെടുക്കുക"
+msgstr ""
+"ഡ്രോപ്പ്ഡൗണിൽ %1$sതിരയൽ എഞ്ചിനുകൾ എഡിറ്റ് ചെയ്യുക...%2$s എന്നത് "
+"തിരഞ്ഞെടുക്കുക"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sManage add-ons%s from the dropdown menu"
-msgstr "ഡ്രോപ്പ്ഡൗൺ മെനുവിൽ നിന്ന് %1$sആഡ്-ഓണുകൾ മാനേജ് ചെയ്യുക%2$s എന്നത് തിരഞ്ഞെടുക്കുക"
+msgstr ""
+"ഡ്രോപ്പ്ഡൗൺ മെനുവിൽ നിന്ന് %1$sആഡ്-ഓണുകൾ മാനേജ് ചെയ്യുക%2$s എന്നത് "
+"തിരഞ്ഞെടുക്കുക"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -18358,8 +18560,8 @@ msgstr "ഡ്രോപ്പ്ഡൗൺ മെനുവിൽ നിന്ന�
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
 msgstr ""
-"(Mac-ൽ) %1$sOpera > മുൻഗണനകൾ%2$s എന്നും (Windows-ൽ) %3$sമെനു > ക്രമീകരണം%4$s എന്നും "
-"തിരഞ്ഞെടുക്കുക"
+"(Mac-ൽ) %1$sOpera > മുൻഗണനകൾ%2$s എന്നും (Windows-ൽ) %3$sമെനു > ക്രമീകരണം%4$s "
+"എന്നും തിരഞ്ഞെടുക്കുക"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -18367,8 +18569,8 @@ msgstr ""
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
 msgstr ""
-"(Mac-ൽ) %1$sOpera > മുൻഗണനകൾ%2$s എന്നും (Windows-ൽ) %3$sOpera > ഓപ്ഷനുകൾ%4$s എന്നും "
-"തിരഞ്ഞെടുക്കുക"
+"(Mac-ൽ) %1$sOpera > മുൻഗണനകൾ%2$s എന്നും (Windows-ൽ) %3$sOpera > ഓപ്ഷനുകൾ%4$s "
+"എന്നും തിരഞ്ഞെടുക്കുക"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -18433,14 +18635,16 @@ msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
 msgstr ""
-"%1$sഈ വെബ് പേജ് നിങ്ങളുടെ ഏക ഹോം പേജായി ഉപയോഗിക്കുക%2$s എന്നത് തിരഞ്ഞെടുക്കുക (അല്ലെങ്കിൽ "
-"നിങ്ങൾ ഇഷ്ടപ്പെടുന്നെങ്കിൽ മറ്റ് ഓപ്ഷനുകളിൽ ഒന്ന്)"
+"%1$sഈ വെബ് പേജ് നിങ്ങളുടെ ഏക ഹോം പേജായി ഉപയോഗിക്കുക%2$s എന്നത് "
+"തിരഞ്ഞെടുക്കുക (അല്ലെങ്കിൽ നിങ്ങൾ ഇഷ്ടപ്പെടുന്നെങ്കിൽ മറ്റ് ഓപ്ഷനുകളിൽ ഒന്ന്)"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "ലിസ്റ്റിൽ %1$sനിങ്ങളുടെ ബ്രൗസർ%2$s തിരഞ്ഞെടുത്ത് ലൊക്കേഷൻ ആക്സസ് %3$sഅനുവദിക്കുക%4$s"
+msgstr ""
+"ലിസ്റ്റിൽ %1$sനിങ്ങളുടെ ബ്രൗസർ%2$s തിരഞ്ഞെടുത്ത് ലൊക്കേഷൻ ആക്സസ് "
+"%3$sഅനുവദിക്കുക%4$s"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18513,7 +18717,8 @@ msgstr "%1$s-ൽ നിന്ന് തിരഞ്ഞെടുത്ത ടെ�
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
 msgstr ""
-"തിരഞ്ഞെടുത്ത വാചകം വളരെ ദൈർഘ്യമേറിയതാണ്. ദൈർഘ്യം കുറഞ്ഞത് തിരഞ്ഞെടുത്ത് വീണ്ടും ശ്രമിക്കൂ."
+"തിരഞ്ഞെടുത്ത വാചകം വളരെ ദൈർഘ്യമേറിയതാണ്. ദൈർഘ്യം കുറഞ്ഞത് തിരഞ്ഞെടുത്ത് "
+"വീണ്ടും ശ്രമിക്കൂ."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -18557,9 +18762,9 @@ msgid ""
 "respond. These instructions will apply to all of your conversations going "
 "forward."
 msgstr ""
-"എങ്ങനെ പ്രതികരിക്കണമെന്നതിനെക്കുറിച്ചുള്ള നിർദ്ദേശങ്ങളുള്ള നിങ്ങളുടെ സന്ദേശങ്ങളുമായി AI "
-"മോഡലുകളിലേക്ക് ഒരു പ്രോംപ്റ്റ് അയയ്ക്കുന്നു. ഈ നിർദ്ദേശങ്ങൾ ഇനി മുതൽ എല്ലാ സംഭാഷണങ്ങൾക്കും "
-"ബാധകമാകും."
+"എങ്ങനെ പ്രതികരിക്കണമെന്നതിനെക്കുറിച്ചുള്ള നിർദ്ദേശങ്ങളുള്ള നിങ്ങളുടെ "
+"സന്ദേശങ്ങളുമായി AI മോഡലുകളിലേക്ക് ഒരു പ്രോംപ്റ്റ് അയയ്ക്കുന്നു. ഈ "
+"നിർദ്ദേശങ്ങൾ ഇനി മുതൽ എല്ലാ സംഭാഷണങ്ങൾക്കും ബാധകമാകും."
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -18682,8 +18887,8 @@ msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ ഉപകരണങ്ങളിലുടനീളം സമന്വയിപ്പിച്ച് നിലനിർത്താൻ, ചാറ്റ് ചരിത്രം ഓണാക്കിയ "
-"ശേഷം Sync & Backup സജ്ജമാക്കുക."
+"നിങ്ങളുടെ ചാറ്റുകൾ ഉപകരണങ്ങളിലുടനീളം സമന്വയിപ്പിച്ച് നിലനിർത്താൻ, ചാറ്റ് "
+"ചരിത്രം ഓണാക്കിയ ശേഷം Sync & Backup സജ്ജമാക്കുക."
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -18765,7 +18970,9 @@ msgstr "പങ്കിടുക"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "DuckDuckGo പങ്കിടുക, സുഹൃത്തുക്കളെ അവരുടെ സ്വകാര്യത തിരികെ കൊണ്ടുവരാൻ സഹായിക്കുക!"
+msgstr ""
+"DuckDuckGo പങ്കിടുക, സുഹൃത്തുക്കളെ അവരുടെ സ്വകാര്യത തിരികെ കൊണ്ടുവരാൻ "
+"സഹായിക്കുക!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -18792,8 +18999,9 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"പ്രസക്തി മെച്ചപ്പെടുത്തുന്നതിന് AI മോഡലുകളുമായി ഒരു നഗരതല ലൊക്കേഷൻ പങ്കിടുക. Duck.ai "
-"ഒരിക്കലും നിങ്ങളുടെ കൃത്യമായ ലൊക്കേഷൻ ഞങ്ങൾക്കോ AI മോഡലുകൾക്കോ വെളിപ്പെടുത്തുകയില്ല."
+"പ്രസക്തി മെച്ചപ്പെടുത്തുന്നതിന് AI മോഡലുകളുമായി ഒരു നഗരതല ലൊക്കേഷൻ പങ്കിടുക. "
+"Duck.ai ഒരിക്കലും നിങ്ങളുടെ കൃത്യമായ ലൊക്കേഷൻ ഞങ്ങൾക്കോ AI മോഡലുകൾക്കോ "
+"വെളിപ്പെടുത്തുകയില്ല."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -18889,8 +19097,8 @@ msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
 msgstr ""
-"നിങ്ങളുടെ പ്രോംപ്റ്റും ചാറ്റ് പ്രതികരണവും DuckDuckGo-യുമായി പങ്കിടുക (നിയമവിരുദ്ധവും "
-"ദോഷകരവുമായ റിപ്പോർട്ടിന് ആവശ്യമാണ്)"
+"നിങ്ങളുടെ പ്രോംപ്റ്റും ചാറ്റ് പ്രതികരണവും DuckDuckGo-യുമായി പങ്കിടുക "
+"(നിയമവിരുദ്ധവും ദോഷകരവുമായ റിപ്പോർട്ടിന് ആവശ്യമാണ്)"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -18917,8 +19125,9 @@ msgid ""
 "Shield your online activity with our no-log, fast VPN. Simple to set up and "
 "easy to turn on and off anytime."
 msgstr ""
-"ഞങ്ങളുടെ നോ-ലോഗ്, വേഗതയേറിയ VPN ഉപയോഗിച്ച് നിങ്ങളുടെ ഓൺലൈൻ പ്രവർത്തനം സംരക്ഷിക്കൂ. "
-"സജ്ജീകരിക്കാൻ ലളിതവും എപ്പോൾ വേണമെങ്കിലും എളുപ്പത്തിൽ ഓൺ ചെയ്യാനും ഓഫ് ചെയ്യാനും കഴിയുന്നതും."
+"ഞങ്ങളുടെ നോ-ലോഗ്, വേഗതയേറിയ VPN ഉപയോഗിച്ച് നിങ്ങളുടെ ഓൺലൈൻ പ്രവർത്തനം "
+"സംരക്ഷിക്കൂ. സജ്ജീകരിക്കാൻ ലളിതവും എപ്പോൾ വേണമെങ്കിലും എളുപ്പത്തിൽ ഓൺ "
+"ചെയ്യാനും ഓഫ് ചെയ്യാനും കഴിയുന്നതും."
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -18936,7 +19145,7 @@ msgstr "ഷോപ്പ് ചെയ്യുക"
 #. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
 msgctxt "Button in the merchandise logo modal (mobile)"
 msgid "Shop Now"
-msgstr ""
+msgstr "ഇപ്പോൾ ഷോപ്പ് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -19044,7 +19253,9 @@ msgstr "DuckAssist <sup>BETA</sup> കാണിക്കുക"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr "DuckAssist കൂടുതൽ തവണ കാണിക്കുക. (നിങ്ങൾക്ക് ഇത് പൂർണ്ണമായും %1$sഓഫാക്കാം%2$s.)"
+msgstr ""
+"DuckAssist കൂടുതൽ തവണ കാണിക്കുക. (നിങ്ങൾക്ക് ഇത് പൂർണ്ണമായും "
+"%1$sഓഫാക്കാം%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -19227,7 +19438,9 @@ msgstr "സൈഡ്ബാർ കാണിക്കുക"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr "Duck.ai പരമാവധി പ്രയോജനപ്പെടുത്തുന്നതിനുള്ള ഘട്ടം ഘട്ടമായുള്ള നുറുങ്ങുകൾ കാണിക്കുക."
+msgstr ""
+"Duck.ai പരമാവധി പ്രയോജനപ്പെടുത്തുന്നതിനുള്ള ഘട്ടം ഘട്ടമായുള്ള നുറുങ്ങുകൾ "
+"കാണിക്കുക."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -19282,8 +19495,9 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
 msgstr ""
-"DuckDuckGo-യിലെ തിരയലുകൾ എല്ലായ്പ്പോഴും സ്വകാര്യമാണെന്നുള്ള ഒരു ഓർമ്മപ്പെടുത്തൽ കാണിക്കുന്നു. "
-"ഇത് ഓഫാക്കുന്നത് ഓർമ്മപ്പെടുത്തൽ മറയ്ക്കുന്നു, കൂടാതെ തിരയലിന്റെ സ്വകാര്യതയെ ഒരിക്കലും ബാധിക്കില്ല."
+"DuckDuckGo-യിലെ തിരയലുകൾ എല്ലായ്പ്പോഴും സ്വകാര്യമാണെന്നുള്ള ഒരു "
+"ഓർമ്മപ്പെടുത്തൽ കാണിക്കുന്നു. ഇത് ഓഫാക്കുന്നത് ഓർമ്മപ്പെടുത്തൽ മറയ്ക്കുന്നു, "
+"കൂടാതെ തിരയലിന്റെ സ്വകാര്യതയെ ഒരിക്കലും ബാധിക്കില്ല."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19291,9 +19505,9 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
 msgstr ""
-"DuckDuckGo-യിലെ തിരയലുകൾ എല്ലായ്പ്പോഴും പരിരക്ഷിക്കപ്പെടുന്നു എന്നുള്ള ഒരു ഓർമ്മപ്പെടുത്തൽ "
-"കാണിക്കുന്നു. ഇത് ഓഫാക്കുന്നത് ഓർമ്മപ്പെടുത്തൽ മറയ്ക്കുന്നു, കൂടാതെ തിരയൽ പരിരക്ഷയെ ഒരിക്കലും "
-"ബാധിക്കുന്നില്ല."
+"DuckDuckGo-യിലെ തിരയലുകൾ എല്ലായ്പ്പോഴും പരിരക്ഷിക്കപ്പെടുന്നു എന്നുള്ള ഒരു "
+"ഓർമ്മപ്പെടുത്തൽ കാണിക്കുന്നു. ഇത് ഓഫാക്കുന്നത് ഓർമ്മപ്പെടുത്തൽ മറയ്ക്കുന്നു, "
+"കൂടാതെ തിരയൽ പരിരക്ഷയെ ഒരിക്കലും ബാധിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19304,7 +19518,8 @@ msgstr "ഫല പേജ് ഇടവേളകളിൽ തിരശ്ചീന
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
 msgstr ""
-"DuckDuckGo നിങ്ങളുടെ ബ്രൗസറിലേക്ക് കൂട്ടിച്ചേർക്കാനുള്ള നിർദേശങ്ങളിലേക്കുള്ള ലിങ്കുകൾ കാണിക്കുന്നു"
+"DuckDuckGo നിങ്ങളുടെ ബ്രൗസറിലേക്ക് കൂട്ടിച്ചേർക്കാനുള്ള നിർദേശങ്ങളിലേക്കുള്ള "
+"ലിങ്കുകൾ കാണിക്കുന്നു"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -19321,21 +19536,23 @@ msgstr "പുതിയ ടാബ് പേജിൽ ഏറ്റവും ക�
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
 msgstr ""
-"നിങ്ങളുടെ ബ്രൗസറിലേക്ക് DuckDuckGo ചേർക്കാനുള്ള ഇടയ്ക്കിടെയുള്ള ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
+"നിങ്ങളുടെ ബ്രൗസറിലേക്ക് DuckDuckGo ചേർക്കാനുള്ള ഇടയ്ക്കിടെയുള്ള "
+"ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്ക് DuckDuckGo ചേർക്കാനുള്ള ഇടയ്ക്കിടെയുള്ള ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
+"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്ക് DuckDuckGo ചേർക്കാനുള്ള ഇടയ്ക്കിടെയുള്ള "
+"ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
 msgstr ""
-"DuckDuckGo സ്വകാര്യതാ വാർത്താക്കുറിപ്പുകൾക്കായി സൈൻ അപ്പ് ചെയ്യുന്നതിന് ഇടയ്ക്കിടെയുള്ള "
-"ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
+"DuckDuckGo സ്വകാര്യതാ വാർത്താക്കുറിപ്പുകൾക്കായി സൈൻ അപ്പ് ചെയ്യുന്നതിന് "
+"ഇടയ്ക്കിടെയുള്ള ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19443,12 +19660,16 @@ msgstr "സൈറ്റുകളുടെ പേരുകൾ"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr "സൈറ്റ് തിരയൽ താൽക്കാലികമായി ലഭ്യമല്ല. ഞങ്ങൾ ഒരു പരിഹാരം കണ്ടെത്താൻ പ്രവർത്തിക്കുന്നു."
+msgstr ""
+"സൈറ്റ് തിരയൽ താൽക്കാലികമായി ലഭ്യമല്ല. ഞങ്ങൾ ഒരു പരിഹാരം കണ്ടെത്താൻ "
+"പ്രവർത്തിക്കുന്നു."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr "നിങ്ങൾ ബ്ലോക്ക് ചെയ്യുന്ന സൈറ്റുകൾ നിങ്ങളുടെ എല്ലാ തിരയൽ ഫലങ്ങളിൽ നിന്നും മറയ്ക്കും"
+msgstr ""
+"നിങ്ങൾ ബ്ലോക്ക് ചെയ്യുന്ന സൈറ്റുകൾ നിങ്ങളുടെ എല്ലാ തിരയൽ ഫലങ്ങളിൽ നിന്നും "
+"മറയ്ക്കും"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19608,7 +19829,8 @@ msgstr "സെർവറിലേക്ക് സംരക്ഷിക്കു�
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
 msgstr ""
-"Sync & Backup പ്രവർത്തനക്ഷമമാക്കുമ്പോൾ എന്തോ കുഴപ്പം സംഭവിച്ചു. ദയവായി വീണ്ടും ശ്രമിക്കുക."
+"Sync & Backup പ്രവർത്തനക്ഷമമാക്കുമ്പോൾ എന്തോ കുഴപ്പം സംഭവിച്ചു. ദയവായി "
+"വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -19639,8 +19861,8 @@ msgstr "ചിലപ്പോൾ"
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
 msgstr ""
-"ക്ഷമിക്കണം, എനിക്ക് സഹായിക്കാനാകില്ല, ദയവായി നിങ്ങളുടെ ചിത്രത്തെ മറ്റൊരു രീതിയിൽ "
-"വിവരിക്കുക."
+"ക്ഷമിക്കണം, എനിക്ക് സഹായിക്കാനാകില്ല, ദയവായി നിങ്ങളുടെ ചിത്രത്തെ മറ്റൊരു "
+"രീതിയിൽ വിവരിക്കുക."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19679,8 +19901,8 @@ msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
 msgstr ""
-"ക്ഷമിക്കണം, അപ്‌ലോഡ് ചെയ്ത ചിത്രം പ്രോസസ്സ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി മറ്റൊരു ചിത്രമോ "
-"ഫോർമാറ്റോ പരീക്ഷിച്ചുനോക്കൂ."
+"ക്ഷമിക്കണം, അപ്‌ലോഡ് ചെയ്ത ചിത്രം പ്രോസസ്സ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി "
+"മറ്റൊരു ചിത്രമോ ഫോർമാറ്റോ പരീക്ഷിച്ചുനോക്കൂ."
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -19689,16 +19911,16 @@ msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
 msgstr ""
-"ക്ഷമിക്കണം, ഈ കോഡ് അസാധുവാണ്. ശരിയായ കോഡ് ആണ് നൽകിയത് അല്ലെങ്കിൽ സ്കാൻ ചെയ്തതെന്ന് "
-"ഉറപ്പാക്കുക."
+"ക്ഷമിക്കണം, ഈ കോഡ് അസാധുവാണ്. ശരിയായ കോഡ് ആണ് നൽകിയത് അല്ലെങ്കിൽ സ്കാൻ "
+"ചെയ്തതെന്ന് ഉറപ്പാക്കുക."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid ""
 "Sorry, we couldn't generate a richer answer. You can try asking Duck.ai."
 msgstr ""
-"ക്ഷമിക്കണം, ഞങ്ങൾക്ക് കൂടുതൽ മികച്ച ഒരു ഉത്തരം സൃഷ്ടിക്കാൻ കഴിഞ്ഞില്ല. നിങ്ങൾക്ക് Duck.ai-യോട് "
-"ചോദിക്കാൻ ശ്രമിക്കാം."
+"ക്ഷമിക്കണം, ഞങ്ങൾക്ക് കൂടുതൽ മികച്ച ഒരു ഉത്തരം സൃഷ്ടിക്കാൻ കഴിഞ്ഞില്ല. "
+"നിങ്ങൾക്ക് Duck.ai-യോട് ചോദിക്കാൻ ശ്രമിക്കാം."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and that they could try to refresh the page to resolve the error. Placeholders are for markup, please ignore.
@@ -19707,15 +19929,16 @@ msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
 msgstr ""
-"ക്ഷമിക്കണം, ഈ ഫലങ്ങൾ പ്രദർശിപ്പിക്കുന്നതിൽ ഞങ്ങൾക്ക് ഒരു പിശക് നേരിട്ടു. വീണ്ടും ശ്രമിക്കാൻ "
-"%1$sഇവിടെ ക്ലിക്ക് ചെയ്യുക%2$s ."
+"ക്ഷമിക്കണം, ഈ ഫലങ്ങൾ പ്രദർശിപ്പിക്കുന്നതിൽ ഞങ്ങൾക്ക് ഒരു പിശക് നേരിട്ടു. "
+"വീണ്ടും ശ്രമിക്കാൻ %1$sഇവിടെ ക്ലിക്ക് ചെയ്യുക%2$s ."
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
 msgstr ""
-"ക്ഷമിക്കണം, നിങ്ങളുടെ ഫീഡ്ബാക്ക് സമർപ്പിക്കാൻ ഞങ്ങൾക്ക് കഴിഞ്ഞില്ല. പിന്നീട് വീണ്ടും ശ്രമിക്കുക."
+"ക്ഷമിക്കണം, നിങ്ങളുടെ ഫീഡ്ബാക്ക് സമർപ്പിക്കാൻ ഞങ്ങൾക്ക് കഴിഞ്ഞില്ല. പിന്നീട് "
+"വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19770,8 +19993,8 @@ msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
 msgstr ""
-"സംഗ്രഹിക്കാൻ കഴിയാത്തത്ര ദൈർഘ്യമുള്ളതാണ് ഉറവിട ടെക്‌സ്റ്റ്. ദൈർഘ്യം കുറഞ്ഞത് തിരഞ്ഞെടുത്ത് വീണ്ടും "
-"ശ്രമിക്കൂ."
+"സംഗ്രഹിക്കാൻ കഴിയാത്തത്ര ദൈർഘ്യമുള്ളതാണ് ഉറവിട ടെക്‌സ്റ്റ്. ദൈർഘ്യം കുറഞ്ഞത് "
+"തിരഞ്ഞെടുത്ത് വീണ്ടും ശ്രമിക്കൂ."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -19976,7 +20199,9 @@ msgstr "DuckDuckGo-യിൽ തുടരുക"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr "ഞങ്ങളുടെ സ്വകാര്യതാ വാർത്താക്കുറിപ്പുകൾ ഉപയോഗിച്ച് പരിരക്ഷയോടെയും അറിവുള്ളവരായും തുടരുക."
+msgstr ""
+"ഞങ്ങളുടെ സ്വകാര്യതാ വാർത്താക്കുറിപ്പുകൾ ഉപയോഗിച്ച് പരിരക്ഷയോടെയും "
+"അറിവുള്ളവരായും തുടരുക."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -20026,7 +20251,9 @@ msgstr "സൃഷ്ടിക്കൽ നിർത്തുക"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr "മറ്റ് വെബ്‌സൈറ്റുകളിൽ പതിയിരിക്കുന്ന മറയ്ക്കപ്പെട്ട ട്രാക്കറുകൾ പ്രതിരോധിക്കുക."
+msgstr ""
+"മറ്റ് വെബ്‌സൈറ്റുകളിൽ പതിയിരിക്കുന്ന മറയ്ക്കപ്പെട്ട ട്രാക്കറുകൾ "
+"പ്രതിരോധിക്കുക."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -20121,8 +20348,8 @@ msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
 msgstr ""
-"Duck.ai-ൽ ഉയർന്ന പരിധികൾ അൺലോക്ക് ചെയ്യാൻ DuckDuckGo സബ്‌സ്‌ക്രൈബ് ചെയ്യുക, അല്ലെങ്കിൽ "
-"കൂടുതൽ ഇമേജുകൾ സൃഷ്ടിക്കാൻ പിന്നീട് തിരികെ വരിക."
+"Duck.ai-ൽ ഉയർന്ന പരിധികൾ അൺലോക്ക് ചെയ്യാൻ DuckDuckGo സബ്‌സ്‌ക്രൈബ് ചെയ്യുക, "
+"അല്ലെങ്കിൽ കൂടുതൽ ഇമേജുകൾ സൃഷ്ടിക്കാൻ പിന്നീട് തിരികെ വരിക."
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -20191,8 +20418,8 @@ msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
 msgstr ""
-"ഒരു ശസ്ത്രക്രിയയിൽ നിന്ന് സുഖം പ്രാപിക്കുന്ന ഒരാൾക്ക് ഒരു ഗെറ്റ്-വെൽ കാർഡിൽ എഴുതാൻ ഒരു വാക്യം "
-"നിർദ്ദേശിക്കാമോ?"
+"ഒരു ശസ്ത്രക്രിയയിൽ നിന്ന് സുഖം പ്രാപിക്കുന്ന ഒരാൾക്ക് ഒരു ഗെറ്റ്-വെൽ കാർഡിൽ "
+"എഴുതാൻ ഒരു വാക്യം നിർദ്ദേശിക്കാമോ?"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
@@ -20528,7 +20755,9 @@ msgstr "%1$sഎന്നതിലേക്ക് മാറി"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr "മാറുന്നത് നിങ്ങളുടെ ചാറ്റിനെ ദാതാവിന്റെ ദൃശ്യപരതയില്ലാത്ത ഒരു മോഡലിലേക്ക് അയയ്ക്കും"
+msgstr ""
+"മാറുന്നത് നിങ്ങളുടെ ചാറ്റിനെ ദാതാവിന്റെ ദൃശ്യപരതയില്ലാത്ത ഒരു മോഡലിലേക്ക് "
+"അയയ്ക്കും"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -20582,7 +20811,9 @@ msgstr "Sync & Backup പ്രവർത്തനക്ഷമമാക്കി!
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr "Sync & Backup ഡാറ്റ 18 മാസത്തെ നിഷ്‌ക്രിയത്വത്തിന് ശേഷം വീണ്ടെടുക്കാൻ കഴിയില്ല."
+msgstr ""
+"Sync & Backup ഡാറ്റ 18 മാസത്തെ നിഷ്‌ക്രിയത്വത്തിന് ശേഷം വീണ്ടെടുക്കാൻ "
+"കഴിയില്ല."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
@@ -20591,6 +20822,8 @@ msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
 msgstr ""
+"Sync & Backup നിങ്ങളുടെ കൂടുതൽ ചാറ്റുകൾ സംരക്ഷിക്കുകയും അവയെ നിങ്ങളുടെ എല്ലാ "
+"ഉപകരണങ്ങളിലും ഉടനീളം സമന്വയിപ്പിക്കുകയും ചെയ്യുന്നു."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20639,25 +20872,27 @@ msgid ""
 msgstr ""
 "വീണ്ടെടുക്കൽ കോഡ് സമന്വയിപ്പിക്കുക\n"
 "\n"
-" ഒന്നിലധികം ഉപകരണങ്ങളിലുടനീളം നിങ്ങളുടെ പാസ്‌വേഡുകൾ സമന്വയിപ്പിക്കാനും, ഡാറ്റ ഓട്ടോഫിൽ "
-"ചെയ്യാനും, Duck.ai ചാറ്റുകൾ ഉപയോഗിക്കാനും, ഒരു ഉപകരണത്തിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെടുകയാണെങ്കിൽ "
-"നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ വീണ്ടെടുക്കാനും വീണ്ടെടുക്കൽ കോഡ് നിങ്ങളെ അനുവദിക്കുന്നു.\n"
+" ഒന്നിലധികം ഉപകരണങ്ങളിലുടനീളം നിങ്ങളുടെ പാസ്‌വേഡുകൾ സമന്വയിപ്പിക്കാനും, "
+"ഡാറ്റ ഓട്ടോഫിൽ ചെയ്യാനും, Duck.ai ചാറ്റുകൾ ഉപയോഗിക്കാനും, ഒരു "
+"ഉപകരണത്തിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെടുകയാണെങ്കിൽ നിങ്ങളുടെ സമന്വയിപ്പിച്ച "
+"ഡാറ്റ വീണ്ടെടുക്കാനും വീണ്ടെടുക്കൽ കോഡ് നിങ്ങളെ അനുവദിക്കുന്നു.\n"
 "\n"
 "ഈ വിവരങ്ങൾ സുരക്ഷിതമായി സൂക്ഷിക്കുക.\n"
-"ഈ കോഡിന് പ്രവേശനം ഉള്ള ആരും നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ ആക്‌സസ് ചെയ്യാൻ കഴിയും.\n"
+"ഈ കോഡിന് പ്രവേശനം ഉള്ള ആരും നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ ആക്‌സസ് ചെയ്യാൻ "
+"കഴിയും.\n"
 "\n"
 "%1$s\n"
 "\n"
 "ഈ കോഡ് എങ്ങനെയാണ് പ്രവർത്തിക്കുന്നത്?\n"
 "1. നിങ്ങളുടെ ബ്രൗസറിൽ Duck.ai-ലേക്ക് പോയി Duck.ai സെറ്റിംഗ്സ് തുറക്കുക.\n"
-"2. \"Sync & Backup\" തിരഞ്ഞെടുക്കുക, തുടർന്ന് \"സമന്വയിപ്പിച്ച ഡാറ്റ വീണ്ടെടുക്കുക\" "
-"തിരഞ്ഞെടുക്കുക.\n"
-"3. മുകളിലുള്ള വീണ്ടെടുക്കൽ കോഡ് പകർത്തി \"നിങ്ങളുടെ കോഡ് ഇവിടെ ഒട്ടിക്കുക\" എന്ന് പറയുന്നിടത്ത് "
-"ഒട്ടിക്കുക.\n"
+"2. \"Sync & Backup\" തിരഞ്ഞെടുക്കുക, തുടർന്ന് \"സമന്വയിപ്പിച്ച ഡാറ്റ "
+"വീണ്ടെടുക്കുക\" തിരഞ്ഞെടുക്കുക.\n"
+"3. മുകളിലുള്ള വീണ്ടെടുക്കൽ കോഡ് പകർത്തി \"നിങ്ങളുടെ കോഡ് ഇവിടെ ഒട്ടിക്കുക\" "
+"എന്ന് പറയുന്നിടത്ത് ഒട്ടിക്കുക.\n"
 "\n"
-"Sync & Backup പ്രവർത്തനക്ഷമമാക്കിയ ഒരു DuckDuckGo ബ്രൗസർ ഉപയോഗിക്കാതെ നിങ്ങൾ 18 "
-"മാസത്തിൽ കൂടുതൽ ചെലവഴിച്ചാൽ, നിങ്ങളുടെ ഡാറ്റ സെർവറിൽ നിന്ന് ഇല്ലാതാക്കപ്പെടും, അത് "
-"പുനഃസ്ഥാപിക്കാൻ കഴിയില്ല."
+"Sync & Backup പ്രവർത്തനക്ഷമമാക്കിയ ഒരു DuckDuckGo ബ്രൗസർ ഉപയോഗിക്കാതെ നിങ്ങൾ "
+"18 മാസത്തിൽ കൂടുതൽ ചെലവഴിച്ചാൽ, നിങ്ങളുടെ ഡാറ്റ സെർവറിൽ നിന്ന് "
+"ഇല്ലാതാക്കപ്പെടും, അത് പുനഃസ്ഥാപിക്കാൻ കഴിയില്ല."
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -20711,7 +20946,7 @@ msgstr "നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങള�
 #. Headline in sync-enabled chat history about modals explaining cross-device sync.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Sync your chats across all your devices"
-msgstr ""
+msgstr "നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിലും ചാറ്റുകൾ സമന്വയിപ്പിക്കുക"
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -20796,8 +21031,9 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
-"Duck.ai നിങ്ങൾക്കൊപ്പം എല്ലായിടത്തും കൂടെ കരുതൂ. നിങ്ങൾ എവിടെയായിരുന്നാലും വേഗത്തിൽ ആക്സസ് "
-"ചെയ്യുന്നതിന് ഞങ്ങളുടെ സൗജന്യ ആപ്പിൽ ഇത് ബിൽറ്റ് ഇൻ ചെയ്ത് നേടൂ."
+"Duck.ai നിങ്ങൾക്കൊപ്പം എല്ലായിടത്തും കൂടെ കരുതൂ. നിങ്ങൾ എവിടെയായിരുന്നാലും "
+"വേഗത്തിൽ ആക്സസ് ചെയ്യുന്നതിന് ഞങ്ങളുടെ സൗജന്യ ആപ്പിൽ ഇത് ബിൽറ്റ് ഇൻ ചെയ്ത് "
+"നേടൂ."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20806,8 +21042,9 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
-"Duck.ai നിങ്ങൾക്കൊപ്പം എല്ലായിടത്തും കൂടെ കരുതൂ. നിങ്ങൾ എവിടെ ബ്രൗസ് ചെയ്യുമ്പോഴും വേഗത്തിലുള്ള "
-"ആക്സസിനായി ഞങ്ങളുടെ സൗജന്യ ബ്രൗസറിൽ ഇത് ഉൾപ്പെടുത്തൂ."
+"Duck.ai നിങ്ങൾക്കൊപ്പം എല്ലായിടത്തും കൂടെ കരുതൂ. നിങ്ങൾ എവിടെ ബ്രൗസ് "
+"ചെയ്യുമ്പോഴും വേഗത്തിലുള്ള ആക്സസിനായി ഞങ്ങളുടെ സൗജന്യ ബ്രൗസറിൽ ഇത് "
+"ഉൾപ്പെടുത്തൂ."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20830,7 +21067,9 @@ msgstr "നിങ്ങളുടെ സ്വകാര്യ ഡാറ്റയ�
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr "Duck.ai എങ്ങനെ മെച്ചപ്പെടുത്താമെന്ന് ഞങ്ങളെ അറിയിക്കാൻ ഈ അജ്ഞാത സർവേയിൽ പങ്കെടുക്കൂ."
+msgstr ""
+"Duck.ai എങ്ങനെ മെച്ചപ്പെടുത്താമെന്ന് ഞങ്ങളെ അറിയിക്കാൻ ഈ അജ്ഞാത സർവേയിൽ "
+"പങ്കെടുക്കൂ."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -21051,9 +21290,10 @@ msgid ""
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണത്തിനും ഈ ലിങ്കിന് പിന്നിലെ വെബ്‌പോജിനുമിടയിൽ അയച്ച വിവരങ്ങൾ ഒരു മൂന്നാം "
-"കക്ഷി തടസ്സപ്പെടുത്താനുള്ള സാധ്യത കൂടുതലാണ് എന്നാണ് ഇതിനർഥം. അപൂർവ സന്ദർഭങ്ങളിൽ ഇതിൽ "
-"പാസ്‍വേഡുകൾ അല്ലെങ്കിൽ പേയ്മെന്റ് വിശദാംശങ്ങൾ ഉൾപ്പെടുന്നു."
+"നിങ്ങളുടെ ഉപകരണത്തിനും ഈ ലിങ്കിന് പിന്നിലെ വെബ്‌പോജിനുമിടയിൽ അയച്ച വിവരങ്ങൾ "
+"ഒരു മൂന്നാം കക്ഷി തടസ്സപ്പെടുത്താനുള്ള സാധ്യത കൂടുതലാണ് എന്നാണ് ഇതിനർഥം. "
+"അപൂർവ സന്ദർഭങ്ങളിൽ ഇതിൽ പാസ്‍വേഡുകൾ അല്ലെങ്കിൽ പേയ്മെന്റ് വിശദാംശങ്ങൾ "
+"ഉൾപ്പെടുന്നു."
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -21062,8 +21302,8 @@ msgid ""
 "The Cloud Save bookmarklet allows any changes you make to your settings to "
 "automatically save in the cloud."
 msgstr ""
-"നിങ്ങളുടെ ക്രമീകരണത്തിൽ വരുത്തുന്ന ഏത് മാറ്റങ്ങളും ക്ലൗഡിൽ സ്വയമേവ സംരക്ഷിക്കാൻ Cloud Save "
-"ബുക്ക്‌മാർക്ക്‌ലെറ്റ് അനുവദിക്കുന്നു."
+"നിങ്ങളുടെ ക്രമീകരണത്തിൽ വരുത്തുന്ന ഏത് മാറ്റങ്ങളും ക്ലൗഡിൽ സ്വയമേവ "
+"സംരക്ഷിക്കാൻ Cloud Save ബുക്ക്‌മാർക്ക്‌ലെറ്റ് അനുവദിക്കുന്നു."
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -21093,15 +21333,17 @@ msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
 msgstr ""
-"എൻക്രിപ്ഷൻ കീ നിങ്ങളുടെ ബ്രൗസറിന്റെ ലോക്കൽ സ്റ്റോറേജിൽ മാത്രമേ സംരക്ഷിക്കപ്പെടുകയുള്ളൂ, കൂടാതെ "
-"നിങ്ങൾക്ക് മാത്രമേ അത് ആക്‌സസ് ചെയ്യാൻ കഴിയൂ."
+"എൻക്രിപ്ഷൻ കീ നിങ്ങളുടെ ബ്രൗസറിന്റെ ലോക്കൽ സ്റ്റോറേജിൽ മാത്രമേ "
+"സംരക്ഷിക്കപ്പെടുകയുള്ളൂ, കൂടാതെ നിങ്ങൾക്ക് മാത്രമേ അത് ആക്‌സസ് ചെയ്യാൻ കഴിയൂ."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider deletes all chat data within 30 days.
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr "ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഏതൊരു ഡാറ്റയും 30 ദിവസത്തിനുള്ളിൽ മോഡൽ ദാതാവ് ഇല്ലാതാക്കും."
+msgstr ""
+"ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഏതൊരു ഡാറ്റയും 30 ദിവസത്തിനുള്ളിൽ മോഡൽ ദാതാവ് "
+"ഇല്ലാതാക്കും."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -21174,9 +21416,9 @@ msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
 msgstr ""
-"ഈ ചാറ്റ് പ്രാദേശികമായി സേവ് ചെയ്യുന്നതിൽ ഒരു പിശക് സംഭവിച്ചു. പ്രാദേശിക ഡാറ്റ സംഭരണം "
-"പ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന് ഉറപ്പുവരുത്താൻ ദയവായി നിങ്ങളുടെ ബ്രൗസർ ക്രമീകരണങ്ങൾ "
-"പരിശോധിക്കുക."
+"ഈ ചാറ്റ് പ്രാദേശികമായി സേവ് ചെയ്യുന്നതിൽ ഒരു പിശക് സംഭവിച്ചു. പ്രാദേശിക "
+"ഡാറ്റ സംഭരണം പ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന് ഉറപ്പുവരുത്താൻ ദയവായി "
+"നിങ്ങളുടെ ബ്രൗസർ ക്രമീകരണങ്ങൾ പരിശോധിക്കുക."
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -21191,8 +21433,8 @@ msgid ""
 "There was still an error displaying the search results. Please wait a few "
 "minutes before you try again."
 msgstr ""
-"തിരയൽ ഫലങ്ങൾ പ്രദർശിപ്പിക്കുന്നതിൽ ഇപ്പോഴും ഒരു പിശകുണ്ടായിരുന്നു. നിങ്ങൾ വീണ്ടും ശ്രമിക്കുന്നതിന് "
-"മുമ്പ് ഏതാനും മിനിറ്റ് കാത്തിരിക്കൂ."
+"തിരയൽ ഫലങ്ങൾ പ്രദർശിപ്പിക്കുന്നതിൽ ഇപ്പോഴും ഒരു പിശകുണ്ടായിരുന്നു. നിങ്ങൾ "
+"വീണ്ടും ശ്രമിക്കുന്നതിന് മുമ്പ് ഏതാനും മിനിറ്റ് കാത്തിരിക്കൂ."
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
@@ -21211,10 +21453,10 @@ msgid ""
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
 msgstr ""
-"മറഞ്ഞിരിക്കുന്ന ട്രാക്കറുകൾ തടയുന്നതിലൂടെയും സാധ്യമാകുന്നിടത്ത് കണക്ഷനുകൾ എൻക്രിപ്റ്റ് "
-"ചെയ്യുന്നതിലൂടെയും DuckDuckGo-യെ നിങ്ങളുടെ ഡിഫോൾട്ട് തിരയൽ എഞ്ചിനാക്കി മാറ്റുന്നതിലൂടെയും "
-"നിങ്ങൾ സന്ദർശിക്കുന്ന വെബ്‌സൈറ്റുകളിൽ സ്വകാര്യതാ പരിരക്ഷണം ചേർക്കാൻ ഈ ബ്രൗസർ അനുമതികൾ "
-"ഉപയോഗിക്കുന്നു."
+"മറഞ്ഞിരിക്കുന്ന ട്രാക്കറുകൾ തടയുന്നതിലൂടെയും സാധ്യമാകുന്നിടത്ത് കണക്ഷനുകൾ "
+"എൻക്രിപ്റ്റ് ചെയ്യുന്നതിലൂടെയും DuckDuckGo-യെ നിങ്ങളുടെ ഡിഫോൾട്ട് തിരയൽ "
+"എഞ്ചിനാക്കി മാറ്റുന്നതിലൂടെയും നിങ്ങൾ സന്ദർശിക്കുന്ന വെബ്‌സൈറ്റുകളിൽ "
+"സ്വകാര്യതാ പരിരക്ഷണം ചേർക്കാൻ ഈ ബ്രൗസർ അനുമതികൾ ഉപയോഗിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -21260,8 +21502,8 @@ msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
 msgstr ""
-"ഈ AI മോഡൽ പതിപ്പിനെ ഇനി പിന്തുണയ്ക്കുന്നില്ല. ഈ മോഡലിന്റെ ഏറ്റവും പുതിയ പതിപ്പിൽ ഒരു പുതിയ "
-"ചാറ്റ് ആരംഭിക്കാൻ ശ്രമിക്കൂ."
+"ഈ AI മോഡൽ പതിപ്പിനെ ഇനി പിന്തുണയ്ക്കുന്നില്ല. ഈ മോഡലിന്റെ ഏറ്റവും പുതിയ "
+"പതിപ്പിൽ ഒരു പുതിയ ചാറ്റ് ആരംഭിക്കാൻ ശ്രമിക്കൂ."
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -21296,18 +21538,22 @@ msgid ""
 "This chat and its generated images become public when you create and copy "
 "the link."
 msgstr ""
+"ലിങ്ക് സൃഷ്ടിച്ച് പകർത്തുമ്പോൾ ഈ ചാറ്റും അതിൽ സൃഷ്ടിച്ച ചിത്രങ്ങളും "
+"പൊതുവായിത്തീരും."
 
 # smartling.placeholder_format=C
 #. Explains that creating and copying a share link makes the selected chat content public.
 msgctxt "Share modal info bullet about public access"
 msgid "This chat becomes public when you create and copy the link."
-msgstr ""
+msgstr "ലിങ്ക് സൃഷ്ടിച്ച് പകർത്തുമ്പോൾ ഈ ചാറ്റ് പൊതുവായിത്തീരും."
 
 # smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
-msgstr "ഈ ചാറ്റ് Duck.ai-യിൽ തന്നെ തുടരുകയും നിങ്ങൾക്ക് സ്വകാര്യമായിരിക്കുകയും ചെയ്യും."
+msgstr ""
+"ഈ ചാറ്റ് Duck.ai-യിൽ തന്നെ തുടരുകയും നിങ്ങൾക്ക് സ്വകാര്യമായിരിക്കുകയും "
+"ചെയ്യും."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21316,9 +21562,9 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"%2$s-ന്റെ %3$s മോഡൽ ഉപയോഗിച്ച് Duck.ai (%1$s) വഴിയാണ് ഈ സംഭാഷണം സൃഷ്ടിച്ചത്. AI "
-"ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം (കൂടുതൽ വിവരങ്ങൾക്ക് "
-"%4$s കാണുക)."
+"%2$s-ന്റെ %3$s മോഡൽ ഉപയോഗിച്ച് Duck.ai (%1$s) വഴിയാണ് ഈ സംഭാഷണം സൃഷ്ടിച്ചത്. "
+"AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം "
+"(കൂടുതൽ വിവരങ്ങൾക്ക് %4$s കാണുക)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21328,9 +21574,9 @@ msgid ""
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"ഒന്നിലധികം ചാറ്റ് മോഡലുകൾ ഉപയോഗിച്ച് Duck.ai (%1$s) ഉപയോഗിച്ചാണ് ഈ സംഭാഷണം സൃഷ്ടിച്ചത്. "
-"AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം (കൂടുതൽ വിവരങ്ങൾക്ക് "
-"%2$s കാണുക)."
+"ഒന്നിലധികം ചാറ്റ് മോഡലുകൾ ഉപയോഗിച്ച് Duck.ai (%1$s) ഉപയോഗിച്ചാണ് ഈ സംഭാഷണം "
+"സൃഷ്ടിച്ചത്. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ "
+"പ്രദർശിപ്പിച്ചേക്കാം (കൂടുതൽ വിവരങ്ങൾക്ക് %2$s കാണുക)."
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21339,8 +21585,9 @@ msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
 msgstr ""
-"Duck.ai വോയ്സ് ചാറ്റ് (%1$s) ഉപയോഗിച്ചാണ് ഈ സംഭാഷണം സൃഷ്ടിച്ചത്. AI കൃത്യതയില്ലാത്തതോ "
-"കുറ്റകരമോ ആയ വിവരങ്ങൾ നൽകിയേക്കാം. (കൂടുതൽ വിവരങ്ങൾക്ക് %2$s കാണുക)."
+"Duck.ai വോയ്സ് ചാറ്റ് (%1$s) ഉപയോഗിച്ചാണ് ഈ സംഭാഷണം സൃഷ്ടിച്ചത്. AI "
+"കൃത്യതയില്ലാത്തതോ കുറ്റകരമോ ആയ വിവരങ്ങൾ നൽകിയേക്കാം. (കൂടുതൽ വിവരങ്ങൾക്ക് "
+"%2$s കാണുക)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -21350,9 +21597,9 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"%2$s-ന്റെ %3$s മോഡൽ ഉപയോഗിച്ച് DuckDuckGo AI Chat (%1$s) ഉപയോഗിച്ചാണ് ഈ സംഭാഷണം "
-"സൃഷ്ടിച്ചത്. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം (കൂടുതൽ "
-"വിവരങ്ങൾക്ക് %4$s കാണുക)."
+"%2$s-ന്റെ %3$s മോഡൽ ഉപയോഗിച്ച് DuckDuckGo AI Chat (%1$s) ഉപയോഗിച്ചാണ് ഈ "
+"സംഭാഷണം സൃഷ്ടിച്ചത്. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ "
+"പ്രദർശിപ്പിച്ചേക്കാം (കൂടുതൽ വിവരങ്ങൾക്ക് %4$s കാണുക)."
 
 # smartling.placeholder_format=C
 #. Renders to the right of the device name for the row that matches this device's id.
@@ -21369,8 +21616,9 @@ msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
 msgstr ""
-"മറ്റ് ഉപകരണങ്ങളിലുള്ള നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ ആക്‌സസ് ചെയ്യാൻ ഈ ഉപകരണത്തിന് ഇനി "
-"കഴിയില്ല. അവസാന %1$s ചാറ്റുകൾ ഇപ്പോഴും ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും."
+"മറ്റ് ഉപകരണങ്ങളിലുള്ള നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ ആക്‌സസ് ചെയ്യാൻ ഈ "
+"ഉപകരണത്തിന് ഇനി കഴിയില്ല. അവസാന %1$s ചാറ്റുകൾ ഇപ്പോഴും ലോക്കൽ സ്റ്റോറേജിൽ "
+"ലഭ്യമാകും."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21402,7 +21650,9 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s"
-msgstr "ഈ ഫയൽ തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു %1$s അല്ലെങ്കിൽ %2$s അറ്റാച്ചുചെയ്യുക"
+msgstr ""
+"ഈ ഫയൽ തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു %1$s അല്ലെങ്കിൽ %2$s "
+"അറ്റാച്ചുചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Error message for unsupported file type when multiple types are accepted. First placeholder is a comma-separated list of all accepted types except the last (e.g. PNG, JPG, WebP, GIF). Second placeholder is the last accepted type (e.g. PDF). Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF
@@ -21410,7 +21660,9 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s."
-msgstr "ഈ ഫയൽ തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു %1$s അല്ലെങ്കിൽ %2$s അറ്റാച്ച് ചെയ്യുക."
+msgstr ""
+"ഈ ഫയൽ തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു %1$s അല്ലെങ്കിൽ %2$s അറ്റാച്ച് "
+"ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to upload an unsupported file type and we know which types are accepted. Placeholder is a single accepted type. E.g. This file type is not supported, please attach a PDF
@@ -21442,7 +21694,8 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
 msgstr ""
-"ഈ ഇമേജ് തരം പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു JPG, PNG, WebP, അല്ലെങ്കിൽ GIF ചേർക്കുക"
+"ഈ ഇമേജ് തരം പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു JPG, PNG, WebP, അല്ലെങ്കിൽ GIF "
+"ചേർക്കുക"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
@@ -21450,7 +21703,8 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
 msgstr ""
-"ഈ ഇമേജ് തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി JPG, PNG, WebP, അല്ലെങ്കിൽ GIF ചേർക്കുക."
+"ഈ ഇമേജ് തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി JPG, PNG, WebP, അല്ലെങ്കിൽ GIF "
+"ചേർക്കുക."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -21470,8 +21724,8 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
-"ഇതൊരു സാമ്പിൾ ചാറ്റ് മാത്രമാണ്. നിങ്ങളുടെ ചാറ്റുകളുടെ മുകളിൽ നിലനിർത്താൻ ഇതിന്റെ മെനു (മൂന്ന് "
-"ഡോട്ടുകൾ) തുറന്ന് പിൻ തിരഞ്ഞെടുക്കുക!"
+"ഇതൊരു സാമ്പിൾ ചാറ്റ് മാത്രമാണ്. നിങ്ങളുടെ ചാറ്റുകളുടെ മുകളിൽ നിലനിർത്താൻ "
+"ഇതിന്റെ മെനു (മൂന്ന് ഡോട്ടുകൾ) തുറന്ന് പിൻ തിരഞ്ഞെടുക്കുക!"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -21480,7 +21734,8 @@ msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
 msgstr ""
-"ഇതൊരു സാമ്പിൾ ചാറ്റ് മാത്രമാണ്. ഇത് ഇല്ലാതാക്കാൻ വശത്തുള്ള മെനുവിലെ Fire Button ഉപയോഗിക്കുക!"
+"ഇതൊരു സാമ്പിൾ ചാറ്റ് മാത്രമാണ്. ഇത് ഇല്ലാതാക്കാൻ വശത്തുള്ള മെനുവിലെ Fire "
+"Button ഉപയോഗിക്കുക!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -21501,8 +21756,8 @@ msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
 msgstr ""
-"ഈ മോഡൽ ദാതാവ് ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഡാറ്റ 30 ദിവസത്തിനുള്ളിൽ ഇല്ലാതാക്കും. മറ്റ് മോഡൽ "
-"ദാതാക്കൾ പൂജ്യം ഡാറ്റ നിലനിർത്തൽ മോഡൽ പിന്തുടരുന്നു."
+"ഈ മോഡൽ ദാതാവ് ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഡാറ്റ 30 ദിവസത്തിനുള്ളിൽ "
+"ഇല്ലാതാക്കും. മറ്റ് മോഡൽ ദാതാക്കൾ പൂജ്യം ഡാറ്റ നിലനിർത്തൽ മോഡൽ പിന്തുടരുന്നു."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -21511,8 +21766,8 @@ msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
 msgstr ""
-"ഈ മോഡൽ ദാതാവ് ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഒരു ഡാറ്റയും സംഭരിക്കുന്നില്ല. മറ്റ് മോഡൽ ദാതാക്കൾ ഒരു "
-"പരിമിത ഡാറ്റ നിലനിർത്തൽ മാതൃക പിന്തുടരുന്നു."
+"ഈ മോഡൽ ദാതാവ് ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഒരു ഡാറ്റയും സംഭരിക്കുന്നില്ല. മറ്റ് "
+"മോഡൽ ദാതാക്കൾ ഒരു പരിമിത ഡാറ്റ നിലനിർത്തൽ മാതൃക പിന്തുടരുന്നു."
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -21549,8 +21804,9 @@ msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
 msgstr ""
-"ഇത് നിങ്ങളുടെ ചാറ്റുകൾ DuckDuckGo-യുടെ സുരക്ഷിത സെർവറിൽ എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് "
-"സംരക്ഷിക്കുന്നു, പിന്നീട് ഏത് ബ്രൗസറിൽ നിന്നും ഇത് ആക്‌സസ് ചെയ്യാൻ കഴിയും."
+"ഇത് നിങ്ങളുടെ ചാറ്റുകൾ DuckDuckGo-യുടെ സുരക്ഷിത സെർവറിൽ എൻഡ്-ടു-എൻഡ് "
+"എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് സംരക്ഷിക്കുന്നു, പിന്നീട് ഏത് ബ്രൗസറിൽ നിന്നും ഇത് "
+"ആക്‌സസ് ചെയ്യാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21559,8 +21815,9 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"ഈ ക്രമീകരണം നിങ്ങളുടെ ബ്രൗസറിൽ സൂക്ഷിച്ചിരിക്കുന്നു, അതായത് നിങ്ങൾ duckduckgo.com ബ്രൗസർ "
-"ഡാറ്റ മായ്ക്കുകയാണെങ്കിൽ, നിങ്ങൾക്ക് AI സഹായമുള്ള ഉത്തരങ്ങൾ വീണ്ടും കാണാൻ കഴിയുമെന്നർത്ഥം."
+"ഈ ക്രമീകരണം നിങ്ങളുടെ ബ്രൗസറിൽ സൂക്ഷിച്ചിരിക്കുന്നു, അതായത് നിങ്ങൾ "
+"duckduckgo.com ബ്രൗസർ ഡാറ്റ മായ്ക്കുകയാണെങ്കിൽ, നിങ്ങൾക്ക് AI സഹായമുള്ള "
+"ഉത്തരങ്ങൾ വീണ്ടും കാണാൻ കഴിയുമെന്നർത്ഥം."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21570,10 +21827,10 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"ഈ ക്രമീകരണം നിങ്ങളുടെ ബ്രൗസറിൽ സൂക്ഷിച്ചിരിക്കുന്നു, അതായത് നിങ്ങൾ duckduckgo.com ബ്രൗസർ "
-"ഡാറ്റ മായ്ക്കുകയാണെങ്കിൽ, നിങ്ങൾക്ക് AI സഹായമുള്ള ഉത്തരങ്ങൾ വീണ്ടും കാണാൻ കഴിയുമെന്നർത്ഥം. "
-"എന്നിരുന്നാലും, %1$s-ൽ AI സഹായത്തോടെ ഉത്തരങ്ങൾ ഒരിക്കലും കാണിക്കാത്ത ഒരു ആരംഭ പേജും "
-"ഞങ്ങൾക്ക് ഉണ്ട്."
+"ഈ ക്രമീകരണം നിങ്ങളുടെ ബ്രൗസറിൽ സൂക്ഷിച്ചിരിക്കുന്നു, അതായത് നിങ്ങൾ "
+"duckduckgo.com ബ്രൗസർ ഡാറ്റ മായ്ക്കുകയാണെങ്കിൽ, നിങ്ങൾക്ക് AI സഹായമുള്ള "
+"ഉത്തരങ്ങൾ വീണ്ടും കാണാൻ കഴിയുമെന്നർത്ഥം. എന്നിരുന്നാലും, %1$s-ൽ AI "
+"സഹായത്തോടെ ഉത്തരങ്ങൾ ഒരിക്കലും കാണിക്കാത്ത ഒരു ആരംഭ പേജും ഞങ്ങൾക്ക് ഉണ്ട്."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
@@ -21614,7 +21871,9 @@ msgstr "ഈ വീഡിയോ ഇതുവരെ ഇവിടെ കാണാ�
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "ഈ വെബ്‌പേജ് സുരക്ഷിതവും എൻക്രിപ്റ്റ് ചെയ്തതുമായ കണക്ഷൻ (HTTPS) ഉപയോഗിക്കുന്നില്ല."
+msgstr ""
+"ഈ വെബ്‌പേജ് സുരക്ഷിതവും എൻക്രിപ്റ്റ് ചെയ്തതുമായ കണക്ഷൻ (HTTPS) "
+"ഉപയോഗിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21624,9 +21883,10 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"ഇത് ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെ എല്ലാ Duck.ai ചാറ്റുകളും ഇല്ലാതാക്കുകയും Sync & Backup "
-"വിച്ഛേദിക്കുകയും ചെയ്യും. Sync & Backup-ലേക്ക് കണക്റ്റ് ചെയ്തിരിക്കുന്ന മറ്റ് ബ്രൗസറുകളിൽ "
-"നിങ്ങൾക്ക് തുടർന്നും ചാറ്റുകൾ ആക്സസ് ചെയ്യാൻ കഴിയും."
+"ഇത് ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെ എല്ലാ Duck.ai ചാറ്റുകളും ഇല്ലാതാക്കുകയും "
+"Sync & Backup വിച്ഛേദിക്കുകയും ചെയ്യും. Sync & Backup-ലേക്ക് കണക്റ്റ് "
+"ചെയ്തിരിക്കുന്ന മറ്റ് ബ്രൗസറുകളിൽ നിങ്ങൾക്ക് തുടർന്നും ചാറ്റുകൾ ആക്സസ് "
+"ചെയ്യാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -21635,8 +21895,8 @@ msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
 msgstr ""
-"നിങ്ങളുടെ സമീപകാല ചാറ്റുകളെല്ലാം പിൻ ചെയ്തിട്ടില്ലെങ്കിൽ ഇത് ഇല്ലാതാക്കും. ഇത് "
-"പഴയപടിയാക്കാനാവില്ല."
+"നിങ്ങളുടെ സമീപകാല ചാറ്റുകളെല്ലാം പിൻ ചെയ്തിട്ടില്ലെങ്കിൽ ഇത് ഇല്ലാതാക്കും. "
+"ഇത് പഴയപടിയാക്കാനാവില്ല."
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -21655,7 +21915,8 @@ msgstr "ഇത് എല്ലാ ക്രമീകരണവും മായ്
 msgctxt "settings"
 msgid "This will reset your saved settings to default values. Continue?"
 msgstr ""
-"ഇത് നിങ്ങളുടെ സംരക്ഷിച്ച ക്രമീകരണം ഡിഫോൾട്ട് മൂല്യങ്ങളിലേക്ക് പുനഃക്രമീകരിക്കും. തുടരണോ?"
+"ഇത് നിങ്ങളുടെ സംരക്ഷിച്ച ക്രമീകരണം ഡിഫോൾട്ട് മൂല്യങ്ങളിലേക്ക് "
+"പുനഃക്രമീകരിക്കും. തുടരണോ?"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard column: holes completed in current round
@@ -21752,7 +22013,9 @@ msgstr "ശീർഷക അടിവര"
 # smartling.placeholder_format=C
 #. Informative header on a list of steps for the user to take to disable their adblocker
 msgid "To allowlist DuckDuckGo in other ad blocker extensions:"
-msgstr "മറ്റ് പരസ്യ ബ്ലോക്കർ എക്സ്റ്ൻഷനുകളിൽ DuckDuckGo-യെ അനുവദിക്കുന്ന ലിസ്റ്ൽ ചേർക്കാൻ:"
+msgstr ""
+"മറ്റ് പരസ്യ ബ്ലോക്കർ എക്സ്റ്ൻഷനുകളിൽ DuckDuckGo-യെ അനുവദിക്കുന്ന ലിസ്റ്ൽ "
+"ചേർക്കാൻ:"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to Duck.ai’s Privacy Policy and Terms of Service'
@@ -21775,8 +22038,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"ദിശകൾ പ്രിന്റ് ചെയ്യാൻ:%1$sമാപ്പിലേക്ക് മടങ്ങുക.%2$sനിങ്ങൾക്ക് പ്രിന്റ് ചെയ്യേണ്ട റൂട്ട് "
-"തിരഞ്ഞെടുക്കുക.%3$sപ്രിന്റ് ഐക്കണിൽ ക്ലിക്ക് ചെയ്യുക.%4$s"
+"ദിശകൾ പ്രിന്റ് ചെയ്യാൻ:%1$sമാപ്പിലേക്ക് മടങ്ങുക.%2$sനിങ്ങൾക്ക് പ്രിന്റ് "
+"ചെയ്യേണ്ട റൂട്ട് തിരഞ്ഞെടുക്കുക.%3$sപ്രിന്റ് ഐക്കണിൽ ക്ലിക്ക് ചെയ്യുക.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -21786,9 +22049,10 @@ msgid ""
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
 msgstr ""
-"നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ പുനഃസ്ഥാപിക്കാൻ, നിങ്ങൾ ആദ്യമായി സമന്വയം സജ്ജമാക്കുമ്പോൾ "
-"സംരക്ഷിച്ച വീണ്ടെടുക്കൽ കോഡ് ആവശ്യമാണ്. നിങ്ങൾ സമന്വയം സജ്ജമാക്കാൻ ആദ്യം ഉപയോഗിച്ച "
-"ഉപകരണത്തിൽ ഈ കോഡ് ഒരു PDF ആയി സേവ് ചെയ്‌തിരിക്കാം."
+"നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ പുനഃസ്ഥാപിക്കാൻ, നിങ്ങൾ ആദ്യമായി സമന്വയം "
+"സജ്ജമാക്കുമ്പോൾ സംരക്ഷിച്ച വീണ്ടെടുക്കൽ കോഡ് ആവശ്യമാണ്. നിങ്ങൾ സമന്വയം "
+"സജ്ജമാക്കാൻ ആദ്യം ഉപയോഗിച്ച ഉപകരണത്തിൽ ഈ കോഡ് ഒരു PDF ആയി സേവ് "
+"ചെയ്‌തിരിക്കാം."
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -21797,8 +22061,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റ് ചരിത്രം Duck.ai-ലേക്ക് മാറ്റാൻ, DuckDuckGo ബ്രൗസർ ഏറ്റവും പുതിയ "
-"പതിപ്പിലേക്ക് അപ്ഡേറ്റ് ചെയ്ത് വീണ്ടും ശ്രമിക്കുക."
+"നിങ്ങളുടെ ചാറ്റ് ചരിത്രം Duck.ai-ലേക്ക് മാറ്റാൻ, DuckDuckGo ബ്രൗസർ ഏറ്റവും "
+"പുതിയ പതിപ്പിലേക്ക് അപ്ഡേറ്റ് ചെയ്ത് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -21806,8 +22070,8 @@ msgid ""
 "To use dictation, allow your browser to access the microphone in your system "
 "settings."
 msgstr ""
-"ഡിക്ടേഷൻ ഉപയോഗിക്കാൻ, നിങ്ങളുടെ ബ്രൗസറിനെ സിസ്റ്റം ക്രമീകരണത്തിൽ മൈക്രോഫോൺ ആക്‌സസ് ചെയ്യാൻ "
-"അനുവദിക്കുക."
+"ഡിക്ടേഷൻ ഉപയോഗിക്കാൻ, നിങ്ങളുടെ ബ്രൗസറിനെ സിസ്റ്റം ക്രമീകരണത്തിൽ മൈക്രോഫോൺ "
+"ആക്‌സസ് ചെയ്യാൻ അനുവദിക്കുക."
 
 # smartling.placeholder_format=C
 msgid "Today"
@@ -21830,14 +22094,16 @@ msgstr "ഇന്ന്"
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
+"സ്വകാര്യ AI ചാറ്റിലേക്ക് ടോഗിൾ ചെയ്യുക അല്ലെങ്കിൽ %1$sക്രമീകരണങ്ങളിൽ "
+"പ്രവർത്തനരഹിതമാക്കുക%2$s."
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
-"സ്വകാര്യ AI ചാറ്റ് പരീക്ഷിക്കാൻ ടോഗിൾ ചെയ്യുക, അല്ലെങ്കിൽ %1$s %2$s മെനുവിൽ ഇത് "
-"പ്രവർത്തനരഹിതമാക്കുക.%3$s"
+"സ്വകാര്യ AI ചാറ്റ് പരീക്ഷിക്കാൻ ടോഗിൾ ചെയ്യുക, അല്ലെങ്കിൽ %1$s %2$s മെനുവിൽ "
+"ഇത് പ്രവർത്തനരഹിതമാക്കുക.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -22011,8 +22277,8 @@ msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
 msgstr ""
-"DuckDuckGo തടഞ്ഞ ട്രാക്കിംഗ് ശ്രമങ്ങൾ ഇവിടെ ദൃശ്യമാകും. ഞങ്ങൾ എത്രയെണ്ണം ബ്ലോക്ക് ചെയ്യുന്നു "
-"എന്നറിയാൻ ബ്രൗസ് ചെയ്യുന്നത് തുടരുക."
+"DuckDuckGo തടഞ്ഞ ട്രാക്കിംഗ് ശ്രമങ്ങൾ ഇവിടെ ദൃശ്യമാകും. ഞങ്ങൾ എത്രയെണ്ണം "
+"ബ്ലോക്ക് ചെയ്യുന്നു എന്നറിയാൻ ബ്രൗസ് ചെയ്യുന്നത് തുടരുക."
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -22060,8 +22326,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"ഈ വാചകം ഫ്രഞ്ചിലേക്ക് വിവർത്തനം ചെയ്യുക: “അടുത്തുള്ള സിനിമാ തിയേറ്ററിലേക്ക് ഞാൻ എങ്ങനെ "
-"എത്തും?”"
+"ഈ വാചകം ഫ്രഞ്ചിലേക്ക് വിവർത്തനം ചെയ്യുക: “അടുത്തുള്ള സിനിമാ തിയേറ്ററിലേക്ക് "
+"ഞാൻ എങ്ങനെ എത്തും?”"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -22070,8 +22336,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"ഈ വാചകം ഫ്രഞ്ചിലേക്ക് വിവർത്തനം ചെയ്യുക: “അടുത്തുള്ള സിനിമാ തിയേറ്ററിലേക്ക് ഞാൻ എങ്ങനെ "
-"എത്തും?”"
+"ഈ വാചകം ഫ്രഞ്ചിലേക്ക് വിവർത്തനം ചെയ്യുക: “അടുത്തുള്ള സിനിമാ തിയേറ്ററിലേക്ക് "
+"ഞാൻ എങ്ങനെ എത്തും?”"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -22319,8 +22585,8 @@ msgstr "വ്യത്യസ്ത കീവേഡുകൾ പരീക്ഷ�
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
 msgstr ""
-"കൂടുതൽ ഫലങ്ങൾ കാണാൻ DuckDuckGo-യിൽ നിന്നുള്ള നിങ്ങളുടെ പരസ്യ ബ്ലോക്കർ പ്രവർത്തനരഹിതമാക്കാൻ "
-"ശ്രമിക്കുക."
+"കൂടുതൽ ഫലങ്ങൾ കാണാൻ DuckDuckGo-യിൽ നിന്നുള്ള നിങ്ങളുടെ പരസ്യ ബ്ലോക്കർ "
+"പ്രവർത്തനരഹിതമാക്കാൻ ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
@@ -22385,7 +22651,9 @@ msgstr "സൗജന്യമായി പരീക്ഷിക്കൂ"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr "സൗജന്യമായി പരീക്ഷിക്കൂ! സുരക്ഷിതമായ VPN, വിപുലവും സ്വകാര്യവുമായ AI, അങ്ങനെ പലതും."
+msgstr ""
+"സൗജന്യമായി പരീക്ഷിക്കൂ! സുരക്ഷിതമായ VPN, വിപുലവും സ്വകാര്യവുമായ AI, അങ്ങനെ "
+"പലതും."
 
 # smartling.placeholder_format=C
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
@@ -22518,7 +22786,8 @@ msgstr "അടുത്തിടെ ചേർത്തിട്ടുള്ള o
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
 msgstr ""
-"ആരംഭിക്കുന്നതിന് ഈ പ്രോംപ്റ്റുകൾ പരീക്ഷിക്കുക, അല്ലെങ്കിൽ ചുവടെ നിങ്ങളുടെ സ്വന്തം പ്രോംപ്റ്റ് നൽകുക"
+"ആരംഭിക്കുന്നതിന് ഈ പ്രോംപ്റ്റുകൾ പരീക്ഷിക്കുക, അല്ലെങ്കിൽ ചുവടെ നിങ്ങളുടെ "
+"സ്വന്തം പ്രോംപ്റ്റ് നൽകുക"
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -22552,8 +22821,9 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"AI ഫീച്ചറുകൾ പ്രവർത്തനരഹിതമാക്കാൻ ശ്രമിക്കുകയാണോ? നിങ്ങളുടെ ക്രമീകരണങ്ങൾ ഓർമ്മിക്കാൻ "
-"%1$sDuckDuckGo No AI%2$s സെർച്ച് എക്സ്റ്റൻഷൻ ഇൻസ്റ്റാൾ ചെയ്യുക. %3$sകൂടുതലറിയുക%4$s"
+"AI ഫീച്ചറുകൾ പ്രവർത്തനരഹിതമാക്കാൻ ശ്രമിക്കുകയാണോ? നിങ്ങളുടെ ക്രമീകരണങ്ങൾ "
+"ഓർമ്മിക്കാൻ %1$sDuckDuckGo No AI%2$s സെർച്ച് എക്സ്റ്റൻഷൻ ഇൻസ്റ്റാൾ ചെയ്യുക. "
+"%3$sകൂടുതലറിയുക%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -22562,8 +22832,9 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"AI ഫീച്ചറുകൾ പ്രവർത്തനരഹിതമാക്കാൻ ശ്രമിക്കുകയാണോ? നിങ്ങളുടെ ക്രമീകരണങ്ങൾ ഓർമ്മിക്കാൻ "
-"%1$sDuckDuckGo No AI%2$s സെർച്ച് എക്സ്റ്റൻഷനിലേക്ക് മാറുക. %3$sകൂടുതലറിയുക%4$s"
+"AI ഫീച്ചറുകൾ പ്രവർത്തനരഹിതമാക്കാൻ ശ്രമിക്കുകയാണോ? നിങ്ങളുടെ ക്രമീകരണങ്ങൾ "
+"ഓർമ്മിക്കാൻ %1$sDuckDuckGo No AI%2$s സെർച്ച് എക്സ്റ്റൻഷനിലേക്ക് മാറുക. "
+"%3$sകൂടുതലറിയുക%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -22764,8 +23035,9 @@ msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
 msgstr ""
-"DuckAssist ഉത്തരങ്ങൾ സൃഷ്ടിക്കുമ്പോൾ ടൈപ്പ് ചെയ്യുന്നു. ഇത് ഓഫാക്കുന്നത് തിരയലിനും ഉത്തരം "
-"കാണിക്കുന്നതിനും ഇടയിൽ ഒരു ചെറിയ കാലതാമസത്തിന് കാരണമായേക്കാം."
+"DuckAssist ഉത്തരങ്ങൾ സൃഷ്ടിക്കുമ്പോൾ ടൈപ്പ് ചെയ്യുന്നു. ഇത് ഓഫാക്കുന്നത് "
+"തിരയലിനും ഉത്തരം കാണിക്കുന്നതിനും ഇടയിൽ ഒരു ചെറിയ കാലതാമസത്തിന് "
+"കാരണമായേക്കാം."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -22863,13 +23135,17 @@ msgstr "ഫീഡ് ബാക്ക് അയയ്ക്കുവാൻ സാ
 #. Message shown to the user when the voice chat failed to establish a connection, and they should try again later.
 msgctxt "voice chat"
 msgid "Unable to connect to voice chat, please try again later."
-msgstr "വോയ്സ് ചാറ്റിലേക്ക് കണക്റ്റ് ചെയ്യാൻ കഴിയുന്നില്ല, ദയവായി പിന്നീട് വീണ്ടും ശ്രമിക്കുക."
+msgstr ""
+"വോയ്സ് ചാറ്റിലേക്ക് കണക്റ്റ് ചെയ്യാൻ കഴിയുന്നില്ല, ദയവായി പിന്നീട് വീണ്ടും "
+"ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Message shown to the user when there was an issue connecting to their microphone.
 msgctxt "voice chat"
 msgid "Unable to connect to your mic. Please try again."
-msgstr "നിങ്ങളുടെ മൈക്കിലേക്ക് കണക്റ്റ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി വീണ്ടും ശ്രമിക്കുക."
+msgstr ""
+"നിങ്ങളുടെ മൈക്കിലേക്ക് കണക്റ്റ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി വീണ്ടും "
+"ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when answer fails to load
@@ -22895,8 +23171,8 @@ msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
 msgstr ""
-"%1$sആരംഭത്തിൽ%2$s എന്നതിന് കീഴിൽ, %3$sഒരു നിർദിഷ്ട പേജ് തുറക്കുക %4$s എന്നത് ക്ലിക്ക് "
-"ചെയ്യുക, തുടർന്ന് %5$sപേജുകൾ സജ്ജമാക്കുക%6$s ക്ലിക്ക് ചെയ്യുക."
+"%1$sആരംഭത്തിൽ%2$s എന്നതിന് കീഴിൽ, %3$sഒരു നിർദിഷ്ട പേജ് തുറക്കുക %4$s എന്നത് "
+"ക്ലിക്ക് ചെയ്യുക, തുടർന്ന് %5$sപേജുകൾ സജ്ജമാക്കുക%6$s ക്ലിക്ക് ചെയ്യുക."
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
@@ -22904,21 +23180,22 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"%1$sആരംഭത്തിൽ%2$s എന്നതിന് കീഴിൽ, %3$sഹോംപേജ്%4$s തിരഞ്ഞെടുത്ത് ഇത് എന്റർ ചെയ്യുക: "
-"https://duckduckgo.com"
+"%1$sആരംഭത്തിൽ%2$s എന്നതിന് കീഴിൽ, %3$sഹോംപേജ്%4$s തിരഞ്ഞെടുത്ത് ഇത് എന്റർ "
+"ചെയ്യുക: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
 msgstr ""
-"%1$sഇതിൽ തുറക്കുക%2$s എന്നതിന് കീഴിൽ, %3$sഒരു പ്രത്യേക പേജ് അല്ലെങ്കിൽ പേജുകൾ%4$s "
-"തിരഞ്ഞെടുക്കുക"
+"%1$sഇതിൽ തുറക്കുക%2$s എന്നതിന് കീഴിൽ, %3$sഒരു പ്രത്യേക പേജ് അല്ലെങ്കിൽ "
+"പേജുകൾ%4$s തിരഞ്ഞെടുക്കുക"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"%1$sആരംഭം > ഹോംപേജ് %2$s എന്നതിന് കീഴിൽ ഇത് എന്റർ ചെയ്യുക: https://duckduckgo.com"
+"%1$sആരംഭം > ഹോംപേജ് %2$s എന്നതിന് കീഴിൽ ഇത് എന്റർ ചെയ്യുക: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22929,30 +23206,32 @@ msgstr "%1$sതിരയൽ ക്രമീകരണം%2$s എന്നതി�
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
 msgstr ""
-"%1$sഇത് സഹിതം വിലാസ ബാറിൽ തിരയുക%2$s എന്നതിന് കീഴിൽ %3$sപുതിയത് ചേർക്കുക%4$s എന്നത് "
-"തിരഞ്ഞെടുക്കുക"
+"%1$sഇത് സഹിതം വിലാസ ബാറിൽ തിരയുക%2$s എന്നതിന് കീഴിൽ %3$sപുതിയത് ചേർക്കുക%4$s "
+"എന്നത് തിരഞ്ഞെടുക്കുക"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"%1$sതിരയുക%2$s വിഭാഗത്തിന് കീഴിൽ, %3$sതിരയൽ എഞ്ചിനുകൾ മാനേജ് ചെയ്യുക...%4$s ക്ലിക്ക് "
-"ചെയ്യുക"
+"%1$sതിരയുക%2$s വിഭാഗത്തിന് കീഴിൽ, %3$sതിരയൽ എഞ്ചിനുകൾ മാനേജ് ചെയ്യുക...%4$s "
+"ക്ലിക്ക് ചെയ്യുക"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
 msgstr ""
-"ആരംഭത്തിൽ എന്നതിന് കീഴിൽ %1$sഒരു നിർദിഷ്ട പേജ് അല്ലെങ്കിൽ ഒരു കൂട്ടം പേജുകൾ തുറക്കുക%2$s "
-"എന്നത് തിരഞ്ഞെടുക്കുക"
+"ആരംഭത്തിൽ എന്നതിന് കീഴിൽ %1$sഒരു നിർദിഷ്ട പേജ് അല്ലെങ്കിൽ ഒരു കൂട്ടം പേജുകൾ "
+"തുറക്കുക%2$s എന്നത് തിരഞ്ഞെടുക്കുക"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr "തിരയൽ എന്നതിന് കീഴിൽ ഡ്രോപ്പ്ഡൗൺ ക്ലിക്ക് ചെയ്ത് %1$sDuckDuckGo%2$s തിരഞ്ഞെടുക്കുക"
+msgstr ""
+"തിരയൽ എന്നതിന് കീഴിൽ ഡ്രോപ്പ്ഡൗൺ ക്ലിക്ക് ചെയ്ത് %1$sDuckDuckGo%2$s "
+"തിരഞ്ഞെടുക്കുക"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -23030,8 +23309,8 @@ msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
 msgstr ""
-"Pro-യിലേക്ക് അപ്‌ഗ്രേഡ് ചെയ്യുന്നതിലൂടെ %1$s, ഉയർന്ന AI റീസണിംഗ്, പ്ലസ് പ്ലാനിനേക്കാൾ 2 മടങ്ങ് "
-"ഉയർന്ന ഉപയോഗ പരിധി എന്നിവ അൺലോക്ക് ചെയ്യുക."
+"Pro-യിലേക്ക് അപ്‌ഗ്രേഡ് ചെയ്യുന്നതിലൂടെ %1$s, ഉയർന്ന AI റീസണിംഗ്, പ്ലസ് "
+"പ്ലാനിനേക്കാൾ 2 മടങ്ങ് ഉയർന്ന ഉപയോഗ പരിധി എന്നിവ അൺലോക്ക് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -23053,7 +23332,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"DuckDuckGo സബ്സ്ക്രിപ്ഷൻ ഉപയോഗിച്ച് നൂതന AI മോഡലുകളും ഉയർന്ന പരിധികളും അൺലോക്ക് ചെയ്യുക"
+"DuckDuckGo സബ്സ്ക്രിപ്ഷൻ ഉപയോഗിച്ച് നൂതന AI മോഡലുകളും ഉയർന്ന പരിധികളും "
+"അൺലോക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -23084,7 +23364,9 @@ msgstr "നൂതന മോഡലുകൾ അൺലോക്ക് ചെയ്
 #. Upsell message shown in the voice chat duration limit modal for free users.
 msgctxt "voice chat duration limit modal"
 msgid "Unlock longer voice chats with a DuckDuckGo Subscription"
-msgstr "DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷൻ ഉപയോഗിച്ച് ദൈർഘ്യമേറിയ വോയ്സ് ചാറ്റുകൾ അൺലോക്ക് ചെയ്യുക"
+msgstr ""
+"DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷൻ ഉപയോഗിച്ച് ദൈർഘ്യമേറിയ വോയ്സ് ചാറ്റുകൾ അൺലോക്ക് "
+"ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Text informing the user that more capable AI models can be unlocked with a subscription, with a trailing call-to-action link. %s is replaced with either the 'Try for free' link (for unauthenticated users) or the 'Learn more' link (for authenticated users). The link opens the subscription modal. Example: Unlock more capable AI models with a DuckDuckGo subscription. Try for free
@@ -23092,7 +23374,9 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr "DuckDuckGo സബ്സ്ക്രിപ്ഷൻ ഉപയോഗിച്ച് കൂടുതൽ കഴിവുള്ള AI മോഡലുകൾ അൺലോക്ക് ചെയ്യുക. %1$s"
+msgstr ""
+"DuckDuckGo സബ്സ്ക്രിപ്ഷൻ ഉപയോഗിച്ച് കൂടുതൽ കഴിവുള്ള AI മോഡലുകൾ അൺലോക്ക് "
+"ചെയ്യുക. %1$s"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -23190,8 +23474,8 @@ msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
 msgstr ""
-"Duck.ai-ൽ നിങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ സജീവമാക്കാനും നൂതന മോഡലുകൾ ആക്സസ് ചെയ്യാനും DuckDuckGo "
-"ബ്രൗസർ അപ്‌ഡേറ്റ് ചെയ്യുക"
+"Duck.ai-ൽ നിങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ സജീവമാക്കാനും നൂതന മോഡലുകൾ ആക്സസ് "
+"ചെയ്യാനും DuckDuckGo ബ്രൗസർ അപ്‌ഡേറ്റ് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -23316,15 +23600,16 @@ msgid ""
 "Upgrade to Pro to unlock 2x higher limits than Plus, or come back later to "
 "create more images."
 msgstr ""
-"Plus-നേക്കാൾ 2 മടങ്ങ് ഉയർന്ന പരിധി അൺലോക്ക് ചെയ്യാൻ Pro-യിലേക്ക് അപ്ഗ്രേഡ് ചെയ്യുക, "
-"അല്ലെങ്കിൽ കൂടുതൽ ചിത്രങ്ങൾ സൃഷ്ടിക്കാനായി പിന്നീട് മടങ്ങി വരിക."
+"Plus-നേക്കാൾ 2 മടങ്ങ് ഉയർന്ന പരിധി അൺലോക്ക് ചെയ്യാൻ Pro-യിലേക്ക് അപ്ഗ്രേഡ് "
+"ചെയ്യുക, അല്ലെങ്കിൽ കൂടുതൽ ചിത്രങ്ങൾ സൃഷ്ടിക്കാനായി പിന്നീട് മടങ്ങി വരിക."
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
 msgstr ""
-"Plus-നേക്കാൾ 2x ഉയർന്ന ഉപയോഗ പരിധികൾ അൺലോക്ക് ചെയ്യാൻ Pro-യിലേക്ക് അപ്ഗ്രേഡ് ചെയ്യുക"
+"Plus-നേക്കാൾ 2x ഉയർന്ന ഉപയോഗ പരിധികൾ അൺലോക്ക് ചെയ്യാൻ Pro-യിലേക്ക് അപ്ഗ്രേഡ് "
+"ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -23420,9 +23705,9 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"ChatGPT, Claude, മറ്റ് AI-കൾ സ്വകാര്യമായി ഉപയോഗിക്കൂ. ഹാക്കർമാരിൽ നിന്നും, സ്കാമർമാരിൽ "
-"നിന്നും, കമ്പനികളിൽ നിന്നും നിന്റെ ചാറ്റുകൾ സംരക്ഷിക്കുക. വിവരങ്ങൾ രഹസ്യമായി സൂക്ഷിക്കൂ. "
-"സൗജന്യം. അക്കൗണ്ട് ആവശ്യമില്ല."
+"ChatGPT, Claude, മറ്റ് AI-കൾ സ്വകാര്യമായി ഉപയോഗിക്കൂ. ഹാക്കർമാരിൽ നിന്നും, "
+"സ്കാമർമാരിൽ നിന്നും, കമ്പനികളിൽ നിന്നും നിന്റെ ചാറ്റുകൾ സംരക്ഷിക്കുക. "
+"വിവരങ്ങൾ രഹസ്യമായി സൂക്ഷിക്കൂ. സൗജന്യം. അക്കൗണ്ട് ആവശ്യമില്ല."
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -23435,8 +23720,8 @@ msgstr "DuckDuckGo Private Search ഉപയോഗിക്കുക"
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
 msgstr ""
-"നിങ്ങളുടെ iPad, iPhone അല്ലെങ്കിൽ Android എന്നിവയിൽ DuckDuckGo private search "
-"ഉപയോഗിക്കുക!"
+"നിങ്ങളുടെ iPad, iPhone അല്ലെങ്കിൽ Android എന്നിവയിൽ DuckDuckGo private "
+"search ഉപയോഗിക്കുക!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -23479,8 +23764,8 @@ msgid ""
 "Use this code to restore your data if you lose access to your devices. Keep "
 "it safe."
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെട്ടാൽ, നിങ്ങളുടെ ഡാറ്റ വീണ്ടെടുക്കാൻ ഈ കോഡ് "
-"ഉപയോഗിക്കുക. ഇത് സുരക്ഷിതമായി സൂക്ഷിക്കുക."
+"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെട്ടാൽ, നിങ്ങളുടെ ഡാറ്റ "
+"വീണ്ടെടുക്കാൻ ഈ കോഡ് ഉപയോഗിക്കുക. ഇത് സുരക്ഷിതമായി സൂക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
 #. First sentence of the recovery section. The 18-month inactivity notice is rendered by the component using DUCKCHAT_SYNC_RECOVERY_INACTIVITY_NOTICE so both surfaces stay consistent.
@@ -23488,8 +23773,8 @@ msgctxt "Description for the recovery section inside Manage"
 msgid ""
 "Use this code to restore your saved chats if you lose access to your devices."
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്സസ് നഷ്ടപ്പെട്ടാൽ, സംരക്ഷിച്ച ചാറ്റുകൾ വീണ്ടെടുക്കാൻ ഈ കോഡ് "
-"ഉപയോഗിക്കുക."
+"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്സസ് നഷ്ടപ്പെട്ടാൽ, സംരക്ഷിച്ച ചാറ്റുകൾ "
+"വീണ്ടെടുക്കാൻ ഈ കോഡ് ഉപയോഗിക്കുക."
 
 # smartling.placeholder_format=C
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
@@ -23639,8 +23924,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
 msgstr ""
-"പരസ്യങ്ങൾ കാണുന്നത് DuckDuckGo സ്വകാര്യതാ പരിരക്ഷ ചെയ്തിരിക്കുന്നു. പരസ്യ ക്ലിക്കുകൾ "
-"നിയന്ത്രിക്കുന്നത് Microsoft-ന്റെ പരസ്യ നെറ്റ്‌വർക്കാണ്"
+"പരസ്യങ്ങൾ കാണുന്നത് DuckDuckGo സ്വകാര്യതാ പരിരക്ഷ ചെയ്തിരിക്കുന്നു. പരസ്യ "
+"ക്ലിക്കുകൾ നിയന്ത്രിക്കുന്നത് Microsoft-ന്റെ പരസ്യ നെറ്റ്‌വർക്കാണ്"
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -23649,8 +23934,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
 msgstr ""
-"പരസ്യങ്ങൾ കാണുന്നത് DuckDuckGo സംരക്ഷിച്ചിരിക്കുന്ന സ്വകാര്യതയാണ്. പരസ്യ ക്ലിക്കുകൾ "
-"നിയന്ത്രിക്കുന്നത് TripAdvisor ന്റെ പരസ്യ ശൃംഖലയാണ്."
+"പരസ്യങ്ങൾ കാണുന്നത് DuckDuckGo സംരക്ഷിച്ചിരിക്കുന്ന സ്വകാര്യതയാണ്. പരസ്യ "
+"ക്ലിക്കുകൾ നിയന്ത്രിക്കുന്നത് TripAdvisor ന്റെ പരസ്യ ശൃംഖലയാണ്."
 
 # smartling.placeholder_format=C
 #. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
@@ -23659,6 +23944,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Yelp's ad network."
 msgstr ""
+"പരസ്യങ്ങൾ കാണുന്നത് DuckDuckGo സംരക്ഷിച്ചിരിക്കുന്ന സ്വകാര്യതയാണ്. Yelp-ന്റെ "
+"പരസ്യ ശൃംഖലയാണ് പരസ്യ ക്ലിക്കുകൾ നിയന്ത്രിക്കുന്നത്."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -23670,8 +23957,8 @@ msgctxt "duckassist"
 msgid ""
 "Visit %sAssist Settings%s to adjust how this feature works or turn it off."
 msgstr ""
-"ഈ ഫീച്ചർ എങ്ങനെ പ്രവർത്തിക്കണമെന്ന് ക്രമീകരിക്കാനോ അത് ഓഫ് ചെയ്യാനോ %1$sAssist "
-"ക്രമീകരണം%2$s സന്ദർശിക്കുക."
+"ഈ ഫീച്ചർ എങ്ങനെ പ്രവർത്തിക്കണമെന്ന് ക്രമീകരിക്കാനോ അത് ഓഫ് ചെയ്യാനോ "
+"%1$sAssist ക്രമീകരണം%2$s സന്ദർശിക്കുക."
 
 # smartling.placeholder_format=C
 #. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
@@ -23680,8 +23967,8 @@ msgid ""
 "Visit %sDuckAssist Settings%s to adjust how this feature works or turn it "
 "off."
 msgstr ""
-"ഈ ഫീച്ചർ എങ്ങനെ പ്രവർത്തിക്കണമെന്ന് ക്രമീകരിക്കാനോ അത് ഓഫ് ചെയ്യാനോ %1$sDuckAssist "
-"ക്രമീകരണം%2$s സന്ദർശിക്കുക."
+"ഈ ഫീച്ചർ എങ്ങനെ പ്രവർത്തിക്കണമെന്ന് ക്രമീകരിക്കാനോ അത് ഓഫ് ചെയ്യാനോ "
+"%1$sDuckAssist ക്രമീകരണം%2$s സന്ദർശിക്കുക."
 
 # smartling.placeholder_format=C
 #. Prompt to visit DuckDuckGo on another device.
@@ -23690,8 +23977,8 @@ msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
 msgstr ""
-"നിങ്ങളുടെ ടാബ്‍ലെറ്റിലോ ഫോണിലോ %1$sDuckDuckGo.com%2$s സന്ദർശിച്ച് നൽകിയ നിർദേശങ്ങൾ "
-"പാലിക്കുക."
+"നിങ്ങളുടെ ടാബ്‍ലെറ്റിലോ ഫോണിലോ %1$sDuckDuckGo.com%2$s സന്ദർശിച്ച് നൽകിയ "
+"നിർദേശങ്ങൾ പാലിക്കുക."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -23706,9 +23993,9 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"നിങ്ങളുടെ മറ്റ് ബ്രൗസറിൽ Duck.ai സന്ദർശിച്ച് %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s > %3$sSync & "
-"Backup%4$s > %5$sമാനേജ് ചെയ്യുക%6$s എന്നതിലേക്ക് പോയി %7$sമറ്റൊരു ഉപകരണവുമായി "
-"സമന്വയിപ്പിക്കുക%8$s തിരഞ്ഞെടുക്കുക."
+"നിങ്ങളുടെ മറ്റ് ബ്രൗസറിൽ Duck.ai സന്ദർശിച്ച് %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s > "
+"%3$sSync & Backup%4$s > %5$sമാനേജ് ചെയ്യുക%6$s എന്നതിലേക്ക് പോയി %7$sമറ്റൊരു "
+"ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%8$s തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23718,9 +24005,10 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിൽ Duck.ai സന്ദർശിച്ച് Duck.ai ക്രമീകരണങ്ങൾ തുറക്കുക. Sync & "
-"Backup എന്നതിന് കീഴിൽ \"ഓണാക്കുക\" തിരഞ്ഞെടുത്ത് \"മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക\" "
-"തിരഞ്ഞെടുക്കുക. അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി PDF-ലെ QR സ്കാൻ ചെയ്യുക."
+"നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിൽ Duck.ai സന്ദർശിച്ച് Duck.ai ക്രമീകരണങ്ങൾ "
+"തുറക്കുക. Sync & Backup എന്നതിന് കീഴിൽ \"ഓണാക്കുക\" തിരഞ്ഞെടുത്ത് \"മറ്റൊരു "
+"ഉപകരണവുമായി സമന്വയിപ്പിക്കുക\" തിരഞ്ഞെടുക്കുക. അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി "
+"PDF-ലെ QR സ്കാൻ ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -23730,9 +24018,10 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ Duck.ai സന്ദർശിച്ച്, %1$sDuck.ai "
-"ക്രമീകരണങ്ങൾ%2$s > %3$sSync & Backup%4$s > %5$sമാനേജ് ചെയ്യുക%6$s എന്നിടത്ത് "
-"%7$sമറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%8$s തിരഞ്ഞെടുക്കുക."
+"നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ Duck.ai സന്ദർശിച്ച്, "
+"%1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s > %3$sSync & Backup%4$s > %5$sമാനേജ് "
+"ചെയ്യുക%6$s എന്നിടത്ത് %7$sമറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%8$s "
+"തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23742,9 +24031,10 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"നിങ്ങളുടെ മറ്റ് ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ Duck.ai സന്ദർശിച്ച് Duck.ai ക്രമീകരണങ്ങൾ "
-"തുറക്കുക. Sync & Backup എന്നതിന് കീഴിൽ \"ഓണാക്കുക\" തിരഞ്ഞെടുത്ത് \"മറ്റൊരു ഉപകരണവുമായി "
-"സമന്വയിപ്പിക്കുക\" തിരഞ്ഞെടുക്കുക. അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി PDF-ലെ QR സ്കാൻ ചെയ്യുക."
+"നിങ്ങളുടെ മറ്റ് ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ Duck.ai സന്ദർശിച്ച് Duck.ai "
+"ക്രമീകരണങ്ങൾ തുറക്കുക. Sync & Backup എന്നതിന് കീഴിൽ \"ഓണാക്കുക\" "
+"തിരഞ്ഞെടുത്ത് \"മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക\" തിരഞ്ഞെടുക്കുക. "
+"അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി PDF-ലെ QR സ്കാൻ ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23797,8 +24087,8 @@ msgstr "വോയ്സ് ചാറ്റ് അവസാനിച്ചു"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"വോയ്സ് ചാറ്റ് ഞങ്ങൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഒരിക്കലും "
-"ഉപയോഗിച്ചിട്ടില്ല."
+"വോയ്സ് ചാറ്റ് ഞങ്ങൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ AI മോഡലുകളെ "
+"പരിശീലിപ്പിക്കാൻ ഒരിക്കലും ഉപയോഗിച്ചിട്ടില്ല."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -23942,8 +24232,9 @@ msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
-"YouTube-ൽ വ്യക്തിഗതമാക്കിയ പരസ്യങ്ങൾ തടയുന്നതിനും നിങ്ങളുടെ കാഴ്ച പ്രവർത്തനത്തെ YouTube "
-"ശുപാർശകൾ സ്വാധീനിക്കുന്നതിൽ നിന്ന് തടയുന്നതിനും Duck Player-ൽ കാണുക."
+"YouTube-ൽ വ്യക്തിഗതമാക്കിയ പരസ്യങ്ങൾ തടയുന്നതിനും നിങ്ങളുടെ കാഴ്ച "
+"പ്രവർത്തനത്തെ YouTube ശുപാർശകൾ സ്വാധീനിക്കുന്നതിൽ നിന്ന് തടയുന്നതിനും Duck "
+"Player-ൽ കാണുക."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -23963,10 +24254,11 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"ഇവിടെ ഒരു വീഡിയോ കാണുക എന്നതിനർത്ഥം അത് ഹോസ്റ്റ് ചെയ്തിരിക്കുന്ന വെബ്‌സൈറ്റിന് നിങ്ങളെ ട്രാക്ക് "
-"ചെയ്യാൻ കഴിയും എന്നാണ്, കാരണം ഞങ്ങൾ അവിടെ നിന്ന് ഉള്ളടക്കം സ്ട്രീം ചെയ്യേണ്ടതുണ്ട്. "
-"DuckDuckGo ഒരു സ്വതന്ത്ര കമ്പനിയാണ് കൂടാതെ മിക്ക വീഡിയോകളും ഹോസ്റ്റ് ചെയ്യുന്ന YouTube-മായി "
-"യാതൊരു ബന്ധവുമില്ല."
+"ഇവിടെ ഒരു വീഡിയോ കാണുക എന്നതിനർത്ഥം അത് ഹോസ്റ്റ് ചെയ്തിരിക്കുന്ന "
+"വെബ്‌സൈറ്റിന് നിങ്ങളെ ട്രാക്ക് ചെയ്യാൻ കഴിയും എന്നാണ്, കാരണം ഞങ്ങൾ അവിടെ "
+"നിന്ന് ഉള്ളടക്കം സ്ട്രീം ചെയ്യേണ്ടതുണ്ട്. DuckDuckGo ഒരു സ്വതന്ത്ര "
+"കമ്പനിയാണ് കൂടാതെ മിക്ക വീഡിയോകളും ഹോസ്റ്റ് ചെയ്യുന്ന YouTube-മായി യാതൊരു "
+"ബന്ധവുമില്ല."
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -23979,8 +24271,8 @@ msgstr "ഞങ്ങൾ അജ്ഞാതമാക്കുന്നു"
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
 msgstr ""
-"നിങ്ങൾക്ക് കൂടുതൽ കൃത്യമായ ഫലങ്ങൾ കാണിക്കുന്നതിന് ഞങ്ങൾക്ക്%1$s നിങ്ങളുടെ ലൊക്കേഷൻ%2$s "
-"അജ്ഞാതമാക്കാൻ കഴിയും."
+"നിങ്ങൾക്ക് കൂടുതൽ കൃത്യമായ ഫലങ്ങൾ കാണിക്കുന്നതിന് ഞങ്ങൾക്ക്%1$s നിങ്ങളുടെ "
+"ലൊക്കേഷൻ%2$s അജ്ഞാതമാക്കാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -23992,9 +24284,10 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
-"കാണാൻ കഴിയുന്നത് മാത്രമേ ഞങ്ങൾക്ക് പരിഹരിക്കാൻ കഴിയൂ. ദോഷകരമോ നിയമവിരുദ്ധമോ ആയ ഒരു "
-"പ്രതികരണം റിപ്പോർട്ട് ചെയ്യാൻ, ദയവായി ഈ സംഭാഷണം DuckDuckGo-യുമായി പങ്കിടുക, അതുവഴി "
-"ഞങ്ങൾക്ക് പ്രശ്നത്തെക്കുറിച്ച് അന്വേഷിച്ച് പരിഹരിക്കാൻ കഴിയും."
+"കാണാൻ കഴിയുന്നത് മാത്രമേ ഞങ്ങൾക്ക് പരിഹരിക്കാൻ കഴിയൂ. ദോഷകരമോ നിയമവിരുദ്ധമോ "
+"ആയ ഒരു പ്രതികരണം റിപ്പോർട്ട് ചെയ്യാൻ, ദയവായി ഈ സംഭാഷണം DuckDuckGo-യുമായി "
+"പങ്കിടുക, അതുവഴി ഞങ്ങൾക്ക് പ്രശ്നത്തെക്കുറിച്ച് അന്വേഷിച്ച് പരിഹരിക്കാൻ "
+"കഴിയും."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -24006,17 +24299,18 @@ msgid ""
 "please share your prompt and response so we can investigate and address the "
 "issue."
 msgstr ""
-"കാണാൻ കഴിയുന്നത് മാത്രമേ ഞങ്ങൾക്ക് ശരിയാക്കാൻ കഴിയൂ. ദോഷകരമോ നിയമവിരുദ്ധമോ ആയ ഒരു "
-"പ്രതികരണം റിപ്പോർട്ട് ചെയ്യാൻ, ദയവായി നിങ്ങളുടെ പ്രോംപ്റ്റും പ്രതികരണവും പങ്കിടുക, അതുവഴി "
-"ഞങ്ങൾക്ക് പ്രശ്നം അന്വേഷിച്ച് പരിഹരിക്കാൻ കഴിയും."
+"കാണാൻ കഴിയുന്നത് മാത്രമേ ഞങ്ങൾക്ക് ശരിയാക്കാൻ കഴിയൂ. ദോഷകരമോ നിയമവിരുദ്ധമോ "
+"ആയ ഒരു പ്രതികരണം റിപ്പോർട്ട് ചെയ്യാൻ, ദയവായി നിങ്ങളുടെ പ്രോംപ്റ്റും "
+"പ്രതികരണവും പങ്കിടുക, അതുവഴി ഞങ്ങൾക്ക് പ്രശ്നം അന്വേഷിച്ച് പരിഹരിക്കാൻ "
+"കഴിയും."
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can use your anonymous%s location%s to show you nearby results."
 msgstr ""
-"സമീപത്തുള്ള ഫലങ്ങൾ കാണിക്കുന്നതിന് ഞങ്ങൾക്ക് നിങ്ങളുടെ അജ്ഞാത%1$s ലൊക്കേഷൻ%2$s "
-"ഉപയോഗിക്കാനാകും."
+"സമീപത്തുള്ള ഫലങ്ങൾ കാണിക്കുന്നതിന് ഞങ്ങൾക്ക് നിങ്ങളുടെ അജ്ഞാത%1$s "
+"ലൊക്കേഷൻ%2$s ഉപയോഗിക്കാനാകും."
 
 # smartling.placeholder_format=C
 #. Error message displayed when one or more attached files are encrypted and cannot be read.
@@ -24024,8 +24318,8 @@ msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
 msgstr ""
-"അറ്റാച്ച് ചെയ്ത ഫയലുകളിൽ ഒരെണ്ണമെങ്കിലും എൻക്രിപ്റ്റ് ചെയ്തിരിക്കുന്നതിനാൽ ഞങ്ങൾക്ക് അവ "
-"വായിക്കാൻ കഴിയില്ല."
+"അറ്റാച്ച് ചെയ്ത ഫയലുകളിൽ ഒരെണ്ണമെങ്കിലും എൻക്രിപ്റ്റ് ചെയ്തിരിക്കുന്നതിനാൽ "
+"ഞങ്ങൾക്ക് അവ വായിക്കാൻ കഴിയില്ല."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24036,13 +24330,16 @@ msgstr "പരസ്യങ്ങളുമായി ഞങ്ങൾ നിങ്�
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr "ഞങ്ങൾ ഉപയോക്തൃനാമങ്ങളോ വ്യക്തിപരമായി തിരിച്ചറിയിക്കുന്ന വിവരങ്ങളോ സംഭരിക്കുന്നില്ല."
+msgstr ""
+"ഞങ്ങൾ ഉപയോക്തൃനാമങ്ങളോ വ്യക്തിപരമായി തിരിച്ചറിയിക്കുന്ന വിവരങ്ങളോ "
+"സംഭരിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
 msgstr ""
-"ഞങ്ങൾ നിങ്ങളുടെ സ്വകാര്യ വിവരങ്ങൾ സംഭരിക്കുകയോ നിങ്ങളെ ട്രാക്ക് ചെയ്യുകയോ ഇല്ല. എപ്പോഴും."
+"ഞങ്ങൾ നിങ്ങളുടെ സ്വകാര്യ വിവരങ്ങൾ സംഭരിക്കുകയോ നിങ്ങളെ ട്രാക്ക് ചെയ്യുകയോ "
+"ഇല്ല. എപ്പോഴും."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24054,8 +24351,8 @@ msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
 msgstr ""
-"നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾ ഞങ്ങൾ സംഭരിക്കാറില്ല. പരസ്യങ്ങളുമായി ഞങ്ങൾ നിങ്ങളെ "
-"പിന്തുടരില്ല. ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യില്ല. എപ്പോഴും."
+"നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾ ഞങ്ങൾ സംഭരിക്കാറില്ല. പരസ്യങ്ങളുമായി ഞങ്ങൾ "
+"നിങ്ങളെ പിന്തുടരില്ല. ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യില്ല. എപ്പോഴും."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24069,8 +24366,9 @@ msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
 msgstr ""
-"ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല, അതിനാൽ ഇന്ന് നിങ്ങളെ തിരികെ കൊണ്ടുവന്നത് എന്താണെന്ന് "
-"ഞങ്ങളോട് പറയാൻ നിങ്ങളുടെ സഹായം ഞങ്ങൾക്ക് ഉപയോഗിക്കാം:"
+"ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല, അതിനാൽ ഇന്ന് നിങ്ങളെ തിരികെ "
+"കൊണ്ടുവന്നത് എന്താണെന്ന് ഞങ്ങളോട് പറയാൻ നിങ്ങളുടെ സഹായം ഞങ്ങൾക്ക് "
+"ഉപയോഗിക്കാം:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -24079,8 +24377,9 @@ msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
 msgstr ""
-"ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല, അതിനാൽ ഇന്ന് ഞങ്ങളെ പരീക്ഷിച്ചുനോക്കാൻ നിങ്ങൾക്ക് "
-"ബോധ്യംപകർന്നത് എന്താണെന്ന് ഞങ്ങളോട് പറയാൻ നിങ്ങളുടെ സഹായം ഞങ്ങൾക്ക് ഉപയോഗിക്കാം:"
+"ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല, അതിനാൽ ഇന്ന് ഞങ്ങളെ പരീക്ഷിച്ചുനോക്കാൻ "
+"നിങ്ങൾക്ക് ബോധ്യംപകർന്നത് എന്താണെന്ന് ഞങ്ങളോട് പറയാൻ നിങ്ങളുടെ സഹായം "
+"ഞങ്ങൾക്ക് ഉപയോഗിക്കാം:"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24091,7 +24390,9 @@ msgstr "ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr "ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല. ചുരുക്കത്തിൽ അതാണ് ഞങ്ങളുടെ സ്വകാര്യതാ നയം."
+msgstr ""
+"ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല. ചുരുക്കത്തിൽ അതാണ് ഞങ്ങളുടെ സ്വകാര്യതാ "
+"നയം."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -24120,8 +24421,8 @@ msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
 msgstr ""
-"ഞങ്ങൾ നിങ്ങളുടെ തിരയൽ ചരിത്രം സൂക്ഷിക്കില്ല. അതുകൊണ്ട് നിങ്ങളെ ഇന്റർനെറ്റിൽ ഉടനീളം "
-"പിന്തുടരുന്ന പരസ്യദാതാക്കൾക്ക് വിൽക്കാൻ ഞങ്ങൾക്ക് ഒന്നുമില്ല"
+"ഞങ്ങൾ നിങ്ങളുടെ തിരയൽ ചരിത്രം സൂക്ഷിക്കില്ല. അതുകൊണ്ട് നിങ്ങളെ ഇന്റർനെറ്റിൽ "
+"ഉടനീളം പിന്തുടരുന്ന പരസ്യദാതാക്കൾക്ക് വിൽക്കാൻ ഞങ്ങൾക്ക് ഒന്നുമില്ല"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -24147,8 +24448,8 @@ msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
 msgstr ""
-"ഡാറ്റാ ബ്രോക്കർ സൈറ്റുകളിൽ നിന്ന് ഞങ്ങൾ നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾ കണ്ടെത്തി നീക്കം "
-"ചെയ്യുന്നു. Plus, ഒരു VPN-ഉം അതിലധികവും നേടൂ."
+"ഡാറ്റാ ബ്രോക്കർ സൈറ്റുകളിൽ നിന്ന് ഞങ്ങൾ നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾ "
+"കണ്ടെത്തി നീക്കം ചെയ്യുന്നു. Plus, ഒരു VPN-ഉം അതിലധികവും നേടൂ."
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -24157,8 +24458,8 @@ msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ AI-കളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കപ്പെടുകയില്ലെന്ന് ഉറപ്പാക്കാൻ എല്ലാ AI "
-"ദാതാക്കളുമായും ഞങ്ങൾക്ക് കരാറുകളുണ്ട്."
+"നിങ്ങളുടെ ചാറ്റുകൾ AI-കളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കപ്പെടുകയില്ലെന്ന് "
+"ഉറപ്പാക്കാൻ എല്ലാ AI ദാതാക്കളുമായും ഞങ്ങൾക്ക് കരാറുകളുണ്ട്."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -24175,7 +24476,9 @@ msgstr "ഞങ്ങൾക്ക് കണക്ഷൻ നഷ്ടപ്പെ�
 #. We store chats for 15 minutes in the BE. If the user tries to fetch it after the 15 minutes elapsed or if we had an issue saving it we show them this error message so they can re-submit their prompt.
 msgctxt "AI Chat: Error message for unsaved or expired chats saved in sync"
 msgid "We lost the connection. Please try sending your message again."
-msgstr "ഞങ്ങൾക്ക് കണക്ഷൻ നഷ്ടപ്പെട്ടു. ദയവായി നിങ്ങളുടെ സന്ദേശം വീണ്ടും അയയ്ക്കാൻ ശ്രമിക്കൂ."
+msgstr ""
+"ഞങ്ങൾക്ക് കണക്ഷൻ നഷ്ടപ്പെട്ടു. ദയവായി നിങ്ങളുടെ സന്ദേശം വീണ്ടും അയയ്ക്കാൻ "
+"ശ്രമിക്കൂ."
 
 # smartling.placeholder_format=C
 #. Message asking the user to disable their ad blocker, with a link to how our ads don't track you. The placeholders are for the start and end tags of that link (e.g. <a href="%">, </a>)
@@ -24183,8 +24486,8 @@ msgid ""
 "We make money from %sprivacy-respecting search ads%s, not by exploiting your "
 "data."
 msgstr ""
-"ഞങ്ങൾ നിങ്ങളുടെ ഡാറ്റ ചൂഷണം ചെയ്യുന്നതിലൂടെയല്ല, %1$sസ്വകാര്യത മാനിക്കുന്ന തിരയൽ "
-"പരസ്യങ്ങളിൽ%2$s നിന്നാണ് പണം സമ്പാദിക്കുന്നത്."
+"ഞങ്ങൾ നിങ്ങളുടെ ഡാറ്റ ചൂഷണം ചെയ്യുന്നതിലൂടെയല്ല, %1$sസ്വകാര്യത മാനിക്കുന്ന "
+"തിരയൽ പരസ്യങ്ങളിൽ%2$s നിന്നാണ് പണം സമ്പാദിക്കുന്നത്."
 
 # smartling.placeholder_format=C
 #. Message describing how DuckDuckGo users location access anonymously to provide better search results.
@@ -24193,8 +24496,9 @@ msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
 msgstr ""
-"നിങ്ങളുടെ സമീപത്തുള്ള മികച്ച ഫലങ്ങൾ നൽകാൻ മാത്രമേ ഞങ്ങൾ നിങ്ങളുടെ അജ്ഞാത ലൊക്കേഷൻ "
-"ഉപയോഗിക്കുകയുള്ളൂ. പിന്നീട് എപ്പോൾ വേണമെങ്കിലും നിങ്ങളുടെ മനസ്സ് മാറ്റാൻ കഴിയും."
+"നിങ്ങളുടെ സമീപത്തുള്ള മികച്ച ഫലങ്ങൾ നൽകാൻ മാത്രമേ ഞങ്ങൾ നിങ്ങളുടെ അജ്ഞാത "
+"ലൊക്കേഷൻ ഉപയോഗിക്കുകയുള്ളൂ. പിന്നീട് എപ്പോൾ വേണമെങ്കിലും നിങ്ങളുടെ മനസ്സ് "
+"മാറ്റാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
@@ -24203,20 +24507,24 @@ msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
 msgstr ""
-"നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾക്കായി ഞങ്ങൾ ഡാറ്റാ ബ്രോക്കർ സൈറ്റുകൾ പതിവായി സ്കാൻ ചെയ്യുകയും, "
-"ഉപയോഗിക്കാൻ എളുപ്പമുള്ള ഡാഷ്‌ബോർഡിൽ ഞങ്ങളുടെ പുരോഗതി നിങ്ങളുമായി പങ്കിടുകയും ചെയ്യുന്നു."
+"നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾക്കായി ഞങ്ങൾ ഡാറ്റാ ബ്രോക്കർ സൈറ്റുകൾ പതിവായി "
+"സ്കാൻ ചെയ്യുകയും, ഉപയോഗിക്കാൻ എളുപ്പമുള്ള ഡാഷ്‌ബോർഡിൽ ഞങ്ങളുടെ പുരോഗതി "
+"നിങ്ങളുമായി പങ്കിടുകയും ചെയ്യുന്നു."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
 msgstr ""
-"എല്ലാവർക്കും DuckDuckGo മികച്ചതാക്കാൻ ഞങ്ങൾ നിങ്ങളുടെ അജ്ഞാത ഫീഡ്ബാക്കിനെ ആശ്രയിക്കുന്നു."
+"എല്ലാവർക്കും DuckDuckGo മികച്ചതാക്കാൻ ഞങ്ങൾ നിങ്ങളുടെ അജ്ഞാത ഫീഡ്ബാക്കിനെ "
+"ആശ്രയിക്കുന്നു."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr "ഞങ്ങൾ ഉൾപ്പെടെ, നിങ്ങളുടെ തിരയൽ ചരിത്രം ആർക്കും ലഭിക്കുന്നതിൽ നിന്ന് ഞങ്ങൾ തടയുന്നു."
+msgstr ""
+"ഞങ്ങൾ ഉൾപ്പെടെ, നിങ്ങളുടെ തിരയൽ ചരിത്രം ആർക്കും ലഭിക്കുന്നതിൽ നിന്ന് ഞങ്ങൾ "
+"തടയുന്നു."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -24232,15 +24540,16 @@ msgid ""
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
 msgstr ""
-"DuckDuckGo മെച്ചപ്പെടുത്തുന്നതിന് ഞങ്ങൾ ഇതുപോലുള്ള ഫീഡ്ബാക്ക് ഉപയോഗിക്കാറുണ്ട്. %1$s-ന്റെ "
-"വിവേചനാധികാര പ്രകാരം നിർദേശങ്ങൾ സംയോജിപ്പിക്കുന്നതാണ്. തിരുത്തലുകൾ ഫലങ്ങളിൽ സത്വരം "
-"ദൃശ്യമാകണമെന്നില്ല."
+"DuckDuckGo മെച്ചപ്പെടുത്തുന്നതിന് ഞങ്ങൾ ഇതുപോലുള്ള ഫീഡ്ബാക്ക് "
+"ഉപയോഗിക്കാറുണ്ട്. %1$s-ന്റെ വിവേചനാധികാര പ്രകാരം നിർദേശങ്ങൾ "
+"സംയോജിപ്പിക്കുന്നതാണ്. തിരുത്തലുകൾ ഫലങ്ങളിൽ സത്വരം ദൃശ്യമാകണമെന്നില്ല."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
 msgstr ""
-"നിങ്ങൾ ബ്രൗസ് ചെയ്യുമ്പോൾ നിങ്ങളുടെ ഡാറ്റ ശേഖരിക്കാൻ ശ്രമിക്കുന്ന ട്രാക്കർമാരെ ഞങ്ങൾ തടയും."
+"നിങ്ങൾ ബ്രൗസ് ചെയ്യുമ്പോൾ നിങ്ങളുടെ ഡാറ്റ ശേഖരിക്കാൻ ശ്രമിക്കുന്ന "
+"ട്രാക്കർമാരെ ഞങ്ങൾ തടയും."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
@@ -24249,8 +24558,9 @@ msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
 msgstr ""
-"നിങ്ങളുടെ ഇമെയിൽ, പേര്, വിലാസം എന്നിവയും മറ്റും ഞങ്ങൾ ഡാറ്റാ ബ്രോക്കർ സൈറ്റുകളിൽ സ്കാൻ "
-"ചെയ്യുകയും, നിങ്ങളെക്കുറിച്ച് കണ്ടെത്തുന്നത് നീക്കം ചെയ്യാൻ പ്രവർത്തിക്കുകയും ചെയ്യും."
+"നിങ്ങളുടെ ഇമെയിൽ, പേര്, വിലാസം എന്നിവയും മറ്റും ഞങ്ങൾ ഡാറ്റാ ബ്രോക്കർ "
+"സൈറ്റുകളിൽ സ്കാൻ ചെയ്യുകയും, നിങ്ങളെക്കുറിച്ച് കണ്ടെത്തുന്നത് നീക്കം ചെയ്യാൻ "
+"പ്രവർത്തിക്കുകയും ചെയ്യും."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24260,8 +24570,8 @@ msgid ""
 "continue to see this error, please reach out to %s."
 msgstr ""
 "ഈ പ്രശ്നത്തെക്കുറിച്ച് ഞങ്ങൾക്കറിയാം, അത് പരിഹരിക്കാൻ ഞങ്ങൾ ഇപ്പോൾ "
-"പ്രവർത്തിച്ചുകൊണ്ടിരിക്കുകയാണ്. നിങ്ങൾക്ക് ഈ പിശക് തുടർന്നും കാണുകയാണെങ്കിൽ, ദയവായി %1$s-നെ "
-"സമീപിക്കുക."
+"പ്രവർത്തിച്ചുകൊണ്ടിരിക്കുകയാണ്. നിങ്ങൾക്ക് ഈ പിശക് തുടർന്നും കാണുകയാണെങ്കിൽ, "
+"ദയവായി %1$s-നെ സമീപിക്കുക."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -24271,7 +24581,8 @@ msgid ""
 "clearing your browser's cache can help."
 msgstr ""
 "ഈ പ്രശ്നത്തെക്കുറിച്ച് ഞങ്ങൾക്കറിയാം, അത് പരിഹരിക്കാൻ ഞങ്ങൾ ഇപ്പോൾ "
-"പ്രവർത്തിച്ചുകൊണ്ടിരിക്കുകയാണ്. ചിലപ്പോൾ നിങ്ങളുടെ ബ്രൗസറിന്റെ കാഷെ മായ്ക്കുന്നത് സഹായിക്കാം."
+"പ്രവർത്തിച്ചുകൊണ്ടിരിക്കുകയാണ്. ചിലപ്പോൾ നിങ്ങളുടെ ബ്രൗസറിന്റെ കാഷെ "
+"മായ്ക്കുന്നത് സഹായിക്കാം."
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -24286,8 +24597,8 @@ msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
 msgstr ""
-"ഈ അസൗകര്യത്തിന് ഞങ്ങൾ ക്ഷമ ചോദിക്കുന്നു. നിങ്ങളുടെ അനുഭവം മികച്ചതാക്കാൻ ഞങ്ങൾ കഠിനമായി "
-"പരിശ്രമിക്കുന്നു."
+"ഈ അസൗകര്യത്തിന് ഞങ്ങൾ ക്ഷമ ചോദിക്കുന്നു. നിങ്ങളുടെ അനുഭവം മികച്ചതാക്കാൻ "
+"ഞങ്ങൾ കഠിനമായി പരിശ്രമിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -24296,8 +24607,8 @@ msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
 msgstr ""
-"ഞങ്ങൾ Duck.ai സേവനം അപ്ഡേറ്റ് ചെയ്തു. മാറ്റം പ്രാബല്യത്തിൽ വരാൻ, നമ്മൾ പേജ് വീണ്ടും ലോഡ് "
-"ചെയ്യേണ്ടതുണ്ട്."
+"ഞങ്ങൾ Duck.ai സേവനം അപ്ഡേറ്റ് ചെയ്തു. മാറ്റം പ്രാബല്യത്തിൽ വരാൻ, നമ്മൾ പേജ് "
+"വീണ്ടും ലോഡ് ചെയ്യേണ്ടതുണ്ട്."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -24405,7 +24716,9 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Weekly usage limit reached. You can keep chatting by using your monthly "
 "limit."
-msgstr "പ്രതിവാര ഉപയോഗ പരിധി എത്തി. നിങ്ങളുടെ പ്രതിമാസ പരിധി ഉപയോഗിച്ച് ചാറ്റ് തുടരാം."
+msgstr ""
+"പ്രതിവാര ഉപയോഗ പരിധി എത്തി. നിങ്ങളുടെ പ്രതിമാസ പരിധി ഉപയോഗിച്ച് ചാറ്റ് "
+"തുടരാം."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -24419,8 +24732,9 @@ msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
 msgstr ""
-"Duck.ai-യിലേക്ക് സ്വാഗതം! ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും സ്വകാര്യമാണ്, അവ ഞങ്ങൾ "
-"അജ്ഞാതമാക്കും, കൂടാതെ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല."
+"Duck.ai-യിലേക്ക് സ്വാഗതം! ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും "
+"സ്വകാര്യമാണ്, അവ ഞങ്ങൾ അജ്ഞാതമാക്കും, കൂടാതെ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ "
+"ഉപയോഗിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -24429,9 +24743,9 @@ msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat-ലേക്ക് സ്വാഗതം! ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും സ്വകാര്യമാണ്, അവ "
-"ഒരിക്കലും DuckDuckGo സംഭരിക്കുകയോ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുകയോ "
-"ചെയ്യുന്നില്ല."
+"DuckDuckGo AI Chat-ലേക്ക് സ്വാഗതം! ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും "
+"സ്വകാര്യമാണ്, അവ ഒരിക്കലും DuckDuckGo സംഭരിക്കുകയോ AI മോഡലുകളെ "
+"പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുകയോ ചെയ്യുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -24441,16 +24755,17 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat-ലേക്ക് സ്വാഗതം! ഈ ചാറ്റ് സെഷൻ നൽകുന്നത് %1$s-ൻ്റെ %2$s ആണ്. "
-"ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും സ്വകാര്യമാണ്, അവ ഒരിക്കലും DuckDuckGo സംഭരിക്കുകയോ AI "
-"മോഡലുകളെ പരിശീലിപ്പിക്കുകയോ ചെയ്യുന്നില്ല."
+"DuckDuckGo AI Chat-ലേക്ക് സ്വാഗതം! ഈ ചാറ്റ് സെഷൻ നൽകുന്നത് %1$s-ൻ്റെ %2$s "
+"ആണ്. ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും സ്വകാര്യമാണ്, അവ ഒരിക്കലും "
+"DuckDuckGo സംഭരിക്കുകയോ AI മോഡലുകളെ പരിശീലിപ്പിക്കുകയോ ചെയ്യുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
 msgstr ""
-"പുതിയ Duck.ai-യിലേക്ക് സ്വാഗതം! ഇപ്പോൾ നിങ്ങൾ ഡൗൺലോഡ് ചെയ്ത ചാറ്റുകൾ ഇംപോർട്ട് ചെയ്യാം."
+"പുതിയ Duck.ai-യിലേക്ക് സ്വാഗതം! ഇപ്പോൾ നിങ്ങൾ ഡൗൺലോഡ് ചെയ്ത ചാറ്റുകൾ "
+"ഇംപോർട്ട് ചെയ്യാം."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24518,8 +24833,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"ഞങ്ങൾക്കു വളരെ ക്ഷമിക്കണം, പക്ഷേ Duck.ai ലോഡ് ചെയ്യുന്നതിൽ ഒരു പ്രശ്നമുണ്ടായതായി തോന്നുന്നു. "
-"പേജ് വീണ്ടും ലോഡ് ചെയ്യാൻ ശ്രമിക്കൂ."
+"ഞങ്ങൾക്കു വളരെ ക്ഷമിക്കണം, പക്ഷേ Duck.ai ലോഡ് ചെയ്യുന്നതിൽ ഒരു "
+"പ്രശ്നമുണ്ടായതായി തോന്നുന്നു. പേജ് വീണ്ടും ലോഡ് ചെയ്യാൻ ശ്രമിക്കൂ."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -24534,8 +24849,8 @@ msgid ""
 "What are some arguments, counter-arguments, and rebuttals to the concept of "
 "a plant-based diet?"
 msgstr ""
-"ഒരു സസ്യാധിഷ്ഠിത ഭക്ഷണക്രമ ആശയത്തിനുള്ള ചില വാദങ്ങളും എതിർവാദങ്ങളും പ്രതിവാദങ്ങളും "
-"എന്തൊക്കെയാണ്?"
+"ഒരു സസ്യാധിഷ്ഠിത ഭക്ഷണക്രമ ആശയത്തിനുള്ള ചില വാദങ്ങളും എതിർവാദങ്ങളും "
+"പ്രതിവാദങ്ങളും എന്തൊക്കെയാണ്?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
@@ -24556,8 +24871,8 @@ msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
 msgstr ""
-"“ഞങ്ങൾ ശരിക്കും മികച്ചത് ചെയ്യേണ്ടതുണ്ട്” എന്ന പശ്ചാത്തലത്തിൽ 'മികച്ചത്' എന്ന വാക്കിനുള്ള ചില "
-"ഓപ്ഷനുകൾ എന്തൊക്കെയാണ്."
+"“ഞങ്ങൾ ശരിക്കും മികച്ചത് ചെയ്യേണ്ടതുണ്ട്” എന്ന പശ്ചാത്തലത്തിൽ 'മികച്ചത്' "
+"എന്ന വാക്കിനുള്ള ചില ഓപ്ഷനുകൾ എന്തൊക്കെയാണ്."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -24582,11 +24897,12 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"Duck.ai ഉപയോഗിക്കാൻ താൽപ്പര്യമുള്ള ഒരാൾക്ക് DuckDuckGo ബ്രൗസർ ഡൗൺലോഡ് ചെയ്യുന്നതിന്റെ "
-"പ്രയോജനങ്ങൾ എന്തൊക്കെയാണ്? ഔദ്യോഗിക DuckDuckGo സ്രോതസ്സുകൾ മാത്രം അവലംബിക്കുന്നു. Duck.ai "
-"സംയോജനങ്ങളിലും സ്വകാര്യതാ സംരക്ഷണങ്ങളിലും ശ്രദ്ധ കേന്ദ്രീകരിച്ച്, തലക്കെട്ടുകൾ ഉപയോഗിച്ച് "
-"പ്രതികരണത്തെ വ്യക്തമായ വിഭാഗങ്ങളായി വിഭജിക്കുന്നു. AI അല്ലെങ്കിൽ സാങ്കേതിക പരിചയം "
-"കൂടുതലുള്ളവർക്കും ഇല്ലാത്തവർക്കും ഇത് വളരെ ചെറുതും ലളിതവും മനസ്സിലാക്കാൻ എളുപ്പവുമാക്കുന്നു."
+"Duck.ai ഉപയോഗിക്കാൻ താൽപ്പര്യമുള്ള ഒരാൾക്ക് DuckDuckGo ബ്രൗസർ ഡൗൺലോഡ് "
+"ചെയ്യുന്നതിന്റെ പ്രയോജനങ്ങൾ എന്തൊക്കെയാണ്? ഔദ്യോഗിക DuckDuckGo സ്രോതസ്സുകൾ "
+"മാത്രം അവലംബിക്കുന്നു. Duck.ai സംയോജനങ്ങളിലും സ്വകാര്യതാ സംരക്ഷണങ്ങളിലും "
+"ശ്രദ്ധ കേന്ദ്രീകരിച്ച്, തലക്കെട്ടുകൾ ഉപയോഗിച്ച് പ്രതികരണത്തെ വ്യക്തമായ "
+"വിഭാഗങ്ങളായി വിഭജിക്കുന്നു. AI അല്ലെങ്കിൽ സാങ്കേതിക പരിചയം കൂടുതലുള്ളവർക്കും "
+"ഇല്ലാത്തവർക്കും ഇത് വളരെ ചെറുതും ലളിതവും മനസ്സിലാക്കാൻ എളുപ്പവുമാക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24672,7 +24988,8 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
 msgstr ""
-"ഈ സ്ഥലത്തിന്റെ പ്രവർത്തന സമയം, ലൊക്കേഷൻ, ബന്ധപ്പെടാനുള്ള വിവരങ്ങൾ എന്നിവ എന്തൊക്കെയാണ്?"
+"ഈ സ്ഥലത്തിന്റെ പ്രവർത്തന സമയം, ലൊക്കേഷൻ, ബന്ധപ്പെടാനുള്ള വിവരങ്ങൾ എന്നിവ "
+"എന്തൊക്കെയാണ്?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -24823,8 +25140,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Cloud Save ബുക്ക്മാര്‍ക്കലെറ്റ് എന്നാല്‍ എന്ത്? URL പാരാമീറ്റർ ബുക്ക്മാർക്ലറ്റിൽ നിന്ന് ഇത് എങ്ങനെ "
-"വ്യത്യാസപ്പെട്ടിരിക്കുന്നു?"
+"Cloud Save ബുക്ക്മാര്‍ക്കലെറ്റ് എന്നാല്‍ എന്ത്? URL പാരാമീറ്റർ "
+"ബുക്ക്മാർക്ലറ്റിൽ നിന്ന് ഇത് എങ്ങനെ വ്യത്യാസപ്പെട്ടിരിക്കുന്നു?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -24900,7 +25217,8 @@ msgstr "നിങ്ങൾ എന്തിനെക്കുറിച്ചാ�
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
 msgstr ""
-"DuckDuckGo-യിൽ നിങ്ങൾ എന്ത് കാണുന്നുവെന്നത് YouTube-ലെ നിങ്ങളുടെ ശുപാർശകളെ സ്വാധീനിക്കില്ല."
+"DuckDuckGo-യിൽ നിങ്ങൾ എന്ത് കാണുന്നുവെന്നത് YouTube-ലെ നിങ്ങളുടെ ശുപാർശകളെ "
+"സ്വാധീനിക്കില്ല."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -24926,8 +25244,8 @@ msgid ""
 "When buying an electric guitar for a beginner, what are the top product "
 "brands I should consider?"
 msgstr ""
-"ഒരു തുടക്കക്കാരന് വേണ്ടി ഒരു ഇലക്ട്രിക് ഗിറ്റാർ വാങ്ങുമ്പോൾ, ഞാൻ പരിഗണിക്കേണ്ട മുൻനിര ഉൽപ്പന്ന "
-"ബ്രാൻഡുകൾ എന്തൊക്കെയാണ്?"
+"ഒരു തുടക്കക്കാരന് വേണ്ടി ഒരു ഇലക്ട്രിക് ഗിറ്റാർ വാങ്ങുമ്പോൾ, ഞാൻ "
+"പരിഗണിക്കേണ്ട മുൻനിര ഉൽപ്പന്ന ബ്രാൻഡുകൾ എന്തൊക്കെയാണ്?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -24951,7 +25269,8 @@ msgstr "<strong>%1$s</strong> എവിടെ കാണാം"
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
 msgstr ""
-"അത് ഹോംപേജ് എന്ന് പറയുന്നിടത്ത്, %1$sനിലവിലെ പേജിലേക്ക് സജ്ജമാക്കുക%2$s എന്നത് ക്ലിക്ക് ചെയ്യുക."
+"അത് ഹോംപേജ് എന്ന് പറയുന്നിടത്ത്, %1$sനിലവിലെ പേജിലേക്ക് സജ്ജമാക്കുക%2$s "
+"എന്നത് ക്ലിക്ക് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -24992,7 +25311,8 @@ msgstr "ആരാണ് ഞങ്ങൾ"
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
 msgstr ""
-"പ്രധാന അഭിനേതാക്കളും അണിയറപ്രവർത്തകരും ആരൊക്കെയാണ്, അവർ മറ്റെന്തിനൊക്കെയാണ് അറിയപ്പെടുന്നത്?"
+"പ്രധാന അഭിനേതാക്കളും അണിയറപ്രവർത്തകരും ആരൊക്കെയാണ്, അവർ മറ്റെന്തിനൊക്കെയാണ് "
+"അറിയപ്പെടുന്നത്?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -25130,9 +25450,9 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
-"Duck.ai ഉപയോഗിച്ച്, നിങ്ങളുടെ ചാറ്റുകൾ അജ്ഞാതമാക്കപ്പെടുന്നു, കൂടാതെ AI പരിശീലിപ്പിക്കാൻ "
-"ഒരിക്കലും ഉപയോഗിക്കില്ല. '%1$s' മെനുവിൽ എപ്പോൾ വേണമെങ്കിലും ഇത് ഓണാക്കുകയോ ഓഫാക്കുകയോ "
-"ചെയ്യാം."
+"Duck.ai ഉപയോഗിച്ച്, നിങ്ങളുടെ ചാറ്റുകൾ അജ്ഞാതമാക്കപ്പെടുന്നു, കൂടാതെ AI "
+"പരിശീലിപ്പിക്കാൻ ഒരിക്കലും ഉപയോഗിക്കില്ല. '%1$s' മെനുവിൽ എപ്പോൾ വേണമെങ്കിലും "
+"ഇത് ഓണാക്കുകയോ ഓഫാക്കുകയോ ചെയ്യാം."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
@@ -25141,6 +25461,8 @@ msgid ""
 "With chat history on, up to %s of your most recent chats will be saved on "
 "this device."
 msgstr ""
+"ചാറ്റ് ചരിത്രം ഓണായിരിക്കുമ്പോൾ, നിങ്ങളുടെ ഏറ്റവും പുതിയ ചാറ്റുകളിൽ %1$s വരെ "
+"ഈ ഉപകരണത്തിൽ സംരക്ഷിക്കപ്പെടും."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline in the About Chat History modal.
@@ -25148,6 +25470,8 @@ msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, your most recent chats will be saved on this device."
 msgstr ""
+"ചാറ്റ് ചരിത്രം ഓണായിരിക്കുമ്പോൾ, നിങ്ങളുടെ ഏറ്റവും പുതിയ ചാറ്റുകൾ ഈ "
+"ഉപകരണത്തിൽ സംരക്ഷിക്കപ്പെടും."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -25162,8 +25486,9 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
-"ഡാറ്റ ബ്രോക്കർ സൈറ്റുകളിൽ നിന്ന് നിങ്ങളുടെ ഇമെയിൽ, പേര്, വിലാസം എന്നിവയും അതിലേറെയും "
-"നീക്കം ചെയ്യാൻ നിങ്ങളുടെ ഉപകരണത്തിൽ നിന്ന് നേരിട്ട് പ്രവർത്തിക്കുന്നു."
+"ഡാറ്റ ബ്രോക്കർ സൈറ്റുകളിൽ നിന്ന് നിങ്ങളുടെ ഇമെയിൽ, പേര്, വിലാസം എന്നിവയും "
+"അതിലേറെയും നീക്കം ചെയ്യാൻ നിങ്ങളുടെ ഉപകരണത്തിൽ നിന്ന് നേരിട്ട് "
+"പ്രവർത്തിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25412,7 +25737,8 @@ msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
 msgstr ""
-"അതെ, നിങ്ങൾ ഡാറ്റ പൂർത്തിയാക്കുമ്പോൾ ഞങ്ങൾ അത് വലിച്ചെറിയുന്നു, അത് വീണ്ടെടുക്കാൻ കഴിയില്ല."
+"അതെ, നിങ്ങൾ ഡാറ്റ പൂർത്തിയാക്കുമ്പോൾ ഞങ്ങൾ അത് വലിച്ചെറിയുന്നു, അത് "
+"വീണ്ടെടുക്കാൻ കഴിയില്ല."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -25432,8 +25758,8 @@ msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
 msgstr ""
-"നിങ്ങൾ %1$s എന്നയാളുമായി ചാറ്റ് ചെയ്യുന്നു. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ "
-"വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം."
+"നിങ്ങൾ %1$s എന്നയാളുമായി ചാറ്റ് ചെയ്യുന്നു. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ "
+"കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -25442,8 +25768,8 @@ msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
 msgstr ""
-"%2$s തിരയൽ കുറുക്കുവഴികൾ ഉപയോഗിച്ച് നിങ്ങൾക്ക് %1$s അല്ലെങ്കിൽ DuckDuckGo-യിൽ നിന്ന് മറ്റ് "
-"തിരയൽ എഞ്ചിനുകളിൽ നേരിട്ട് തിരയാൻ കഴിയും."
+"%2$s തിരയൽ കുറുക്കുവഴികൾ ഉപയോഗിച്ച് നിങ്ങൾക്ക് %1$s അല്ലെങ്കിൽ "
+"DuckDuckGo-യിൽ നിന്ന് മറ്റ് തിരയൽ എഞ്ചിനുകളിൽ നേരിട്ട് തിരയാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -25457,8 +25783,8 @@ msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
 msgstr ""
-"നിങ്ങൾക്ക് %1$s എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്നത് ക്രമീകരിക്കാനോ %2$sതിരയൽ ക്രമീകരണങ്ങൾ%3$s-ൽ "
-"എപ്പോൾ വേണമെങ്കിലും അത് ഓഫാക്കാനോ കഴിയും."
+"നിങ്ങൾക്ക് %1$s എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്നത് ക്രമീകരിക്കാനോ %2$sതിരയൽ "
+"ക്രമീകരണങ്ങൾ%3$s-ൽ എപ്പോൾ വേണമെങ്കിലും അത് ഓഫാക്കാനോ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -25467,21 +25793,22 @@ msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
 msgstr ""
-"Assist എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്നത് ക്രമീകരിക്കാനോ %1$sതിരയൽ ക്രമീകരണങ്ങൾ%2$s-ൽ അത് "
-"എപ്പോൾ വേണമെങ്കിലും ഓഫാക്കാനോ നിങ്ങൾക്ക് കഴിയും."
+"Assist എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്നത് ക്രമീകരിക്കാനോ %1$sതിരയൽ "
+"ക്രമീകരണങ്ങൾ%2$s-ൽ അത് എപ്പോൾ വേണമെങ്കിലും ഓഫാക്കാനോ നിങ്ങൾക്ക് കഴിയും."
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
 msgstr ""
-"ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാനും വാചകം സംഗ്രഹിക്കാനും നിങ്ങൾക്ക് %1$sDuck.ai%2$s ഉപയോഗിക്കാം."
+"ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാനും വാചകം സംഗ്രഹിക്കാനും നിങ്ങൾക്ക് %1$sDuck.ai%2$s "
+"ഉപയോഗിക്കാം."
 
 # smartling.placeholder_format=C
 msgid ""
 "You can also use %sDuckDuckGo AI Chat%s to answer questions or summarize "
 "text."
 msgstr ""
-"ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാനോ വാചകം സംഗ്രഹിക്കാനോ നിങ്ങൾക്ക് %1$sDuckDuckGo AI Chat%2$s "
-"ഉപയോഗിക്കാനും കഴിയും."
+"ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാനോ വാചകം സംഗ്രഹിക്കാനോ നിങ്ങൾക്ക് %1$sDuckDuckGo AI "
+"Chat%2$s ഉപയോഗിക്കാനും കഴിയും."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach more text selections than are allowed. Placeholder is the maximum number of text selections. E.g. You can attach up to 5 text selections.
@@ -25495,8 +25822,8 @@ msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
 msgstr ""
-"%1$sതിരയൽ ക്രമീകരണങ്ങൾ%2$s എന്നതിൽ നിങ്ങൾക്ക് എത്ര തവണ Search Assist കാണണമെന്നത് "
-"മാറ്റാനോ, പൂർണ്ണമായും ഓഫാക്കാനോ കഴിയും."
+"%1$sതിരയൽ ക്രമീകരണങ്ങൾ%2$s എന്നതിൽ നിങ്ങൾക്ക് എത്ര തവണ Search Assist "
+"കാണണമെന്നത് മാറ്റാനോ, പൂർണ്ണമായും ഓഫാക്കാനോ കഴിയും."
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -25517,8 +25844,8 @@ msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
 msgstr ""
-"ആദ്യ സെറ്റ് ഓപ്ഷണലായി ഇല്ലാതാക്കിക്കൊണ്ട്, നിങ്ങളുടെ ക്രമീകരണം മറ്റൊരു പാസ്‌ഫ്രെയ്സിന് കീഴിൽ "
-"സംരക്ഷിച്ചുകൊണ്ട് നിങ്ങൾക്ക് ഇത് ചെയ്യാൻ കഴിയും."
+"ആദ്യ സെറ്റ് ഓപ്ഷണലായി ഇല്ലാതാക്കിക്കൊണ്ട്, നിങ്ങളുടെ ക്രമീകരണം മറ്റൊരു "
+"പാസ്‌ഫ്രെയ്സിന് കീഴിൽ സംരക്ഷിച്ചുകൊണ്ട് നിങ്ങൾക്ക് ഇത് ചെയ്യാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -25548,7 +25875,8 @@ msgstr "നിങ്ങളുടെ പ്രതിമാസ പരിധി ഉ
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
 msgstr ""
-"നിങ്ങൾക്ക് ഇപ്പോൾ ഈ ഉപകരണത്തിൽ 100 ചാറ്റുകൾ വരെ സംരക്ഷിക്കാൻ കഴിയും. ചാറ്റ് തുടർന്നോളൂ!"
+"നിങ്ങൾക്ക് ഇപ്പോൾ ഈ ഉപകരണത്തിൽ 100 ചാറ്റുകൾ വരെ സംരക്ഷിക്കാൻ കഴിയും. ചാറ്റ് "
+"തുടർന്നോളൂ!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -25612,8 +25940,8 @@ msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
 msgstr ""
-"നിങ്ങൾക്ക് %1$s സൈറ്റുകൾ വരെ മാത്രമേ ബ്ലോക്ക് ചെയ്യാനാകൂ. %2$s തടയാൻ, ആദ്യം മറ്റൊരു സൈറ്റ് "
-"അൺബ്ലോക്ക് ചെയ്യണം."
+"നിങ്ങൾക്ക് %1$s സൈറ്റുകൾ വരെ മാത്രമേ ബ്ലോക്ക് ചെയ്യാനാകൂ. %2$s തടയാൻ, ആദ്യം "
+"മറ്റൊരു സൈറ്റ് അൺബ്ലോക്ക് ചെയ്യണം."
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -25649,7 +25977,9 @@ msgstr "നിങ്ങൾക്ക് ഈ പുതിയ ഡൊമെയ്ന
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can store several sets of settings for different purposes."
-msgstr "പലതരം ആവശ്യങ്ങൾക്കായി ക്രമീകരണത്തിന്റെ വിവിധ സെറ്റുകൾ നിങ്ങൾക്ക് ഇവിടെ സൂക്ഷിക്കാം."
+msgstr ""
+"പലതരം ആവശ്യങ്ങൾക്കായി ക്രമീകരണത്തിന്റെ വിവിധ സെറ്റുകൾ നിങ്ങൾക്ക് ഇവിടെ "
+"സൂക്ഷിക്കാം."
 
 # smartling.placeholder_format=C
 #. Instructions for user once they've failed the bot challenge
@@ -25677,8 +26007,8 @@ msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
 msgstr ""
-"നിങ്ങൾക്ക് ഇപ്പോൾ %1$s എന്നതിലേക്ക് ആക്സസ് ഉണ്ട്, ഉയർന്ന AI റീസണിംഗ്, Plus-നേക്കാൾ 2 മടങ്ങ് "
-"ഉയർന്ന ഉപയോഗ പരിധി എന്നിവയുണ്ട്."
+"നിങ്ങൾക്ക് ഇപ്പോൾ %1$s എന്നതിലേക്ക് ആക്സസ് ഉണ്ട്, ഉയർന്ന AI റീസണിംഗ്, "
+"Plus-നേക്കാൾ 2 മടങ്ങ് ഉയർന്ന ഉപയോഗ പരിധി എന്നിവയുണ്ട്."
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -25687,8 +26017,9 @@ msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
 msgstr ""
-"നിങ്ങൾക്ക് ഇപ്പോൾ നൂതന AI മോഡലുകളിലേക്ക് ആക്‌സസ് ഉണ്ട്. നിങ്ങൾക്ക് DuckDuckGo ബ്രൗസറിൽ VPN, "
-"മറ്റ് DuckDuckGo സബ്സ്ക്രിപ്ഷൻ പരിരക്ഷകൾ ആക്സസ് ചെയ്യാം."
+"നിങ്ങൾക്ക് ഇപ്പോൾ നൂതന AI മോഡലുകളിലേക്ക് ആക്‌സസ് ഉണ്ട്. നിങ്ങൾക്ക് "
+"DuckDuckGo ബ്രൗസറിൽ VPN, മറ്റ് DuckDuckGo സബ്സ്ക്രിപ്ഷൻ പരിരക്ഷകൾ ആക്സസ് "
+"ചെയ്യാം."
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -25710,9 +26041,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെസംരക്ഷിച്ച ചാറ്റുകൾ ഇനി നിങ്ങൾക്ക് ആക്‌സസ് ചെയ്യാൻ കഴിയില്ല. അവസാന "
-"30 ചാറ്റുകൾ ഇപ്പോഴും ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും. ഇത് എൻക്രിപ്റ്റ് ചെയ്ത സെർവറിൽ നിന്ന് "
-"നിങ്ങളുടെ ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
+"ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെസംരക്ഷിച്ച ചാറ്റുകൾ ഇനി നിങ്ങൾക്ക് ആക്‌സസ് "
+"ചെയ്യാൻ കഴിയില്ല. അവസാന 30 ചാറ്റുകൾ ഇപ്പോഴും ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും. "
+"ഇത് എൻക്രിപ്റ്റ് ചെയ്ത സെർവറിൽ നിന്ന് നിങ്ങളുടെ ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -25722,9 +26053,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെ സംരക്ഷിച്ച ചാറ്റുകൾ ഇനി ആക്‌സസ് ചെയ്യാൻ കഴിയില്ല. അവസാന 30 "
-"ചാറ്റുകൾ ഇപ്പോഴും ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും. ഇത് എൻക്രിപ്റ്റ് ചെയ്ത സെർവറിൽ നിന്ന് നിങ്ങളുടെ "
-"ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
+"ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെ സംരക്ഷിച്ച ചാറ്റുകൾ ഇനി ആക്‌സസ് ചെയ്യാൻ "
+"കഴിയില്ല. അവസാന 30 ചാറ്റുകൾ ഇപ്പോഴും ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും. ഇത് "
+"എൻക്രിപ്റ്റ് ചെയ്ത സെർവറിൽ നിന്ന് നിങ്ങളുടെ ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -25738,8 +26069,8 @@ msgid ""
 "You'll receive automatic DuckDuckGo app updates once you have the latest "
 "version."
 msgstr ""
-"ഏറ്റവും പുതിയ പതിപ്പ് ലഭിച്ചുകഴിഞ്ഞാൽ നിങ്ങൾക്ക് സ്വയമേവയുള്ള DuckDuckGo ആപ്പ് അപ്ഡേറ്റുകൾ "
-"ലഭിക്കും."
+"ഏറ്റവും പുതിയ പതിപ്പ് ലഭിച്ചുകഴിഞ്ഞാൽ നിങ്ങൾക്ക് സ്വയമേവയുള്ള DuckDuckGo "
+"ആപ്പ് അപ്ഡേറ്റുകൾ ലഭിക്കും."
 
 # smartling.placeholder_format=C
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
@@ -25754,8 +26085,9 @@ msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
 msgstr ""
-"നിങ്ങൾ ഇപ്പോൾ Chrome-ൽ സ്വകാര്യമായി തിരയുന്നു. സ്വകാര്യമായി ബ്രൗസ് ചെയ്യുന്നതിന് Chrome-ന് "
-"പകരം ഞങ്ങളുടെ ആപ്പും ഉപയോഗിക്കുക. ഇത് ഇതിനകം ഇൻസ്റ്റാൾ ചെയ്തിട്ടുണ്ട്, ഇതിന് ഇവ ചെയ്യാനാകും:"
+"നിങ്ങൾ ഇപ്പോൾ Chrome-ൽ സ്വകാര്യമായി തിരയുന്നു. സ്വകാര്യമായി ബ്രൗസ് "
+"ചെയ്യുന്നതിന് Chrome-ന് പകരം ഞങ്ങളുടെ ആപ്പും ഉപയോഗിക്കുക. ഇത് ഇതിനകം "
+"ഇൻസ്റ്റാൾ ചെയ്തിട്ടുണ്ട്, ഇതിന് ഇവ ചെയ്യാനാകും:"
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -25768,8 +26100,8 @@ msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
 msgstr ""
-"നിങ്ങൾ ഇപ്പോൾ സ്വകാര്യത ഉപയോഗിച്ച് തിരയുന്നു. %1$sനിങ്ങളുടെ പാദമുദ്ര ഇനിയും കുറയ്ക്കുന്നതിന് "
-"നുറുങ്ങുകൾ നേടുക."
+"നിങ്ങൾ ഇപ്പോൾ സ്വകാര്യത ഉപയോഗിച്ച് തിരയുന്നു. %1$sനിങ്ങളുടെ പാദമുദ്ര ഇനിയും "
+"കുറയ്ക്കുന്നതിന് നുറുങ്ങുകൾ നേടുക."
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -25819,8 +26151,8 @@ msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
 msgstr ""
-"നിങ്ങൾ തൽക്കാലത്തേക്ക് സന്ദേശങ്ങളുടെ പരമാവധി എണ്ണത്തിൽ എത്തിയിരിക്കുന്നു. ദയവായി വീണ്ടും "
-"ശ്രമിക്കുക."
+"നിങ്ങൾ തൽക്കാലത്തേക്ക് സന്ദേശങ്ങളുടെ പരമാവധി എണ്ണത്തിൽ എത്തിയിരിക്കുന്നു. "
+"ദയവായി വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -25847,8 +26179,9 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"അറ്റാച്ചുമെന്റുകളുള്ള Duck.ai ചാറ്റുകൾക്കുള്ള നിങ്ങളുടെ Sync & Backup സംഭരണം തീർന്നു. സമന്വയം "
-"പുനരാരംഭിക്കാൻ ഏറ്റവും പഴയ %1$s ചാറ്റുകൾ ഇല്ലാതാക്കുക. പിൻ ചെയ്ത ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
+"അറ്റാച്ചുമെന്റുകളുള്ള Duck.ai ചാറ്റുകൾക്കുള്ള നിങ്ങളുടെ Sync & Backup സംഭരണം "
+"തീർന്നു. സമന്വയം പുനരാരംഭിക്കാൻ ഏറ്റവും പഴയ %1$s ചാറ്റുകൾ ഇല്ലാതാക്കുക. പിൻ "
+"ചെയ്ത ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25859,8 +26192,8 @@ msgid ""
 "deleted."
 msgstr ""
 "Duck.ai ചാറ്റുകൾക്കുള്ള Sync & Backup സ്റ്റോറേജ് തീർന്നിരിക്കുന്നു. സമന്വയം "
-"പുനരാരംഭിക്കുന്നതിന് അറ്റാച്ചുമെന്റുകളുള്ള %1$s ഏറ്റവും പഴയ ചാറ്റുകൾ ഇല്ലാതാക്കുക. പിൻ ചെയ്ത "
-"ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
+"പുനരാരംഭിക്കുന്നതിന് അറ്റാച്ചുമെന്റുകളുള്ള %1$s ഏറ്റവും പഴയ ചാറ്റുകൾ "
+"ഇല്ലാതാക്കുക. പിൻ ചെയ്ത ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -25874,8 +26207,9 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"(Google ഉടമസ്ഥതയിലുള്ള) YouTube അജ്ഞാതനായി വീഡിയോകൾ കാണാൻ നിങ്ങളെ അനുവദിക്കുന്നില്ല. "
-"അതുപോലെ, ഇവിടെ YouTube വീഡിയോകൾ കാണുന്നത് YouTube/Google ട്രാക്ക് ചെയ്യും."
+"(Google ഉടമസ്ഥതയിലുള്ള) YouTube അജ്ഞാതനായി വീഡിയോകൾ കാണാൻ നിങ്ങളെ "
+"അനുവദിക്കുന്നില്ല. അതുപോലെ, ഇവിടെ YouTube വീഡിയോകൾ കാണുന്നത് "
+"YouTube/Google ട്രാക്ക് ചെയ്യും."
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -25896,14 +26230,18 @@ msgctxt ""
 msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
-msgstr "നിങ്ങളുടെ ഏറ്റവും പുതിയ %1$s ചാറ്റുകൾ ഈ ബ്രൗസറുകളിലെ ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും:"
+msgstr ""
+"നിങ്ങളുടെ ഏറ്റവും പുതിയ %1$s ചാറ്റുകൾ ഈ ബ്രൗസറുകളിലെ ലോക്കൽ സ്റ്റോറേജിൽ "
+"ലഭ്യമാകും:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr "നിങ്ങളുടെ Duck.ai ചാറ്റുകൾ എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷനോടെ സമന്വയിപ്പിക്കപ്പെടുന്നു."
+msgstr ""
+"നിങ്ങളുടെ Duck.ai ചാറ്റുകൾ എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷനോടെ "
+"സമന്വയിപ്പിക്കപ്പെടുന്നു."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -25935,8 +26273,8 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
 msgstr ""
-"DuckDuckGo-യുടെ സെർവറിൽ നിന്ന് നിങ്ങളുടെ ബാക്കപ്പ് ഇല്ലാതാക്കപ്പെടും. എല്ലാ ഉപകരണങ്ങളും "
-"സമന്വയത്തിൽ നിന്ന് വിച്ഛേദിക്കപ്പെടും."
+"DuckDuckGo-യുടെ സെർവറിൽ നിന്ന് നിങ്ങളുടെ ബാക്കപ്പ് ഇല്ലാതാക്കപ്പെടും. എല്ലാ "
+"ഉപകരണങ്ങളും സമന്വയത്തിൽ നിന്ന് വിച്ഛേദിക്കപ്പെടും."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25946,9 +26284,9 @@ msgid ""
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
 msgstr ""
-"DuckDuckGo-യുടെ സെർവറിൽ നിന്ന് നിങ്ങളുടെ ബാക്കപ്പ് ഇല്ലാതാക്കപ്പെടും. എല്ലാ ഉപകരണങ്ങളും "
-"സമന്വയത്തിൽ നിന്ന് വിച്ഛേദിക്കപ്പെടും. നിങ്ങളുടെ ഏറ്റവും പുതിയ %1$s ചാറ്റുകൾ ഈ ബ്രൗസറുകളിലെ "
-"ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും:"
+"DuckDuckGo-യുടെ സെർവറിൽ നിന്ന് നിങ്ങളുടെ ബാക്കപ്പ് ഇല്ലാതാക്കപ്പെടും. എല്ലാ "
+"ഉപകരണങ്ങളും സമന്വയത്തിൽ നിന്ന് വിച്ഛേദിക്കപ്പെടും. നിങ്ങളുടെ ഏറ്റവും പുതിയ "
+"%1$s ചാറ്റുകൾ ഈ ബ്രൗസറുകളിലെ ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും:"
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -25958,9 +26296,9 @@ msgid ""
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
 msgstr ""
-"DuckDuckGo-യുടെ സെർവറിൽ നിന്ന് നിങ്ങളുടെ ബാക്കപ്പ് ഇല്ലാതാക്കപ്പെടും. എല്ലാ ഉപകരണങ്ങളും "
-"സമന്വയത്തിൽ നിന്ന് വിച്ഛേദിക്കപ്പെടും. നിങ്ങളുടെ ഏറ്റവും പുതിയ 100 ചാറ്റുകൾ ഈ ബ്രൗസറുകളിലെ "
-"ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും:"
+"DuckDuckGo-യുടെ സെർവറിൽ നിന്ന് നിങ്ങളുടെ ബാക്കപ്പ് ഇല്ലാതാക്കപ്പെടും. എല്ലാ "
+"ഉപകരണങ്ങളും സമന്വയത്തിൽ നിന്ന് വിച്ഛേദിക്കപ്പെടും. നിങ്ങളുടെ ഏറ്റവും പുതിയ "
+"100 ചാറ്റുകൾ ഈ ബ്രൗസറുകളിലെ ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും:"
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -25976,7 +26314,9 @@ msgstr "നിങ്ങൾ ഈ ലിങ്ക് സന്ദർശിച്ച
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid "Your browser provides a list of your most-visited sites."
-msgstr "നിങ്ങൾ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ ഒരു ലിസ്റ്റ് നിങ്ങളുടെ ബ്രൗസർ നൽകുന്നു."
+msgstr ""
+"നിങ്ങൾ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ ഒരു ലിസ്റ്റ് നിങ്ങളുടെ ബ്രൗസർ "
+"നൽകുന്നു."
 
 # smartling.placeholder_format=C
 #. Used as a description in a menu
@@ -25985,8 +26325,8 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"നിങ്ങൾ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ ഒരു ലിസ്റ്റ് നിങ്ങളുടെ ബ്രൗസർ നൽകുന്നു. DuckDuckGo-"
-"യ്ക്ക് ഒരിക്കലും ഈ ഡാറ്റയിലേക്ക് ആക്സസ് ഇല്ല."
+"നിങ്ങൾ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ ഒരു ലിസ്റ്റ് നിങ്ങളുടെ ബ്രൗസർ "
+"നൽകുന്നു. DuckDuckGo-യ്ക്ക് ഒരിക്കലും ഈ ഡാറ്റയിലേക്ക് ആക്സസ് ഇല്ല."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -25994,8 +26334,8 @@ msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
 msgstr ""
-"നിങ്ങളുടെ ബ്രൗസർ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ പട്ടിക നൽകുന്നു. DuckDuckGo-യ്ക്ക് "
-"ഒരിക്കലും ഈ ഡാറ്റയിലേക്ക് ആക്സസ് ഇല്ല."
+"നിങ്ങളുടെ ബ്രൗസർ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ പട്ടിക നൽകുന്നു. "
+"DuckDuckGo-യ്ക്ക് ഒരിക്കലും ഈ ഡാറ്റയിലേക്ക് ആക്സസ് ഇല്ല."
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -26004,8 +26344,8 @@ msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
 msgstr ""
-"%1$s -നോടുള്ള നിങ്ങളുടെ ചാറ്റ് സ്വകാര്യമാണ്. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ "
-"വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം."
+"%1$s -നോടുള്ള നിങ്ങളുടെ ചാറ്റ് സ്വകാര്യമാണ്. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ "
+"കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം."
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -26018,15 +26358,16 @@ msgstr "നിങ്ങളുടെ ചാറ്റുകൾ ഇപ്പോൾ 
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, മാത്രമല്ല AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഒരിക്കലും "
-"സംരക്ഷിക്കുകയോ ഉപയോഗിക്കുകയോ ചെയ്യുന്നില്ല"
+"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, മാത്രമല്ല AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ "
+"ഒരിക്കലും സംരക്ഷിക്കുകയോ ഉപയോഗിക്കുകയോ ചെയ്യുന്നില്ല"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, അവ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഒരിക്കലും ഉപയോഗിക്കില്ല"
+"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, അവ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഒരിക്കലും "
+"ഉപയോഗിക്കില്ല"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -26052,8 +26393,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, ഞങ്ങൾ ഒരിക്കലും സംരക്ഷിച്ചിട്ടില്ല, AI മോഡലുകളെ "
-"പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല."
+"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, ഞങ്ങൾ ഒരിക്കലും സംരക്ഷിച്ചിട്ടില്ല, AI "
+"മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -26061,8 +26402,8 @@ msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, ഞങ്ങൾ ഒരിക്കലും സംരക്ഷിച്ചിട്ടില്ല, AI മോഡലുകളെ "
-"പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല."
+"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, ഞങ്ങൾ ഒരിക്കലും സംരക്ഷിച്ചിട്ടില്ല, AI "
+"മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -26077,9 +26418,9 @@ msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ ഇപ്പോഴും സ്വകാര്യമാണ്, ഞങ്ങൾ അത് അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ അവയെ AI "
-"മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കാറില്ല. നിങ്ങളുടെ ചാറ്റ് ചരിത്രം സൂക്ഷിക്കാൻ ഈ ഘട്ടങ്ങൾ "
-"പാലിക്കൂ."
+"നിങ്ങളുടെ ചാറ്റുകൾ ഇപ്പോഴും സ്വകാര്യമാണ്, ഞങ്ങൾ അത് "
+"അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ അവയെ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ "
+"ഉപയോഗിക്കാറില്ല. നിങ്ങളുടെ ചാറ്റ് ചരിത്രം സൂക്ഷിക്കാൻ ഈ ഘട്ടങ്ങൾ പാലിക്കൂ."
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -26088,8 +26429,8 @@ msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ ഇംപോർട്ട് ചെയ്തിരിക്കുന്നു. നിങ്ങൾ മുന്നോട്ട് പോയി Duck.ai-ൽ നിർത്തിയിടത്ത് "
-"നിന്ന് തുടരൂ."
+"നിങ്ങളുടെ ചാറ്റുകൾ ഇംപോർട്ട് ചെയ്തിരിക്കുന്നു. നിങ്ങൾ മുന്നോട്ട് പോയി "
+"Duck.ai-ൽ നിർത്തിയിടത്ത് നിന്ന് തുടരൂ."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -26137,8 +26478,8 @@ msgctxt ""
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
 msgstr ""
-"നിങ്ങളുടെ ഫീഡ്‌ബാക്ക് അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ "
-"ഉപയോഗിക്കാറില്ല."
+"നിങ്ങളുടെ ഫീഡ്‌ബാക്ക് അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ AI മോഡലുകളെ "
+"പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കാറില്ല."
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -26167,10 +26508,11 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"%1$sSHA-2%2$s എന്നറിയപ്പെടുന്ന ഒരു സുരക്ഷിത ഹാഷ് അൽഗോരിതം ഉപയോഗിച്ച് നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് "
-"ഒരു 512-ബിറ്റ് കീ സൃഷ്ടിക്കുന്നു. കീയും അനുബന്ധ ക്രമീകരണ ഫയലും മാത്രമേ നിങ്ങളുടെ ബ്രൗസർ "
-"ഉപേക്ഷിക്കുകയുള്ളൂ. പേരായി കീ ഉപയോഗിച്ചുകൊണ്ട് ക്രമീകരണ ഫയൽ ഞങ്ങൾ സംരക്ഷിക്കുന്നു. DuckDuckGo-"
-"യ്ക്ക് നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും അറിയില്ല."
+"%1$sSHA-2%2$s എന്നറിയപ്പെടുന്ന ഒരു സുരക്ഷിത ഹാഷ് അൽഗോരിതം ഉപയോഗിച്ച് "
+"നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരു 512-ബിറ്റ് കീ സൃഷ്ടിക്കുന്നു. കീയും അനുബന്ധ "
+"ക്രമീകരണ ഫയലും മാത്രമേ നിങ്ങളുടെ ബ്രൗസർ ഉപേക്ഷിക്കുകയുള്ളൂ. പേരായി കീ "
+"ഉപയോഗിച്ചുകൊണ്ട് ക്രമീകരണ ഫയൽ ഞങ്ങൾ സംരക്ഷിക്കുന്നു. DuckDuckGo-യ്ക്ക് "
+"നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും അറിയില്ല."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -26185,9 +26527,10 @@ msgid ""
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
 msgstr ""
-"നിങ്ങളുടെ നിർദ്ദേശങ്ങൾ DuckDuckGo സെർവറുകളിലൂടെ കൈമാറുകയും വ്യക്തിപരമായി തിരിച്ചറിയാൻ "
-"കഴിയുന്ന മെറ്റാഡാറ്റ നീക്കം ചെയ്യുകയും ചെയ്യുന്നു, അതിനാൽ മോഡൽ ദാതാക്കൾക്ക് നിങ്ങളുടെ "
-"സംഭാഷണങ്ങൾ നിങ്ങളിലേക്ക് തിരികെ ബന്ധിപ്പിക്കാൻ കഴിയില്ല."
+"നിങ്ങളുടെ നിർദ്ദേശങ്ങൾ DuckDuckGo സെർവറുകളിലൂടെ കൈമാറുകയും വ്യക്തിപരമായി "
+"തിരിച്ചറിയാൻ കഴിയുന്ന മെറ്റാഡാറ്റ നീക്കം ചെയ്യുകയും ചെയ്യുന്നു, അതിനാൽ മോഡൽ "
+"ദാതാക്കൾക്ക് നിങ്ങളുടെ സംഭാഷണങ്ങൾ നിങ്ങളിലേക്ക് തിരികെ ബന്ധിപ്പിക്കാൻ "
+"കഴിയില്ല."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -26201,8 +26544,8 @@ msgid ""
 "Your recent chats live here! You can refer to your chats or clear them "
 "anytime."
 msgstr ""
-"നിങ്ങളുടെ സമീപകാല ചാറ്റുകൾ ഇവിടെ കാണാം! നിങ്ങൾക്ക് നിങ്ങളുടെ ചാറ്റുകൾ പരിശോധിക്കാനോ "
-"എപ്പോൾ വേണമെങ്കിലും അവ മായ്ച്ചുകളയാനോ കഴിയും."
+"നിങ്ങളുടെ സമീപകാല ചാറ്റുകൾ ഇവിടെ കാണാം! നിങ്ങൾക്ക് നിങ്ങളുടെ ചാറ്റുകൾ "
+"പരിശോധിക്കാനോ എപ്പോൾ വേണമെങ്കിലും അവ മായ്ച്ചുകളയാനോ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Message on a feedback form.
@@ -26234,8 +26577,9 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
-"നിങ്ങളുടെ ക്രമീകരണങ്ങൾ സംരക്ഷിച്ചിട്ടുണ്ട്, എന്നാൽ കുക്കികൾ മായ്ക്കുന്നത് അവയെ പുനഃസജ്ജമാക്കും. ഇത് "
-"സ്ഥിരമാക്കാൻ %1$sDuckDuckGo No AI%2$s എക്സ്റ്റൻഷൻ പ്രവർത്തനക്ഷമമാക്കുക."
+"നിങ്ങളുടെ ക്രമീകരണങ്ങൾ സംരക്ഷിച്ചിട്ടുണ്ട്, എന്നാൽ കുക്കികൾ മായ്ക്കുന്നത് "
+"അവയെ പുനഃസജ്ജമാക്കും. ഇത് സ്ഥിരമാക്കാൻ %1$sDuckDuckGo No AI%2$s എക്സ്റ്റൻഷൻ "
+"പ്രവർത്തനക്ഷമമാക്കുക."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -26244,9 +26588,9 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"നിങ്ങളുടെ ക്രമീകരണങ്ങൾ സംരക്ഷിച്ചിട്ടുണ്ട്, എന്നാൽ കുക്കികൾ മായ്ക്കുന്നത് അവയെ പുനഃസജ്ജമാക്കും. ഇത് "
-"സ്ഥിരമാക്കാൻ %1$sDuckDuckGo No AI%2$s എക്സ്റ്റൻഷൻ ഇൻസ്റ്റാൾ ചെയ്യുക. %3$sകൂടുതൽ "
-"അറിയുക%4$s"
+"നിങ്ങളുടെ ക്രമീകരണങ്ങൾ സംരക്ഷിച്ചിട്ടുണ്ട്, എന്നാൽ കുക്കികൾ മായ്ക്കുന്നത് "
+"അവയെ പുനഃസജ്ജമാക്കും. ഇത് സ്ഥിരമാക്കാൻ %1$sDuckDuckGo No AI%2$s എക്സ്റ്റൻഷൻ "
+"ഇൻസ്റ്റാൾ ചെയ്യുക. %3$sകൂടുതൽ അറിയുക%4$s"
 
 # smartling.placeholder_format=C
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
@@ -26266,8 +26610,9 @@ msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
 msgstr ""
-"നിങ്ങൾ ഇപ്പോൾ Chrome-ൽ സ്വകാര്യമായി തിരയുന്നു. കൂടുതൽ സുരക്ഷയ്ക്കായി Chrome-ന് പകരം ഞങ്ങളുടെ "
-"ബ്രൗസർ ഉപയോഗിക്കുക. ഇത് ഇതിനകം ഇൻസ്റ്റാൾ ചെയ്തിട്ടുണ്ട്, ഇതിന് ഇവ ചെയ്യാനാകും:"
+"നിങ്ങൾ ഇപ്പോൾ Chrome-ൽ സ്വകാര്യമായി തിരയുന്നു. കൂടുതൽ സുരക്ഷയ്ക്കായി "
+"Chrome-ന് പകരം ഞങ്ങളുടെ ബ്രൗസർ ഉപയോഗിക്കുക. ഇത് ഇതിനകം ഇൻസ്റ്റാൾ "
+"ചെയ്തിട്ടുണ്ട്, ഇതിന് ഇവ ചെയ്യാനാകും:"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -26276,8 +26621,8 @@ msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
 msgstr ""
-"നിങ്ങൾ സന്ദേശത്തിൻ്റെ പരമാവധി വലുപ്പം കവിഞ്ഞു. ദയവായി നിങ്ങളുടെ സന്ദേശം ചുരുക്കി വീണ്ടും "
-"ശ്രമിക്കുക."
+"നിങ്ങൾ സന്ദേശത്തിൻ്റെ പരമാവധി വലുപ്പം കവിഞ്ഞു. ദയവായി നിങ്ങളുടെ സന്ദേശം "
+"ചുരുക്കി വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -26286,8 +26631,8 @@ msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
 msgstr ""
-"ഈ സംഭാഷണത്തിൽ നിങ്ങൾ പരമാവധി ചാറ്റ് ദൈർഘ്യത്തിൽ എത്തി. തുടരാൻ Fire Button ഉപയോഗിച്ച് ഈ "
-"സംഭാഷണം മായ്ക്കുക."
+"ഈ സംഭാഷണത്തിൽ നിങ്ങൾ പരമാവധി ചാറ്റ് ദൈർഘ്യത്തിൽ എത്തി. തുടരാൻ Fire Button "
+"ഉപയോഗിച്ച് ഈ സംഭാഷണം മായ്ക്കുക."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -26296,7 +26641,8 @@ msgid ""
 "You’ve reached the maximum chat length in this conversation. Start a new "
 "chat to continue."
 msgstr ""
-"ഈ സംഭാഷണത്തിൽ നിങ്ങൾ പരമാവധി ചാറ്റ് ദൈർഘ്യത്തിൽ എത്തി. തുടരാൻ ഒരു പുതിയ ചാറ്റ് ആരംഭിക്കുക."
+"ഈ സംഭാഷണത്തിൽ നിങ്ങൾ പരമാവധി ചാറ്റ് ദൈർഘ്യത്തിൽ എത്തി. തുടരാൻ ഒരു പുതിയ "
+"ചാറ്റ് ആരംഭിക്കുക."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -26311,8 +26657,8 @@ msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
 msgstr ""
-"ഒരു ദിവസത്തേക്കുള്ള പരമാവധി സന്ദേശങ്ങളുടെ എണ്ണത്തിൽ നിങ്ങൾ എത്തി. ദയവായി നാളെ ഈ ചാറ്റ് "
-"തുടരുക."
+"ഒരു ദിവസത്തേക്കുള്ള പരമാവധി സന്ദേശങ്ങളുടെ എണ്ണത്തിൽ നിങ്ങൾ എത്തി. ദയവായി "
+"നാളെ ഈ ചാറ്റ് തുടരുക."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -26546,7 +26892,7 @@ msgstr "മാ"
 #. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the chat options menu button"
 msgid "menu"
-msgstr ""
+msgstr "മെനു"
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.
@@ -26621,8 +26967,8 @@ msgstr "ഔദ്യോഗിക വെബ്സൈറ്റ്"
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
 msgstr ""
-"അല്ലെങ്കിൽ നിങ്ങൾക്ക് വേണ്ട നിറത്തിനുള്ള കോഡ് എഴുതുക, ഉദാ. %1$s (%2$s ഒരു എന്‍കോഡ് ചെയ്ത %3$s "
-"പ്രതീകം ആണ്)."
+"അല്ലെങ്കിൽ നിങ്ങൾക്ക് വേണ്ട നിറത്തിനുള്ള കോഡ് എഴുതുക, ഉദാ. %1$s (%2$s ഒരു "
+"എന്‍കോഡ് ചെയ്ത %3$s പ്രതീകം ആണ്)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/mn_MN/LC_MESSAGES/duckduckgo.po
+++ b/locales/mn_MN/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr ""
@@ -1099,6 +1116,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr ""
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1453,6 +1507,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2800,6 +2859,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3200,9 +3266,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3218,6 +3294,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4475,6 +4558,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4759,6 +4847,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5097,6 +5190,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -5993,6 +6091,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6170,6 +6273,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6835,6 +6943,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7253,6 +7366,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8235,6 +8353,11 @@ msgid "How is it anonymous?"
 msgstr ""
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9388,6 +9511,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11125,6 +11253,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12825,6 +12958,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12931,6 +13069,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13919,6 +14062,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14074,6 +14222,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -14989,6 +15144,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16328,6 +16488,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16408,6 +16575,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16868,6 +17040,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17270,6 +17456,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18732,6 +18923,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19881,6 +20079,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20963,6 +21174,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/mr_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/mr_IN/LC_MESSAGES/duckduckgo.po
@@ -980,6 +980,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1083,6 +1088,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "DuckDuckGo जोडा."
@@ -1101,6 +1118,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1140,6 +1175,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1211,6 +1260,11 @@ msgstr ""
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1455,6 +1509,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2802,6 +2861,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3202,9 +3268,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3220,6 +3296,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4478,6 +4561,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4762,6 +4850,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5100,6 +5193,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6004,6 +6102,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6181,6 +6284,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6846,6 +6954,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7264,6 +7377,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8246,6 +8364,11 @@ msgid "How is it anonymous?"
 msgstr "हे निनावी कसे आहे?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9400,6 +9523,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11137,6 +11265,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12837,6 +12970,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12943,6 +13081,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13931,6 +14074,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14086,6 +14234,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15003,6 +15158,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16342,6 +16502,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16422,6 +16589,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16882,6 +17054,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17284,6 +17470,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18746,6 +18937,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19895,6 +20093,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20977,6 +21188,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/ms_MY/LC_MESSAGES/duckduckgo.po
+++ b/locales/ms_MY/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Tambah DuckDuckGo"
@@ -1099,6 +1116,24 @@ msgstr "Tambah DuckDuckGo sebagai enjin carian"
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr "Tambahan"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1455,6 +1509,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2802,6 +2861,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3204,9 +3270,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3222,6 +3298,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4486,6 +4569,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4770,6 +4858,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5108,6 +5201,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6004,6 +6102,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6181,6 +6284,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6849,6 +6957,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7267,6 +7380,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8249,6 +8367,11 @@ msgid "How is it anonymous?"
 msgstr "Kenapa ia tidak bernama?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9407,6 +9530,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11145,6 +11273,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12851,6 +12984,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12957,6 +13095,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13945,6 +14088,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14100,6 +14248,13 @@ msgstr "Cari"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15021,6 +15176,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16360,6 +16520,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16440,6 +16607,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16900,6 +17072,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17302,6 +17488,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18770,6 +18961,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19919,6 +20117,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21006,6 +21217,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/nb_NO/LC_MESSAGES/duckduckgo.po
+++ b/locales/nb_NO/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: nb\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -506,8 +506,7 @@ msgstr "%1$sFinn ut mer%2$s"
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr ""
-"%1$sFinn ut mer%2$s om hvordan chatter lagres privat på DuckDuckGos server."
+msgstr "%1$sFinn ut mer%2$s om hvordan chatter lagres privat på DuckDuckGos server."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -876,8 +875,7 @@ msgstr "6 timers bruksgrense er nådd."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"6 timers bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
+msgstr "6 timers bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -1214,7 +1212,7 @@ msgstr "Om annonsene våre"
 #. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
 msgctxt "Modal header for chat history with sync information"
 msgid "About Chat History with Sync & Backup"
-msgstr ""
+msgstr "Om chattehistorikk med Sync & Backup"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
@@ -1349,7 +1347,7 @@ msgstr "Annonsen er mistenkelig"
 #. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
 msgctxt "Button to open menu for attaching images or page context to AI chat"
 msgid "Add"
-msgstr ""
+msgstr "Legg til"
 
 # smartling.placeholder_format=C
 #. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
@@ -1357,7 +1355,7 @@ msgctxt ""
 "Primary button that attaches the tabs the user checked in the tab picker "
 "dialog"
 msgid "Add"
-msgstr ""
+msgstr "Legg til"
 
 # smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
@@ -1392,13 +1390,13 @@ msgstr "Legg til DuckDuckGo i %1$s"
 msgctxt ""
 "Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
 msgid "Add File"
-msgstr ""
+msgstr "Legg til fil"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
 msgid "Add Image"
-msgstr ""
+msgstr "Legg til bilde"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
@@ -1406,7 +1404,7 @@ msgctxt ""
 "Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
 "item)"
 msgid "Add Image or File"
-msgstr ""
+msgstr "Legg til bilde eller fil"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1459,7 +1457,7 @@ msgctxt ""
 "Open the tab picker to attach browser tab content to the AI chat message "
 "(attach dropdown menu item)"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Legg til faner"
 
 # smartling.placeholder_format=C
 #. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
@@ -1467,7 +1465,7 @@ msgctxt ""
 "Title and accessible name of the tab-picker dialog opened from the attach "
 "dropdown menu"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Legg til faner"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1558,7 +1556,7 @@ msgstr "Legger siste hånd på verket"
 #. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
 msgctxt "Aria label for the additional instructions textarea"
 msgid "Additional instructions"
-msgstr ""
+msgstr "Flere instruksjoner"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1867,7 +1865,7 @@ msgstr "Ferdig!"
 #. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the read-only textarea listing all AI instructions"
 msgid "All instructions"
-msgstr ""
+msgstr "Alle instruksjoner"
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -1881,8 +1879,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr ""
-"Alle modelleverandører er forhindret i å trene AI-ene sine på samtalene dine."
+msgstr "Alle modelleverandører er forhindret i å trene AI-ene sine på samtalene dine."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1936,8 +1933,7 @@ msgstr "Tillat"
 msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
-msgstr ""
-"Gi DuckDuckGo mikrofontilgang i systeminnstillingene for å bruke talechat."
+msgstr "Gi DuckDuckGo mikrofontilgang i systeminnstillingene for å bruke talechat."
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1959,8 +1955,7 @@ msgstr "Vil du tillate anonym gjennomgang av filer i denne chatten?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Tillat annonser som respekterer personvernet på DuckDuckGo Private Search"
+msgstr "Tillat annonser som respekterer personvernet på DuckDuckGo Private Search"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2292,8 +2287,7 @@ msgstr "Er du der fortsatt?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"Er du sikker på at du vil fjerne alle chattene dine? Dette kan ikke angres."
+msgstr "Er du sikker på at du vil fjerne alle chattene dine? Dette kan ikke angres."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2525,12 +2519,12 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist er en valgfri funksjon i søkeresultatene våre, som kan generere KI-"
-"assisterte svar anonymt på søkeforespørsler. For å gjøre dette skanner den "
-"nettet etter relevant innhold, og bruker deretter KI-drevet naturlig språk-"
-"teknologi til å generere et kort svar basert på relevant informasjon den har "
-"funnet. Det er viktig å huske at svarene genereres automatisk fra siterte "
-"kilder og er basert på %1$sgjennomsøking av nettet%2$s."
+"Assist er en valgfri funksjon i søkeresultatene våre, som kan generere "
+"KI-assisterte svar anonymt på søkeforespørsler. For å gjøre dette skanner "
+"den nettet etter relevant innhold, og bruker deretter KI-drevet naturlig "
+"språk-teknologi til å generere et kort svar basert på relevant informasjon "
+"den har funnet. Det er viktig å huske at svarene genereres automatisk fra "
+"siterte kilder og er basert på %1$sgjennomsøking av nettet%2$s."
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2631,8 +2625,7 @@ msgstr "Lyd lagres ikke av oss eller av OpenAI etter at chatten er avsluttet."
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"Lyd lagres ikke av oss eller av OpenAI etter at chatten er transkribert."
+msgstr "Lyd lagres ikke av oss eller av OpenAI etter at chatten er transkribert."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2679,8 +2672,7 @@ msgstr "Autogenerert basert på oppførte kilder. Kan inneholde unøyaktigheter.
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
-msgstr ""
-"Autogenerert basert på oppførte kilder. Svarene kan inneholde unøyaktigheter."
+msgstr "Autogenerert basert på oppførte kilder. Svarene kan inneholde unøyaktigheter."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
@@ -3320,8 +3312,8 @@ msgid ""
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
 "Bruk nettleseren som vanlig, så legger vi til personvernbeskyttelse. Vi har "
-"samlet søkemotoren, sporingsblokkeren og krypteringsvakten i én %1$s%2$s-"
-"utvidelse%3$s."
+"samlet søkemotoren, sporingsblokkeren og krypteringsvakten i én "
+"%1$s%2$s-utvidelse%3$s."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3576,7 +3568,7 @@ msgctxt ""
 "Secondary button that dismisses the tab picker dialog without attaching "
 "anything"
 msgid "Cancel"
-msgstr ""
+msgstr "Avbryt"
 
 # smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
@@ -3964,8 +3956,8 @@ msgid ""
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
 "Med chatten (via Duck.ai-tjenesten vår) kan du ha anonyme samtaler med "
-"tredjeparts AI-chatmodeller. Disse støtter modeller fra OpenAI, Anthropic m."
-"m. Hvis du slår av denne innstillingen, skjules chat-knapper og -lenker på "
+"tredjeparts AI-chatmodeller. Disse støtter modeller fra OpenAI, Anthropic "
+"m.m. Hvis du slår av denne innstillingen, skjules chat-knapper og -lenker på "
 "DuckDuckGo Search. Men du kan likevel få tilgang til chatten når denne "
 "innstillingen er av, ved å gå til %1$shttps.://duck.ai%2$s direkte."
 
@@ -4022,8 +4014,7 @@ msgstr "Chat privat"
 #. Mobile variant of DUCKCHAT_BROWSER_UPSELL_PROMO_TEXT. Shorter version for the promotional card encouraging third-party browser users to download the DuckDuckGo browser.
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
-msgstr ""
-"Chat privat på ethvert nettsted med Duck.ai innebygd i vår gratis nettleser."
+msgstr "Chat privat på ethvert nettsted med Duck.ai innebygd i vår gratis nettleser."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
@@ -4074,7 +4065,7 @@ msgstr "Chattens svar er støtende"
 #. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
 msgctxt "Chat history about modal list item headline"
 msgid "Chat storage varies by browser"
-msgstr ""
+msgstr "Lagring av chatter varierer fra nettleser til nettleser"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4086,7 +4077,7 @@ msgstr "Chat med %1$s"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Chat with popular AI models, anonymized by us."
-msgstr ""
+msgstr "Chat med populære AI-modeller, anonymisert av oss."
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4113,6 +4104,8 @@ msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
 msgstr ""
+"Chattene lagres sikkert på DuckDuckGos server med ende-til-ende-kryptering. "
+"Ingen kan se dataene dine, ikke vi engang."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4624,8 +4617,7 @@ msgstr "Klikk %1$sher%2$s for å laste ned DuckDuckGo-utvidelsen"
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr ""
-"Klikk på %1$sÅpne%2$s for å laste ned og åpne DuckDuckGo sin Safari-utvidelse"
+msgstr "Klikk på %1$sÅpne%2$s for å laste ned og åpne DuckDuckGo sin Safari-utvidelse"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4658,8 +4650,7 @@ msgstr "Klikk på %1$sInnstillinger%2$s i nedtrekksmenyen."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Klikk på %1$sVelg nåværende sider%2$s, og %3$sklikk deretter på OK%4$s."
+msgstr "Klikk på %1$sVelg nåværende sider%2$s, og %3$sklikk deretter på OK%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -5711,7 +5702,7 @@ msgstr "Nåværende rekke"
 #. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
 msgctxt "Suffix label indicating a tab is the currently active browser tab"
 msgid "Current Tab"
-msgstr ""
+msgstr "Gjeldende fane"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
@@ -6065,7 +6056,7 @@ msgstr "Slett chatter som er eldre enn 30 dager"
 #. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
 msgctxt "Button text in the modal for deleting all recent chats"
 msgid "Delete Chats and Shared Links"
-msgstr ""
+msgstr "Slett chatter og delte chatlenker"
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6157,8 +6148,7 @@ msgstr "Vil du slette de eldste chattene for å frigjøre lagringsplass?"
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr ""
-"Vil du slette de eldste chattene med vedlegg for å frigjøre lagringsplass?"
+msgstr "Vil du slette de eldste chattene med vedlegg for å frigjøre lagringsplass?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
@@ -6200,8 +6190,7 @@ msgstr ""
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
 msgctxt "settings"
 msgid "Deleting cookies will reset these settings."
-msgstr ""
-"Hvis du sletter informasjonskapslene, blir disse innstillingene tilbakestilt."
+msgstr "Hvis du sletter informasjonskapslene, blir disse innstillingene tilbakestilt."
 
 # smartling.placeholder_format=C
 msgid "Democratic People's Republic of Korea"
@@ -6291,8 +6280,7 @@ msgstr "Diktering i Duck.ai"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr ""
-"Diktering anonymiseres av oss, og brukes aldri til å trene AI-modeller."
+msgstr "Diktering anonymiseres av oss, og brukes aldri til å trene AI-modeller."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6485,7 +6473,7 @@ msgstr "Avvis kampanje"
 #. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the close button on the survey banner"
 msgid "Dismiss survey"
-msgstr ""
+msgstr "Avvis spørreundersøkelsen"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6646,8 +6634,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"Vil du ikke ha AI? Besøk %1$snoai.duckduckgo.com%2$s for å søke uten AI-"
-"funksjoner og med AI-bilder filtrert ut. %3$sFinn ut mer%4$s"
+"Vil du ikke ha AI? Besøk %1$snoai.duckduckgo.com%2$s for å søke uten "
+"AI-funksjoner og med AI-bilder filtrert ut. %3$sFinn ut mer%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -7049,8 +7037,8 @@ msgstr ""
 "Med Duck.ai kan du ha anonyme samtaler med tredjeparts AI-chatmodeller, som "
 "OpenAI, Anthropic og andre. Hvis du slår av denne innstillingen, skjules "
 "Duck.ai-knapper og -lenker på DuckDuckGo Search. Men du kan likevel få "
-"tilgang til Duck.ai når denne innstillingen er av, ved å gå til %1$shttps://"
-"duck.ai%2$s direkte."
+"tilgang til Duck.ai når denne innstillingen er av, ved å gå til "
+"%1$shttps://duck.ai%2$s direkte."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -7445,8 +7433,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo anonymiserer chattene dine. Ved å klikke på «%1$s» godtar du Duck."
-"ai's %2$s."
+"DuckDuckGo anonymiserer chattene dine. Ved å klikke på «%1$s» godtar du "
+"Duck.ai's %2$s."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7542,8 +7530,7 @@ msgctxt ""
 "Description of the DuckDuckGo subscription setting when it is not available "
 "in the user region"
 msgid "DuckDuckGo subscriptions are not available to purchase in this region."
-msgstr ""
-"DuckDuckGo-abonnementer er ikke tilgjengelige for kjøp i denne regionen."
+msgstr "DuckDuckGo-abonnementer er ikke tilgjengelige for kjøp i denne regionen."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use 'ducky' tone in its responses. When this option is selected, the AI assistant speaks like a duck.
@@ -7656,7 +7643,7 @@ msgstr "Rediger ledetekst"
 #. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the message-editing text area"
 msgid "Edit message"
-msgstr ""
+msgstr "Rediger melding"
 
 # smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
@@ -7827,8 +7814,7 @@ msgstr "Aktiver diktering i Duck.ai"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr ""
-"Aktiver posisjonsinnstillinger på enheten din for å bruke anonym posisjon"
+msgstr "Aktiver posisjonsinnstillinger på enheten din for å bruke anonym posisjon"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -7885,7 +7871,7 @@ msgstr "Kryptert modell"
 #. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
 msgctxt "Share modal info bullet about encryption"
 msgid "Encrypted so DuckDuckGo can't read your chat."
-msgstr ""
+msgstr "Kryptert, så DuckDuckGo ikke kan lese chatten din."
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8547,8 +8533,7 @@ msgstr "Filtrerer ut AI-genererte bilder fra bildesøkresultater"
 msgctxt "settings"
 msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
-msgstr ""
-"Filtrerer ut AI-genererte bilder fra bildesøkresultater. %1$sFinn ut mer%2$s"
+msgstr "Filtrerer ut AI-genererte bilder fra bildesøkresultater. %1$sFinn ut mer%2$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8634,8 +8619,7 @@ msgstr "Søk nærmere der du er."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr ""
-"Finn resultater nær deg. %1$sPosisjonen din forblir privat, sikker og anonym."
+msgstr "Finn resultater nær deg. %1$sPosisjonen din forblir privat, sikker og anonym."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8717,7 +8701,7 @@ msgstr "Oppfølgingsspørsmål"
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
-msgstr ""
+msgstr "Fortsettelsen er privat."
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8853,8 +8837,7 @@ msgstr "Kan deles og brukes kommersielt"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr ""
-"Frigjør plass ved å slette chattene dine. Festede chatter blir ikke slettet."
+msgstr "Frigjør plass ved å slette chattene dine. Festede chatter blir ikke slettet."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -9236,7 +9219,7 @@ msgstr "Få DuckDuckGo VPN, avansert Duck.ai og Identity Theft Restoration."
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
 msgctxt "Tooltip on the header logo for sunglasses searches"
 msgid "Get DuckDuckGo sunglasses and other gear."
-msgstr ""
+msgstr "Kjøp DuckDuckGo-solbriller og annet utstyr."
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9393,8 +9376,8 @@ msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
 msgstr ""
-"Få vår raske VPN uten aktivitetslogger, valgfri tilgang til avanserte AI-"
-"modeller med høyere chattegrenser og flere førsteklasses beskyttelser."
+"Få vår raske VPN uten aktivitetslogger, valgfri tilgang til avanserte "
+"AI-modeller med høyere chattegrenser og flere førsteklasses beskyttelser."
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -10471,7 +10454,7 @@ msgstr "Slik fungerer det"
 #. Headline in chat history about modals for the temporary encrypted server storage explanation.
 msgctxt "Chat history about modal list item headline"
 msgid "How it works"
-msgstr ""
+msgstr "Slik fungerer det"
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -10720,8 +10703,8 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"Hvis du har bekymringer om chat-leverandørene våre eller et bestemt chat-"
-"svar, kan du også kontakte støttesiden til %1$s og %2$s direkte."
+"Hvis du har bekymringer om chat-leverandørene våre eller et bestemt "
+"chat-svar, kan du også kontakte støttesiden til %1$s og %2$s direkte."
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -11921,7 +11904,7 @@ msgstr "Lenken utløper om syv dager."
 #. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days. People can save a chat copy."
-msgstr ""
+msgstr "Lenken utløper om syv dager. Folk kan lagre en kopi av chatten."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11937,8 +11920,7 @@ msgstr "Lenker:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
-"Si hvilke verktøy, materialer eller forutsetninger jeg trenger til dette."
+msgstr "Si hvilke verktøy, materialer eller forutsetninger jeg trenger til dette."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12049,8 +12031,7 @@ msgstr "Laster flere bilderesultater når du ruller"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr ""
-"Laster inn flere resultater i Bilder, Videoer og Shopping når du ruller"
+msgstr "Laster inn flere resultater i Bilder, Videoer og Shopping når du ruller"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -12826,8 +12807,7 @@ msgstr "Månedlig grense er nådd"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Månedlig bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
+msgstr "Månedlig bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -14044,7 +14024,7 @@ msgstr "OK – forstått!"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "OPTIONAL"
-msgstr ""
+msgstr "VALGFRITT"
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -14300,8 +14280,8 @@ msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
 msgstr ""
-"Bare innstillingene du har endret. De er spesifisert på siden %1$sURL-"
-"parameter%2$s."
+"Bare innstillingene du har endret. De er spesifisert på siden "
+"%1$sURL-parameter%2$s."
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -16132,8 +16112,7 @@ msgstr "Spør meg"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"Spør meg om å bruke omtrentlig lokasjon for å få resultater i nærheten."
+msgstr "Spør meg om å bruke omtrentlig lokasjon for å få resultater i nærheten."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -16168,7 +16147,7 @@ msgstr "Beskyttet"
 #. Headline in sync-enabled chat history about modals explaining encrypted server storage.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Protected with end-to-end encryption"
-msgstr ""
+msgstr "Beskyttet med ende-til-ende-kryptering"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -16307,7 +16286,7 @@ msgstr "Rangeringer"
 #. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
 msgctxt "star rating on a product"
 msgid "Rated %s out of %s"
-msgstr ""
+msgstr "Vurdert til %1$s av %2$s"
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -16406,8 +16385,7 @@ msgstr "Resonnering kan gi bedre svar på komplekse spørsmål."
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
-msgstr ""
-"Resonnering er grundigere, men når bruksgrensen 2–5 ganger raskere. %1$s"
+msgstr "Resonnering er grundigere, men når bruksgrensen 2–5 ganger raskere. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
@@ -16463,8 +16441,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"Nylige chatter som lagres lokalt på enheten din, i stedet for på DuckDuckGo-"
-"servere eller andre eksterne servere."
+"Nylige chatter som lagres lokalt på enheten din, i stedet for på "
+"DuckDuckGo-servere eller andre eksterne servere."
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -16473,8 +16451,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"Nylige chatter lagres lokalt på enheten din i stedet for på DuckDuckGo-"
-"servere eller andre eksterne servere."
+"Nylige chatter lagres lokalt på enheten din i stedet for på "
+"DuckDuckGo-servere eller andre eksterne servere."
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -17528,8 +17506,7 @@ msgstr "Lagre opptil 30 av de siste chattene lokalt på enheten din."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Lagre Duck.ai-chattene mellom enhetene dine med ende-til-ende-kryptering."
+msgstr "Lagre Duck.ai-chattene mellom enhetene dine med ende-til-ende-kryptering."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17541,7 +17518,7 @@ msgstr "Lagre chatter på alle enhetene dine."
 #. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
 msgctxt "Chat history about modal list item headline"
 msgid "Save your chats on this device"
-msgstr ""
+msgstr "Lagre chattene dine på denne enheten"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
@@ -17724,8 +17701,7 @@ msgstr "Rull ned til %1$sDuckDuckGo%2$s og la den bruke posisjonen din."
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr ""
-"Rull ned til %1$sTjenester%2$s-delen, og klikk på %3$sAdresselinje%4$s."
+msgstr "Rull ned til %1$sTjenester%2$s-delen, og klikk på %3$sAdresselinje%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -17750,7 +17726,7 @@ msgctxt ""
 "Placeholder and accessibility label for the search input in the tab picker "
 "dialog"
 msgid "Search"
-msgstr ""
+msgstr "Søk"
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -17963,8 +17939,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"Søkeforespørsler er inkludert i URL-en (hvis avslått, vil søkene bruke POST-"
-"forespørsler)"
+"Søkeforespørsler er inkludert i URL-en (hvis avslått, vil søkene bruke "
+"POST-forespørsler)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -18083,8 +18059,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Lagre nesten ubegrenset med chatter sikkert på serveren vår med ende-til-"
-"ende-kryptering, og få tilgang til dem fra alle enhetene dine."
+"Lagre nesten ubegrenset med chatter sikkert på serveren vår med "
+"ende-til-ende-kryptering, og få tilgang til dem fra alle enhetene dine."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -18093,8 +18069,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Lagre nesten ubegrenset med chatter sikkert på serveren vår med ende-til-"
-"ende-kryptering, og få tilgang til dem fra alle enhetene dine."
+"Lagre nesten ubegrenset med chatter sikkert på serveren vår med "
+"ende-til-ende-kryptering, og få tilgang til dem fra alle enhetene dine."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18248,8 +18224,7 @@ msgstr "Se noen av våre nyeste oppdateringer"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr ""
-"Se %1$sreferansesiden for nettadresseparametere%2$s for mer informasjon."
+msgstr "Se %1$sreferansesiden for nettadresseparametere%2$s for mer informasjon."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -18403,8 +18378,7 @@ msgstr "Velg %1$sInnstillinger%2$s fra nedtrekksmenyen."
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sAdvanced settings%s"
-msgstr ""
-"Velg %1$sInnstillinger%2$s, og deretter %3$sAvanserte innstillinger%4$s"
+msgstr "Velg %1$sInnstillinger%2$s, og deretter %3$sAvanserte innstillinger%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -18432,8 +18406,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"Velg %1$snettleseren din%2$s i listen og %3$stillat%4$s posisjonstilgang"
+msgstr "Velg %1$snettleseren din%2$s i listen og %3$stillat%4$s posisjonstilgang"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18785,8 +18758,8 @@ msgid ""
 "never reveals your precise location to us or AI models."
 msgstr ""
 "Del plassering så nær som nærmeste by med AI-modeller for å forbedre "
-"relevansen. Duck.ai avslører aldri din nøyaktige plassering til oss eller AI-"
-"modeller."
+"relevansen. Duck.ai avslører aldri din nøyaktige plassering til oss eller "
+"AI-modeller."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -18929,7 +18902,7 @@ msgstr "Gå til butikk"
 #. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
 msgctxt "Button in the merchandise logo modal (mobile)"
 msgid "Shop Now"
-msgstr ""
+msgstr "Gå til butikken"
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -19315,14 +19288,12 @@ msgstr "Viser de mest besøkte lenkene på ny fane"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Viser sporadiske påminnelser om å legge til DuckDuckGo i nettleseren din"
+msgstr "Viser sporadiske påminnelser om å legge til DuckDuckGo i nettleseren din"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Viser sporadiske påminnelser om å legge til DuckDuckGo på enhetene dine"
+msgstr "Viser sporadiske påminnelser om å legge til DuckDuckGo på enhetene dine"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19634,8 +19605,7 @@ msgstr "Noen ganger"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr ""
-"Beklager at jeg ikke kan hjelpe deg. Prøv å beskrive bildet på en annen måte."
+msgstr "Beklager at jeg ikke kan hjelpe deg. Prøv å beskrive bildet på en annen måte."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19709,8 +19679,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Beklager, vi kunne ikke sende inn tilbakemeldingen din. Prøv igjen senere."
+msgstr "Beklager, vi kunne ikke sende inn tilbakemeldingen din. Prøv igjen senere."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19764,8 +19733,7 @@ msgstr "Kildetekst fjernet"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr ""
-"Kildeteksten er for lang til å oppsummere. Prøv igjen med en kortere tekst."
+msgstr "Kildeteksten er for lang til å oppsummere. Prøv igjen med en kortere tekst."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -19970,8 +19938,7 @@ msgstr "Bli på DuckDuckGo"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr ""
-"Beskytt deg selv og hold deg informert med personvern-nyhetsbrevet vårt."
+msgstr "Beskytt deg selv og hold deg informert med personvern-nyhetsbrevet vårt."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -20579,8 +20546,7 @@ msgstr "Sync & Backup er aktivert!"
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr ""
-"Sync & Backup-data kan ikke gjenopprettes etter 18 måneder med inaktivitet."
+msgstr "Sync & Backup-data kan ikke gjenopprettes etter 18 måneder med inaktivitet."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
@@ -20589,6 +20555,8 @@ msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
 msgstr ""
+"Sync & Backup lagrer flere chatter og synkroniserer dem mellom alle enhetene "
+"dine."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20637,9 +20605,9 @@ msgid ""
 msgstr ""
 "Synkroniseringsgjenopprettingskode\n"
 "\n"
-"Gjenopprettingskoden lar deg synkronisere passord, autofylle data og Duck.ai-"
-"chatter på tvers av flere enheter, og gjenopprette synkroniserte data hvis "
-"du mister tilgangen til en enhet.\n"
+"Gjenopprettingskoden lar deg synkronisere passord, autofylle data og "
+"Duck.ai-chatter på tvers av flere enheter, og gjenopprette synkroniserte "
+"data hvis du mister tilgangen til en enhet.\n"
 "\n"
 "Ta godt vare på denne informasjonen.\n"
 "Alle som har tilgang til denne koden kan få tilgang til de synkroniserte "
@@ -20709,7 +20677,7 @@ msgstr "Synkroniser chattene dine mellom alle enhetene dine."
 #. Headline in sync-enabled chat history about modals explaining cross-device sync.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Sync your chats across all your devices"
-msgstr ""
+msgstr "Synkroniser chatter mellom alle enhetene dine"
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21080,8 +21048,7 @@ msgstr "De vedlagte filene overskrider den totale størrelsesgrensen på %1$s MB
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB."
-msgstr ""
-"De vedlagte filene overskrider den totale størrelsesgrensen på %1$s MB."
+msgstr "De vedlagte filene overskrider den totale størrelsesgrensen på %1$s MB."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
@@ -21103,8 +21070,7 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr ""
-"Modelleverandøren sletter alle data knyttet til denne chatten innen 30 dager."
+msgstr "Modelleverandøren sletter alle data knyttet til denne chatten innen 30 dager."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -21273,8 +21239,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Dette øyeblikkelige svaret ble laget av %1$sDuckDuckHack%2$s-samfunnet."
+msgstr "Dette øyeblikkelige svaret ble laget av %1$sDuckDuckHack%2$s-samfunnet."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -21303,12 +21268,14 @@ msgid ""
 "This chat and its generated images become public when you create and copy "
 "the link."
 msgstr ""
+"Denne chatten og de genererte bildene blir offentlige når du oppretter og "
+"kopierer lenken."
 
 # smartling.placeholder_format=C
 #. Explains that creating and copying a share link makes the selected chat content public.
 msgctxt "Share modal info bullet about public access"
 msgid "This chat becomes public when you create and copy the link."
-msgstr ""
+msgstr "Denne chatten blir offentlig når du oppretter og kopierer lenken."
 
 # smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
@@ -21323,9 +21290,9 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"Denne samtalen ble generert med Duck.ai (%1$s) ved hjelp av %2$ss %3$s-"
-"modell. KI-chatter kan vise feil eller støtende informasjon (se %4$s for mer "
-"informasjon)."
+"Denne samtalen ble generert med Duck.ai (%1$s) ved hjelp av %2$ss "
+"%3$s-modell. KI-chatter kan vise feil eller støtende informasjon (se %4$s "
+"for mer informasjon)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21449,16 +21416,14 @@ msgstr "Dette bildet kunne ikke opprettes."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr ""
-"Denne bildetypen støttes ikke. Legg ved en JPG-, PNG-, WebP- eller GIF-fil"
+msgstr "Denne bildetypen støttes ikke. Legg ved en JPG-, PNG-, WebP- eller GIF-fil"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr ""
-"Denne bildetypen støttes ikke. Legg heller ved en JPG, PNG, WebP eller GIF."
+msgstr "Denne bildetypen støttes ikke. Legg heller ved en JPG, PNG, WebP eller GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -21618,8 +21583,7 @@ msgstr "Denne oversettelsen er feil"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Videoen er ikke ennå i stand til å spilles av her. Du kan se den på %1$s."
+msgstr "Videoen er ikke ennå i stand til å spilles av her. Du kan se den på %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -21810,8 +21774,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"For å overføre chat-historikken din til Duck.ai, oppdater DuckDuckGo-"
-"nettleseren din til den nyeste versjonen og prøv igjen."
+"For å overføre chat-historikken din til Duck.ai, oppdater "
+"DuckDuckGo-nettleseren din til den nyeste versjonen og prøv igjen."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -21842,7 +21806,7 @@ msgstr "I dag"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
-msgstr ""
+msgstr "Bytt til privat AI-chat eller %1$sdeaktiver i innstillingene%2$s."
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -22930,8 +22894,8 @@ msgstr "Under %1$sÅpne med%2$s velger du %3$sEn spesifikk side eller sider%4$s"
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"Under %1$sOPPSTART > Startside%2$s startside skriver du inn: https://"
-"duckduckgo.com"
+"Under %1$sOPPSTART > Startside%2$s startside skriver du inn: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22953,8 +22917,7 @@ msgstr "Under %1$sSøke%2$sseksjon trykker du på %3$sBehandle søkemotorer …%
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr ""
-"Under Ved oppstart velger du %1$sÅpne en spesifikk side eller flere sider%2$s"
+msgstr "Under Ved oppstart velger du %1$sÅpne en spesifikk side eller flere sider%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -23061,8 +23024,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Få tilgang til avanserte AI-modeller og høyere grenser med et DuckDuckGo-"
-"abonnement"
+"Få tilgang til avanserte AI-modeller og høyere grenser med et "
+"DuckDuckGo-abonnement"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -23667,6 +23630,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Yelp's ad network."
 msgstr ""
+"Annonser er personvernbeskyttet av DuckDuckGo. Annonseklikk administreres av "
+"Yelps annonsenettverk."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -23714,9 +23679,9 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"Gå til Duck.ai i den andre nettleseren din og så til %1$sDuck.ai-"
-"innstillinger%2$s > %3$sSync & Backup%4$s > %5$sAdministrer%6$s. Velg "
-"deretter %7$sSynkroniser med en annen enhet%8$s."
+"Gå til Duck.ai i den andre nettleseren din og så til "
+"%1$sDuck.ai-innstillinger%2$s > %3$sSync & Backup%4$s > %5$sAdministrer%6$s. "
+"Velg deretter %7$sSynkroniser med en annen enhet%8$s."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23752,8 +23717,8 @@ msgid ""
 msgstr ""
 "Gå til Duck.ai i nettleseren din eller i DuckDuckGo-appen, og åpne "
 "innstillingene for Duck.ai. Velg «Slå på» under Sync & Backup og velg "
-"«Synkroniser med en annen enhet». Eller skann QR-koden på gjenopprettings-"
-"PDF-en din."
+"«Synkroniser med en annen enhet». Eller skann QR-koden på "
+"gjenopprettings-PDF-en din."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23805,8 +23770,7 @@ msgstr "Talechatten er avsluttet"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr ""
-"Talechatten anonymiseres av oss og brukes aldri til å trene AI-modeller."
+msgstr "Talechatten anonymiseres av oss og brukes aldri til å trene AI-modeller."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -24042,8 +24006,7 @@ msgstr "Vi følger ikke etter deg med annonser."
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr ""
-"Vi lager hverken brukernavn eller informasjon som kan identifisere personer."
+msgstr "Vi lager hverken brukernavn eller informasjon som kan identifisere personer."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -24223,8 +24186,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr ""
-"Vi stopper alle fra å få tak i søkehistorikken din, inkludert oss selv."
+msgstr "Vi stopper alle fra å få tak i søkehistorikken din, inkludert oss selv."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -24247,8 +24209,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr ""
-"Vi blokkerer sporere som prøver å samle inn dataene dine mens du surfer."
+msgstr "Vi blokkerer sporere som prøver å samle inn dataene dine mens du surfer."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
@@ -24292,8 +24253,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr ""
-"Vi beklager ulempen. Vi jobber hardt for å gjøre opplevelsen din bedre."
+msgstr "Vi beklager ulempen. Vi jobber hardt for å gjøre opplevelsen din bedre."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -24403,8 +24363,7 @@ msgstr "Ukentlig bruksgrense er nådd"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Ukentlig bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
+msgstr "Ukentlig bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -24457,15 +24416,13 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"Velkommen til nye Duck.ai! Du kan nå importere de nedlastede chattene dine."
+msgstr "Velkommen til nye Duck.ai! Du kan nå importere de nedlastede chattene dine."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai, it's time to import your chats"
-msgstr ""
-"Velkommen til den nye Duck.ai, det er på tide å importere chattene dine"
+msgstr "Velkommen til den nye Duck.ai, det er på tide å importere chattene dine"
 
 # smartling.placeholder_format=C
 #. Welcome message for new DuckDuckGo users.
@@ -25149,13 +25106,15 @@ msgid ""
 "With chat history on, up to %s of your most recent chats will be saved on "
 "this device."
 msgstr ""
+"Når chathistorikk er på, lagres opptil %1$s av de siste chattene på denne "
+"enheten."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline in the About Chat History modal.
 msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, your most recent chats will be saved on this device."
-msgstr ""
+msgstr "Når chathistorikk er på, lagres de siste chattene på denne enheten."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -25419,8 +25378,7 @@ msgstr "Ja, ny bruker!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr ""
-"Ja, vi kaster data du er ferdig med, og dataene kan ikke gjenopprettes."
+msgstr "Ja, vi kaster data du er ferdig med, og dataene kan ikke gjenopprettes."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -25439,8 +25397,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"Du chatter med %1$s. AI-chatter kan vise feil eller støtende informasjon."
+msgstr "Du chatter med %1$s. AI-chatter kan vise feil eller støtende informasjon."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -25626,8 +25583,7 @@ msgstr ""
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can restore your settings after deleting cookies."
-msgstr ""
-"Du kan gjenopprette innstillingene etter at informasjonskapslene er slettet."
+msgstr "Du kan gjenopprette innstillingene etter at informasjonskapslene er slettet."
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -25777,8 +25733,7 @@ msgstr "Du søker nå med personvern!"
 msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
-msgstr ""
-"Du søker nå med personvern. %1$sFå flere tips til å redusere ditt fotavtrykk."
+msgstr "Du søker nå med personvern. %1$sFå flere tips til å redusere ditt fotavtrykk."
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -25827,8 +25782,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr ""
-"Du har nådd maksimalt antall meldinger for øyeblikket. Prøv igjen senere."
+msgstr "Du har nådd maksimalt antall meldinger for øyeblikket. Prøv igjen senere."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -26030,8 +25984,8 @@ msgstr "Chattene dine blir nå lagret."
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"Chattene dine er private og verken lagres eller brukes til å trene opp AI-"
-"modeller"
+"Chattene dine er private og verken lagres eller brukes til å trene opp "
+"AI-modeller"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
@@ -26063,8 +26017,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"Chattene dine er private, lagres aldri av oss og brukes ikke til å trene AI-"
-"modeller."
+"Chattene dine er private, lagres aldri av oss og brukes ikke til å trene "
+"AI-modeller."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -26072,8 +26026,8 @@ msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"Chattene dine er private, lagres aldri av oss og brukes ikke til å trene AI-"
-"modeller."
+"Chattene dine er private, lagres aldri av oss og brukes ikke til å trene "
+"AI-modeller."
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -26174,10 +26128,11 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"Passordet ditt genererer en 512-biters nøkkel ved hjelp av Secure Hash-"
-"algoritmen kjent som %1$sSHA-2%2$s. Det er kun nøkkelen og den tilhørende "
-"innstillingsfilen som forlater nettleseren din. Vi lagrer innstillingsfilen "
-"ved å bruke nøkkelen som navn. DuckDuckGo vet aldri passordet ditt."
+"Passordet ditt genererer en 512-biters nøkkel ved hjelp av Secure "
+"Hash-algoritmen kjent som %1$sSHA-2%2$s. Det er kun nøkkelen og den "
+"tilhørende innstillingsfilen som forlater nettleseren din. Vi lagrer "
+"innstillingsfilen ved å bruke nøkkelen som navn. DuckDuckGo vet aldri "
+"passordet ditt."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -26555,7 +26510,7 @@ msgstr "min"
 #. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the chat options menu button"
 msgid "menu"
-msgstr ""
+msgstr "meny"
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.
@@ -26629,8 +26584,7 @@ msgstr "det offisielle nettstedet"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr ""
-"eller skriv fargekoden du ønsker, f.eks. %1$s (%2$s er et kodet %3$s-tegn)."
+msgstr "eller skriv fargekoden du ønsker, f.eks. %1$s (%2$s er et kodet %3$s-tegn)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/nb_NO/LC_MESSAGES/duckduckgo.po
+++ b/locales/nb_NO/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: nb\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1211,6 +1211,12 @@ msgid "About our ads"
 msgstr "Om annonsene våre"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1340,6 +1346,20 @@ msgid "Ad is suspicious"
 msgstr "Annonsen er mistenkelig"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Legg til DuckDuckGo"
@@ -1366,6 +1386,27 @@ msgstr "Legg til DuckDuckGo som søkemotor"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Legg til DuckDuckGo i %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1411,6 +1452,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Legg til sideinnhold"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1496,6 +1553,12 @@ msgstr "Utvidelser"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Legger siste hånd på verket"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1799,6 +1862,12 @@ msgstr "Alle farger"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Ferdig!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3502,6 +3571,14 @@ msgid "Cancel"
 msgstr "Avbryt"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3994,10 +4071,22 @@ msgid "Chat response is offensive"
 msgstr "Chattens svar er støtende"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Chat med %1$s"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4016,6 +4105,14 @@ msgstr "Chatter"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Chatter"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5611,6 +5708,12 @@ msgid "Current Streak"
 msgstr "Nåværende rekke"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5957,6 +6060,12 @@ msgstr "Slett chatter"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Slett chatter som er eldre enn 30 dager"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6371,6 +6480,12 @@ msgstr "Avslå for alltid"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Avvis kampanje"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7538,6 +7653,12 @@ msgid "Edit Prompt"
 msgstr "Rediger ledetekst"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7759,6 +7880,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Kryptert modell"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8587,6 +8714,12 @@ msgid "Follow-up question"
 msgstr "Oppfølgingsspørsmål"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9098,6 +9231,12 @@ msgstr ""
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr "Få DuckDuckGo VPN, avansert Duck.ai og Identity Theft Restoration."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10327,6 +10466,12 @@ msgstr "Hvordan er det anonymt?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Slik fungerer det"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11771,6 +11916,12 @@ msgstr "Antall lineouts vunnet"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "Lenken utløper om syv dager."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13888,6 +14039,12 @@ msgstr "OK"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "OK – forstått!"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16008,6 +16165,12 @@ msgid "Protected"
 msgstr "Beskyttet"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Beskyttelse. Personvern. Ro i sjelen."
@@ -16139,6 +16302,12 @@ msgstr "Regn"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Rangeringer"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17369,6 +17538,12 @@ msgid "Save your chats across all your devices."
 msgstr "Lagre chatter på alle enhetene dine."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17568,6 +17743,14 @@ msgstr "Søk"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Søk"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18741,6 +18924,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Gå til butikk"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20394,6 +20583,14 @@ msgstr ""
 "Sync & Backup-data kan ikke gjenopprettes etter 18 måneder med inaktivitet."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20507,6 +20704,12 @@ msgstr "Synkroniser med en enhet i nærheten."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Synkroniser chattene dine mellom alle enhetene dine."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21092,6 +21295,22 @@ msgid "This Week"
 msgstr "Denne uken"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21618,6 +21837,12 @@ msgstr "I dag"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "I dag"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23436,6 +23661,14 @@ msgstr ""
 "administreres av TripAdvisors annonsenettverk."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Jomfruøyene"
 
@@ -24910,6 +25143,21 @@ msgstr ""
 "det av eller på når som helst i «%1$s»-menyen."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26302,6 +26550,12 @@ msgstr "min"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "min"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/ne_NP/LC_MESSAGES/duckduckgo.po
+++ b/locales/ne_NP/LC_MESSAGES/duckduckgo.po
@@ -980,6 +980,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1083,6 +1088,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr ""
@@ -1101,6 +1118,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1140,6 +1175,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1211,6 +1260,11 @@ msgstr "जोडिएको"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1455,6 +1509,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2802,6 +2861,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3202,9 +3268,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3220,6 +3296,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4477,6 +4560,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4761,6 +4849,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5099,6 +5192,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6007,6 +6105,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6184,6 +6287,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6849,6 +6957,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7267,6 +7380,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8249,6 +8367,11 @@ msgid "How is it anonymous?"
 msgstr "यो कसरी अज्ञात छ?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9406,6 +9529,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11143,6 +11271,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12843,6 +12976,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12949,6 +13087,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13937,6 +14080,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14092,6 +14240,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15009,6 +15164,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16348,6 +16508,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16428,6 +16595,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16888,6 +17060,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17290,6 +17476,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18752,6 +18943,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19901,6 +20099,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20983,6 +21194,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/nl_BE/LC_MESSAGES/duckduckgo.po
+++ b/locales/nl_BE/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Voeg DuckDuckGo toe"
@@ -1100,6 +1117,24 @@ msgstr "Voeg DuckDuckGo toe als zoekmachine"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Voeg DuckDuckGo toe aan %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr ""
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1455,6 +1509,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2802,6 +2861,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3202,9 +3268,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3220,6 +3296,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4488,6 +4571,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4772,6 +4860,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5110,6 +5203,11 @@ msgstr "Niet meer tonen"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6006,6 +6104,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6183,6 +6286,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6851,6 +6959,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7269,6 +7382,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8251,6 +8369,11 @@ msgid "How is it anonymous?"
 msgstr "Hoe is het anoniem?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9408,6 +9531,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11145,6 +11273,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "OK! ik snap het!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12853,6 +12986,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12959,6 +13097,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13947,6 +14090,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14104,6 +14252,13 @@ msgstr "Zoeken"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15030,6 +15185,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16370,6 +16530,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16450,6 +16617,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16910,6 +17082,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17313,6 +17499,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18782,6 +18973,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19939,6 +20137,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21030,6 +21241,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/nl_NL/LC_MESSAGES/duckduckgo.po
+++ b/locales/nl_NL/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: nl_NL\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -95,8 +95,7 @@ msgstr "%1$s en %2$s AI-modellen"
 #. Message that appears above the search results encouraging them to filter results by domain. The placeholder string would include a the name of a website. E.g. 'Reddit appears in some of the top results for this search.'
 msgctxt "Site filter message"
 msgid "%s appears in some of the top results for this search."
-msgstr ""
-"%1$s komt voor in een aantal van de beste resultaten voor deze zoekopdracht."
+msgstr "%1$s komt voor in een aantal van de beste resultaten voor deze zoekopdracht."
 
 # smartling.placeholder_format=C
 #. Number of tracking attempts blocked, when there is more than 1. Eg: '2 attempts' or '302 attempts'
@@ -443,8 +442,7 @@ msgstr "%1$s woorden"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr ""
-"%1$sKlik op %2$sToevoegen%3$sSelecteer %4$sToestaan%5$s en klik op %6$sOK%7$s"
+msgstr "%1$sKlik op %2$sToevoegen%3$sSelecteer %4$sToestaan%5$s en klik op %6$sOK%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -514,8 +512,7 @@ msgstr ""
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr ""
-"%1$sLees meer%2$s over hoe chats privé worden opgeslagen op je apparaat."
+msgstr "%1$sLees meer%2$s over hoe chats privé worden opgeslagen op je apparaat."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -882,8 +879,7 @@ msgstr "De 6-uurs gebruikslimiet is bereikt."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"De 6-uurs gebruikslimiet is bereikt. Je kunt dit gesprek voortzetten na %1$s."
+msgstr "De 6-uurs gebruikslimiet is bereikt. Je kunt dit gesprek voortzetten na %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -1220,7 +1216,7 @@ msgstr "Over onze advertenties"
 #. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
 msgctxt "Modal header for chat history with sync information"
 msgid "About Chat History with Sync & Backup"
-msgstr ""
+msgstr "Over chatgeschiedenis met Sync & Backup"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
@@ -1355,7 +1351,7 @@ msgstr "Advertentie is verdacht"
 #. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
 msgctxt "Button to open menu for attaching images or page context to AI chat"
 msgid "Add"
-msgstr ""
+msgstr "Toevoegen"
 
 # smartling.placeholder_format=C
 #. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
@@ -1363,7 +1359,7 @@ msgctxt ""
 "Primary button that attaches the tabs the user checked in the tab picker "
 "dialog"
 msgid "Add"
-msgstr ""
+msgstr "Toevoegen"
 
 # smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
@@ -1398,13 +1394,13 @@ msgstr "DuckDuckGo toevoegen aan %1$s"
 msgctxt ""
 "Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
 msgid "Add File"
-msgstr ""
+msgstr "Bestand toevoegen"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
 msgid "Add Image"
-msgstr ""
+msgstr "Afbeelding toevoegen"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
@@ -1412,7 +1408,7 @@ msgctxt ""
 "Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
 "item)"
 msgid "Add Image or File"
-msgstr ""
+msgstr "Afbeelding of bestand toevoegen"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1465,7 +1461,7 @@ msgctxt ""
 "Open the tab picker to attach browser tab content to the AI chat message "
 "(attach dropdown menu item)"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Tabbladen toevoegen"
 
 # smartling.placeholder_format=C
 #. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
@@ -1473,7 +1469,7 @@ msgctxt ""
 "Title and accessible name of the tab-picker dialog opened from the attach "
 "dropdown menu"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Tabbladen toevoegen"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1564,7 +1560,7 @@ msgstr "De puntjes worden op de i gezet"
 #. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
 msgctxt "Aria label for the additional instructions textarea"
 msgid "Additional instructions"
-msgstr ""
+msgstr "Aanvullende instructies"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1872,7 +1868,7 @@ msgstr "Helemaal klaar!"
 #. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the read-only textarea listing all AI instructions"
 msgid "All instructions"
-msgstr ""
+msgstr "Alle instructies"
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -1964,8 +1960,7 @@ msgstr "Anonieme bestandscontrole toestaan voor deze chat?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Advertenties die de privacy respecteren toestaan in DuckDuckGo Private Search"
+msgstr "Advertenties die de privacy respecteren toestaan in DuckDuckGo Private Search"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2125,8 +2120,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"Anonieme toegang tot populaire AI-modellen, waaronder %1$s, %2$s, en open-"
-"source %3$s en %4$s."
+"Anonieme toegang tot populaire AI-modellen, waaronder %1$s, %2$s, en "
+"open-source %3$s en %4$s."
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -2135,8 +2130,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"Anonieme toegang tot populaire AI-modellen, waaronder %1$s, %2$s, en open-"
-"source %3$s en %4$s."
+"Anonieme toegang tot populaire AI-modellen, waaronder %1$s, %2$s, en "
+"open-source %3$s en %4$s."
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -2521,8 +2516,8 @@ msgstr ""
 "relevante webinhoud samen te vatten. Je kunt kiezen hoe vaak je wilt dat "
 "Assist wordt weergegeven: 'Nooit' (de Assist-gebruikersinterface wordt "
 "helemaal uit de zoekresultaten verwijderd), 'Op verzoek' (AI-antwoorden "
-"worden alleen weergegeven als je op de Assist-knop klikt), 'Soms' (AI-"
-"antwoorden worden alleen weergegeven als ze zeer relevant zijn), of "
+"worden alleen weergegeven als je op de Assist-knop klikt), 'Soms' "
+"(AI-antwoorden worden alleen weergegeven als ze zeer relevant zijn), of "
 "'Vaak' (wordt vaker weergegeven bij een breder scala aan zoekopdrachten). "
 "Voorlopig zijn AI-antwoorden alleen beschikbaar in de Amerikaanse regio."
 
@@ -2536,8 +2531,8 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist is een optionele functie in onze zoekresultaten die anoniem AI-"
-"ondersteunde antwoorden op zoekopdrachten kan genereren. De functie scant "
+"Assist is een optionele functie in onze zoekresultaten die anoniem "
+"AI-ondersteunde antwoorden op zoekopdrachten kan genereren. De functie scant "
 "het web op relevante inhoud en gebruikt vervolgens AI-technologie op basis "
 "van natuurlijke taal om een kort antwoord te genereren aan de hand van de "
 "gevonden relevante informatie. Het is belangrijk om te onthouden dat "
@@ -3601,7 +3596,7 @@ msgctxt ""
 "Secondary button that dismisses the tab picker dialog without attaching "
 "anything"
 msgid "Cancel"
-msgstr ""
+msgstr "Annuleren"
 
 # smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
@@ -3838,8 +3833,7 @@ msgstr "Wijzigt hoe URL's van resultaten worden weergegeven"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr ""
-"Wijzigt de weergave van de header en bepaalt wat ermee gebeurt als je scrolt"
+msgstr "Wijzigt de weergave van de header en bepaalt wat ermee gebeurt als je scrolt"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -4050,16 +4044,14 @@ msgstr "Privé chatten"
 #. Mobile variant of DUCKCHAT_BROWSER_UPSELL_PROMO_TEXT. Shorter version for the promotional card encouraging third-party browser users to download the DuckDuckGo browser.
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
-msgstr ""
-"Chat privé op elke website met Duck.ai, ingebouwd in onze gratis browser."
+msgstr "Chat privé op elke website met Duck.ai, ingebouwd in onze gratis browser."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
-msgstr ""
-"Chat privé op elke website met de Duck.ai-zijbalk in onze gratis browser."
+msgstr "Chat privé op elke website met de Duck.ai-zijbalk in onze gratis browser."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4101,7 +4093,7 @@ msgstr "Het antwoord in de chatservice is aanstootgevend"
 #. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
 msgctxt "Chat history about modal list item headline"
 msgid "Chat storage varies by browser"
-msgstr ""
+msgstr "Chatopslag verschilt per browser"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4113,7 +4105,7 @@ msgstr "Chatten met %1$s"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Chat with popular AI models, anonymized by us."
-msgstr ""
+msgstr "Chat met populaire AI-modellen, door ons geanonimiseerd."
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4140,6 +4132,9 @@ msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
 msgstr ""
+"Chats worden veilig opgeslagen op de server van DuckDuckGo met "
+"end-to-end-versleuteling. Niemand anders dan jij kan je gegevens zien, zelfs "
+"wij niet."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5556,8 +5551,7 @@ msgstr "Costa Rica"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr ""
-"Uw herstelcode kon niet worden geladen. Sluit dit en probeer het opnieuw."
+msgstr "Uw herstelcode kon niet worden geladen. Sluit dit en probeer het opnieuw."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5612,8 +5606,7 @@ msgstr "Deellink aanmaken"
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
-msgstr ""
-"Maak een boodschappenlijst met de juiste hoeveelheden om dit recept te maken."
+msgstr "Maak een boodschappenlijst met de juiste hoeveelheden om dit recept te maken."
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5743,7 +5736,7 @@ msgstr "Huidige streak"
 #. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
 msgctxt "Suffix label indicating a tab is the currently active browser tab"
 msgid "Current Tab"
-msgstr ""
+msgstr "Huidig tabblad"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
@@ -5898,8 +5891,7 @@ msgstr "Dagelijkse limiet bereikt"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Dagelijkse gebruikslimiet bereikt. Je kunt dit gesprek voortzetten na %1$s."
+msgstr "Dagelijkse gebruikslimiet bereikt. Je kunt dit gesprek voortzetten na %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -6098,7 +6090,7 @@ msgstr "Wis chats die ouder zijn dan 30 dagen"
 #. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
 msgctxt "Button text in the modal for deleting all recent chats"
 msgid "Delete Chats and Shared Links"
-msgstr ""
+msgstr "Chats en gedeelde links verwijderen"
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6424,8 +6416,7 @@ msgstr "Uitschakelen en loskoppelen"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr ""
-"Chatgeschiedenis uitschakelen en de verbinding met Sync & Backup verbreken?"
+msgstr "Chatgeschiedenis uitschakelen en de verbinding met Sync & Backup verbreken?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6519,7 +6510,7 @@ msgstr "Promotie sluiten"
 #. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the close button on the survey banner"
 msgid "Dismiss survey"
-msgstr ""
+msgstr "Enquête negeren"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6680,8 +6671,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"Liever geen AI? Ga naar %1$snoai.duckduckgo.com%2$s om te zoeken zonder AI-"
-"functies en met AI-afbeeldingen weggefilterd. %3$sMeer informatie%4$s"
+"Liever geen AI? Ga naar %1$snoai.duckduckgo.com%2$s om te zoeken zonder "
+"AI-functies en met AI-afbeeldingen weggefilterd. %3$sMeer informatie%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6910,8 +6901,7 @@ msgstr "Sleep je foto's of PDF-bestanden"
 # smartling.placeholder_format=C
 #. A title explaining what Duck Player (DDG's feature to watch youtube videos more privately) does
 msgid "Duck Player lets you watch YouTube without targeted ads"
-msgstr ""
-"Met Duck Player kun je YouTube-video's bekijken zonder gerichte advertenties"
+msgstr "Met Duck Player kun je YouTube-video's bekijken zonder gerichte advertenties"
 
 # smartling.placeholder_format=C
 #. This is the DDG version of "Google it", meaning "search it".
@@ -7047,8 +7037,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai is tijdelijk niet beschikbaar. Als dit aanhoudt, stuur dan een e-"
-"mail met deze anonieme code %1$s naar %2$s"
+"Duck.ai is tijdelijk niet beschikbaar. Als dit aanhoudt, stuur dan een "
+"e-mail met deze anonieme code %1$s naar %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7110,8 +7100,7 @@ msgstr ""
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai now can read and analyze PDFs. Give it a try!"
-msgstr ""
-"Duck.ai kan nu pdf-bestanden lezen en analyseren. Probeer het maar eens!"
+msgstr "Duck.ai kan nu pdf-bestanden lezen en analyseren. Probeer het maar eens!"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown above the chat input only when coming from a DuckAssist grounded response into ungrounded models.
@@ -7155,8 +7144,8 @@ msgid ""
 "models, privacy focused AI, no account AI chat"
 msgstr ""
 "Duck.ai, DuckDuckGo AI, privé AI-chatbot, gratis AI-chat, anonieme AI-chat, "
-"AI-chat zonder aanmelden, OpenAI, Anthropic, Llama, Mistral, open source  AI-"
-"modellen, privacy  AI, AI-chat zonder account"
+"AI-chat zonder aanmelden, OpenAI, Anthropic, Llama, Mistral, open "
+"source  AI-modellen, privacy  AI, AI-chat zonder account"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7228,9 +7217,9 @@ msgid ""
 msgstr ""
 "DuckAssist is een nieuwe functie in onze zoekresultaten die anoniem "
 "antwoorden voor zoekopdrachten kan genereren. Hij scant daarvoor Wikipedia "
-"en gerelateerde sites op relevante inhoud en gebruikt vervolgens AI-"
-"technologie voor natuurlijke taal om die informatie samen te vatten. Let op: "
-"de antwoorden zijn op dit moment gebaseerd op Wikipedia en gerelateerde "
+"en gerelateerde sites op relevante inhoud en gebruikt vervolgens "
+"AI-technologie voor natuurlijke taal om die informatie samen te vatten. Let "
+"op: de antwoorden zijn op dit moment gebaseerd op Wikipedia en gerelateerde "
 "inhoud en worden niet gecontroleerd op juistheid."
 
 # smartling.placeholder_format=C
@@ -7328,8 +7317,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chat is tijdelijk niet beschikbaar. Probeer het later opnieuw."
+msgstr "DuckDuckGo AI Chat is tijdelijk niet beschikbaar. Probeer het later opnieuw."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7588,8 +7576,7 @@ msgctxt ""
 "Description of the DuckDuckGo subscription setting when it is not available "
 "in the user region"
 msgid "DuckDuckGo subscriptions are not available to purchase in this region."
-msgstr ""
-"DuckDuckGo-abonnementen zijn niet beschikbaar voor aankoop in deze regio."
+msgstr "DuckDuckGo-abonnementen zijn niet beschikbaar voor aankoop in deze regio."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use 'ducky' tone in its responses. When this option is selected, the AI assistant speaks like a duck.
@@ -7703,7 +7690,7 @@ msgstr "Prompt bewerken"
 #. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the message-editing text area"
 msgid "Edit message"
-msgstr ""
+msgstr "Bericht bewerken"
 
 # smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
@@ -7934,7 +7921,7 @@ msgstr "Versleuteld model"
 #. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
 msgctxt "Share modal info bullet about encryption"
 msgid "Encrypted so DuckDuckGo can't read your chat."
-msgstr ""
+msgstr "Versleuteld zodat DuckDuckGo je chat niet kan lezen."
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -7992,8 +7979,7 @@ msgstr "Ben je tevreden met Duck.ai?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr ""
-"Zorg dat %1$s'Toestaan'%2$s is geselecteerd voor de instelling 'Locatie'."
+msgstr "Zorg dat %1$s'Toestaan'%2$s is geselecteerd voor de instelling 'Locatie'."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -8207,8 +8193,7 @@ msgstr "Kaart uitvouwen"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr ""
-"Vakkundig vervaardigde producten voor mensen die echt om privacy geven."
+msgstr "Vakkundig vervaardigde producten voor mensen die echt om privacy geven."
 
 # smartling.placeholder_format=C
 #. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
@@ -8590,8 +8575,7 @@ msgstr "Filters niet effectief"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Filters out AI-generated images from image search results"
-msgstr ""
-"Filtert AI-gegenereerde afbeeldingen uit de zoekresultaten van afbeeldingen."
+msgstr "Filtert AI-gegenereerde afbeeldingen uit de zoekresultaten van afbeeldingen."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8771,7 +8755,7 @@ msgstr "Vervolgvraag"
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
-msgstr ""
+msgstr "Vervolgvragen blijven privé."
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8990,9 +8974,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Selecteer in de menubalk van de app voor Mac de optie <strong>DuckDuckGo</"
-"strong> &gt; <strong>Controleren op updates...</strong> en selecteer "
-"vervolgens <strong>Update installeren</strong>."
+"Selecteer in de menubalk van de app voor Mac de optie "
+"<strong>DuckDuckGo</strong> &gt; <strong>Controleren op updates...</strong> "
+"en selecteer vervolgens <strong>Update installeren</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9285,14 +9269,13 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr ""
-"Krijg DuckDuckGo VPN, geavanceerde Duck.ai en Identity Theft Restoration."
+msgstr "Krijg DuckDuckGo VPN, geavanceerde Duck.ai en Identity Theft Restoration."
 
 # smartling.placeholder_format=C
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
 msgctxt "Tooltip on the header logo for sunglasses searches"
 msgid "Get DuckDuckGo sunglasses and other gear."
-msgstr ""
+msgstr "Koop DuckDuckGo-zonnebrillen en andere merchandise."
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9406,8 +9389,9 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Krijg toegang tot geavanceerde AI-modellen in Duck.ai met een DuckDuckGo-"
-"abonnement, dat ook onze VPN en andere premium privacybeschermingen omvat."
+"Krijg toegang tot geavanceerde AI-modellen in Duck.ai met een "
+"DuckDuckGo-abonnement, dat ook onze VPN en andere premium "
+"privacybeschermingen omvat."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9451,8 +9435,8 @@ msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
 msgstr ""
-"Krijg onze snelle, no-log VPN, optionele toegang tot geavanceerde AI-"
-"modellen met hogere chatlimieten en meer premium beschermingen."
+"Krijg onze snelle, no-log VPN, optionele toegang tot geavanceerde "
+"AI-modellen met hogere chatlimieten en meer premium beschermingen."
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9586,9 +9570,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"Ga naar %1$sDuck.ai-instellingen%2$s in je andere browser, of de DuckDuckGo-"
-"app en ga naar %3$sChats › Synchroniseren en back-ups › Synchroniseren met "
-"een ander apparaat%4$s"
+"Ga naar %1$sDuck.ai-instellingen%2$s in je andere browser, of de "
+"DuckDuckGo-app en ga naar %3$sChats › Synchroniseren en back-ups › "
+"Synchroniseren met een ander apparaat%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9598,9 +9582,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"Ga naar %1$sDuck.ai-instellingen%2$s in je andere browser, of de DuckDuckGo-"
-"app en ga naar %3$sChats › Synchroniseren en back-ups › Synchroniseren met "
-"een ander apparaat%4$s en scan deze code:"
+"Ga naar %1$sDuck.ai-instellingen%2$s in je andere browser, of de "
+"DuckDuckGo-app en ga naar %3$sChats › Synchroniseren en back-ups › "
+"Synchroniseren met een ander apparaat%4$s en scan deze code:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9612,8 +9596,8 @@ msgid ""
 msgstr ""
 "Ga naar %1$sDuck.ai-instellingen%2$s in je andere browser, of naar de "
 "DuckDuckGo-app en ga naar %3$sChats › Synchroniseren en back-ups › "
-"Synchroniseren met een ander apparaat%4$s. Of scan de QR-code op je herstel-"
-"PDF."
+"Synchroniseren met een ander apparaat%4$s. Of scan de QR-code op je "
+"herstel-PDF."
 
 # smartling.placeholder_format=C
 #. Path to the pairing code on the other device. Bold segments are UI path labels.
@@ -10532,7 +10516,7 @@ msgstr "Hoe werkt het"
 #. Headline in chat history about modals for the temporary encrypted server storage explanation.
 msgctxt "Chat history about modal list item headline"
 msgid "How it works"
-msgstr ""
+msgstr "Hoe het werkt"
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -10949,8 +10933,8 @@ msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
 msgstr ""
-"Verbetert de leesbaarheid van het resultaat met een bijgewerkte URL-"
-"indeling, -plaatsing en -kleur"
+"Verbetert de leesbaarheid van het resultaat met een bijgewerkte "
+"URL-indeling, -plaatsing en -kleur"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -11840,8 +11824,7 @@ msgstr "Lees meer over hoe het werkt"
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
 msgid "Learn why reducing online tracking is important."
-msgstr ""
-"Informatie over waarom het terugdringen van online tracking belangrijk is."
+msgstr "Informatie over waarom het terugdringen van online tracking belangrijk is."
 
 # smartling.placeholder_format=C
 #. A link that takes users to a page where they can learn more about the dangers of online tracking.
@@ -11989,7 +11972,7 @@ msgstr "Link verloopt over 7 dagen."
 #. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days. People can save a chat copy."
-msgstr ""
+msgstr "Link verloopt over 7 dagen. Mensen kunnen een kopie van een chat opslaan."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -12306,8 +12289,7 @@ msgstr "Zorg ervoor dat alle woorden correct gespeld zijn."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr ""
-"Controleer of %1$s'Dit wordt mijn standaard zoekmachine'%2$s is aangevinkt"
+msgstr "Controleer of %1$s'Dit wordt mijn standaard zoekmachine'%2$s is aangevinkt"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -13773,8 +13755,7 @@ msgstr "Geen resultaten gevonden."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr ""
-"Geen spraak gedetecteerd. Probeer het nog eens en spreek in de microfoon."
+msgstr "Geen spraak gedetecteerd. Probeer het nog eens en spreek in de microfoon."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -14119,7 +14100,7 @@ msgstr "Oké, ik snap het!"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "OPTIONAL"
-msgstr ""
+msgstr "OPTIONEEL"
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -14446,8 +14427,7 @@ msgstr "%1$s-website openen"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr ""
-"Open %1$sLocatie%2$s en zorg ervoor dat locatie %3$sis ingeschakeld%4$s"
+msgstr "Open %1$sLocatie%2$s en zorg ervoor dat locatie %3$sis ingeschakeld%4$s"
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -14616,8 +14596,7 @@ msgstr "Open het paneel 'Hoe Duck.ai werkt'"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Open het Safari-menu en selecteer %1$sInstellingen voor DuckDuckGo...%2$s"
+msgstr "Open het Safari-menu en selecteer %1$sInstellingen voor DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -15931,8 +15910,7 @@ msgstr "Prijs"
 #. Category of feedback a user can select on a feedback form.
 msgctxt "feedback form"
 msgid "Price shown doesn't reflect merchant site"
-msgstr ""
-"De weergegeven prijs komt niet overeen met die op de site van de verkoper"
+msgstr "De weergegeven prijs komt niet overeen met die op de site van de verkoper"
 
 # smartling.placeholder_format=C
 #. A button that prints the contents of a page.
@@ -16215,8 +16193,7 @@ msgstr "Vraag het mij"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"Vraag me om mijn geschatte locatie te gebruiken voor resultaten in de buurt."
+msgstr "Vraag me om mijn geschatte locatie te gebruiken voor resultaten in de buurt."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -16251,7 +16228,7 @@ msgstr "Beschermd"
 #. Headline in sync-enabled chat history about modals explaining encrypted server storage.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Protected with end-to-end encryption"
-msgstr ""
+msgstr "Beschermd met end-to-end-versleuteling"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -16390,7 +16367,7 @@ msgstr "Scores"
 #. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
 msgctxt "star rating on a product"
 msgid "Rated %s out of %s"
-msgstr ""
+msgstr "Beoordeeld met %1$s op een schaal van %2$s"
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -16864,8 +16841,7 @@ msgstr "Mijn keuze onthouden"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Onthoud mijn keuze (dit kun je wijzigen in de %1$s%2$s%3$sInstellingen%4$s)"
+msgstr "Onthoud mijn keuze (dit kun je wijzigen in de %1$s%2$s%3$sInstellingen%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -17616,8 +17592,7 @@ msgstr "Bewaar maximaal 30 van je meest recente chats op je apparaat."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Bewaar je Duck.ai-chats tussen je apparaten met end-to-end-versleuteling."
+msgstr "Bewaar je Duck.ai-chats tussen je apparaten met end-to-end-versleuteling."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17629,7 +17604,7 @@ msgstr "Bewaar je chats op al je apparaten."
 #. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
 msgctxt "Chat history about modal list item headline"
 msgid "Save your chats on this device"
-msgstr ""
+msgstr "Bewaar je chats op dit apparaat"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
@@ -17763,15 +17738,13 @@ msgstr "Schotland"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Scroll down and click %sView advanced settings%s"
-msgstr ""
-"Scroll naar beneden en klik op %1$sGeavanceerde instellingen weergeven%2$s"
+msgstr "Scroll naar beneden en klik op %1$sGeavanceerde instellingen weergeven%2$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr ""
-"Scroll naar beneden en klik op %1$sGeavanceerde instellingen weergeven%2$s."
+msgstr "Scroll naar beneden en klik op %1$sGeavanceerde instellingen weergeven%2$s."
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -17843,7 +17816,7 @@ msgctxt ""
 "Placeholder and accessibility label for the search input in the tab picker "
 "dialog"
 msgid "Search"
-msgstr ""
+msgstr "Zoeken"
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18028,8 +18001,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"Zoek op andere sites met snelkoppelingen naar %1$s: een zoekopdracht naar \"!"
-"w ducks\" zal onmiddellijk op Wikipedia naar \"eenden\" zoeken."
+"Zoek op andere sites met snelkoppelingen naar %1$s: een zoekopdracht naar "
+"\"!w ducks\" zal onmiddellijk op Wikipedia naar \"eenden\" zoeken."
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -18214,8 +18187,7 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr ""
-"Veilig opgeslagen op de server van DuckDuckGo met end-to-end-versleuteling."
+msgstr "Veilig opgeslagen op de server van DuckDuckGo met end-to-end-versleuteling."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -18342,8 +18314,7 @@ msgstr "Bekijk enkele van onze nieuwste updates"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr ""
-"Kijk op de %1$sreferentiepagina voor URL-parameters%2$s voor meer informatie."
+msgstr "Kijk op de %1$sreferentiepagina voor URL-parameters%2$s voor meer informatie."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -18370,8 +18341,7 @@ msgstr "Selecteer %1$s%2$s%3$s en vervolgens %4$sZoekmachine%5$s"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
-msgstr ""
-"Selecteer %1$s'Instellingen voor deze website...'%2$s vanuit het Safari-menu."
+msgstr "Selecteer %1$s'Instellingen voor deze website...'%2$s vanuit het Safari-menu."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -18384,21 +18354,18 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Selecteer %1$sDuckDuckGo%2$s en klik op %3$sToevoegen als standaard%4$s."
+msgstr "Selecteer %1$sDuckDuckGo%2$s en klik op %3$sToevoegen als standaard%4$s."
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"Selecteer %1$sDuckDuckGo%2$s en klik op %3$sInstellen als standaard%4$s"
+msgstr "Selecteer %1$sDuckDuckGo%2$s en klik op %3$sInstellen als standaard%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"Selecteer %1$sDuckDuckGo%2$s en klik op %3$sInstellen als standaard%4$s."
+msgstr "Selecteer %1$sDuckDuckGo%2$s en klik op %3$sInstellen als standaard%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -18410,8 +18377,7 @@ msgstr "Selecteer %1$sDuckDuckGo%2$s in het uitklapmenu Standaard zoekmachine"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"Selecteer %1$sDuckDuckGo%2$s in de lijst en geef %3$stoegang tot%4$s locatie"
+msgstr "Selecteer %1$sDuckDuckGo%2$s in de lijst en geef %3$stoegang tot%4$s locatie"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18423,8 +18389,7 @@ msgstr "Selecteer %1$sDuckDuckGo%2$s in de lijst met zoekmachines"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr ""
-"Selecteer %1$sDuckDuckGo%2$s in het gedeelte %3$sStandaard zoekmachine%4$s"
+msgstr "Selecteer %1$sDuckDuckGo%2$s in het gedeelte %3$sStandaard zoekmachine%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -18511,8 +18476,7 @@ msgstr ""
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr ""
-"Selecteer %1$sInstellingen%2$s en vervolgens %3$sStandaard zoekmachine%4$s"
+msgstr "Selecteer %1$sInstellingen%2$s en vervolgens %3$sStandaard zoekmachine%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -18534,8 +18498,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"Selecteer %1$sje browser%2$s in de lijst en %3$slaat%4$s locatietoegang toe"
+msgstr "Selecteer %1$sje browser%2$s in de lijst en %3$slaat%4$s locatietoegang toe"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18888,8 +18851,8 @@ msgid ""
 "never reveals your precise location to us or AI models."
 msgstr ""
 "Deel een locatie op stadsniveau met AI-modellen om de relevantie te "
-"verbeteren. Duck.ai onthult nooit je precieze locatie aan ons of aan AI-"
-"modellen."
+"verbeteren. Duck.ai onthult nooit je precieze locatie aan ons of aan "
+"AI-modellen."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -19032,7 +18995,7 @@ msgstr "Winkelen"
 #. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
 msgctxt "Button in the merchandise logo modal (mobile)"
 msgid "Shop Now"
-msgstr ""
+msgstr "Nu winkelen"
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -19420,8 +19383,7 @@ msgstr "Meest bezochte links weergeven op een nieuw tabblad"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Geeft af en toe herinneringen weer om DuckDuckGo aan je browser toe te voegen"
+msgstr "Geeft af en toe herinneringen weer om DuckDuckGo aan je browser toe te voegen"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19435,8 +19397,8 @@ msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
 msgstr ""
-"Geeft af en toe herinneringen weer om je aan te melden voor de DuckDuckGo-"
-"nieuwsbrieven over privacy"
+"Geeft af en toe herinneringen weer om je aan te melden voor de "
+"DuckDuckGo-nieuwsbrieven over privacy"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19446,8 +19408,7 @@ msgstr "Geeft paginanummers weer naast resultaatpagina-einden"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows sign-up form for the DuckDuckGo privacy newsletters"
-msgstr ""
-"Geeft een inschrijfformulier weer voor de DuckDuckGo-privacynieuwsbrieven"
+msgstr "Geeft een inschrijfformulier weer voor de DuckDuckGo-privacynieuwsbrieven"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/94erFcS.png
@@ -19476,8 +19437,8 @@ msgstr "Geeft een welkomstbericht weer bovenaan de pagina met zoekresultaten"
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
 msgstr ""
-"Geeft een welkomstbericht weer aan gebruikers van het EU-Android-"
-"voorkeursmenu"
+"Geeft een welkomstbericht weer aan gebruikers van het "
+"EU-Android-voorkeursmenu"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -19709,8 +19670,7 @@ msgstr "Er is iets misgegaan bij het laden van deze gedeelde chat."
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr ""
-"Er is iets misgegaan tijdens het opslaan naar de server. Probeer het opnieuw."
+msgstr "Er is iets misgegaan tijdens het opslaan naar de server. Probeer het opnieuw."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
@@ -19748,8 +19708,7 @@ msgstr "Soms"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr ""
-"Sorry, ik kan het niet helpen. Omschrijf je afbeelding op een andere manier."
+msgstr "Sorry, ik kan het niet helpen. Omschrijf je afbeelding op een andere manier."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19823,8 +19782,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Sorry, we konden je feedback niet verzenden. Probeer het later opnieuw."
+msgstr "Sorry, we konden je feedback niet verzenden. Probeer het later opnieuw."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -20140,8 +20098,7 @@ msgstr "Stop verborgen trackers die op de loer liggen op andere websites."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Stop de meeste verborgen trackers die op de loer liggen op andere websites."
+msgstr "Stop de meeste verborgen trackers die op de loer liggen op andere websites."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20709,6 +20666,8 @@ msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
 msgstr ""
+"Synchronisatie en back-up bewaart meer van je chats en synchroniseert ze op "
+"al je apparaten."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20830,7 +20789,7 @@ msgstr "Synchroniseer je chats op al je apparaten."
 #. Headline in sync-enabled chat history about modals explaining cross-device sync.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Sync your chats across all your devices"
-msgstr ""
+msgstr "Synchroniseer je chats op al je apparaten"
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21195,15 +21154,13 @@ msgstr "Gambia"
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB"
-msgstr ""
-"De bijgevoegde bestanden overschrijden de totale groottelimiet van %1$sMB"
+msgstr "De bijgevoegde bestanden overschrijden de totale groottelimiet van %1$sMB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB."
-msgstr ""
-"De bijgevoegde bestanden overschrijden de totale groottelimiet van %1$s MB."
+msgstr "De bijgevoegde bestanden overschrijden de totale groottelimiet van %1$s MB."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
@@ -21259,8 +21216,7 @@ msgstr "Het verzoek is verlopen. Probeer het opnieuw."
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "The server encountered an error and could not complete your request."
-msgstr ""
-"De server heeft een fout aangetroffen en kon je verzoek niet voltooien."
+msgstr "De server heeft een fout aangetroffen en kon je verzoek niet voltooien."
 
 # smartling.placeholder_format=C
 #. Title for the theme menu:
@@ -21400,8 +21356,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Dit directe antwoord is gemaakt door de %1$sDuckDuckHack%2$s-community."
+msgstr "Dit directe antwoord is gemaakt door de %1$sDuckDuckHack%2$s-community."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -21430,12 +21385,14 @@ msgid ""
 "This chat and its generated images become public when you create and copy "
 "the link."
 msgstr ""
+"Deze chat en de bijbehorende gegenereerde afbeeldingen worden openbaar "
+"wanneer je de link aanmaakt en kopieert."
 
 # smartling.placeholder_format=C
 #. Explains that creating and copying a share link makes the selected chat content public.
 msgctxt "Share modal info bullet about public access"
 msgid "This chat becomes public when you create and copy the link."
-msgstr ""
+msgstr "Deze chat wordt openbaar wanneer je de link maakt en kopieert."
 
 # smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
@@ -21667,8 +21624,7 @@ msgstr "Voor deze pagina moet JavaScript zijn ingeschakeld."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"De inhoud van deze pagina wordt samen met je bericht naar Duck.ai gestuurd"
+msgstr "De inhoud van deze pagina wordt samen met je bericht naar Duck.ai gestuurd"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21720,8 +21676,7 @@ msgstr ""
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr ""
-"Deze gedeelde chat kon niet worden geopend. De link is mogelijk onvolledig."
+msgstr "Deze gedeelde chat kon niet worden geopend. De link is mogelijk onvolledig."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
@@ -21750,15 +21705,13 @@ msgstr "Deze vertaling is onjuist"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Deze video kan hier nog niet worden bekeken. Je kunt 'm bekijken op %1$s."
+msgstr "Deze video kan hier nog niet worden bekeken. Je kunt 'm bekijken op %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Deze webpagina gebruikt geen beveiligde, versleutelde verbinding (HTTPS)."
+msgstr "Deze webpagina gebruikt geen beveiligde, versleutelde verbinding (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21877,8 +21830,8 @@ msgstr "Tips"
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
 msgstr ""
-"Ben je het zat om online te worden gevolgd? %1$sWij kunnen je hierbij helpen."
-"%2$s"
+"Ben je het zat om online te worden gevolgd? %1$sWij kunnen je hierbij "
+"helpen.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -21910,8 +21863,7 @@ msgstr ""
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to Duck.ai’s %s and %s"
-msgstr ""
-"Om door te gaan, moet je akkoord gaan met het %1$s en het %2$s van Duck.ai"
+msgstr "Om door te gaan, moet je akkoord gaan met het %1$s en het %2$s van Duck.ai"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to AI Chat Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to DuckDuckGo AI Chat’s Privacy Policy and Terms of Service'
@@ -21952,8 +21904,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"Opdate om je chatgeschiedenis over te zetten naar Duck.ai je DuckDuckGo-"
-"browser naar de nieuwste versie en probeer het opnieuw."
+"Opdate om je chatgeschiedenis over te zetten naar Duck.ai je "
+"DuckDuckGo-browser naar de nieuwste versie en probeer het opnieuw."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -21985,6 +21937,8 @@ msgstr "Vandaag"
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
+"Schakel over naar privé AI-chat of %1$sschakel het uit in de "
+"instellingen%2$s."
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -22340,8 +22294,7 @@ msgstr "Probeer %1$s om dit soort berichten niet meer te zien."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Probeer %1$s, ons eerste model zonder enige zichtbaarheid bij zorgverleners."
+msgstr "Probeer %1$s, ons eerste model zonder enige zichtbaarheid bij zorgverleners."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -22482,16 +22435,14 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Probeer anonieme locatie in te schakelen voor nauwkeurigere resultaten."
+msgstr "Probeer anonieme locatie in te schakelen voor nauwkeurigere resultaten."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Probeer met alle modellen te experimenteren. Ze reageren allemaal anders."
+msgstr "Probeer met alle modellen te experimenteren. Ze reageren allemaal anders."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -22543,8 +22494,7 @@ msgstr "Probeer het gratis"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr ""
-"Probeer het gratis! Een veilige VPN, geavanceerde en privé-AI, en meer."
+msgstr "Probeer het gratis! Een veilige VPN, geavanceerde en privé-AI, en meer."
 
 # smartling.placeholder_format=C
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
@@ -22583,8 +22533,7 @@ msgstr "Probeer onze browser"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr ""
-"Probeer onze homepage, waar je deze berichten nooit te zien zult krijgen:"
+msgstr "Probeer onze homepage, waar je deze berichten nooit te zien zult krijgen:"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time; shown in the US. Invites the user to start a free trial of the paid subscription.
@@ -23035,8 +22984,7 @@ msgstr ""
 #. Message shown to the user when there was an issue connecting to their microphone.
 msgctxt "voice chat"
 msgid "Unable to connect to your mic. Please try again."
-msgstr ""
-"Er kan geen verbinding worden gemaakt met je microfoon. Probeer het opnieuw."
+msgstr "Er kan geen verbinding worden gemaakt met je microfoon. Probeer het opnieuw."
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when answer fails to load
@@ -23077,8 +23025,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"Bij %1$sOpenen met%2$s selecteer je %3$sEen specifieke pagina of pagina's%4$s"
+msgstr "Bij %1$sOpenen met%2$s selecteer je %3$sEen specifieke pagina of pagina's%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -23093,15 +23040,13 @@ msgstr "Bij %1$sZoekinstellingen%2$s selecteer je %3$sDuckDuckGo%4$s"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr ""
-"Bij %1$sZoek in de adresbalk met%2$s selecteer je %3$sNieuwe toevoegen%4$s"
+msgstr "Bij %1$sZoek in de adresbalk met%2$s selecteer je %3$sNieuwe toevoegen%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr ""
-"Bij het gedeelte %1$sZoeken%2$s klik je op %3$sZoekmachines beheren...%4$s"
+msgstr "Bij het gedeelte %1$sZoeken%2$s klik je op %3$sZoekmachines beheren...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -23115,8 +23060,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr ""
-"Bij Zoeken klik je op het uitklapmenu en selecteer je %1$sDuckDuckGo%2$s"
+msgstr "Bij Zoeken klik je op het uitklapmenu en selecteer je %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -23217,8 +23161,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Ontgrendel geavanceerde AI-modellen en hogere limieten met een DuckDuckGo-"
-"abonnement"
+"Ontgrendel geavanceerde AI-modellen en hogere limieten met een "
+"DuckDuckGo-abonnement"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -23490,8 +23434,7 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr ""
-"Upgrade naar Pro om 2x hogere gebruikslimieten dan Plus te ontgrendelen"
+msgstr "Upgrade naar Pro om 2x hogere gebruikslimieten dan Plus te ontgrendelen"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -23601,8 +23544,7 @@ msgstr "Gebruik DuckDuckGo Private Search"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"Gebruik DuckDuckGo Private Search op je iPad, iPhone of Android-apparaat."
+msgstr "Gebruik DuckDuckGo Private Search op je iPad, iPhone of Android-apparaat."
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -23826,6 +23768,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Yelp's ad network."
 msgstr ""
+"De weergave van advertenties wordt beschermd door DuckDuckGo. "
+"Advertentieklikken worden beheerd door het advertentienetwerk van Yelp."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -23909,10 +23853,10 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"Bezoek Duck.ai in je andere browser of de DuckDuckGo-app en open 'Duck.ai-"
-"instellingen'. Selecteer 'Inschakelen' onder Sync & Backup en selecteer "
-"'Synchroniseren met een ander apparaat'. Of scan de QR-code op je herstel-"
-"PDF."
+"Bezoek Duck.ai in je andere browser of de DuckDuckGo-app en open "
+"'Duck.ai-instellingen'. Selecteer 'Inschakelen' onder Sync & Backup en "
+"selecteer 'Synchroniseren met een ander apparaat'. Of scan de QR-code op je "
+"herstel-PDF."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -24111,8 +24055,8 @@ msgid ""
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
 "Kijk in Duck Player om gepersonaliseerde advertenties op YouTube te "
-"blokkeren en te voorkomen dat je kijkactiviteit invloed heeft op YouTube-"
-"aanbevelingen."
+"blokkeren en te voorkomen dat je kijkactiviteit invloed heeft op "
+"YouTube-aanbevelingen."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -24205,14 +24149,12 @@ msgstr "We achtervolgen je niet met advertenties."
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr ""
-"We slaan geen gebruikersnamen of persoonlijk identificeerbare informatie op."
+msgstr "We slaan geen gebruikersnamen of persoonlijk identificeerbare informatie op."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr ""
-"We slaan je persoonlijke gegevens niet op en volgen je ook niet. Nooit."
+msgstr "We slaan je persoonlijke gegevens niet op en volgen je ook niet. Nooit."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24238,8 +24180,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr ""
-"We volgen je niet, dus we horen graag van je waarom je bij ons terugkeert:"
+msgstr "We volgen je niet, dus we horen graag van je waarom je bij ons terugkeert:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -24247,8 +24188,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
-msgstr ""
-"We volgen je niet, dus we horen graag van je waarom je ons wilt uitproberen:"
+msgstr "We volgen je niet, dus we horen graag van je waarom je ons wilt uitproberen:"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24345,8 +24285,7 @@ msgstr "De verbinding is verbroken. Probeer het later opnieuw."
 #. We store chats for 15 minutes in the BE. If the user tries to fetch it after the 15 minutes elapsed or if we had an issue saving it we show them this error message so they can re-submit their prompt.
 msgctxt "AI Chat: Error message for unsaved or expired chats saved in sync"
 msgid "We lost the connection. Please try sending your message again."
-msgstr ""
-"We hebben de verbinding verloren. Probeer je bericht opnieuw te verzenden."
+msgstr "We hebben de verbinding verloren. Probeer je bericht opnieuw te verzenden."
 
 # smartling.placeholder_format=C
 #. Message asking the user to disable their ad blocker, with a link to how our ads don't track you. The placeholders are for the start and end tags of that link (e.g. <a href="%">, </a>)
@@ -24388,8 +24327,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr ""
-"We zorgen ervoor dat niemand je zoekgeschiedenis kan inzien, ook wij niet."
+msgstr "We zorgen ervoor dat niemand je zoekgeschiedenis kan inzien, ook wij niet."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -24412,8 +24350,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr ""
-"We blokkeren trackers die je gegevens willen verzamelen terwijl je surft."
+msgstr "We blokkeren trackers die je gegevens willen verzamelen terwijl je surft."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
@@ -24457,8 +24394,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr ""
-"Onze excuses voor dit ongemak. We doen ons best om je ervaring te verbeteren."
+msgstr "Onze excuses voor dit ongemak. We doen ons best om je ervaring te verbeteren."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -24568,8 +24504,7 @@ msgstr "Wekelijkse gebruikslimiet bereikt"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Wekelijkse gebruikslimiet bereikt. Je kunt dit gesprek voortzetten na %1$s."
+msgstr "Wekelijkse gebruikslimiet bereikt. Je kunt dit gesprek voortzetten na %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -24622,8 +24557,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"Welkom bij de nieuwe Duck.ai! Je kunt nu je gedownloade chats importeren."
+msgstr "Welkom bij de nieuwe Duck.ai! Je kunt nu je gedownloade chats importeren."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -25316,6 +25250,8 @@ msgid ""
 "With chat history on, up to %s of your most recent chats will be saved on "
 "this device."
 msgstr ""
+"Als chatgeschiedenis is ingeschakeld, worden maximaal %1$s van je meest "
+"recente chats op dit apparaat opgeslagen."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline in the About Chat History modal.
@@ -25323,6 +25259,8 @@ msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, your most recent chats will be saved on this device."
 msgstr ""
+"Als chatgeschiedenis is ingeschakeld, worden je meest recente chats op dit "
+"apparaat opgeslagen."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -25685,8 +25623,7 @@ msgstr "Je kunt dit op elk moment wijzigen in %1$sZoekinstellingen%2$s"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr ""
-"Je kunt dit gesprek voortzetten wanneer je limiet op %1$s wordt gereset."
+msgstr "Je kunt dit gesprek voortzetten wanneer je limiet op %1$s wordt gereset."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -25869,8 +25806,8 @@ msgid ""
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
 msgstr ""
 "Je hebt nu toegang tot geavanceerde AI-modellen. Je hebt toegang tot de VPN "
-"en andere beveiligingen van het DuckDuckGo-abonnement in de DuckDuckGo-"
-"browser."
+"en andere beveiligingen van het DuckDuckGo-abonnement in de "
+"DuckDuckGo-browser."
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -26022,8 +25959,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"Je hebt je limiet voor dicteergebruik bereikt. probeer het later opnieuw"
+msgstr "Je hebt je limiet voor dicteergebruik bereikt. probeer het later opnieuw"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -26221,8 +26157,8 @@ msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om AI-"
-"modellen te trainen."
+"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om "
+"AI-modellen te trainen."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
@@ -26230,8 +26166,8 @@ msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om AI-"
-"modellen te trainen."
+"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om "
+"AI-modellen te trainen."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -26264,8 +26200,8 @@ msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
 msgstr ""
-"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om AI-"
-"modellen te trainen. Volg deze stappen om je chatgeschiedenis te bewaren."
+"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om "
+"AI-modellen te trainen. Volg deze stappen om je chatgeschiedenis te bewaren."
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -26503,8 +26439,7 @@ msgstr ""
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr ""
-"Je hebt de limiet voor spraakchat voor nu bereikt. Probeer het later opnieuw."
+msgstr "Je hebt de limiet voor spraakchat voor nu bereikt. Probeer het later opnieuw."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -26587,8 +26522,7 @@ msgstr "door %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"Door DuckDuckGo — online bescherming vertrouwd door miljoenen elke dag."
+msgstr "Door DuckDuckGo — online bescherming vertrouwd door miljoenen elke dag."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"
@@ -26733,7 +26667,7 @@ msgstr "m"
 #. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the chat options menu button"
 msgid "menu"
-msgstr ""
+msgstr "menu"
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/nl_NL/LC_MESSAGES/duckduckgo.po
+++ b/locales/nl_NL/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: nl_NL\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1217,6 +1217,12 @@ msgid "About our ads"
 msgstr "Over onze advertenties"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1346,6 +1352,20 @@ msgid "Ad is suspicious"
 msgstr "Advertentie is verdacht"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "DuckDuckGo toevoegen"
@@ -1372,6 +1392,27 @@ msgstr "Voeg DuckDuckGo toe als zoekmachine"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "DuckDuckGo toevoegen aan %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1417,6 +1458,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Pagina-inhoud toevoegen"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1502,6 +1559,12 @@ msgstr "Add-ons"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "De puntjes worden op de i gezet"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1804,6 +1867,12 @@ msgstr "Alle kleuren"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Helemaal klaar!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3527,6 +3596,14 @@ msgid "Cancel"
 msgstr "Annuleren"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4021,10 +4098,22 @@ msgid "Chat response is offensive"
 msgstr "Het antwoord in de chatservice is aanstootgevend"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Chatten met %1$s"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4043,6 +4132,14 @@ msgstr "Chats"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Chats"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5643,6 +5740,12 @@ msgid "Current Streak"
 msgstr "Huidige streak"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5990,6 +6093,12 @@ msgstr "Chats verwijderen"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Wis chats die ouder zijn dan 30 dagen"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6405,6 +6514,12 @@ msgstr "Verbergen"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Promotie sluiten"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7585,6 +7700,12 @@ msgid "Edit Prompt"
 msgstr "Prompt bewerken"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7808,6 +7929,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Versleuteld model"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8641,6 +8768,12 @@ msgid "Follow-up question"
 msgstr "Vervolgvraag"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9154,6 +9287,12 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
 "Krijg DuckDuckGo VPN, geavanceerde Duck.ai en Identity Theft Restoration."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10388,6 +10527,12 @@ msgstr "Waarom is het anoniem?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Hoe werkt het"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11839,6 +11984,12 @@ msgstr "Line-outs gewonnen"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "Link verloopt over 7 dagen."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13963,6 +14114,12 @@ msgstr "OK"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "Oké, ik snap het!"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16091,6 +16248,12 @@ msgid "Protected"
 msgstr "Beschermd"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Bescherming. Privacy.Gemoedsrust."
@@ -16222,6 +16385,12 @@ msgstr "Regen"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Scores"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17457,6 +17626,12 @@ msgid "Save your chats across all your devices."
 msgstr "Bewaar je chats op al je apparaten."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17661,6 +17836,14 @@ msgstr "Zoeken"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Zoeken"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18844,6 +19027,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Winkelen"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20514,6 +20703,14 @@ msgstr ""
 "inactiviteit."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20628,6 +20825,12 @@ msgstr "Synchroniseer met een apparaat in de buurt."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Synchroniseer je chats op al je apparaten."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21219,6 +21422,22 @@ msgid "This Week"
 msgstr "Deze week"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21760,6 +21979,12 @@ msgstr "Vandaag"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Vandaag"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23595,6 +23820,14 @@ msgstr ""
 "TripAdvisor."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Maagdeneilanden"
 
@@ -25077,6 +25310,21 @@ msgstr ""
 "trainen. Schakel het op elk gewenst moment in of uit in het menu '%1$s'."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26480,6 +26728,12 @@ msgstr "m"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "m"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/nn_NO/LC_MESSAGES/duckduckgo.po
+++ b/locales/nn_NO/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr "Om oss"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "Annonsa er mistenkjeleg"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Legg til DuckDuckGo"
@@ -1100,6 +1117,24 @@ msgstr "Legg til DuckDuckGo som søkjemotor"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Legg til DuckDuckGo i %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr "Utvidingar"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1455,6 +1509,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2802,6 +2861,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3202,9 +3268,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3220,6 +3296,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4486,6 +4569,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4770,6 +4858,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5108,6 +5201,11 @@ msgstr "Ikkje vis dette meir"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6004,6 +6102,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6181,6 +6284,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6850,6 +6958,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7268,6 +7381,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8250,6 +8368,11 @@ msgid "How is it anonymous?"
 msgstr "Korleis er det anonymt?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9405,6 +9528,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11142,6 +11270,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "OK, eg forstår det!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12850,6 +12983,11 @@ msgstr "Vern dine data på alle einingar."
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12956,6 +13094,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13944,6 +14087,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14101,6 +14249,13 @@ msgstr "Søk"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15025,6 +15180,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16364,6 +16524,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16444,6 +16611,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16904,6 +17076,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17308,6 +17494,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18774,6 +18965,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19933,6 +20131,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21023,6 +21234,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/od_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/od_IN/LC_MESSAGES/duckduckgo.po
@@ -981,6 +981,11 @@ msgstr "ଆମ ସମ୍ବନ୍ଧରେ"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1084,6 +1089,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "ବିଜ୍ଞାପନଟି ସନ୍ଦିଗ୍ଧ ଅଟେ"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "DuckDuckGo କୁ ଯୋଗ କରନ୍ତୁ"
@@ -1103,6 +1120,24 @@ msgstr "DuckDuckGo କୁ ଏକ ଖୋଜା ଇଞ୍ଜିନ ଭଳି ଯ�
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "DuckDuckGo କୁ %s ରେ ଯୋଡ଼ନ୍ତୁ"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1141,6 +1176,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1212,6 +1261,11 @@ msgstr "ଯୋଗୋପକରଣ"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1456,6 +1510,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2805,6 +2864,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3205,9 +3271,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3223,6 +3299,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4482,6 +4565,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4766,6 +4854,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5104,6 +5197,11 @@ msgstr "ସବୁଦିନପାଇଁ ଖାରଜ"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6000,6 +6098,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6177,6 +6280,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6845,6 +6953,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7263,6 +7376,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8247,6 +8365,11 @@ msgid "How is it anonymous?"
 msgstr "ଏହା ନାମହୀନ କିପରି?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9404,6 +9527,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11141,6 +11269,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "ଠିକ ଅଛି, ଆଣନ୍ତୁ!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12845,6 +12978,11 @@ msgstr "ଆପଣଙ୍କର ତଥ୍ୟକୁ ପ୍ରତ୍ୟେକ ଯନ
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12951,6 +13089,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13939,6 +14082,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14096,6 +14244,13 @@ msgstr "ଖୋଜନ୍ତୁ"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15020,6 +15175,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16359,6 +16519,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16439,6 +16606,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16905,6 +17077,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17307,6 +17493,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18773,6 +18964,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19930,6 +20128,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21022,6 +21233,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/pl_PL/LC_MESSAGES/duckduckgo.po
+++ b/locales/pl_PL/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: pl_PL\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1217,6 +1217,12 @@ msgid "About our ads"
 msgstr "Informacje o naszych reklamach"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1346,6 +1352,20 @@ msgid "Ad is suspicious"
 msgstr "Reklama jest podejrzana"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Dodaj DuckDuckGo"
@@ -1372,6 +1392,27 @@ msgstr "Dodaj DuckDuckGo jako wyszukiwarkę"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Dodaj DuckDuckGo do %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1417,6 +1458,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Dodaj zawartość strony"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1502,6 +1559,12 @@ msgstr "Rozszerzenia"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Dodawanie elementów wykończeniowych"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1806,6 +1869,12 @@ msgstr "Wszystkie kolory"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Wszystko gotowe!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3538,6 +3607,14 @@ msgid "Cancel"
 msgstr "Anuluj"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4032,10 +4109,22 @@ msgid "Chat response is offensive"
 msgstr "Odpowiedź czatu jest obraźliwa"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Porozmawiaj z %1$s"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4054,6 +4143,14 @@ msgstr "Czaty"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Czaty"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5660,6 +5757,12 @@ msgid "Current Streak"
 msgstr "Bieżąca seria"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -6007,6 +6110,12 @@ msgstr "Usuń czaty"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Usuń czaty starsze niż 30 dni"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6420,6 +6529,12 @@ msgstr "Odrzuć na zawsze"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Odrzuć promocję"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7603,6 +7718,12 @@ msgid "Edit Prompt"
 msgstr "Edytuj prompt"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7825,6 +7946,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Szyfrowany model"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8666,6 +8793,12 @@ msgid "Follow-up question"
 msgstr "Pytanie uzupełniające"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9182,6 +9315,12 @@ msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
 "Uzyskaj dostęp do usług DuckDuckGo VPN oraz Identity Theft Restoration i "
 "zaawansowanych funkcji Duck.ai."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10417,6 +10556,12 @@ msgstr "W jaki sposób jest to anonimowe?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Jak to działa"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11869,6 +12014,12 @@ msgstr "Wygrane auty"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "Link wygasa za 7 dni."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13988,6 +14139,12 @@ msgstr "OK"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "OK, rozumiem!"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16122,6 +16279,12 @@ msgid "Protected"
 msgstr "Chroniony"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Ochrona. Prywatność. Spokój."
@@ -16253,6 +16416,12 @@ msgstr "Deszcz"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Rankingi"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17497,6 +17666,12 @@ msgid "Save your chats across all your devices."
 msgstr "Zapisz czaty na wszystkich urządzeniach."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17697,6 +17872,14 @@ msgstr "Szukaj"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Szukaj"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18884,6 +19067,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Sklep"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20552,6 +20741,14 @@ msgstr ""
 "Danych Sync & Backup nie można odzyskać po 18 miesiącach braku aktywności."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20666,6 +20863,12 @@ msgstr "Synchronizuj z urządzeniem znajdującym się w pobliżu."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Synchronizuj czaty na wszystkich urządzeniach."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21250,6 +21453,22 @@ msgid "This Week"
 msgstr "W tym tygodniu"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21785,6 +22004,12 @@ msgstr "Dziś"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Dziś"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23620,6 +23845,14 @@ msgstr ""
 "reklam zarządzane jest przez sieć reklamową MicrosoftTripAdvisor."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Wyspy Dziewicze"
 
@@ -25107,6 +25340,21 @@ msgstr ""
 "menu %1$s."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26512,6 +26760,12 @@ msgstr "min"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "min"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/pl_PL/LC_MESSAGES/duckduckgo.po
+++ b/locales/pl_PL/LC_MESSAGES/duckduckgo.po
@@ -2,16 +2,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: pl_PL\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
-"|| n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -309,8 +308,7 @@ msgstr "Rankingi %1$s nie są jeszcze dostępne"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits 2-5x faster than other models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
-msgstr ""
-"%1$s osiąga limity użycia 2-5 razy szybciej niż podstawowe modele. %2$s"
+msgstr "%1$s osiąga limity użycia 2-5 razy szybciej niż podstawowe modele. %2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -524,8 +522,7 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr ""
-"%1$sNaciśnij i przytrzymaj%2$s ikonę aplikacji DuckDuckGo na ekranie głównym"
+msgstr "%1$sNaciśnij i przytrzymaj%2$s ikonę aplikacji DuckDuckGo na ekranie głównym"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -882,8 +879,7 @@ msgstr "Osiągnięto limit 6 godzin użytkowania."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Osiągnięto limit 6 godzin użytkowania. Możesz kontynuować tę rozmowę po %1$s."
+msgstr "Osiągnięto limit 6 godzin użytkowania. Możesz kontynuować tę rozmowę po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -1010,8 +1006,8 @@ msgstr ""
 "Funkcja AI Chat umożliwia prowadzenie anonimowych rozmów z modelami czatu AI "
 "oferowanymi przez inne firmy. Wyłączenie tej opcji spowoduje ukrycie funkcji "
 "AI Chat w DuckDuckGo Search. Nawet w przypadku wyłączenia tego ustawienia "
-"możesz uzyskać dostęp do funkcji AI Chat na stronie %1$sduckduckgo.com/"
-"aichat%2$s."
+"możesz uzyskać dostęp do funkcji AI Chat na stronie "
+"%1$sduckduckgo.com/aichat%2$s."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1220,7 +1216,7 @@ msgstr "Informacje o naszych reklamach"
 #. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
 msgctxt "Modal header for chat history with sync information"
 msgid "About Chat History with Sync & Backup"
-msgstr ""
+msgstr "Informacje o historii czatu z Sync & Backup"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
@@ -1355,7 +1351,7 @@ msgstr "Reklama jest podejrzana"
 #. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
 msgctxt "Button to open menu for attaching images or page context to AI chat"
 msgid "Add"
-msgstr ""
+msgstr "Dodaj"
 
 # smartling.placeholder_format=C
 #. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
@@ -1363,7 +1359,7 @@ msgctxt ""
 "Primary button that attaches the tabs the user checked in the tab picker "
 "dialog"
 msgid "Add"
-msgstr ""
+msgstr "Dodaj"
 
 # smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
@@ -1398,13 +1394,13 @@ msgstr "Dodaj DuckDuckGo do %1$s"
 msgctxt ""
 "Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
 msgid "Add File"
-msgstr ""
+msgstr "Dodaj plik"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
 msgid "Add Image"
-msgstr ""
+msgstr "Dodaj obraz"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
@@ -1412,7 +1408,7 @@ msgctxt ""
 "Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
 "item)"
 msgid "Add Image or File"
-msgstr ""
+msgstr "Dodaj obraz lub plik"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1465,7 +1461,7 @@ msgctxt ""
 "Open the tab picker to attach browser tab content to the AI chat message "
 "(attach dropdown menu item)"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Dodaj karty"
 
 # smartling.placeholder_format=C
 #. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
@@ -1473,7 +1469,7 @@ msgctxt ""
 "Title and accessible name of the tab-picker dialog opened from the attach "
 "dropdown menu"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Dodaj karty"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1564,7 +1560,7 @@ msgstr "Dodawanie elementów wykończeniowych"
 #. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
 msgctxt "Aria label for the additional instructions textarea"
 msgid "Additional instructions"
-msgstr ""
+msgstr "Dodatkowe instrukcje"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1874,7 +1870,7 @@ msgstr "Wszystko gotowe!"
 #. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the read-only textarea listing all AI instructions"
 msgid "All instructions"
-msgstr ""
+msgstr "Wszystkie instrukcje"
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2020,8 +2016,7 @@ msgstr "To urządzenie jest już zsynchronizowane."
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Also search privately on your iPad, iPhone, or Android!"
-msgstr ""
-"Możesz też wyszukiwać prywatnie na swoim iPadzie, iPhonie oraz Androidzie!"
+msgstr "Możesz też wyszukiwać prywatnie na swoim iPadzie, iPhonie oraz Androidzie!"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -2710,8 +2705,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
 msgid "Auto-generated from sources. May be inaccurate."
-msgstr ""
-"Generowane automatycznie na podstawie źródeł. Może zawierać nieścisłości."
+msgstr "Generowane automatycznie na podstawie źródeł. Może zawierać nieścisłości."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -3108,8 +3102,7 @@ msgstr "Zablokuj tę witrynę we wszystkich wynikach"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr ""
-"Zablokuj skrypty śledzące i przejmij kontrolę nad swoimi danymi osobowymi"
+msgstr "Zablokuj skrypty śledzące i przejmij kontrolę nad swoimi danymi osobowymi"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3449,8 +3442,7 @@ msgstr "Burundi"
 #. The first %s is the action button label ('Continue'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab.
 msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid "By clicking '%s' you agree to our %s."
-msgstr ""
-"Klikając przycisk „%1$s”, akceptujesz postanowienia naszego dokumentu %2$s."
+msgstr "Klikając przycisk „%1$s”, akceptujesz postanowienia naszego dokumentu %2$s."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3612,7 +3604,7 @@ msgctxt ""
 "Secondary button that dismisses the tab picker dialog without attaching "
 "anything"
 msgid "Cancel"
-msgstr ""
+msgstr "Anuluj"
 
 # smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
@@ -3849,8 +3841,7 @@ msgstr "Zmienia sposób wyświetlania adresów URL wyników"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr ""
-"Zmienia sposób wyświetlania nagłówka i jego zachowanie podczas przewijania"
+msgstr "Zmienia sposób wyświetlania nagłówka i jego zachowanie podczas przewijania"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3869,8 +3860,7 @@ msgstr "Zmienia kolor tła na całej stronie"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr ""
-"Zmienia kolor tła wyników po najechaniu kursorem, modułów i rozwijanych menu"
+msgstr "Zmienia kolor tła wyników po najechaniu kursorem, modułów i rozwijanych menu"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -4003,8 +3993,8 @@ msgstr ""
 "rozmów z zewnętrznymi modelami czatu AI, obsługującymi modele OpenAI, "
 "Anthropic i inne. Wyłączenie tej opcji spowoduje ukrycie przycisków czatu i "
 "linków w DuckDuckGo Search. Nawet w przypadku wyłączenia tego ustawienia "
-"możesz uzyskać dostęp do czatu, przechodząc pod adres %1$shttps://duck."
-"ai%2$s bezpośrednio."
+"możesz uzyskać dostęp do czatu, przechodząc pod adres "
+"%1$shttps://duck.ai%2$s bezpośrednio."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4112,7 +4102,7 @@ msgstr "Odpowiedź czatu jest obraźliwa"
 #. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
 msgctxt "Chat history about modal list item headline"
 msgid "Chat storage varies by browser"
-msgstr ""
+msgstr "Przechowywanie czatów różni się w zależności od przeglądarki"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4124,7 +4114,7 @@ msgstr "Porozmawiaj z %1$s"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Chat with popular AI models, anonymized by us."
-msgstr ""
+msgstr "Czat z popularnymi modelami AI, anonimizowany przez nas."
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4151,6 +4141,8 @@ msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
 msgstr ""
+"Czaty są bezpiecznie przechowywane na serwerze DuckDuckGo z kompleksowym "
+"szyfrowaniem. Nikt poza Tobą nie może zobaczyć Twoich danych, nawet my."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5348,8 +5340,7 @@ msgstr "Kontynuuj blokowanie reklam"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
-"Kontynuuj ostatnie czaty tutaj. Możesz też usunąć je przyciskiem Fire Button."
+msgstr "Kontynuuj ostatnie czaty tutaj. Możesz też usunąć je przyciskiem Fire Button."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5760,7 +5751,7 @@ msgstr "Bieżąca seria"
 #. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
 msgctxt "Suffix label indicating a tab is the currently active browser tab"
 msgid "Current Tab"
-msgstr ""
+msgstr "Bieżąca karta"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
@@ -5915,8 +5906,7 @@ msgstr "Osiągnięto dzienny limit"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Osiągnięto dzienny limit użycia. Możesz kontynuować tę rozmowę po %1$s."
+msgstr "Osiągnięto dzienny limit użycia. Możesz kontynuować tę rozmowę po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -6115,7 +6105,7 @@ msgstr "Usuń czaty starsze niż 30 dni"
 #. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
 msgctxt "Button text in the modal for deleting all recent chats"
 msgid "Delete Chats and Shared Links"
-msgstr ""
+msgstr "Usuń czaty i udostępnione linki"
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6534,7 +6524,7 @@ msgstr "Odrzuć promocję"
 #. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the close button on the survey banner"
 msgid "Dismiss survey"
-msgstr ""
+msgstr "Zignoruj ankietę"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7073,8 +7063,7 @@ msgstr ""
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr ""
-"Funkcja Duck.ai jest chwilowo niedostępna. Odśwież stronę i spróbuj ponownie."
+msgstr "Funkcja Duck.ai jest chwilowo niedostępna. Odśwież stronę i spróbuj ponownie."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7347,8 +7336,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chat jest chwilowo niedostępny. Spróbuj ponownie później."
+msgstr "DuckDuckGo AI Chat jest chwilowo niedostępny. Spróbuj ponownie później."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7721,7 +7709,7 @@ msgstr "Edytuj prompt"
 #. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the message-editing text area"
 msgid "Edit message"
-msgstr ""
+msgstr "Edytuj wiadomość"
 
 # smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
@@ -7951,7 +7939,7 @@ msgstr "Szyfrowany model"
 #. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
 msgctxt "Share modal info bullet about encryption"
 msgid "Encrypted so DuckDuckGo can't read your chat."
-msgstr ""
+msgstr "Twój czat jest zaszyfrowany, więc DuckDuckGo nie może go odczytać."
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8029,8 +8017,7 @@ msgstr "Upewnij się, że opcja „Lokalizacja” jest ustawiona na %1$szezwalaj
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s."
-msgstr ""
-"Upewnij się, że opcja „Lokalizacja” jest ustawiona na %1$szezwalaj%2$s."
+msgstr "Upewnij się, że opcja „Lokalizacja” jest ustawiona na %1$szezwalaj%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -8170,8 +8157,7 @@ msgstr "Gwinea Równikowa"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"Błyskawicznie usuń dane przeglądania za pomocą przycisku %1$sFire Button%2$s"
+msgstr "Błyskawicznie usuń dane przeglądania za pomocą przycisku %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -8231,8 +8217,7 @@ msgstr "Rozwiń mapę"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr ""
-"Profesjonalnie wykonane produkty dla osób, które naprawdę dbają o prywatność."
+msgstr "Profesjonalnie wykonane produkty dla osób, które naprawdę dbają o prywatność."
 
 # smartling.placeholder_format=C
 #. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
@@ -8796,7 +8781,7 @@ msgstr "Pytanie uzupełniające"
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
-msgstr ""
+msgstr "Pytania uzupełniające pozostają prywatne."
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8902,8 +8887,7 @@ msgstr "Bezpłatne i prywatne czaty anonimizowane przez nas"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Darmowe i prywatne czaty, anonimizowane przez nas. Nie trzeba zakładać konta."
+msgstr "Darmowe i prywatne czaty, anonimizowane przez nas. Nie trzeba zakładać konta."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9147,22 +9131,19 @@ msgstr "Ogólnego przeznaczenia"
 #. Text with short description for an AI (Artificial Intelligence) Model that has a high moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with high built-in moderation"
-msgstr ""
-"Sztuczna inteligencja ogólnego przeznaczenia z wysoką wbudowaną moderacją"
+msgstr "Sztuczna inteligencja ogólnego przeznaczenia z wysoką wbudowaną moderacją"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a low moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with low built-in moderation"
-msgstr ""
-"Sztuczna inteligencja ogólnego przeznaczenia z niską wbudowaną moderacją"
+msgstr "Sztuczna inteligencja ogólnego przeznaczenia z niską wbudowaną moderacją"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a medium moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with medium built-in moderation"
-msgstr ""
-"Sztuczna inteligencja ogólnego przeznaczenia ze średnią wbudowaną moderacją"
+msgstr "Sztuczna inteligencja ogólnego przeznaczenia ze średnią wbudowaną moderacją"
 
 # smartling.placeholder_format=C
 #. Text indicating that the AI (Artificial Intelligence) model is a model for general purpose use. General-purpose AI refers to AI systems that can perform a wide range of tasks, rather than being specialized for a specific task.
@@ -9320,7 +9301,7 @@ msgstr ""
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
 msgctxt "Tooltip on the header logo for sunglasses searches"
 msgid "Get DuckDuckGo sunglasses and other gear."
-msgstr ""
+msgstr "Kup okulary przeciwsłoneczne DuckDuckGo i inne gadżety."
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9544,8 +9525,8 @@ msgstr "Pobierz aplikację"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"Pobierz darmową przeglądarkę DuckDuckGo, aby %1$sblokować reklamy na YouTube."
-"%2$s"
+"Pobierz darmową przeglądarkę DuckDuckGo, aby %1$sblokować reklamy na "
+"YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9658,8 +9639,7 @@ msgstr ""
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr ""
-"Wybierz kolejno %1$sPrywatność i bezpieczeństwo > Usługi lokalizacji%2$s"
+msgstr "Wybierz kolejno %1$sPrywatność i bezpieczeństwo > Usługi lokalizacji%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -10187,8 +10167,7 @@ msgstr "Podaj powód negatywnej oceny"
 #. A subtitle of a page that encourages users to share DuckDuckGo with their friends.
 msgctxt "showcase_spread"
 msgid "Help your friends and family join the Duck Side!"
-msgstr ""
-"Pomóż swoim przyjaciołom oraz rodzinie dołączyć do społeczności DuckDuckGo!"
+msgstr "Pomóż swoim przyjaciołom oraz rodzinie dołączyć do społeczności DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Text description for the Spread card in the SERP footer
@@ -10561,7 +10540,7 @@ msgstr "Jak to działa"
 #. Headline in chat history about modals for the temporary encrypted server storage explanation.
 msgctxt "Chat history about modal list item headline"
 msgid "How it works"
-msgstr ""
+msgstr "Jak to działa"
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -10841,8 +10820,7 @@ msgstr "Jeśli chcesz nas wesprzeć, %1$spomóż nam rozpowszechnić DuckDuckGo%
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr ""
-"Jeśli chcesz używać DuckDuckGo bez JavaScript, użyj wersji %1$s lub %2$s."
+msgstr "Jeśli chcesz używać DuckDuckGo bez JavaScript, użyj wersji %1$s lub %2$s."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -11034,8 +11012,7 @@ msgstr "W menu na górze ekranu wybierz %1$sNarzędzia%2$s > %3$sUstawienia%4$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
-msgstr ""
-"W wyskakującym okienku zaznacz %1$sUstaw jako domyślną wyszukiwarkę%2$s"
+msgstr "W wyskakującym okienku zaznacz %1$sUstaw jako domyślną wyszukiwarkę%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -11413,8 +11390,7 @@ msgstr "Jest szybki, bezpłatny i zapewnia Ci jeszcze większą ochronę online.
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Zgadzam się na (bardzo rzadkie) pytania o moje doświadczenia z DuckDuckGo"
+msgstr "Zgadzam się na (bardzo rzadkie) pytania o moje doświadczenia z DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11479,8 +11455,7 @@ msgstr "Dołącz do nas!"
 # smartling.placeholder_format=C
 msgctxt "showcase_donate"
 msgid "Join our $500,000 Privacy Challenge"
-msgstr ""
-"Dołącz do naszego konkursu na ochronę prywatności w wysokości 500 000 USD"
+msgstr "Dołącz do naszego konkursu na ochronę prywatności w wysokości 500 000 USD"
 
 # smartling.placeholder_format=C
 msgid "Jordan"
@@ -12019,7 +11994,7 @@ msgstr "Link wygasa za 7 dni."
 #. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days. People can save a chat copy."
-msgstr ""
+msgstr "Link wygasa za 7 dni. Odbiorcy mogą zapisać kopię czatu."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -12035,8 +12010,7 @@ msgstr "Linki:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
-"Wymień narzędzia, materiały lub warunki wstępne, których do tego potrzebuję."
+msgstr "Wymień narzędzia, materiały lub warunki wstępne, których do tego potrzebuję."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12147,8 +12121,7 @@ msgstr "Ładuj więcej obrazów podczas przewijania"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr ""
-"Automatycznie wczytuje więcej obrazów, filmów i zakupów podczas przewijania"
+msgstr "Automatycznie wczytuje więcej obrazów, filmów i zakupów podczas przewijania"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -12926,8 +12899,7 @@ msgstr "Osiągnięty limit miesięczny"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Osiągnięto miesięczny limit użycia. Możesz kontynuować tę rozmowę po %1$s."
+msgstr "Osiągnięto miesięczny limit użycia. Możesz kontynuować tę rozmowę po %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -14144,7 +14116,7 @@ msgstr "OK, rozumiem!"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "OPTIONAL"
-msgstr ""
+msgstr "Opcjonalne"
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16264,8 +16236,7 @@ msgstr "Chroń swoje dane podczas wyszukiwania i przeglądania."
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
-msgstr ""
-"Chroń swoje dane podczas wyszukiwania, przeglądania i korzystania z AI."
+msgstr "Chroń swoje dane podczas wyszukiwania, przeglądania i korzystania z AI."
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -16282,7 +16253,7 @@ msgstr "Chroniony"
 #. Headline in sync-enabled chat history about modals explaining encrypted server storage.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Protected with end-to-end encryption"
-msgstr ""
+msgstr "Chronione szyfrowaniem kompleksowym"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -16421,7 +16392,7 @@ msgstr "Rankingi"
 #. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
 msgctxt "star rating on a product"
 msgid "Rated %s out of %s"
-msgstr ""
+msgstr "Ocena: %1$s na %2$s"
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -16496,22 +16467,19 @@ msgstr "Wnioskowanie AI"
 #. Text with short description for a reasoning AI (Artificial Intelligence) Model that has a high moderation level. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with high built-in moderation"
-msgstr ""
-"Rozumująca sztuczna inteligencja z wysokim poziomem wbudowanej moderacji"
+msgstr "Rozumująca sztuczna inteligencja z wysokim poziomem wbudowanej moderacji"
 
 # smartling.placeholder_format=C
 #. Text with short description for a reasoning AI (Artificial Intelligence) Model that has a low moderation level. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with low built-in moderation"
-msgstr ""
-"Rozumująca sztuczna inteligencja z niskim poziomem wbudowanej moderacji"
+msgstr "Rozumująca sztuczna inteligencja z niskim poziomem wbudowanej moderacji"
 
 # smartling.placeholder_format=C
 #. Text with short description for a reasoning AI (Artificial Intelligence) Model that has a medium moderation level. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
-msgstr ""
-"Rozumująca sztuczna inteligencja ze średnim poziomem wbudowanej moderacji"
+msgstr "Rozumująca sztuczna inteligencja ze średnim poziomem wbudowanej moderacji"
 
 # smartling.placeholder_format=C
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
@@ -16531,8 +16499,7 @@ msgstr ""
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr ""
-"Rozumowanie jest dokładniejsze, ale zużywa limity 2-5 razy szybciej. %1$s"
+msgstr "Rozumowanie jest dokładniejsze, ale zużywa limity 2-5 razy szybciej. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -17656,8 +17623,8 @@ msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
 msgstr ""
-"Zapisuj swoje czaty Duck.ai między urządzeniami dzięki szyfrowaniu typu end-"
-"to-end."
+"Zapisuj swoje czaty Duck.ai między urządzeniami dzięki szyfrowaniu typu "
+"end-to-end."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17669,7 +17636,7 @@ msgstr "Zapisz czaty na wszystkich urządzeniach."
 #. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
 msgctxt "Chat history about modal list item headline"
 msgid "Save your chats on this device"
-msgstr ""
+msgstr "Zapisz czaty na tym urządzeniu"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
@@ -17879,7 +17846,7 @@ msgctxt ""
 "Placeholder and accessibility label for the search input in the tab picker "
 "dialog"
 msgid "Search"
-msgstr ""
+msgstr "Szukaj"
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18255,8 +18222,7 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr ""
-"Bezpieczne przechowywanie na serwerze DuckDuckGo z kompleksowym szyfrowaniem."
+msgstr "Bezpieczne przechowywanie na serwerze DuckDuckGo z kompleksowym szyfrowaniem."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -18444,15 +18410,13 @@ msgstr "Wybierz %1$sDuckDuckGo%2$s i kliknij %3$sUstaw jako domyślną%4$s."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr ""
-"Wybierz %1$sDuckDuckGo%2$s w rozwijanym menu jako domyślną wyszukiwarkę"
+msgstr "Wybierz %1$sDuckDuckGo%2$s w rozwijanym menu jako domyślną wyszukiwarkę"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"Wybierz %1$sDuckDuckGo%2$s z listy i %3$szezwól%4$s na dostęp do lokalizacji"
+msgstr "Wybierz %1$sDuckDuckGo%2$s z listy i %3$szezwól%4$s na dostęp do lokalizacji"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18543,8 +18507,7 @@ msgstr "Wybierz %1$sUstawienia%2$s z rozwijanego menu."
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sAdvanced settings%s"
-msgstr ""
-"Wybierz %1$sUstawienia%2$s, a następnie %3$sUstawienia zaawansowane%4$s"
+msgstr "Wybierz %1$sUstawienia%2$s, a następnie %3$sUstawienia zaawansowane%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -18898,8 +18861,7 @@ msgstr "Udostępnij"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Udostępniaj informacje o DuckDuckGo i pomóż znajomym odzyskać prywatność!"
+msgstr "Udostępniaj informacje o DuckDuckGo i pomóż znajomym odzyskać prywatność!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -19072,7 +19034,7 @@ msgstr "Sklep"
 #. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
 msgctxt "Button in the merchandise logo modal (mobile)"
 msgid "Shop Now"
-msgstr ""
+msgstr "Kupuj teraz"
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -19442,8 +19404,7 @@ msgstr "Wyświetla poziome linie pomiędzy stronami z wynikami wyszukiwania"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr ""
-"Wyświetla łącza do instrukcji dodawania DuckDuckGo do Twojej przeglądarki"
+msgstr "Wyświetla łącza do instrukcji dodawania DuckDuckGo do Twojej przeglądarki"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -19459,8 +19420,7 @@ msgstr "Wyświetla najczęściej odwiedzane łącza na stronie nowej karty"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Wyświetla sporadyczne przypomnienia o dodaniu DuckDuckGo do przeglądarki"
+msgstr "Wyświetla sporadyczne przypomnienia o dodaniu DuckDuckGo do przeglądarki"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20174,8 +20134,7 @@ msgstr "Zatrzymaj generowanie"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr ""
-"Blokowanie mechanizmów śledzących ukrytych na innych stronach internetowych."
+msgstr "Blokowanie mechanizmów śledzących ukrytych na innych stronach internetowych."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -20737,8 +20696,7 @@ msgstr "Sync & Backup włączone!"
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr ""
-"Danych Sync & Backup nie można odzyskać po 18 miesiącach braku aktywności."
+msgstr "Danych Sync & Backup nie można odzyskać po 18 miesiącach braku aktywności."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
@@ -20747,6 +20705,8 @@ msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
 msgstr ""
+"Funkcja Sync & Backup zapisuje więcej Twoich czatów i synchronizuje je na "
+"wszystkich urządzeniach."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20868,7 +20828,7 @@ msgstr "Synchronizuj czaty na wszystkich urządzeniach."
 #. Headline in sync-enabled chat history about modals explaining cross-device sync.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Sync your chats across all your devices"
-msgstr ""
+msgstr "Synchronizuj czaty na wszystkich urządzeniach."
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21260,8 +21220,7 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr ""
-"Dostawca modelu usuwa wszelkie dane związane z tym czatem w ciągu 30 dni."
+msgstr "Dostawca modelu usuwa wszelkie dane związane z tym czatem w ciągu 30 dni."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -21461,12 +21420,14 @@ msgid ""
 "This chat and its generated images become public when you create and copy "
 "the link."
 msgstr ""
+"Ten czat i wygenerowane w nim obrazy staną się publiczne, gdy utworzysz i "
+"skopiujesz link."
 
 # smartling.placeholder_format=C
 #. Explains that creating and copying a share link makes the selected chat content public.
 msgctxt "Share modal info bullet about public access"
 msgid "This chat becomes public when you create and copy the link."
-msgstr ""
+msgstr "Ten czat stanie się publiczny, gdy utworzysz i skopiujesz link."
 
 # smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
@@ -21608,16 +21569,14 @@ msgstr "Tego obrazu nie dało się stworzyć."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr ""
-"Ten typ obrazu nie jest obsługiwany, dołącz plik JPG, PNG, WebP lub GIF"
+msgstr "Ten typ obrazu nie jest obsługiwany, dołącz plik JPG, PNG, WebP lub GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr ""
-"Ten typ obrazu nie jest obsługiwany, dołącz plik JPG, PNG, WebP lub GIF."
+msgstr "Ten typ obrazu nie jest obsługiwany, dołącz plik JPG, PNG, WebP lub GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -21696,8 +21655,7 @@ msgstr "Ta strona do działania wymaga włączonego Javascriptu."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Zawartość tej strony zostanie wysłana wraz z Twoją wiadomością do Duck.ai"
+msgstr "Zawartość tej strony zostanie wysłana wraz z Twoją wiadomością do Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21750,8 +21708,7 @@ msgstr ""
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr ""
-"Nie udało się otworzyć tego udostępnionego czatu. Link może być niekompletny."
+msgstr "Nie udało się otworzyć tego udostępnionego czatu. Link może być niekompletny."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
@@ -21818,8 +21775,7 @@ msgstr ""
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
-msgstr ""
-"Spowoduje to usunięcie wybranego obrazu. Tej czynności nie można cofnąć."
+msgstr "Spowoduje to usunięcie wybranego obrazu. Tej czynności nie można cofnąć."
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -21944,8 +21900,7 @@ msgstr "Aby kontynuować, musisz wyrazić zgodę na %1$s i %2$s Duck.ai"
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr ""
-"Aby kontynuować, musisz wyrazić zgodę na %1$s i %2$s DuckDuckGo AI Chat"
+msgstr "Aby kontynuować, musisz wyrazić zgodę na %1$s i %2$s DuckDuckGo AI Chat"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -22009,14 +21964,13 @@ msgstr "Dziś"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
-msgstr ""
+msgstr "Przełącz na prywatny czat AI lub %1$swyłącz tę funkcję w ustawieniach%2$s."
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
-msgstr ""
-"Przełącz, aby wypróbować prywatny czat AI, lub %1$swyłącz go w menu %2$s.%3$s"
+msgstr "Przełącz, aby wypróbować prywatny czat AI, lub %1$swyłącz go w menu %2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -22497,23 +22451,20 @@ msgstr "Spróbuj innych słów kluczowych."
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr ""
-"Spróbuj wyłączyć blokadę reklam w DuckDuckGo, aby zobaczyć więcej wyników."
+msgstr "Spróbuj wyłączyć blokadę reklam w DuckDuckGo, aby zobaczyć więcej wyników."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Spróbuj włączyć anonimową lokalizację, aby uzyskać dokładniejsze wyniki."
+msgstr "Spróbuj włączyć anonimową lokalizację, aby uzyskać dokładniejsze wyniki."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Spróbuj poeksperymentować z każdym modelem — otrzymasz różne odpowiedzi."
+msgstr "Spróbuj poeksperymentować z każdym modelem — otrzymasz różne odpowiedzi."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -22876,8 +22827,7 @@ msgstr "Wyłącz:"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on %sPrecise Location%s for more accurate results"
-msgstr ""
-"Włącz opcję %1$sDokładna lokalizacja%2$s, aby uzyskać dokładniejsze wyniki."
+msgstr "Włącz opcję %1$sDokładna lokalizacja%2$s, aby uzyskać dokładniejsze wyniki."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -23101,15 +23051,14 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"Pod %1$sOtwórz za pomocą%2$s wybierz %3$sKonkretna strona lub strony%4$s"
+msgstr "Pod %1$sOtwórz za pomocą%2$s wybierz %3$sKonkretna strona lub strony%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"Pod %1$sPrzy uruchomieniu > Strona główna \\%2$s wprowadź: https://"
-"duckduckgo.com"
+"Pod %1$sPrzy uruchomieniu > Strona główna \\%2$s wprowadź: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23119,15 +23068,13 @@ msgstr "Pod %1$sUstawienia wyszukiwania%2$s wybierz %3$sDuckDuckGo%4$s"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr ""
-"Pod %1$sWyszukaj w pasku adresu za pomocą%2$s wybierz %3$sDodaj nową%4$s"
+msgstr "Pod %1$sWyszukaj w pasku adresu za pomocą%2$s wybierz %3$sDodaj nową%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr ""
-"W dziale %1$sWyszukiwanie%2$s kliknij %3$sZarządzaj wyszukiwarkami…%4$s"
+msgstr "W dziale %1$sWyszukiwanie%2$s kliknij %3$sZarządzaj wyszukiwarkami…%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -23241,8 +23188,7 @@ msgstr "Odblokuj za pomocą subskrypcji DuckDuckGo"
 msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
-msgstr ""
-"Odblokuj zaawansowane modele AI i wyższe limity dzięki subskrypcji DuckDuckGo"
+msgstr "Odblokuj zaawansowane modele AI i wyższe limity dzięki subskrypcji DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -23281,8 +23227,7 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr ""
-"Odblokuj bardziej wydajne modele AI dzięki subskrypcji DuckDuckGo. %1$s"
+msgstr "Odblokuj bardziej wydajne modele AI dzięki subskrypcji DuckDuckGo. %1$s"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -23686,8 +23631,7 @@ msgstr ""
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
 msgctxt "DuckChat location prompt"
 msgid "Use your approximate location for more accurate results?"
-msgstr ""
-"Czy użyć Twojej przybliżonej lokalizacji, aby uzyskać dokładniejsze wyniki?"
+msgstr "Czy użyć Twojej przybliżonej lokalizacji, aby uzyskać dokładniejsze wyniki?"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes before every user message in the downloaded file, indicating which message it is out of the total number of messages. Example: 'User prompt 3 of 5'
@@ -23851,6 +23795,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Yelp's ad network."
 msgstr ""
+"DuckDuckGo chroni prywatność użytkowników przeglądających reklamy. Klikanie "
+"reklam zarządzane jest przez sieć reklamową Yelp."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -24237,8 +24183,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr ""
-"Nie przechowujemy informacji na Twój temat ani Cię nie śledzimy. Nigdy."
+msgstr "Nie przechowujemy informacji na Twój temat ani Cię nie śledzimy. Nigdy."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24322,8 +24267,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr ""
-"Nie śledzimy Cię, niezależnie od tego czy używasz trybu incognito, czy nie."
+msgstr "Nie śledzimy Cię, niezależnie od tego czy używasz trybu incognito, czy nie."
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
@@ -24335,8 +24279,7 @@ msgstr "Nie śledzimy Cię. To jest nasza polityka prywatności w skrócie…"
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
 msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
-msgstr ""
-"Zakończyliśmy czat z powodu braku aktywności. Chcesz spróbować ponownie?"
+msgstr "Zakończyliśmy czat z powodu braku aktywności. Chcesz spróbować ponownie?"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
@@ -24599,8 +24542,7 @@ msgstr "Osiągnięto tygodniowy limit użycia"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Osiągnięto tygodniowy limit użycia. Możesz kontynuować tę rozmowę po %1$s."
+msgstr "Osiągnięto tygodniowy limit użycia. Możesz kontynuować tę rozmowę po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -25028,8 +24970,7 @@ msgctxt "cloudsave"
 msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
-msgstr ""
-"Czym jest skryptozakładka Cloud Save i czym różni się od skryptozakładki URL?"
+msgstr "Czym jest skryptozakładka Cloud Save i czym różni się od skryptozakładki URL?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -25104,8 +25045,7 @@ msgstr "Na jaki temat chcesz przekazać opinię?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"To, co oglądasz w DuckDuckGo, nie wpłynie na rekomendacje w serwisie YouTube."
+msgstr "To, co oglądasz w DuckDuckGo, nie wpłynie na rekomendacje w serwisie YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -25346,6 +25286,8 @@ msgid ""
 "With chat history on, up to %s of your most recent chats will be saved on "
 "this device."
 msgstr ""
+"Gdy historia czatów jest włączona, na tym urządzeniu zostanie zapisanych do "
+"%1$s ostatnich czatów."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline in the About Chat History modal.
@@ -25353,6 +25295,8 @@ msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, your most recent chats will be saved on this device."
 msgstr ""
+"Po włączeniu historii czatu najnowsze czaty będą zapisywane na tym "
+"urządzeniu."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -25367,8 +25311,8 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
-"Działa bezpośrednio z Twojego urządzenia, pozwalając usunąć Twój adres e-"
-"mail, imię i nazwisko, adres i inne dane z witryn brokerów danych."
+"Działa bezpośrednio z Twojego urządzenia, pozwalając usunąć Twój adres "
+"e-mail, imię i nazwisko, adres i inne dane z witryn brokerów danych."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25653,8 +25597,7 @@ msgstr ""
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
 msgctxt "Information about direct access to DuckDuckGo AI Chat"
 msgid "You can access DuckDuckGo AI Chat directly at %s."
-msgstr ""
-"Możesz uzyskać dostęp do DuckDuckGo AI Chat bezpośrednio pod adresem %1$s."
+msgstr "Możesz uzyskać dostęp do DuckDuckGo AI Chat bezpośrednio pod adresem %1$s."
 
 # smartling.placeholder_format=C
 #. Search Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Search Assist.
@@ -25708,8 +25651,7 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr ""
-"Możesz to zmienić w dowolnym momencie w %1$sustawieniach wyszukiwania%2$s"
+msgstr "Możesz to zmienić w dowolnym momencie w %1$sustawieniach wyszukiwania%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
@@ -25754,8 +25696,7 @@ msgstr "Możesz kontynuować rozmowę, korzystając z limitu miesięcznego."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Teraz możesz zapisać do 100 czatów na tym urządzeniu. Rozmawiajcie śmiało!"
+msgstr "Teraz możesz zapisać do 100 czatów na tym urządzeniu. Rozmawiajcie śmiało!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -25832,8 +25773,7 @@ msgstr "Można przywrócić swoje ustawienia po usunięciu plików cookie."
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can share your settings among computers and browsers."
-msgstr ""
-"Możesz używać tych samych ustawień na różnych komputerach i przeglądarkach."
+msgstr "Możesz używać tych samych ustawień na różnych komputerach i przeglądarkach."
 
 # smartling.placeholder_format=C
 #. Alternative option description on export screen.
@@ -26038,8 +25978,7 @@ msgstr ""
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr ""
-"Osiągnięto maksymalny czas trwania czatu głosowego w ramach jednej sesji."
+msgstr "Osiągnięto maksymalny czas trwania czatu głosowego w ramach jednej sesji."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
@@ -26119,8 +26058,7 @@ msgstr ""
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr ""
-"Twoje czaty Duck.ai są synchronizowane z użyciem szyfrowania end-to-end."
+msgstr "Twoje czaty Duck.ai są synchronizowane z użyciem szyfrowania end-to-end."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -26202,8 +26140,8 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"Twoja przeglądarka udostępnia listę najczęściej odwiedzanych witryn."
-"DuckDuckGo nigdy nie ma dostępu do tych danych."
+"Twoja przeglądarka udostępnia listę najczęściej odwiedzanych "
+"witryn.DuckDuckGo nigdy nie ma dostępu do tych danych."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -26242,8 +26180,7 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr ""
-"Twoje czaty są prywatne i nigdy nie są wykorzystywane do trenowania modeli AI"
+msgstr "Twoje czaty są prywatne i nigdy nie są wykorzystywane do trenowania modeli AI"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -26765,7 +26702,7 @@ msgstr "min"
 #. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the chat options menu button"
 msgid "menu"
-msgstr ""
+msgstr "Menu"
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/ps_AF/LC_MESSAGES/duckduckgo.po
+++ b/locales/ps_AF/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr ""
@@ -1099,6 +1116,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr ""
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1453,6 +1507,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2800,6 +2859,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3200,9 +3266,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3218,6 +3294,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4475,6 +4558,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4759,6 +4847,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5097,6 +5190,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -5993,6 +6091,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6170,6 +6273,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6835,6 +6943,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7253,6 +7366,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8235,6 +8353,11 @@ msgid "How is it anonymous?"
 msgstr ""
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9388,6 +9511,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11125,6 +11253,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12825,6 +12958,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12931,6 +13069,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13919,6 +14062,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14074,6 +14222,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -14989,6 +15144,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16328,6 +16488,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16408,6 +16575,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16868,6 +17040,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17270,6 +17456,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18732,6 +18923,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19881,6 +20079,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20963,6 +21174,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/pt_BR/LC_MESSAGES/duckduckgo.po
+++ b/locales/pt_BR/LC_MESSAGES/duckduckgo.po
@@ -986,6 +986,11 @@ msgstr "Sobre nós"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1089,6 +1094,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "O anúncio é suspeito"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Adicionar o DuckDuckGo"
@@ -1110,6 +1127,24 @@ msgstr "Adicione o DuckDuckGo como ferramenta de busca"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Adicionar o DuckDuckGo ao %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1148,6 +1183,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1219,6 +1268,11 @@ msgstr "Complementos"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1465,6 +1519,11 @@ msgstr "Todas coloridas"
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2831,6 +2890,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3231,9 +3297,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3249,6 +3325,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4522,6 +4605,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4806,6 +4894,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5144,6 +5237,11 @@ msgstr "Dispensar sempre"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6053,6 +6151,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6234,6 +6337,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6911,6 +7019,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7329,6 +7442,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8319,6 +8437,11 @@ msgid "How is it anonymous?"
 msgstr "Como o anonimato é garantido?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9493,6 +9616,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11233,6 +11361,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "OK, entendi!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12950,6 +13083,11 @@ msgstr "Proteja seus dados em todos os dispositivos."
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -13056,6 +13194,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -14044,6 +14187,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14204,6 +14352,13 @@ msgstr "Busca"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15140,6 +15295,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16489,6 +16649,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16569,6 +16736,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -17037,6 +17209,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17443,6 +17629,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18913,6 +19104,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -20080,6 +20278,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21183,6 +21394,11 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "m"
 msgstr "m"
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.
 msgctxt "Aria label for the menu button"

--- a/locales/pt_PT/LC_MESSAGES/duckduckgo.po
+++ b/locales/pt_PT/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: pt_PT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1221,6 +1221,12 @@ msgid "About our ads"
 msgstr "Sobre os nossos anúncios"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1351,6 +1357,20 @@ msgid "Ad is suspicious"
 msgstr "O anúncio é suspeito"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Adicionar o DuckDuckGo"
@@ -1377,6 +1397,27 @@ msgstr "Adicionar o DuckDuckGo como motor de busca"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Adicionar o DuckDuckGo a %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1422,6 +1463,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Adicionar Conteúdo da Página"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1507,6 +1564,12 @@ msgstr "Extras"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Adicionar os últimos retoques"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1811,6 +1874,12 @@ msgstr "Qualquer cor"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Já está!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3529,6 +3598,14 @@ msgid "Cancel"
 msgstr "Cancelar"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4024,10 +4101,22 @@ msgid "Chat response is offensive"
 msgstr "A resposta do chat é ofensiva"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Conversar com %1$s"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4046,6 +4135,14 @@ msgstr "Conversas"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Chats"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5649,6 +5746,12 @@ msgid "Current Streak"
 msgstr "Série Atual"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5996,6 +6099,12 @@ msgstr "Eliminar conversas"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Eliminar conversas com mais de 30 dias"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6409,6 +6518,12 @@ msgstr "Recusar para sempre"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Ignorar promoção"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7592,6 +7707,12 @@ msgid "Edit Prompt"
 msgstr "Editar pedido"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7815,6 +7936,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Modelo encriptado"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8662,6 +8789,12 @@ msgid "Follow-up question"
 msgstr "Pergunta de acompanhamento"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9176,6 +9309,12 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
 "Obtém a VPN da DuckDuckGo, Duck.ai avançado e Identity Theft Restoration."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10409,6 +10548,12 @@ msgstr "Como é anónimo?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Como funciona"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11854,6 +11999,12 @@ msgstr "Lineouts Ganhos"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "O link expira em 7 dias."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13977,6 +14128,12 @@ msgstr "OK"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "OK, percebido!"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16110,6 +16267,12 @@ msgid "Protected"
 msgstr "Protegido"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Proteção. Privacidade. Tranquilidade."
@@ -16241,6 +16404,12 @@ msgstr "Chuva"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Classificações"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17484,6 +17653,12 @@ msgid "Save your chats across all your devices."
 msgstr "Guarda as tuas conversas em todos os teus dispositivos."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17685,6 +17860,14 @@ msgstr "Pesquisar"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Pesquisar"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18876,6 +19059,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Comprar"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20545,6 +20734,14 @@ msgstr ""
 "inatividade."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20660,6 +20857,12 @@ msgstr "Sincroniza com um dispositivo próximo."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Sincroniza as tuas conversas em todos os teus dispositivos."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21246,6 +21449,22 @@ msgid "This Week"
 msgstr "Esta Semana"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21782,6 +22001,12 @@ msgstr "Hoje"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Hoje"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23616,6 +23841,14 @@ msgstr ""
 "cliques em anúncios são geridos pela rede de publicidade do TripAdvisor."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Ilhas Virgens"
 
@@ -25098,6 +25331,21 @@ msgstr ""
 "para treinar a IA. Ativa ou desativa em qualquer altura no menu \"%1$s\"."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26501,6 +26749,12 @@ msgstr "min"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "min"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/pt_PT/LC_MESSAGES/duckduckgo.po
+++ b/locales/pt_PT/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: pt_PT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -526,8 +526,7 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr ""
-"%1$sPrime sem soltar%2$s o ícone da aplicação DuckDuckGo no ecrã inicial"
+msgstr "%1$sPrime sem soltar%2$s o ícone da aplicação DuckDuckGo no ecrã inicial"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -1224,7 +1223,7 @@ msgstr "Sobre os nossos anúncios"
 #. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
 msgctxt "Modal header for chat history with sync information"
 msgid "About Chat History with Sync & Backup"
-msgstr ""
+msgstr "Sobre o Histórico de Chat com Sync & Backup"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
@@ -1323,8 +1322,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
 msgid "Ad clicks aren’t used to profile you"
-msgstr ""
-"Os cliques em anúncios não são usados para criar perfis de utilizadores"
+msgstr "Os cliques em anúncios não são usados para criar perfis de utilizadores"
 
 # smartling.placeholder_format=C
 #. Category of problem a user can select on a feedback form.
@@ -1360,7 +1358,7 @@ msgstr "O anúncio é suspeito"
 #. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
 msgctxt "Button to open menu for attaching images or page context to AI chat"
 msgid "Add"
-msgstr ""
+msgstr "Adicionar"
 
 # smartling.placeholder_format=C
 #. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
@@ -1368,7 +1366,7 @@ msgctxt ""
 "Primary button that attaches the tabs the user checked in the tab picker "
 "dialog"
 msgid "Add"
-msgstr ""
+msgstr "Adicionar"
 
 # smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
@@ -1403,13 +1401,13 @@ msgstr "Adicionar o DuckDuckGo a %1$s"
 msgctxt ""
 "Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
 msgid "Add File"
-msgstr ""
+msgstr "Adicionar Ficheiro"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
 msgid "Add Image"
-msgstr ""
+msgstr "Adicionar Imagem"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
@@ -1417,7 +1415,7 @@ msgctxt ""
 "Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
 "item)"
 msgid "Add Image or File"
-msgstr ""
+msgstr "Adicionar Imagem ou Ficheiro"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1470,7 +1468,7 @@ msgctxt ""
 "Open the tab picker to attach browser tab content to the AI chat message "
 "(attach dropdown menu item)"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Adicionar Separadores"
 
 # smartling.placeholder_format=C
 #. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
@@ -1478,7 +1476,7 @@ msgctxt ""
 "Title and accessible name of the tab-picker dialog opened from the attach "
 "dropdown menu"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Adicionar separadores"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1569,7 +1567,7 @@ msgstr "Adicionar os últimos retoques"
 #. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
 msgctxt "Aria label for the additional instructions textarea"
 msgid "Additional instructions"
-msgstr ""
+msgstr "Instruções adicionais"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1879,7 +1877,7 @@ msgstr "Já está!"
 #. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the read-only textarea listing all AI instructions"
 msgid "All instructions"
-msgstr ""
+msgstr "Todas as instruções"
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -1973,8 +1971,7 @@ msgstr "Permitir a revisão anónima de ficheiros neste chat?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Permitir anúncios que respeitam a privacidade na Private Search do DuckDuckGo"
+msgstr "Permitir anúncios que respeitam a privacidade na Private Search do DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2695,8 +2692,7 @@ msgstr "Resposta automática"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr ""
-"Gerada automaticamente com base nas fontes listadas. Pode conter imprecisões."
+msgstr "Gerada automaticamente com base nas fontes listadas. Pode conter imprecisões."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -2951,8 +2947,8 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 "Antes de guardar este relatório, o DuckDuckGo irá anonimizar a tua conversa "
-"removendo informações de identificação pessoal, como nomes, endereços de e-"
-"mail e metadados identificativos."
+"removendo informações de identificação pessoal, como nomes, endereços de "
+"e-mail e metadados identificativos."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3603,7 +3599,7 @@ msgctxt ""
 "Secondary button that dismisses the tab picker dialog without attaching "
 "anything"
 msgid "Cancel"
-msgstr ""
+msgstr "Cancelar"
 
 # smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
@@ -3861,8 +3857,7 @@ msgstr "Modifica a cor de fundo em todo o site"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr ""
-"Altera a cor de fundo dos resultados em menus suspensos, hovers e módulos"
+msgstr "Altera a cor de fundo dos resultados em menus suspensos, hovers e módulos"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -4104,7 +4099,7 @@ msgstr "A resposta do chat é ofensiva"
 #. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
 msgctxt "Chat history about modal list item headline"
 msgid "Chat storage varies by browser"
-msgstr ""
+msgstr "O armazenamento de conversas varia consoante o navegador"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4116,7 +4111,7 @@ msgstr "Conversar com %1$s"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Chat with popular AI models, anonymized by us."
-msgstr ""
+msgstr "Conversa com modelos de IA populares, anonimizados por nós."
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4143,6 +4138,9 @@ msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
 msgstr ""
+"As conversas são armazenadas de forma segura no servidor do DuckDuckGo com "
+"encriptação de ponta a ponta. Ninguém além de ti pode ver os teus dados, nem "
+"mesmo nós."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4265,8 +4263,7 @@ msgstr ""
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr ""
-"Consulta a página de estado para atualizações sobre esta indisponibilidade."
+msgstr "Consulta a página de estado para atualizações sobre esta indisponibilidade."
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4749,8 +4746,7 @@ msgstr "Clica em %1$sFornecedores de Pesquisa%2$s em tipos de Add-on"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sTools icon%s in the top-right of the browser"
-msgstr ""
-"No canto superior direito do navegador, clica no %1$sícone de Ferramentas%2$s"
+msgstr "No canto superior direito do navegador, clica no %1$sícone de Ferramentas%2$s"
 
 #  Firefox default search engine instruction
 # smartling.placeholder_format=C
@@ -5508,9 +5504,9 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
-"Copia o código a partir de outro dispositivo. Vai a %1$sDefinições do Duck."
-"ai › Chats › Sync & Backup › Sincronizar com outro dispositivo%2$s e tenta "
-"novamente."
+"Copia o código a partir de outro dispositivo. Vai a %1$sDefinições do "
+"Duck.ai › Chats › Sync & Backup › Sincronizar com outro dispositivo%2$s e "
+"tenta novamente."
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5749,7 +5745,7 @@ msgstr "Série Atual"
 #. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
 msgctxt "Suffix label indicating a tab is the currently active browser tab"
 msgid "Current Tab"
-msgstr ""
+msgstr "Separador atual"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
@@ -5904,8 +5900,7 @@ msgstr "Limite diário atingido"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Limite de utilização diária atingido. Podes continuar este chat após %1$s."
+msgstr "Limite de utilização diária atingido. Podes continuar este chat após %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -6104,7 +6099,7 @@ msgstr "Eliminar conversas com mais de 30 dias"
 #. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
 msgctxt "Button text in the modal for deleting all recent chats"
 msgid "Delete Chats and Shared Links"
-msgstr ""
+msgstr "Eliminar conversas e links partilhados"
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6523,7 +6518,7 @@ msgstr "Ignorar promoção"
 #. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the close button on the survey banner"
 msgid "Dismiss survey"
-msgstr ""
+msgstr "Ignorar inquérito"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7068,8 +7063,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
-msgstr ""
-"O Duck.ai está temporariamente indisponível. Tenta novamente mais tarde."
+msgstr "O Duck.ai está temporariamente indisponível. Tenta novamente mais tarde."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7149,8 +7143,7 @@ msgstr "Duck.ai atualizado!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"O Duck.ai funciona melhor na nossa aplicação privada e gratuita DuckDuckGo!"
+msgstr "O Duck.ai funciona melhor na nossa aplicação privada e gratuita DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7595,8 +7588,7 @@ msgctxt ""
 "Description of the DuckDuckGo subscription setting when it is not available "
 "in the user region"
 msgid "DuckDuckGo subscriptions are not available to purchase in this region."
-msgstr ""
-"As subscrições da DuckDuckGo não estão disponíveis para compra nesta região."
+msgstr "As subscrições da DuckDuckGo não estão disponíveis para compra nesta região."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use 'ducky' tone in its responses. When this option is selected, the AI assistant speaks like a duck.
@@ -7710,7 +7702,7 @@ msgstr "Editar pedido"
 #. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the message-editing text area"
 msgid "Edit message"
-msgstr ""
+msgstr "Editar mensagem"
 
 # smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
@@ -7941,7 +7933,7 @@ msgstr "Modelo encriptado"
 #. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
 msgctxt "Share modal info bullet about encryption"
 msgid "Encrypted so DuckDuckGo can't read your chat."
-msgstr ""
+msgstr "Encriptada, pelo que o DuckDuckGo não consegue ler a tua conversa."
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8007,22 +7999,19 @@ msgstr ""
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr ""
-"Certifica-te de que os \"Serviços de Localização\" estão %1$sativos%2$s."
+msgstr "Certifica-te de que os \"Serviços de Localização\" estão %1$sativos%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr ""
-"Certifica-te de que a \"Localização\" está definida como %1$spermitir%2$s"
+msgstr "Certifica-te de que a \"Localização\" está definida como %1$spermitir%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s."
-msgstr ""
-"Certifica-te de que a \"Localização\" está definida para %1$spermitir%2$s."
+msgstr "Certifica-te de que a \"Localização\" está definida para %1$spermitir%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -8062,15 +8051,13 @@ msgstr ""
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access"
-msgstr ""
-"Certifica-te de que o teu navegador tem permissão para aceder à localização"
+msgstr "Certifica-te de que o teu navegador tem permissão para aceder à localização"
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr ""
-"Certifica-te de que o teu navegador tem permissão para aceder à localização."
+msgstr "Certifica-te de que o teu navegador tem permissão para aceder à localização."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -8792,7 +8779,7 @@ msgstr "Pergunta de acompanhamento"
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
-msgstr ""
+msgstr "As mensagens de acompanhamento permanecem privadas."
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8898,8 +8885,7 @@ msgstr "Chats gratuitos e privados, anonimizados por nós"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Chats gratuitos e privados, anonimizados por nós. Não é necessária conta."
+msgstr "Chats gratuitos e privados, anonimizados por nós. Não é necessária conta."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9307,14 +9293,13 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr ""
-"Obtém a VPN da DuckDuckGo, Duck.ai avançado e Identity Theft Restoration."
+msgstr "Obtém a VPN da DuckDuckGo, Duck.ai avançado e Identity Theft Restoration."
 
 # smartling.placeholder_format=C
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
 msgctxt "Tooltip on the header logo for sunglasses searches"
 msgid "Get DuckDuckGo sunglasses and other gear."
-msgstr ""
+msgstr "Obtém óculos de sol DuckDuckGo e outros artigos."
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9458,8 +9443,7 @@ msgstr "Obter ajuda informática"
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr ""
-"Obtém limites de utilização mais elevados com uma subscrição da DuckDuckGo."
+msgstr "Obtém limites de utilização mais elevados com uma subscrição da DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -9538,8 +9522,8 @@ msgstr "Descarrega a aplicação"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"Obtém o navegador DuckDuckGo gratuito %1$spara bloquear anúncios no YouTube."
-"%2$s"
+"Obtém o navegador DuckDuckGo gratuito %1$spara bloquear anúncios no "
+"YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -10553,7 +10537,7 @@ msgstr "Como funciona"
 #. Headline in chat history about modals for the temporary encrypted server storage explanation.
 msgctxt "Chat history about modal list item headline"
 msgid "How it works"
-msgstr ""
+msgstr "Como funciona"
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11401,8 +11385,7 @@ msgstr "É rápido, gratuito e oferece ainda mais proteção online."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Inquéritos (pouco frequentes) acerca da minha experiência com o DuckDuckGo"
+msgstr "Inquéritos (pouco frequentes) acerca da minha experiência com o DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11804,8 +11787,7 @@ msgstr "Saber mais sobre a Proteção de privacidade ativa"
 # smartling.placeholder_format=C
 msgctxt "showcase_newsletter"
 msgid "Learn about online privacy right in your inbox."
-msgstr ""
-"Sabe mais sobre privacidade online diretamente na tua caixa de entrada."
+msgstr "Sabe mais sobre privacidade online diretamente na tua caixa de entrada."
 
 # smartling.placeholder_format=C
 #. Link to a page with more information about how DuckDuckGo settings are managed.
@@ -11921,8 +11903,7 @@ msgstr "Deixa-te pesquisar anonimamente com o DuckDuckGo"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr ""
-"Permite alternar entre o envio de consultas de pesquisa e pedidos ao Duck.ai"
+msgstr "Permite alternar entre o envio de consultas de pesquisa e pedidos ao Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -12004,7 +11985,7 @@ msgstr "O link expira em 7 dias."
 #. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days. People can save a chat copy."
-msgstr ""
+msgstr "O link expira em 7 dias. As pessoas podem guardar uma cópia da conversa."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -12020,8 +12001,7 @@ msgstr "Ligações:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
-"Lista as ferramentas, materiais ou pré-requisitos de que preciso para isto."
+msgstr "Lista as ferramentas, materiais ou pré-requisitos de que preciso para isto."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12319,8 +12299,8 @@ msgstr "Certifica-te de que todas as palavras estão escritas corretamente."
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
 msgstr ""
-"Certifica-te de marcar %1$s\"Tornar este no meu motor de buscar pré-"
-"definido\"%2$s"
+"Certifica-te de marcar %1$s\"Tornar este no meu motor de buscar "
+"pré-definido\"%2$s"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -12853,8 +12833,7 @@ msgstr "Capitalização do mercado"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Mobile Instructions (not displayed on settings page)"
-msgstr ""
-"Instruções para dispositivos móveis (não disponível na página de definições)"
+msgstr "Instruções para dispositivos móveis (não disponível na página de definições)"
 
 # smartling.placeholder_format=C
 #. A short label indicating that a user is a moderator of a discussion.
@@ -12913,8 +12892,7 @@ msgstr "Limite mensal atingido"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Limite de utilização mensal atingido. Podes continuar este chat após %1$s."
+msgstr "Limite de utilização mensal atingido. Podes continuar este chat após %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -14133,7 +14111,7 @@ msgstr "OK, percebido!"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "OPTIONAL"
-msgstr ""
+msgstr "OPCIONAL"
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -15455,8 +15433,7 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr ""
-"Indica por que motivo a resposta do chat é prejudicial ou ilegal. (opcional)"
+msgstr "Indica por que motivo a resposta do chat é prejudicial ou ilegal. (opcional)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -16270,7 +16247,7 @@ msgstr "Protegido"
 #. Headline in sync-enabled chat history about modals explaining encrypted server storage.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Protected with end-to-end encryption"
-msgstr ""
+msgstr "Protegido com encriptação de ponta a ponta"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -16409,7 +16386,7 @@ msgstr "Classificações"
 #. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
 msgctxt "star rating on a product"
 msgid "Rated %s out of %s"
-msgstr ""
+msgstr "Classificado com %1$s em %2$s"
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -16876,8 +16853,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"Recarrega o DuckDuckGo seguindo as instruções ou clicando no botão &quot;"
-"Atualizar&quot; ou &quot;Recarregar&quot; do teu navegador."
+"Recarrega o DuckDuckGo seguindo as instruções ou clicando no botão "
+"&quot;Atualizar&quot; ou &quot;Recarregar&quot; do teu navegador."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16887,8 +16864,7 @@ msgstr "Memorizar a minha opção"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Lembrar escolha (isto pode ser alterado nas %1$s%2$s%3$sDefinições%4$s)"
+msgstr "Lembrar escolha (isto pode ser alterado nas %1$s%2$s%3$sDefinições%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -17275,8 +17251,7 @@ msgstr "Os resultados excluem informações de sites bloqueados."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr ""
-"Os resultados excluem os teus sites bloqueados, que podes gerir no teu %1$s."
+msgstr "Os resultados excluem os teus sites bloqueados, que podes gerir no teu %1$s."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -17634,8 +17609,7 @@ msgstr ""
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
 msgctxt "Short description for Chat History feature on native DDG browsers"
 msgid "Save up to 30 of your most recent chats locally on your device."
-msgstr ""
-"Guarda até 30 das tuas conversas mais recentes localmente no teu dispositivo."
+msgstr "Guarda até 30 das tuas conversas mais recentes localmente no teu dispositivo."
 
 # smartling.placeholder_format=C
 #. Desktop/mobile intro modal body under the title per Sync Chats Figma (choose step).
@@ -17656,7 +17630,7 @@ msgstr "Guarda as tuas conversas em todos os teus dispositivos."
 #. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
 msgctxt "Chat history about modal list item headline"
 msgid "Save your chats on this device"
-msgstr ""
+msgstr "Guarda as tuas conversas neste dispositivo"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
@@ -17833,8 +17807,7 @@ msgstr "Desce na página e localiza %1$so teu navegador%2$s na lista."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr ""
-"Desce até %1$sDuckDuckGo%2$s e autoriza a utilização da tua localização."
+msgstr "Desce até %1$sDuckDuckGo%2$s e autoriza a utilização da tua localização."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -17867,7 +17840,7 @@ msgctxt ""
 "Placeholder and accessibility label for the search input in the tab picker "
 "dialog"
 msgid "Search"
-msgstr ""
+msgstr "Pesquisar"
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18415,8 +18388,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Seleciona %1$sDuckDuckGo%2$s e clica em %3$sAdicionar como predefinido%4$s!"
+msgstr "Seleciona %1$sDuckDuckGo%2$s e clica em %3$sAdicionar como predefinido%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -18433,8 +18405,7 @@ msgstr "Seleciona %1$sDuckDuckGo%2$s e clica em %3$sPredefinir%4$s."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr ""
-"Seleciona %1$sDuckDuckGo%2$s no menu suspenso de motor de busca predefinido"
+msgstr "Seleciona %1$sDuckDuckGo%2$s no menu suspenso de motor de busca predefinido"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
@@ -18454,8 +18425,7 @@ msgstr "Seleciona %1$sDuckDuckGo%2$s na lista de fornecedores de pesquisa"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr ""
-"Seleciona %1$sDuckDuckGo%2$s na secção%3$sMotor de busca predefinido%4$s"
+msgstr "Seleciona %1$sDuckDuckGo%2$s na secção%3$sMotor de busca predefinido%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -18540,8 +18510,7 @@ msgstr "Seleciona %1$sDefinições%2$s e depois %3$sDefinições Avançadas%4$s"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr ""
-"Seleciona %1$sDefinições%2$s e depois %3$sMotor de busca predefinido%4$s"
+msgstr "Seleciona %1$sDefinições%2$s e depois %3$sMotor de busca predefinido%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -18891,8 +18860,7 @@ msgstr "Partilhar"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Partilha o DuckDuckGo e ajuda os teus amigos a recuperar a sua privacidade!"
+msgstr "Partilha o DuckDuckGo e ajuda os teus amigos a recuperar a sua privacidade!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -19064,7 +19032,7 @@ msgstr "Comprar"
 #. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
 msgctxt "Button in the merchandise logo modal (mobile)"
 msgid "Shop Now"
-msgstr ""
+msgstr "Comprar agora"
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -19291,8 +19259,7 @@ msgstr "Mostrar todos os resultados"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show answers more often. (You can also %sturn them off%s.)"
-msgstr ""
-"Mostra as respostas com mais frequência. (Também podes %1$sdesativá-las%2$s.)"
+msgstr "Mostra as respostas com mais frequência. (Também podes %1$sdesativá-las%2$s.)"
 
 # smartling.placeholder_format=C
 #. Accessible label for the button that reveals a popover listing multiple citation sources in Duck.ai chat responses.
@@ -19434,8 +19401,7 @@ msgstr "Mostrar linhas horizontais nas quebras de página de resultados"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr ""
-"Mostra links para instruções de como adicionar o DuckDuckGo ao teu navegador"
+msgstr "Mostra links para instruções de como adicionar o DuckDuckGo ao teu navegador"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -19451,14 +19417,12 @@ msgstr "Mostra os links mais visitados na página de um novo separador"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Mostra lembretes ocasionais para adicionar o DuckDuckGo ao teu navegador"
+msgstr "Mostra lembretes ocasionais para adicionar o DuckDuckGo ao teu navegador"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Mostra lembretes ocasionais para adicionar o DuckDuckGo aos teus dispositivos"
+msgstr "Mostra lembretes ocasionais para adicionar o DuckDuckGo aos teus dispositivos"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19489,8 +19453,7 @@ msgstr "Mostra sugestões na caixa de pesquisa enquanto digitas"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr ""
-"Mostra os benefícios de privacidade do uso do DuckDuckGo na página inicial"
+msgstr "Mostra os benefícios de privacidade do uso do DuckDuckGo na página inicial"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19500,8 +19463,7 @@ msgstr "Mostra o fundo do botão de pesquisa"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message on top of the search results page"
-msgstr ""
-"Mostra a mensagem de boas-vindas no topo da página dos resultados de pesquisa"
+msgstr "Mostra a mensagem de boas-vindas no topo da página dos resultados de pesquisa"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19828,8 +19790,7 @@ msgctxt "Description for the wrong code error screen"
 msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
-msgstr ""
-"Este código é inválido. Confirma que introduziste ou leste o código correto."
+msgstr "Este código é inválido. Confirma que introduziste ou leste o código correto."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -20116,22 +20077,19 @@ msgstr "Fica no DuckDuckGo"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr ""
-"Mantém-te protegido e informado com a nossa newsletter sobre privacidade."
+msgstr "Mantém-te protegido e informado com a nossa newsletter sobre privacidade."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Mantém-te protegido e informado com as nossas newsletters sobre privacidade."
+msgstr "Mantém-te protegido e informado com as nossas newsletters sobre privacidade."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Mantém-te protegido e informado com as nossas newsletters sobre privacidade."
+msgstr "Mantém-te protegido e informado com as nossas newsletters sobre privacidade."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -20174,8 +20132,7 @@ msgstr "Bloqueia os rastreadores ocultos que se escondem noutros sites."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Bloqueia a maioria dos rastreadores ocultos que se escondem noutros sites."
+msgstr "Bloqueia a maioria dos rastreadores ocultos que se escondem noutros sites."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20348,8 +20305,7 @@ msgstr "Sugere um título para uma publicação num blog"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
-"Sugere artigos ou tópicos relacionados que valha a pena explorar a seguir."
+msgstr "Sugere artigos ou tópicos relacionados que valha a pena explorar a seguir."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -20740,6 +20696,8 @@ msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
 msgstr ""
+"O Sync & Backup guarda mais conversas tuas e sincroniza-as em todos os teus "
+"dispositivos."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20862,7 +20820,7 @@ msgstr "Sincroniza as tuas conversas em todos os teus dispositivos."
 #. Headline in sync-enabled chat history about modals explaining cross-device sync.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Sync your chats across all your devices"
-msgstr ""
+msgstr "Sincroniza as tuas conversas em todos os teus dispositivos"
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21427,8 +21385,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Esta resposta instantânea foi dada pela Comunidade %1$sDuckDuckHack%2$s."
+msgstr "Esta resposta instantânea foi dada pela Comunidade %1$sDuckDuckHack%2$s."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -21457,12 +21414,14 @@ msgid ""
 "This chat and its generated images become public when you create and copy "
 "the link."
 msgstr ""
+"Esta conversa e as imagens geradas da mesma tornam-se públicas quando crias "
+"e copias o link."
 
 # smartling.placeholder_format=C
 #. Explains that creating and copying a share link makes the selected chat content public.
 msgctxt "Share modal info bullet about public access"
 msgid "This chat becomes public when you create and copy the link."
-msgstr ""
+msgstr "Esta conversa torna-se pública quando crias e copias o link."
 
 # smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
@@ -21539,15 +21498,13 @@ msgstr ""
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
-msgstr ""
-"Este ficheiro é demasiado grande. O tamanho máximo do ficheiro é %1$s MB"
+msgstr "Este ficheiro é demasiado grande. O tamanho máximo do ficheiro é %1$s MB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB."
-msgstr ""
-"Este ficheiro é demasiado grande. O tamanho máximo do ficheiro é %1$s MB."
+msgstr "Este ficheiro é demasiado grande. O tamanho máximo do ficheiro é %1$s MB."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -21778,8 +21735,7 @@ msgstr "Esta tradução está errada"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Ainda não é possível visualizar este vídeo aqui. Podes visualizá-lo em %1$s."
+msgstr "Ainda não é possível visualizar este vídeo aqui. Podes visualizá-lo em %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -21813,8 +21769,7 @@ msgstr ""
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
-msgstr ""
-"Isto irá eliminar a imagem selecionada. Esta ação não pode ser anulada."
+msgstr "Isto irá eliminar a imagem selecionada. Esta ação não pode ser anulada."
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -21941,8 +21896,7 @@ msgstr "Para continuar, tens de concordar com a %1$s e os %2$sdo Duck.ai"
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr ""
-"Para continuar, tens de concordar com a %1$s e os %2$s do DuckDuckGo AI Chat"
+msgstr "Para continuar, tens de concordar com a %1$s e os %2$s do DuckDuckGo AI Chat"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -22006,15 +21960,15 @@ msgstr "Hoje"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
-msgstr ""
+msgstr "Muda para o chat com IA privado ou %1$sdesativa-o nas definições%2$s."
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
-"Muda para experimentares o chat privado de IA ou %1$sdesativa-o no menu %2$s."
-"%3$s"
+"Muda para experimentares o chat privado de IA ou %1$sdesativa-o no menu "
+"%2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -22362,8 +22316,7 @@ msgstr "Experimenta %1$s para deixar de ver mensagens como esta."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Experimenta %1$s, o nosso primeiro modelo sem visibilidade para o fornecedor."
+msgstr "Experimenta %1$s, o nosso primeiro modelo sem visibilidade para o fornecedor."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -22504,8 +22457,7 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Tenta permitir a localização anónima para obter resultados mais específicos."
+msgstr "Tenta permitir a localização anónima para obter resultados mais específicos."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
@@ -22686,8 +22638,7 @@ msgstr "Experimenta o novo chat privado de voz em tempo real!"
 #. Text for a promotional card that encourages users to try the recently added open-source AI models. The placeholders are the names of AI models like 'Try the recently added open-source Llama 3.1 and Mistral.'
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source %s and %s"
-msgstr ""
-"Experimenta o %1$s e o %2$s, de código aberto, adicionados recentemente"
+msgstr "Experimenta o %1$s e o %2$s, de código aberto, adicionados recentemente"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the recently added open-source AI models Llama 3.1 and Mixtral.
@@ -23098,14 +23049,12 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"Em %1$s\"Abrir com\"%2$s, seleciona %3$sUma página específica ou várias%4$s"
+msgstr "Em %1$s\"Abrir com\"%2$s, seleciona %3$sUma página específica ou várias%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"Em %1$sNo arranque > Página inicial%2$s, introduz: https://duckduckgo.com"
+msgstr "Em %1$sNo arranque > Página inicial%2$s, introduz: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23270,8 +23219,7 @@ msgstr "Desbloqueia modelos avançados"
 #. Upsell message shown in the voice chat duration limit modal for free users.
 msgctxt "voice chat duration limit modal"
 msgid "Unlock longer voice chats with a DuckDuckGo Subscription"
-msgstr ""
-"Desbloqueia conversas de voz mais longas com uma subscrição da DuckDuckGo"
+msgstr "Desbloqueia conversas de voz mais longas com uma subscrição da DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text informing the user that more capable AI models can be unlocked with a subscription, with a trailing call-to-action link. %s is replaced with either the 'Try for free' link (for unauthenticated users) or the 'Learn more' link (for authenticated users). The link opens the subscription modal. Example: Unlock more capable AI models with a DuckDuckGo subscription. Try for free
@@ -23847,6 +23795,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Yelp's ad network."
 msgstr ""
+"A visualização de anúncios tem proteção de privacidade pelo DuckDuckGo. Os "
+"cliques em anúncios são geridos pela rede de publicidade do Yelp."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -23877,8 +23827,7 @@ msgctxt "mobile promotion on desktop"
 msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
-msgstr ""
-"Vai a %1$sDuckDuckGo.com%2$s no tablet ou smartphone e segue as instruções."
+msgstr "Vai a %1$sDuckDuckGo.com%2$s no tablet ou smartphone e segue as instruções."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -24590,8 +24539,7 @@ msgstr "Limite de utilização semanal atingido"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Limite de utilização semanal atingido. Podes continuar este chat após %1$s."
+msgstr "Limite de utilização semanal atingido. Podes continuar este chat após %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -24736,15 +24684,13 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr ""
-"Quais são alguns fatores a considerar ao comprar um monitor de computador?"
+msgstr "Quais são alguns fatores a considerar ao comprar um monitor de computador?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr ""
-"Quais são algumas das atrações imperdíveis em Paris para a primeira visita?"
+msgstr "Quais são algumas das atrações imperdíveis em Paris para a primeira visita?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -24869,8 +24815,7 @@ msgstr "Quais são os pratos que tens de experimentar aqui?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
-"Quais são os horários de funcionamento, localização e contactos deste local?"
+msgstr "Quais são os horários de funcionamento, localização e contactos deste local?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -25020,8 +24965,7 @@ msgctxt "cloudsave"
 msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
-msgstr ""
-"O que é o marcador Cloud Save e como é que difere do de parâmetros de URL?"
+msgstr "O que é o marcador Cloud Save e como é que difere do de parâmetros de URL?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -25096,8 +25040,7 @@ msgstr "Sobre o que gostarias de dar feedback?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"O que vês no DuckDuckGo não influencia as tuas recomendações no YouTube."
+msgstr "O que vês no DuckDuckGo não influencia as tuas recomendações no YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -25337,6 +25280,8 @@ msgid ""
 "With chat history on, up to %s of your most recent chats will be saved on "
 "this device."
 msgstr ""
+"Com o histórico do chat ativado, até %1$s das tuas conversas mais recentes "
+"serão guardadas neste dispositivo."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline in the About Chat History modal.
@@ -25344,6 +25289,8 @@ msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, your most recent chats will be saved on this device."
 msgstr ""
+"Com o histórico de conversas ativado, as tuas conversas mais recentes serão "
+"guardadas neste dispositivo."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -25700,8 +25647,7 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr ""
-"Podes alterar isto em qualquer altura nas %1$sDefinições de pesquisa%2$s"
+msgstr "Podes alterar isto em qualquer altura nas %1$sDefinições de pesquisa%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
@@ -25746,8 +25692,7 @@ msgstr "Podes continuar a conversar usando o teu limite mensal."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Agora podes guardar até 100 chats neste dispositivo. Conversa à vontade!"
+msgstr "Agora podes guardar até 100 chats neste dispositivo. Conversa à vontade!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -26039,8 +25984,7 @@ msgstr "Atingiste o limite de chat de voz para hoje. Tente novamente amanhã."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"Atingiste o limite de utilização de ditado. tentar novamente mais tarde"
+msgstr "Atingiste o limite de utilização de ditado. tentar novamente mais tarde"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -26296,8 +26240,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr ""
-"Os teus chats foram importados. Continua a partir de onde ficaste no Duck.ai."
+msgstr "Os teus chats foram importados. Continua a partir de onde ficaste no Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -26517,15 +26460,13 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr ""
-"Atingiste o número máximo de mensagens para um dia. Continua o chat amanhã."
+msgstr "Atingiste o número máximo de mensagens para um dia. Continua o chat amanhã."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr ""
-"Atingiste o limite do chat de voz por agora. Tenta novamente mais tarde."
+msgstr "Atingiste o limite do chat de voz por agora. Tenta novamente mais tarde."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -26608,8 +26549,7 @@ msgstr "por %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"DuckDuckGo — proteção online em que milhões de pessoas confiam todos os dias."
+msgstr "DuckDuckGo — proteção online em que milhões de pessoas confiam todos os dias."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"
@@ -26754,7 +26694,7 @@ msgstr "min"
 #. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the chat options menu button"
 msgid "menu"
-msgstr ""
+msgstr "menu"
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/pt_PT/LC_MESSAGES/duckduckgo.po
+++ b/locales/pt_PT/LC_MESSAGES/duckduckgo.po
@@ -26904,7 +26904,7 @@ msgstr "bloqueador de rastreio"
 #. Inform the users that "something" went wrong and discourage the user from immediately reloading the page.
 msgctxt "noresults"
 msgid "try again later"
-msgstr "tentar novamente mais tarde"
+msgstr "tenta novamente mais tarde"
 
 # smartling.placeholder_format=C
 #. A link that will allow users to reload the page, show when no search results loaded due to an error

--- a/locales/ro_RO/LC_MESSAGES/duckduckgo.po
+++ b/locales/ro_RO/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: ro_RO\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1224,6 +1224,12 @@ msgid "About our ads"
 msgstr "Despre reclamele noastre"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1353,6 +1359,20 @@ msgid "Ad is suspicious"
 msgstr "Reclama este suspectă"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Adaugă DuckDuckGo"
@@ -1379,6 +1399,27 @@ msgstr "Adaugă DuckDuckGo ca motor de căutare"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Adăugare DuckDuckGo la %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1424,6 +1465,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Adaugă conținutul paginii"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1511,6 +1568,12 @@ msgstr "Add-on-uri"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Adăugăm tușele finale"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1815,6 +1878,12 @@ msgstr "Toate culorile"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Gata!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3535,6 +3604,14 @@ msgid "Cancel"
 msgstr "Anulează"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4031,10 +4108,22 @@ msgid "Chat response is offensive"
 msgstr "Răspunsul prin chat este jignitor"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Discută cu %1$s"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4053,6 +4142,14 @@ msgstr "Chaturi"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Chaturi"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5661,6 +5758,12 @@ msgid "Current Streak"
 msgstr "Serie curentă"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -6009,6 +6112,12 @@ msgstr "Șterge chaturile"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Șterge chaturile mai vechi de 30 de zile"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6425,6 +6534,12 @@ msgstr "Ignoră pentru totdeauna"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Ignoră promoția"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7609,6 +7724,12 @@ msgid "Edit Prompt"
 msgstr "Editează promptul"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7830,6 +7951,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Model criptat"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8669,6 +8796,12 @@ msgid "Follow-up question"
 msgstr "Întrebare de continuare"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9181,6 +9314,12 @@ msgstr ""
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr "Obține DuckDuckGo VPN, Duck.ai avansat și Identity Theft Restoration."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10417,6 +10556,12 @@ msgstr "Cum rămân anonime?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Cum funcționează"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11861,6 +12006,12 @@ msgstr "Aruncări la margine câștigate"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "Linkul expiră peste 7 zile."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13982,6 +14133,12 @@ msgstr "OK"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "Ok, am înțeles!"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16109,6 +16266,12 @@ msgid "Protected"
 msgstr "Protejate"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Protecție. Confidențialitate. Liniște sufletească."
@@ -16240,6 +16403,12 @@ msgstr "Ploaie"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Clasamente"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17480,6 +17649,12 @@ msgid "Save your chats across all your devices."
 msgstr "Salvează-ți chaturile pe toate dispozitivele."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17682,6 +17857,14 @@ msgstr "Caută"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Caută"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18870,6 +19053,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Cumpără"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20540,6 +20729,14 @@ msgstr ""
 "Datele Sync & Backup nu pot fi recuperate după 18 luni de inactivitate."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20653,6 +20850,12 @@ msgstr "Sincronizează cu un dispozitiv din apropiere."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Sincronizează-ți chaturile pe toate dispozitivele."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21239,6 +21442,22 @@ msgid "This Week"
 msgstr "Săptămâna aceasta"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21775,6 +21994,12 @@ msgstr "Astăzi"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Astăzi"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23615,6 +23840,14 @@ msgstr ""
 "TripAdvisor."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Insulele Virgine"
 
@@ -25113,6 +25346,21 @@ msgstr ""
 "„%1$s”."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26512,6 +26760,12 @@ msgstr "m"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "m"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/ro_RO/LC_MESSAGES/duckduckgo.po
+++ b/locales/ro_RO/LC_MESSAGES/duckduckgo.po
@@ -2,16 +2,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: ro_RO\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < "
-"20)) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < 20)) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -527,8 +526,7 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr ""
-"%1$sApasă lung%2$s pe pictograma aplicației DuckDuckGo din pagina de pornire"
+msgstr "%1$sApasă lung%2$s pe pictograma aplicației DuckDuckGo din pagina de pornire"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -1227,7 +1225,7 @@ msgstr "Despre reclamele noastre"
 #. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
 msgctxt "Modal header for chat history with sync information"
 msgid "About Chat History with Sync & Backup"
-msgstr ""
+msgstr "Despre istoricul chaturilor cu Sync & Backup"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
@@ -1362,7 +1360,7 @@ msgstr "Reclama este suspectă"
 #. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
 msgctxt "Button to open menu for attaching images or page context to AI chat"
 msgid "Add"
-msgstr ""
+msgstr "Adaugă"
 
 # smartling.placeholder_format=C
 #. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
@@ -1370,7 +1368,7 @@ msgctxt ""
 "Primary button that attaches the tabs the user checked in the tab picker "
 "dialog"
 msgid "Add"
-msgstr ""
+msgstr "Adaugă"
 
 # smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
@@ -1405,13 +1403,13 @@ msgstr "Adăugare DuckDuckGo la %1$s"
 msgctxt ""
 "Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
 msgid "Add File"
-msgstr ""
+msgstr "Adaugă fișier"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
 msgid "Add Image"
-msgstr ""
+msgstr "Adaugă imagine"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
@@ -1419,7 +1417,7 @@ msgctxt ""
 "Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
 "item)"
 msgid "Add Image or File"
-msgstr ""
+msgstr "Adaugă imagine sau fișier"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1472,7 +1470,7 @@ msgctxt ""
 "Open the tab picker to attach browser tab content to the AI chat message "
 "(attach dropdown menu item)"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Adaugă file"
 
 # smartling.placeholder_format=C
 #. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
@@ -1480,7 +1478,7 @@ msgctxt ""
 "Title and accessible name of the tab-picker dialog opened from the attach "
 "dropdown menu"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Adaugă file"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1573,7 +1571,7 @@ msgstr "Adăugăm tușele finale"
 #. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
 msgctxt "Aria label for the additional instructions textarea"
 msgid "Additional instructions"
-msgstr ""
+msgstr "Instrucțiuni suplimentare"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1883,7 +1881,7 @@ msgstr "Gata!"
 #. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the read-only textarea listing all AI instructions"
 msgid "All instructions"
-msgstr ""
+msgstr "Toate instrucțiunile"
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2139,8 +2137,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"Acces anonim la modele AI populare, inclusiv %1$s, %2$s și %3$s și %4$s open-"
-"source."
+"Acces anonim la modele AI populare, inclusiv %1$s, %2$s și %3$s și %4$s "
+"open-source."
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -2149,8 +2147,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"Acces anonim la modele AI populare, inclusiv %1$s, %2$s și %3$s și %4$s open-"
-"source."
+"Acces anonim la modele AI populare, inclusiv %1$s, %2$s și %3$s și %4$s "
+"open-source."
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -2312,8 +2310,7 @@ msgstr "Ești încă acolo?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"Sigur dorești să ștergi toate chaturile tale? Acest lucru nu poate fi anulat."
+msgstr "Sigur dorești să ștergi toate chaturile tale? Acest lucru nu poate fi anulat."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2655,8 +2652,7 @@ msgstr "Sunetul nu este stocat de noi sau de OpenAI după încheierea chatului."
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"Sunetul nu este stocat de noi sau de OpenAI după ce chatul este transcris."
+msgstr "Sunetul nu este stocat de noi sau de OpenAI după ce chatul este transcris."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2697,8 +2693,7 @@ msgstr "Răspuns automat"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr ""
-"Generat automat pe baza surselor menționate. Poate conține inexactități."
+msgstr "Generat automat pe baza surselor menționate. Poate conține inexactități."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -3075,8 +3070,7 @@ msgstr "Blochează ferestrele pop-up enervante privind modulele cookie"
 #. DuckDuckGo Email Protection offers the ability to generate random email addresses to protect your personal email address
 msgctxt "SERP footer content"
 msgid "Block email trackers and hide your address."
-msgstr ""
-"Blochează modulele cookie de urmărire pentru e-mail și ascunde-ți adresa."
+msgstr "Blochează modulele cookie de urmărire pentru e-mail și ascunde-ți adresa."
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -3172,8 +3166,7 @@ msgstr "Blocat:"
 #. shown after the DuckDuckGo extension is installed
 msgctxt "welcome message"
 msgid "Blocks trackers on websites you visit"
-msgstr ""
-"Blochează instrumentele de urmărire pe site-urile web pe care le vizitezi"
+msgstr "Blochează instrumentele de urmărire pe site-urile web pe care le vizitezi"
 
 # smartling.placeholder_format=C
 msgid "Blog"
@@ -3609,7 +3602,7 @@ msgctxt ""
 "Secondary button that dismisses the tab picker dialog without attaching "
 "anything"
 msgid "Cancel"
-msgstr ""
+msgstr "Anulează"
 
 # smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
@@ -4111,7 +4104,7 @@ msgstr "Răspunsul prin chat este jignitor"
 #. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
 msgctxt "Chat history about modal list item headline"
 msgid "Chat storage varies by browser"
-msgstr ""
+msgstr "Stocarea chaturilor variază în funcție de browser"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4123,7 +4116,7 @@ msgstr "Discută cu %1$s"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Chat with popular AI models, anonymized by us."
-msgstr ""
+msgstr "Discută cu modele IA populare, într-un mod anonimizat de noi."
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4150,6 +4143,9 @@ msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
 msgstr ""
+"Conversațiile sunt stocate în siguranță pe serverul DuckDuckGo cu criptare "
+"de la un capăt la altul. Nimeni în afară de tine nu-ți poate vedea datele, "
+"nici măcar noi."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4272,8 +4268,7 @@ msgstr ""
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr ""
-"Verifică pagina de stare pentru actualizări despre această întrerupere."
+msgstr "Verifică pagina de stare pentru actualizări despre această întrerupere."
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4675,8 +4670,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr ""
-"Fă click pe %1$sConfidențialitate și Servicii%2$s în bara laterală stângă."
+msgstr "Fă click pe %1$sConfidențialitate și Servicii%2$s în bara laterală stângă."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -4703,8 +4697,7 @@ msgstr "Fă click pe %1$sSetări%2$s în meniul vertical."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Fă click pe %1$sUtilizează paginile curente%2$s apoi %3$sfă click pe OK%4$s."
+msgstr "Fă click pe %1$sUtilizează paginile curente%2$s apoi %3$sfă click pe OK%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4760,8 +4753,7 @@ msgstr "Fă click pe %1$sFurnizori căutare%2$s sub Tipuri Add-on-uri"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sTools icon%s in the top-right of the browser"
-msgstr ""
-"Fă click pe %1$spictograma Instrumente%2$s din dreapta sus a browserului"
+msgstr "Fă click pe %1$spictograma Instrumente%2$s din dreapta sus a browserului"
 
 #  Firefox default search engine instruction
 # smartling.placeholder_format=C
@@ -4836,8 +4828,7 @@ msgstr "Apasă pe pictograma %1$spermisiuni%2$s din bara de adrese"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr ""
-"Fă click pe pictograma Duck din partea de sus a browserului pentru a căuta!"
+msgstr "Fă click pe pictograma Duck din partea de sus a browserului pentru a căuta!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -4889,8 +4880,7 @@ msgstr "Fă click pe lupa din bara de căutare"
 #. Tells users what icon to click in order to make DuckDuckGo the default engine in their browser.
 msgid ""
 "Click the magnifying glass in the search box (at the top of the browser)"
-msgstr ""
-"Fă click pe lupa din căsuța de căutare (în partea de sus a browserului)"
+msgstr "Fă click pe lupa din căsuța de căutare (în partea de sus a browserului)"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -5575,8 +5565,7 @@ msgstr "Costa Rica"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr ""
-"Codul tău de recuperare nu s-a putut încărca. Închide și încearcă din nou."
+msgstr "Codul tău de recuperare nu s-a putut încărca. Închide și încearcă din nou."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5761,7 +5750,7 @@ msgstr "Serie curentă"
 #. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
 msgctxt "Suffix label indicating a tab is the currently active browser tab"
 msgid "Current Tab"
-msgstr ""
+msgstr "Fila existentă"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
@@ -6117,7 +6106,7 @@ msgstr "Șterge chaturile mai vechi de 30 de zile"
 #. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
 msgctxt "Button text in the modal for deleting all recent chats"
 msgid "Delete Chats and Shared Links"
-msgstr ""
+msgstr "Șterge chaturile și linkurile distribuite"
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6444,8 +6433,7 @@ msgstr "Dezactivare și deconectare"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr ""
-"Dezactivezi istoricul chaturilor și te deconectezi de la Sync & Backup?"
+msgstr "Dezactivezi istoricul chaturilor și te deconectezi de la Sync & Backup?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6539,7 +6527,7 @@ msgstr "Ignoră promoția"
 #. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the close button on the survey banner"
 msgid "Dismiss survey"
-msgstr ""
+msgstr "Renunță la sondaj"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6953,8 +6941,8 @@ msgstr "Duck.ai"
 msgctxt "Text on link to the Duck.ai Privacy Policy & Terms of Service page."
 msgid "Duck.ai Privacy Policy and Terms of Service"
 msgstr ""
-"Politica de confidențialitate și Condițiile de utilizare a serviciului Duck."
-"ai"
+"Politica de confidențialitate și Condițiile de utilizare a serviciului "
+"Duck.ai"
 
 # smartling.placeholder_format=C
 #. Title of the modal that contains settings for Duck.ai.
@@ -6978,8 +6966,7 @@ msgstr "Condiții de utilizare Duck.ai"
 #. The HTML <title> for Duck.ai.
 msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
-msgstr ""
-"Duck.ai de la DuckDuckGo. Chat privat cu inteligență artificială. Gratuit."
+msgstr "Duck.ai de la DuckDuckGo. Chat privat cu inteligență artificială. Gratuit."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -7351,8 +7338,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chat este temporar indisponibil. Încearcă din nou mai târziu."
+msgstr "DuckDuckGo AI Chat este temporar indisponibil. Încearcă din nou mai târziu."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7727,7 +7713,7 @@ msgstr "Editează promptul"
 #. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the message-editing text area"
 msgid "Edit message"
-msgstr ""
+msgstr "Editează mesajul"
 
 # smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
@@ -7746,8 +7732,7 @@ msgstr "Se editează imaginea..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr ""
-"Editarea mesajului tău va elimina răspunsul de mai jos și va genera unul nou."
+msgstr "Editarea mesajului tău va elimina răspunsul de mai jos și va genera unul nou."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7956,7 +7941,7 @@ msgstr "Model criptat"
 #. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
 msgctxt "Share modal info bullet about encryption"
 msgid "Encrypted so DuckDuckGo can't read your chat."
-msgstr ""
+msgstr "Criptat, astfel încât DuckDuckGo nu îți poate citi chatul."
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8058,8 +8043,7 @@ msgstr "Asigură-te că accesul la locație este %1$spermis%2$s."
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s"
-msgstr ""
-"Asigură-te că browserul tău are permisiunea de a %1$saccesa locația%2$s"
+msgstr "Asigură-te că browserul tău are permisiunea de a %1$saccesa locația%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -8279,8 +8263,7 @@ msgstr "Explică răspunsul acceptat în termeni simpli."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr ""
-"Explică-mi conceptele fundamentale ale găurilor negre la nivel de liceu."
+msgstr "Explică-mi conceptele fundamentale ale găurilor negre la nivel de liceu."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -8799,7 +8782,7 @@ msgstr "Întrebare de continuare"
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
-msgstr ""
+msgstr "Mesajele ulterioare rămân private."
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8905,8 +8888,7 @@ msgstr "Chaturi gratuite și private, anonimizate de noi"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Chaturi gratuite și private, anonimizate de noi. Nu este nevoie de un cont."
+msgstr "Chaturi gratuite și private, anonimizate de noi. Nu este nevoie de un cont."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8936,8 +8918,7 @@ msgstr "Fără restricții de distrubuire și utilizare comercială"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr ""
-"Eliberează spațiu ștergând chaturile. Chaturile fixate nu vor fi șterse."
+msgstr "Eliberează spațiu ștergând chaturile. Chaturile fixate nu vor fi șterse."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -9018,9 +8999,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Din bara de meniu a aplicației pe Mac, selectează <strong>DuckDuckGo</"
-"strong> &gt; <strong>Caută actualizări...</strong>, apoi selectează "
-"<strong>Instalează actualizările</strong>."
+"Din bara de meniu a aplicației pe Mac, selectează "
+"<strong>DuckDuckGo</strong> &gt; <strong>Caută actualizări...</strong>, apoi "
+"selectează <strong>Instalează actualizările</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9319,7 +9300,7 @@ msgstr "Obține DuckDuckGo VPN, Duck.ai avansat și Identity Theft Restoration."
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
 msgctxt "Tooltip on the header logo for sunglasses searches"
 msgid "Get DuckDuckGo sunglasses and other gear."
-msgstr ""
+msgstr "Obține ochelari de soare DuckDuckGo și alte produse."
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9544,8 +9525,8 @@ msgstr "Descarcă aplicația"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"Obține browserul gratuit DuckDuckGo %1$spentru a bloca reclamele pe YouTube."
-"%2$s"
+"Obține browserul gratuit DuckDuckGo %1$spentru a bloca reclamele pe "
+"YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9657,8 +9638,7 @@ msgstr ""
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr ""
-"Accesează %1$sConfidențialitate și securitate > Servicii de localizare%2$s"
+msgstr "Accesează %1$sConfidențialitate și securitate > Servicii de localizare%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9935,8 +9915,7 @@ msgstr "Guatemala"
 #. Text for a prompt suggestion for guiding through the basic steps of replacing a window wiper.
 msgctxt "Full sentence for learning a new skill"
 msgid "Guide me through the basic steps of replacing a window wiper."
-msgstr ""
-"Ghidează-mă prin pașii de bază ai înlocuirii unui ștergător de ferestre."
+msgstr "Ghidează-mă prin pașii de bază ai înlocuirii unui ștergător de ferestre."
 
 # smartling.placeholder_format=C
 msgid "Guinea"
@@ -10561,7 +10540,7 @@ msgstr "Cum funcționează"
 #. Headline in chat history about modals for the temporary encrypted server storage explanation.
 msgctxt "Chat history about modal list item headline"
 msgid "How it works"
-msgstr ""
+msgstr "Cum funcționează"
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -10585,8 +10564,7 @@ msgstr "Cât de mult vrei să apară răspunsurile asistate de AI?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr ""
-"Ce proporție din limitele tale zilnice și săptămânale ai utilizat până acum."
+msgstr "Ce proporție din limitele tale zilnice și săptămânale ai utilizat până acum."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10828,8 +10806,7 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"Dacă încă dorești să ne susții, %1$sajută-ne să promovăm DuckDuckGo%2$s"
+msgstr "Dacă încă dorești să ne susții, %1$sajută-ne să promovăm DuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -11358,8 +11335,7 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr ""
-"E bun acest loc? Rezumă-i reputația pe baza recenziilor și a evaluărilor."
+msgstr "E bun acest loc? Rezumă-i reputația pe baza recenziilor și a evaluărilor."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -12011,7 +11987,7 @@ msgstr "Linkul expiră peste 7 zile."
 #. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days. People can save a chat copy."
-msgstr ""
+msgstr "Linkul expiră peste 7 zile. Persoanele pot salva o copie a chatului."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -12140,8 +12116,7 @@ msgstr "Încarcă mai multe imagini rezultate când derulezi"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr ""
-"Încarcă mai multe rezultate în imagini, clipuri și cumpărături la derulare"
+msgstr "Încarcă mai multe rezultate în imagini, clipuri și cumpărături la derulare"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -12919,8 +12894,7 @@ msgstr "Limita lunară a fost atinsă"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Limita lunară de utilizare a fost atinsă. Poți continua acest chat după %1$s."
+msgstr "Limita lunară de utilizare a fost atinsă. Poți continua acest chat după %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -13328,8 +13302,7 @@ msgstr "Namibia"
 #. Title of the divisional championship series for the National League division of Major League Baseball
 msgctxt "Sports module"
 msgid "National League Championship Series"
-msgstr ""
-"National League Championship Series (Seria Campionatului Ligii Naționale)"
+msgstr "National League Championship Series (Seria Campionatului Ligii Naționale)"
 
 # smartling.placeholder_format=C
 #. Title of the divisional semi-final series for the National League division of Major League Baseball
@@ -14138,7 +14111,7 @@ msgstr "Ok, am înțeles!"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "OPTIONAL"
-msgstr ""
+msgstr "OPȚIONAL"
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -14464,8 +14437,7 @@ msgstr "Deschide website-ul %1$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr ""
-"Deschide %1$sLocație%2$s și asigură-te că locația este %3$sactivată%4$s"
+msgstr "Deschide %1$sLocație%2$s și asigură-te că locația este %3$sactivată%4$s"
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -15397,8 +15369,7 @@ msgstr "Fixat"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
-"Chaturile fixate vor apărea în partea de sus a chaturilor tale recente."
+msgstr "Chaturile fixate vor apărea în partea de sus a chaturilor tale recente."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -16269,7 +16240,7 @@ msgstr "Protejate"
 #. Headline in sync-enabled chat history about modals explaining encrypted server storage.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Protected with end-to-end encryption"
-msgstr ""
+msgstr "Protejat cu criptare de la un capăt la altul"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -16408,7 +16379,7 @@ msgstr "Clasamente"
 #. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
 msgctxt "star rating on a product"
 msgid "Rated %s out of %s"
-msgstr ""
+msgstr "Evaluat cu %1$s din %2$s"
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -16886,8 +16857,7 @@ msgstr "Reține alegerea mea"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Ține minte alegerea mea (poate fi modificată în %1$s%2$s%3$sSetări%4$s)"
+msgstr "Ține minte alegerea mea (poate fi modificată în %1$s%2$s%3$sSetări%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -17274,8 +17244,7 @@ msgstr "Rezultatele exclud informațiile de pe site-urile blocate."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr ""
-"Rezultatele exclud site-urile blocate, pe care le poți gestiona în %1$s."
+msgstr "Rezultatele exclud site-urile blocate, pe care le poți gestiona în %1$s."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -17631,16 +17600,14 @@ msgstr ""
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
 msgctxt "Short description for Chat History feature on native DDG browsers"
 msgid "Save up to 30 of your most recent chats locally on your device."
-msgstr ""
-"Salvează local pe dispozitiv până la 30 dintre cele mai recente chaturi."
+msgstr "Salvează local pe dispozitiv până la 30 dintre cele mai recente chaturi."
 
 # smartling.placeholder_format=C
 #. Desktop/mobile intro modal body under the title per Sync Chats Figma (choose step).
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Salvează-ți chaturile Duck.ai între dispozitive cu criptare end-to-end."
+msgstr "Salvează-ți chaturile Duck.ai între dispozitive cu criptare end-to-end."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17652,7 +17619,7 @@ msgstr "Salvează-ți chaturile pe toate dispozitivele."
 #. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
 msgctxt "Chat history about modal list item headline"
 msgid "Save your chats on this device"
-msgstr ""
+msgstr "Salvează-ți chaturile pe acest dispozitiv"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
@@ -17864,7 +17831,7 @@ msgctxt ""
 "Placeholder and accessibility label for the search input in the tab picker "
 "dialog"
 msgid "Search"
-msgstr ""
+msgstr "Caută"
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18189,8 +18156,7 @@ msgstr "A doua opinie"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr ""
-"Salvează și sincronizează-ți în siguranță chaturile pe toate dispozitivele."
+msgstr "Salvează și sincronizează-ți în siguranță chaturile pe toate dispozitivele."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18348,8 +18314,7 @@ msgstr "Vezi mai multe pe %1$s"
 # smartling.placeholder_format=C
 #. Title of a notice that DuckDuckGo has noticed the user is blocking its non-tracking ads
 msgid "See more shopping results from popular retailers"
-msgstr ""
-"Vezi mai multe rezultate privind cumpărăturile, de la comercianți populari"
+msgstr "Vezi mai multe rezultate privind cumpărăturile, de la comercianți populari"
 
 # smartling.placeholder_format=C
 #. Text for tooltip shown on hover when displaying the number of reviews the product has on an ad, indicating that users can see more ratings on bing.com
@@ -18367,8 +18332,7 @@ msgstr "Vezi câteva dintre cele mai recente actualizări ale noastre"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr ""
-"Vezi %1$spagina de referință a parametrilor URL%2$s pentru mai multe detalii."
+msgstr "Vezi %1$spagina de referință a parametrilor URL%2$s pentru mai multe detalii."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -18395,8 +18359,7 @@ msgstr "Selectează %1$s%2$s%3$s, apoi %4$sMotor de căutare%5$s"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
-msgstr ""
-"Selectează %1$s„Setare pentru acest site web...”%2$s din meniul Safari."
+msgstr "Selectează %1$s„Setare pentru acest site web...”%2$s din meniul Safari."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -18409,35 +18372,30 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sAdaugă ca implicit%4$s!"
+msgstr "Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sAdaugă ca implicit%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sSetează ca implicit%4$s"
+msgstr "Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sSetează ca implicit%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sSetează ca implicit%4$s."
+msgstr "Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sSetează ca implicit%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr ""
-"Selectează %1$sDuckDuckGo%2$s în meniul vertical Motor de căutare implicit"
+msgstr "Selectează %1$sDuckDuckGo%2$s în meniul vertical Motor de căutare implicit"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"Selectează %1$sDuckDuckGo%2$s din listă și %3$spermite%4$s accesul la locație"
+msgstr "Selectează %1$sDuckDuckGo%2$s din listă și %3$spermite%4$s accesul la locație"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18449,8 +18407,7 @@ msgstr "Selectează %1$sDuckDuckGo%2$s din lista de furnizori de căutare"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr ""
-"Selectează %1$sDuckDuckGo%2$s sub%3$ssecțiunea Motor de căutare implicit%4$s"
+msgstr "Selectează %1$sDuckDuckGo%2$s sub%3$ssecțiunea Motor de căutare implicit%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -18461,8 +18418,7 @@ msgstr "Selectează %1$sDuckDuckGo%2$s!"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr ""
-"Selectează %1$sEditează motoarele de căutare...%2$s din meniul vertical"
+msgstr "Selectează %1$sEditează motoarele de căutare...%2$s din meniul vertical"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18558,8 +18514,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"Selectează %1$sbrowserul%2$s din listă și %3$spermite%4$s accesul la locație"
+msgstr "Selectează %1$sbrowserul%2$s din listă și %3$spermite%4$s accesul la locație"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18631,8 +18586,7 @@ msgstr "Text selectat din %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr ""
-"Textul selectat este prea lung. Încearcă din nou cu o selecție mai scurtă."
+msgstr "Textul selectat este prea lung. Încearcă din nou cu o selecție mai scurtă."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -19058,7 +19012,7 @@ msgstr "Cumpără"
 #. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
 msgctxt "Button in the merchandise logo modal (mobile)"
 msgid "Shop Now"
-msgstr ""
+msgstr "Cumpără acum"
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -19166,8 +19120,7 @@ msgstr "Afișează DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"Arată DuckAssist mai des. (De asemenea, îl poți %1$sdezactiva%2$s complet.)"
+msgstr "Arată DuckAssist mai des. (De asemenea, îl poți %1$sdezactiva%2$s complet.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -19427,8 +19380,7 @@ msgstr "Afișează linii orizontale la sfârșitul paginilor de rezultate"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr ""
-"Afișează linkuri spre instrucțiuni pentru a adăuga DuckDuckGo în browser"
+msgstr "Afișează linkuri spre instrucțiuni pentru a adăuga DuckDuckGo în browser"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -19582,8 +19534,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"Site-urile pe care le blochezi vor fi ascunse din toate rezultatele căutării."
+msgstr "Site-urile pe care le blochezi vor fi ascunse din toate rezultatele căutării."
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19742,8 +19693,7 @@ msgstr "Ceva nu a funcționat, te rugăm să încerci din nou."
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr ""
-"A apărut o eroare la activarea funcției Sync & Backup. Încearcă din nou."
+msgstr "A apărut o eroare la activarea funcției Sync & Backup. Încearcă din nou."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -19798,8 +19748,7 @@ msgstr "Ne pare rău, a survenit o eroare neașteptată."
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid "Sorry, no relevant information was found in our search."
-msgstr ""
-"Ne pare rău, nu au fost găsite informații relevante în căutarea noastră."
+msgstr "Ne pare rău, nu au fost găsite informații relevante în căutarea noastră."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search.
@@ -19848,8 +19797,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Ne pare rău, nu am putut trimite feedbackul tău. Încearcă din nou mai târziu."
+msgstr "Ne pare rău, nu am putut trimite feedbackul tău. Încearcă din nou mai târziu."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -20118,15 +20066,13 @@ msgstr ""
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Rămâi protejat și informat cu newsletterele noastre despre confidențialitate."
+msgstr "Rămâi protejat și informat cu newsletterele noastre despre confidențialitate."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Rămâi protejat și informat cu newsletterele noastre despre confidențialitate."
+msgstr "Rămâi protejat și informat cu newsletterele noastre despre confidențialitate."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -20169,8 +20115,7 @@ msgstr "Oprește instrumentele de urmărire ascunse de pe alte site-uri."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Oprește majoritatea instrumentelor de urmărire ascunse de pe alte site-uri."
+msgstr "Oprește majoritatea instrumentelor de urmărire ascunse de pe alte site-uri."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20344,8 +20289,7 @@ msgstr "Sugerează un titlu pentru o postare pe blog"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
-"Sugerează articole sau subiecte similare care merită explorate în continuare."
+msgstr "Sugerează articole sau subiecte similare care merită explorate în continuare."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -20725,8 +20669,7 @@ msgstr "Sync & Backup activat!"
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr ""
-"Datele Sync & Backup nu pot fi recuperate după 18 luni de inactivitate."
+msgstr "Datele Sync & Backup nu pot fi recuperate după 18 luni de inactivitate."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
@@ -20735,6 +20678,8 @@ msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
 msgstr ""
+"Sync & Backup salvează mai multe dintre chaturile tale și le sincronizează "
+"pe toate dispozitivele tale."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20855,7 +20800,7 @@ msgstr "Sincronizează-ți chaturile pe toate dispozitivele."
 #. Headline in sync-enabled chat history about modals explaining cross-device sync.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Sync your chats across all your devices"
-msgstr ""
+msgstr "Sincronizează-ți chaturile pe toate dispozitivele"
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -20975,8 +20920,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
-"Completează acest sondaj anonim pentru a ne spune cum putem îmbunătăți Duck."
-"ai."
+"Completează acest sondaj anonim pentru a ne spune cum putem îmbunătăți "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -21231,8 +21176,7 @@ msgstr "Fișierele atașate depășesc limita totală de %1$s MB."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
 msgid "The audio could not be processed. Please try recording again."
-msgstr ""
-"Materialul audio nu a putut fi prelucrat. Încearcă să înregistrezi din nou."
+msgstr "Materialul audio nu a putut fi prelucrat. Încearcă să înregistrezi din nou."
 
 # smartling.placeholder_format=C
 #. Second paragraph explaining where the encryption key is stored on the entry screen.
@@ -21420,8 +21364,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Acest răspuns instant a fost creat de Comunitatea %1$sDuckDuckHack%2$s."
+msgstr "Acest răspuns instant a fost creat de Comunitatea %1$sDuckDuckHack%2$s."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -21450,12 +21393,14 @@ msgid ""
 "This chat and its generated images become public when you create and copy "
 "the link."
 msgstr ""
+"Acest chat și imaginile generate în cadrul lui devin publice când creezi și "
+"copiezi linkul."
 
 # smartling.placeholder_format=C
 #. Explains that creating and copying a share link makes the selected chat content public.
 msgctxt "Share modal info bullet about public access"
 msgid "This chat becomes public when you create and copy the link."
-msgstr ""
+msgstr "Acest chat devine public atunci când creezi și copiezi linkul."
 
 # smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
@@ -21532,15 +21477,13 @@ msgstr ""
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
-msgstr ""
-"Fișierul acesta e prea mare. Dimensiunea maximă a fișierului este de %1$s MB"
+msgstr "Fișierul acesta e prea mare. Dimensiunea maximă a fișierului este de %1$s MB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB."
-msgstr ""
-"Fișierul acesta e prea mare. Dimensiunea maximă a fișierului este de %1$s MB."
+msgstr "Fișierul acesta e prea mare. Dimensiunea maximă a fișierului este de %1$s MB."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -21690,8 +21633,7 @@ msgstr "Această pagină necesită JavaScript pentru a funcționa."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Conținutul acestei pagini va fi trimis împreună cu mesajul tău către Duck.ai"
+msgstr "Conținutul acestei pagini va fi trimis împreună cu mesajul tău către Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21806,8 +21748,7 @@ msgstr ""
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
-msgstr ""
-"Aceasta va șterge imaginea selectată de tine. Acest lucru nu poate fi anulat."
+msgstr "Aceasta va șterge imaginea selectată de tine. Acest lucru nu poate fi anulat."
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -21943,8 +21884,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"Pentru a tipări indicații de orientare:%1$sîntoarce-te la hartă."
-"%2$sSelectează ruta pe care dorești să o tipărești.%3$sFă click pe "
+"Pentru a tipări indicații de orientare:%1$sîntoarce-te la "
+"hartă.%2$sSelectează ruta pe care dorești să o tipărești.%3$sFă click pe "
 "pictograma de tipărire.%4$s"
 
 # smartling.placeholder_format=C
@@ -21999,7 +21940,7 @@ msgstr "Astăzi"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
-msgstr ""
+msgstr "Comută la chat privat cu IA sau %1$sdezactivează-l din setări%2$s."
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -22172,8 +22113,7 @@ msgstr "Instrumente de urmărire blocate în ultima oră"
 #. Placeholder for when we cannot report any blocked trackers yet
 msgctxt "tracker_stats"
 msgid "Trackers that DuckDuckGo blocks will appear here"
-msgstr ""
-"Instrumentele de urmărire pe care DuckDuckGo le blochează vor apărea aici"
+msgstr "Instrumentele de urmărire pe care DuckDuckGo le blochează vor apărea aici"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -22560,8 +22500,7 @@ msgstr "Încearcă gratis"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr ""
-"Încearcă gratuit! Un VPN securizat, AI avansată și privată și multe altele."
+msgstr "Încearcă gratuit! Un VPN securizat, AI avansată și privată și multe altele."
 
 # smartling.placeholder_format=C
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
@@ -22600,8 +22539,7 @@ msgstr "Încearcă browserul nostru"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr ""
-"Încearcă pagina noastră de pornire care nu afișează niciodată aceste mesaje:"
+msgstr "Încearcă pagina noastră de pornire care nu afișează niciodată aceste mesaje:"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time; shown in the US. Invites the user to start a free trial of the paid subscription.
@@ -22872,8 +22810,7 @@ msgstr "Activează %1$sLocație precisă%2$s pentru rezultate mai precise"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr ""
-"Activează Duck Player pentru a viziona pe YouTube fără reclame direcționate"
+msgstr "Activează Duck Player pentru a viziona pe YouTube fără reclame direcționate"
 
 # smartling.placeholder_format=C
 #. Button that enables the Search/Duck.ai toggle.
@@ -23090,14 +23027,12 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"Sub %1$sDeschide cu%2$s selectează %3$sUna sau mai multe pagini specifice%4$s"
+msgstr "Sub %1$sDeschide cu%2$s selectează %3$sUna sau mai multe pagini specifice%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"Sub %1$sPORNIRE > Pagina de pornire%2$s introdu: https://duckduckgo.com"
+msgstr "Sub %1$sPORNIRE > Pagina de pornire%2$s introdu: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23107,8 +23042,7 @@ msgstr "Sub %1$sSetări de căutare%2$s selectează %3$sDuckDuckGo%4$s"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr ""
-"Sub %1$sCaută în bara de adrese cu%2$s selectează %3$sAdăugare nouă%4$s"
+msgstr "Sub %1$sCaută în bara de adrese cu%2$s selectează %3$sAdăugare nouă%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -23122,15 +23056,13 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr ""
-"Sub Pornire, selectează %1$sDeschide una sau mai multe pagini specifice%2$s"
+msgstr "Sub Pornire, selectează %1$sDeschide una sau mai multe pagini specifice%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr ""
-"Sub Căutare, fă click pe meniul vertical și selectează %1$sDuckDuckGo%2$s"
+msgstr "Sub Căutare, fă click pe meniul vertical și selectează %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -23604,9 +23536,9 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"Folosește ChatGPT, Claude și alte platforme de IA, în mod privat. Protejează-"
-"ți chaturile împotriva hackerilor, a escrocilor și a companiilor. Păstrează "
-"informațiile confidențiale. Gratuit. Nu este nevoie de un cont."
+"Folosește ChatGPT, Claude și alte platforme de IA, în mod privat. "
+"Protejează-ți chaturile împotriva hackerilor, a escrocilor și a companiilor. "
+"Păstrează informațiile confidențiale. Gratuit. Nu este nevoie de un cont."
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -23846,6 +23778,9 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Yelp's ad network."
 msgstr ""
+"Confidențialitatea ta în timpul vizualizării reclamelor este protejată de "
+"DuckDuckGo. Clickurile pe reclame sunt gestionate de rețeaua publicitară "
+"Yelp."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -24167,8 +24102,7 @@ msgstr "Anonimizăm"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr ""
-"Putem anonimiza%1$s locația ta%2$s pentru a-ți afișa rezultate mai precise."
+msgstr "Putem anonimiza%1$s locația ta%2$s pentru a-ți afișa rezultate mai precise."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -24315,8 +24249,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr ""
-"Noi nu te monitorizăm în interiorul sau în afara modului de navigare privată."
+msgstr "Noi nu te monitorizăm în interiorul sau în afara modului de navigare privată."
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
@@ -24330,8 +24263,7 @@ msgstr ""
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
 msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
-msgstr ""
-"Am încheiat chatul din cauza inactivității. Dorești să încerci din nou?"
+msgstr "Am încheiat chatul din cauza inactivității. Dorești să încerci din nou?"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
@@ -24412,8 +24344,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr ""
-"Împiedicăm pe oricine, inclusiv pe noi, să obțină istoricul căutărilor tale."
+msgstr "Împiedicăm pe oricine, inclusiv pe noi, să obțină istoricul căutărilor tale."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -24719,8 +24650,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"Ne pare foarte rău, dar se pare că a apărut o problemă la încărcarea Duck."
-"ai. Încearcă să reîncarci pagina."
+"Ne pare foarte rău, dar se pare că a apărut o problemă la încărcarea "
+"Duck.ai. Încearcă să reîncarci pagina."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -24789,10 +24720,10 @@ msgid ""
 msgstr ""
 "Care sunt beneficiile descărcării browserului DuckDuckGo pentru tine, dacă "
 "vrei să folosești Duck.ai? Citește doar surse oficiale DuckDuckGo. Împarte "
-"răspunsul în secțiuni clare cu titluri, concentrându-te pe integrările Duck."
-"ai și pe protecția confidențialității. Păstrează-l destul de scurt, simplu "
-"și ușor de înțeles pentru cei care au (sau nu) experiență în IA sau în "
-"domeniul tehnic."
+"răspunsul în secțiuni clare cu titluri, concentrându-te pe integrările "
+"Duck.ai și pe protecția confidențialității. Păstrează-l destul de scurt, "
+"simplu și ușor de înțeles pentru cei care au (sau nu) experiență în IA sau "
+"în domeniul tehnic."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24858,8 +24789,7 @@ msgstr "Care sunt principalele lucruri pe care le voi învăța din acest curs?"
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr ""
-"Care sunt principalele contraargumente sau critici la adresa acestui lucru?"
+msgstr "Care sunt principalele contraargumente sau critici la adresa acestui lucru?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
@@ -25031,8 +24961,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Ce este bookmarklet-ul Cloud Save și cum se diferențiază el de bookmarklet-"
-"ul cu parametri URL?"
+"Ce este bookmarklet-ul Cloud Save și cum se diferențiază el de "
+"bookmarklet-ul cu parametri URL?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -25141,8 +25071,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"Când este activat, Duck.ai va afișa răspunsuri instantanee în conversație."
+msgstr "Când este activat, Duck.ai va afișa răspunsuri instantanee în conversație."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -25160,8 +25089,7 @@ msgstr "Unde să urmărești <strong>%1$s</strong>"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr ""
-"Fă click pe %1$sSetează ca pagină curentă%2$s unde scrie Pagină de pornire."
+msgstr "Fă click pe %1$sSetează ca pagină curentă%2$s unde scrie Pagină de pornire."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -25352,6 +25280,8 @@ msgid ""
 "With chat history on, up to %s of your most recent chats will be saved on "
 "this device."
 msgstr ""
+"Cu istoricul de chat activat, până la %1$s dintre cele mai recente chaturi "
+"ale tale vor fi salvate pe acest dispozitiv."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline in the About Chat History modal.
@@ -25359,6 +25289,8 @@ msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, your most recent chats will be saved on this device."
 msgstr ""
+"Cu istoricul chaturilor activat, cele mai recente chaturi vor fi salvate pe "
+"acest dispozitiv."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -25373,8 +25305,8 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
-"Funcționează direct de pe dispozitivul tău pentru a-ți elimina adresa de e-"
-"mail, numele, adresa și multe altele de pe site-urile brokerilor de date."
+"Funcționează direct de pe dispozitivul tău pentru a-ți elimina adresa de "
+"e-mail, numele, adresa și multe altele de pe site-urile brokerilor de date."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -26030,8 +25962,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr ""
-"Pentru moment, ai atins numărul maxim de mesaje. Încearcă din nou mai târziu."
+msgstr "Pentru moment, ai atins numărul maxim de mesaje. Încearcă din nou mai târziu."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -26058,8 +25989,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"Ai rămas fără spațiu de stocare pentru Sync & Backup pentru chaturile Duck."
-"ai cu atașări. Șterge cele mai vechi %1$s chaturi pentru a relua "
+"Ai rămas fără spațiu de stocare pentru Sync & Backup pentru chaturile "
+"Duck.ai cu atașări. Șterge cele mai vechi %1$s chaturi pentru a relua "
 "sincronizarea. Chaturile fixate nu vor fi șterse."
 
 # smartling.placeholder_format=C
@@ -26118,8 +26049,7 @@ msgstr ""
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr ""
-"Chaturile tale Duck.ai sunt sincronizate cu criptare de la un capăt la altul."
+msgstr "Chaturile tale Duck.ai sunt sincronizate cu criptare de la un capăt la altul."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -26304,8 +26234,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr ""
-"Chaturile tale au fost importate. Continuă de unde ai rămas în Duck.ai."
+msgstr "Chaturile tale au fost importate. Continuă de unde ai rămas în Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -26352,8 +26281,7 @@ msgctxt ""
 "Subtitle of the one-time popover shown above the thumbs up/down buttons on "
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
-msgstr ""
-"Feedbackul tău este anonimizat și nu este folosit pentru antrenarea IA."
+msgstr "Feedbackul tău este anonimizat și nu este folosit pentru antrenarea IA."
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -26527,15 +26455,13 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr ""
-"Ai atins numărul maxim de mesaje pentru o zi. Continuă acest chat mâine."
+msgstr "Ai atins numărul maxim de mesaje pentru o zi. Continuă acest chat mâine."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr ""
-"Ai atins limita de chat vocal pentru moment. Încearcă din nou mai târziu."
+msgstr "Ai atins limita de chat vocal pentru moment. Încearcă din nou mai târziu."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -26765,7 +26691,7 @@ msgstr "m"
 #. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the chat options menu button"
 msgid "menu"
-msgstr ""
+msgstr "meniu"
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/ru_RU/LC_MESSAGES/duckduckgo.po
+++ b/locales/ru_RU/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: ru_RU\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1215,6 +1215,12 @@ msgid "About our ads"
 msgstr "О нашей рекламе"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1344,6 +1350,20 @@ msgid "Ad is suspicious"
 msgstr "Подозрительная реклама"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Добавить DuckDuckGo"
@@ -1370,6 +1390,27 @@ msgstr "Добавьте DuckDuckGo как поисковую систему"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Добавить DuckDuckGo в %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1415,6 +1456,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Добавить содержимое страницы"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1500,6 +1557,12 @@ msgstr "Дополнения"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Добавляю последние штрихи"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1803,6 +1866,12 @@ msgstr "Все цвета"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Всё готово!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3521,6 +3590,14 @@ msgid "Cancel"
 msgstr "Отменить"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4016,10 +4093,22 @@ msgid "Chat response is offensive"
 msgstr "Ответ носит оскорбительный характер"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Пообщаться с %1$s"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4038,6 +4127,14 @@ msgstr "Чаты"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Чаты"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5646,6 +5743,12 @@ msgid "Current Streak"
 msgstr "Текущая серия"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5994,6 +6097,12 @@ msgstr "Удалить чаты"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Удалить чаты старше 30 дней"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6406,6 +6515,12 @@ msgstr "Не показывать снова"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Закрыть рекламу"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7592,6 +7707,12 @@ msgid "Edit Prompt"
 msgstr "Редактировать запрос"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7817,6 +7938,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Зашифрованная модель"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8651,6 +8778,12 @@ msgid "Follow-up question"
 msgstr "Последующий вопрос"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9167,6 +9300,12 @@ msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
 "Получите VPN от DuckDuckGo, продвинутые модели в Duck.ai, а также доступ к "
 "функции Identity Theft Restoration."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10402,6 +10541,12 @@ msgstr "Насколько это анонимно?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Как это работает?"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11857,6 +12002,12 @@ msgstr "Выигранные лайнауты"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "Ссылка истекает через 7 дней."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13978,6 +14129,12 @@ msgstr "Хорошо"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "Хорошо, понятно!"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16108,6 +16265,12 @@ msgid "Protected"
 msgstr "Защищено"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Защита. Конфиденциальность. Спокойствие."
@@ -16239,6 +16402,12 @@ msgstr "Дождь"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Рейтинги"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17476,6 +17645,12 @@ msgid "Save your chats across all your devices."
 msgstr "Чаты сохраняются на всех устройствах."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17678,6 +17853,14 @@ msgstr "Поиск"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Поиск"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18859,6 +19042,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "За покупками"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20515,6 +20704,14 @@ msgstr ""
 "бездействия."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20629,6 +20826,12 @@ msgstr "Синхронизация с устройством поблизост�
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Чаты синхронизируются на всех устройствах."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21209,6 +21412,22 @@ msgid "This Week"
 msgstr "На этой неделе"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21744,6 +21963,12 @@ msgstr "Сегодня"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Сегодня"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23589,6 +23814,14 @@ msgstr ""
 "TripAdvisor."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Виргинские острова"
 
@@ -25058,6 +25291,21 @@ msgstr ""
 "Включить или отключить его можно в любой момент в меню «%1$s»."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26455,6 +26703,12 @@ msgstr "мин."
 msgctxt "published date for videos"
 msgid "m"
 msgstr "мин."
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/ru_RU/LC_MESSAGES/duckduckgo.po
+++ b/locales/ru_RU/LC_MESSAGES/duckduckgo.po
@@ -2,16 +2,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: ru_RU\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -256,8 +255,7 @@ msgstr "Лайков: %1$s"
 #. Disclaimer text shown bellow chat input on mobile, avoid long text if possible. Example: 'GPT-3 may display inaccurate or offensive information.'
 msgctxt "Disclaimer bellow chat input - mobile"
 msgid "%s may display inaccurate or offensive information."
-msgstr ""
-"ИИ-модель %1$s может предложить неточную или оскорбительную информацию."
+msgstr "ИИ-модель %1$s может предложить неточную или оскорбительную информацию."
 
 # smartling.placeholder_format=C
 #. Label showing how many members a discussion has. To be displayed on a card about that discussion.
@@ -508,15 +506,13 @@ msgstr "%1$sПодробнее%2$s"
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr ""
-"%1$sПодробнее%2$s о конфиденциальном хранении чатов на сервере DuckDuckGo."
+msgstr "%1$sПодробнее%2$s о конфиденциальном хранении чатов на сервере DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr ""
-"%1$sПодробнее%2$s о том, как чаты хранятся в тайне на вашем устройстве."
+msgstr "%1$sПодробнее%2$s о том, как чаты хранятся в тайне на вашем устройстве."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -1007,8 +1003,8 @@ msgid ""
 msgstr ""
 "Функция AI Chat позволяет анонимно общаться с нашим чат-ботом на базе "
 "сторонних моделей ИИ. Если отключить эту функцию, она не будет отображаться "
-"в поиске DuckDuckGo Search, но останется доступной по ссылке %1$sduckduckgo."
-"com/aichat%2$s."
+"в поиске DuckDuckGo Search, но останется доступной по ссылке "
+"%1$sduckduckgo.com/aichat%2$s."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1124,8 +1120,7 @@ msgstr "Не добавлять в браузер"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "ATB related (not displayed on settings page)"
-msgstr ""
-"Связано с параметром «Добавить в браузер» (отсутствует на странице настроек)"
+msgstr "Связано с параметром «Добавить в браузер» (отсутствует на странице настроек)"
 
 # smartling.placeholder_format=C
 #. Golf rankings column: average points
@@ -1218,7 +1213,7 @@ msgstr "О нашей рекламе"
 #. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
 msgctxt "Modal header for chat history with sync information"
 msgid "About Chat History with Sync & Backup"
-msgstr ""
+msgstr "Об истории чата с Sync & Backup"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
@@ -1353,7 +1348,7 @@ msgstr "Подозрительная реклама"
 #. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
 msgctxt "Button to open menu for attaching images or page context to AI chat"
 msgid "Add"
-msgstr ""
+msgstr "Добавить"
 
 # smartling.placeholder_format=C
 #. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
@@ -1361,7 +1356,7 @@ msgctxt ""
 "Primary button that attaches the tabs the user checked in the tab picker "
 "dialog"
 msgid "Add"
-msgstr ""
+msgstr "Добавить"
 
 # smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
@@ -1396,13 +1391,13 @@ msgstr "Добавить DuckDuckGo в %1$s"
 msgctxt ""
 "Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
 msgid "Add File"
-msgstr ""
+msgstr "Добавить файл"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
 msgid "Add Image"
-msgstr ""
+msgstr "Добавить изображение"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
@@ -1410,7 +1405,7 @@ msgctxt ""
 "Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
 "item)"
 msgid "Add Image or File"
-msgstr ""
+msgstr "Добавить изображение или файл"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1463,7 +1458,7 @@ msgctxt ""
 "Open the tab picker to attach browser tab content to the AI chat message "
 "(attach dropdown menu item)"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Добавить вкладки"
 
 # smartling.placeholder_format=C
 #. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
@@ -1471,7 +1466,7 @@ msgctxt ""
 "Title and accessible name of the tab-picker dialog opened from the attach "
 "dropdown menu"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Добавить вкладки"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1562,7 +1557,7 @@ msgstr "Добавляю последние штрихи"
 #. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
 msgctxt "Aria label for the additional instructions textarea"
 msgid "Additional instructions"
-msgstr ""
+msgstr "Дополнительные инструкции"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1871,7 +1866,7 @@ msgstr "Всё готово!"
 #. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the read-only textarea listing all AI instructions"
 msgid "All instructions"
-msgstr ""
+msgstr "Все инструкции"
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -1977,8 +1972,8 @@ msgid ""
 msgstr ""
 "Позволяет %1$s выполнить поиск в Интернете, чтобы улучшить ответы на "
 "релевантные запросы. Отправляет в поисковую систему только сгенерированные "
-"ИИ запросы с ограниченным сроком хранения данных. Запросы и ответы %2$s по-"
-"прежнему имеют %3$sнулевую видимость провайдера%4$s."
+"ИИ запросы с ограниченным сроком хранения данных. Запросы и ответы %2$s "
+"по-прежнему имеют %3$sнулевую видимость провайдера%4$s."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2518,10 +2513,9 @@ msgstr ""
 "интеллекта. Вы можете самостоятельно проконтролировать, как часто будут "
 "появляться ответы Assist: «никогда» (интерфейс Assist полностью исключается "
 "из поисковых запросов), «по запросу» (ответы ИИ отображаются при нажатии "
-"кнопки «Ассистент»), «иногда» (только при высокой релевантности) или "
-"«часто» (чаще и в отношении более широкого спектра запросов). Пока что "
-"ответы на базе ИИ предоставляются только на территории США (на английском "
-"языке)."
+"кнопки «Ассистент»), «иногда» (только при высокой релевантности) или «часто» "
+"(чаще и в отношении более широкого спектра запросов). Пока что ответы на "
+"базе ИИ предоставляются только на территории США (на английском языке)."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -3077,8 +3071,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr ""
-"Список блокировки не является исчерпывающим и может содержать неточности."
+msgstr "Список блокировки не является исчерпывающим и может содержать неточности."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3595,7 +3588,7 @@ msgctxt ""
 "Secondary button that dismisses the tab picker dialog without attaching "
 "anything"
 msgid "Cancel"
-msgstr ""
+msgstr "Отменить"
 
 # smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
@@ -3984,11 +3977,11 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"Чат (на сервисе Duck.ai) позволяет анонимно общаться со сторонними чат-"
-"моделями на базе ИИ от OpenAI, Anthropic и других компаний. При отключении "
-"этой настройки из интерфейса DuckDuckGo Search исчезнут кнопка «Чат» и "
-"ссылки на чат-сервис. Вы по-прежнему можете воспользоваться чатом, посетив "
-"его страницу напрямую: %1$shttps://duck.ai%2$s."
+"Чат (на сервисе Duck.ai) позволяет анонимно общаться со сторонними "
+"чат-моделями на базе ИИ от OpenAI, Anthropic и других компаний. При "
+"отключении этой настройки из интерфейса DuckDuckGo Search исчезнут кнопка "
+"«Чат» и ссылки на чат-сервис. Вы по-прежнему можете воспользоваться чатом, "
+"посетив его страницу напрямую: %1$shttps://duck.ai%2$s."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4096,7 +4089,7 @@ msgstr "Ответ носит оскорбительный характер"
 #. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
 msgctxt "Chat history about modal list item headline"
 msgid "Chat storage varies by browser"
-msgstr ""
+msgstr "Хранение чатов зависит от браузера"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4108,7 +4101,7 @@ msgstr "Пообщаться с %1$s"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Chat with popular AI models, anonymized by us."
-msgstr ""
+msgstr "Чат с популярными ИИ-моделями с анонимностью от DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4135,6 +4128,8 @@ msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
 msgstr ""
+"Чаты надежно хранятся на сервере DuckDuckGo с применением сквозного "
+"шифрования. Никто, кроме вас, их не увидит. Даже мы."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4247,8 +4242,7 @@ msgstr "Проверьте орфографию"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr ""
-"Последнюю информацию по этому сбою можно отследить в сабреддите DuckDuckGo."
+msgstr "Последнюю информацию по этому сбою можно отследить в сабреддите DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4686,8 +4680,7 @@ msgstr "Нажмите %1$sНастройки%2$s в выпадающем мен
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Выберите %1$sИспользовать текущие страницы%2$s, затем %3$sНажмите OK%4$s."
+msgstr "Выберите %1$sИспользовать текущие страницы%2$s, затем %3$sНажмите OK%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -5450,8 +5443,7 @@ msgstr "Копировать"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"Скопируйте и вставьте %1$sabout:preferences#search%2$s в адресную строку"
+msgstr "Скопируйте и вставьте %1$sabout:preferences#search%2$s в адресную строку"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5504,8 +5496,8 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
-"Скопируйте код с другого устройства. Перейдите в раздел %1$sНастройки Duck."
-"ai › Чаты › Sync & Backup › Синхронизировать с другим устройством%2$s и "
+"Скопируйте код с другого устройства. Перейдите в раздел %1$sНастройки "
+"Duck.ai › Чаты › Sync & Backup › Синхронизировать с другим устройством%2$s и "
 "повторите попытку."
 
 # smartling.placeholder_format=C
@@ -5615,8 +5607,7 @@ msgstr "Создать ссылку для доступа"
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
-msgstr ""
-"Создай список покупок с указанием количества ингредиентов из этого рецепта."
+msgstr "Создай список покупок с указанием количества ингредиентов из этого рецепта."
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5746,7 +5737,7 @@ msgstr "Текущая серия"
 #. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
 msgctxt "Suffix label indicating a tab is the currently active browser tab"
 msgid "Current Tab"
-msgstr ""
+msgstr "Текущая вкладка"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
@@ -6102,7 +6093,7 @@ msgstr "Удалить чаты старше 30 дней"
 #. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
 msgctxt "Button text in the modal for deleting all recent chats"
 msgid "Delete Chats and Shared Links"
-msgstr ""
+msgstr "Удалить чаты и ссылки общего доступа"
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6326,8 +6317,7 @@ msgstr "Диктовка в Duck.ai"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr ""
-"Диктовка анонимизируется и никогда не используется для обучения моделей ИИ."
+msgstr "Диктовка анонимизируется и никогда не используется для обучения моделей ИИ."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6520,7 +6510,7 @@ msgstr "Закрыть рекламу"
 #. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the close button on the survey banner"
 msgid "Dismiss survey"
-msgstr ""
+msgstr "Закрыть опрос"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6830,8 +6820,7 @@ msgctxt "Full sentence for drafting a social media post"
 msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
-msgstr ""
-"Предложи несколько вариантов поста для соцсетей с приглашением на вечеринку."
+msgstr "Предложи несколько вариантов поста для соцсетей с приглашением на вечеринку."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6853,8 +6842,7 @@ msgstr "Подготовь пост для соцсетей"
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Drag %sThis Button%s on top of the home icon:"
-msgstr ""
-"Переместите %1$sЭту кнопку%2$s на верхнюю часть значка домашней страницы:"
+msgstr "Переместите %1$sЭту кнопку%2$s на верхнюю часть значка домашней страницы:"
 
 # smartling.placeholder_format=C
 #. Indicates this is the number of draws for this team in e.g. soccer
@@ -7075,8 +7063,8 @@ msgid ""
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 "Duck.ai позволяет вести приватные беседы с популярными ИИ-моделями. При "
-"отключении этой настройки кнопки Duck.ai и ссылки будут скрыты, но вы по-"
-"прежнему можете перейти на %1$sduck.ai%2$s и использовать инструмент "
+"отключении этой настройки кнопки Duck.ai и ссылки будут скрыты, но вы "
+"по-прежнему можете перейти на %1$sduck.ai%2$s и использовать инструмент "
 "напрямую."
 
 # smartling.placeholder_format=C
@@ -7160,8 +7148,8 @@ msgid ""
 "models, privacy focused AI, no account AI chat"
 msgstr ""
 "Duck.ai, DuckDuckGo AI, приватный чат-бот, бесплатный чат с ИИ, анонимный "
-"чат с ИИ, ИИ-чат без регистрации, OpenAI, Anthropic, Llama, Mistral, ИИ-"
-"модели с открытым кодом, конфиденциальный ИИ, чат с ИИ без учетной записи"
+"чат с ИИ, ИИ-чат без регистрации, OpenAI, Anthropic, Llama, Mistral, "
+"ИИ-модели с открытым кодом, конфиденциальный ИИ, чат с ИИ без учетной записи"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7337,8 +7325,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"Сервис DuckDuckGo AI Chat временно недоступен. Повторите попытку позже."
+msgstr "Сервис DuckDuckGo AI Chat временно недоступен. Повторите попытку позже."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7652,8 +7639,8 @@ msgid ""
 msgstr ""
 "Каждый раз, когда вы просите нас порекомендовать парольную фразу, мы "
 "запрашиваем с серверов DuckDuckGo длинный список случайных слов. Затем в "
-"браузере мы наугад выбираем из списка 4–5 составных слов длиной минимум 18–"
-"20 символов."
+"браузере мы наугад выбираем из списка 4–5 составных слов длиной минимум "
+"18–20 символов."
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7710,7 +7697,7 @@ msgstr "Редактировать запрос"
 #. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the message-editing text area"
 msgid "Edit message"
-msgstr ""
+msgstr "Редактирование сообщения"
 
 # smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
@@ -7943,7 +7930,7 @@ msgstr "Зашифрованная модель"
 #. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
 msgctxt "Share modal info bullet about encryption"
 msgid "Encrypted so DuckDuckGo can't read your chat."
-msgstr ""
+msgstr "Зашифровано. Ваш чат не сможет прочитать даже DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8781,7 +8768,7 @@ msgstr "Последующий вопрос"
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
-msgstr ""
+msgstr "Последующая переписка остается конфиденциальной."
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -9305,7 +9292,7 @@ msgstr ""
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
 msgctxt "Tooltip on the header logo for sunglasses searches"
 msgid "Get DuckDuckGo sunglasses and other gear."
-msgstr ""
+msgstr "Получите солнцезащитные очки DuckDuckGo и другие товары."
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10188,8 +10175,7 @@ msgstr "Ответ пригодился"
 #. The title of a menu that shows other applications DuckDuckGo has made.
 msgctxt "showcase_aria_dropdown"
 msgid "Here are some things that we made that you might like."
-msgstr ""
-"Мы сделали несколько приложений, которые могут вас заинтересовать. Вот они!"
+msgstr "Мы сделали несколько приложений, которые могут вас заинтересовать. Вот они!"
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -10546,7 +10532,7 @@ msgstr "Как это работает?"
 #. Headline in chat history about modals for the temporary encrypted server storage explanation.
 msgctxt "Chat history about modal list item headline"
 msgid "How it works"
-msgstr ""
+msgstr "Как это работает"
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -10914,8 +10900,7 @@ msgstr "Изображения по запросу «%1$s»"
 # smartling.placeholder_format=C
 #. A label that indicates a specific search result for images has been blocked by the safe search filter. The placeholder value is the name of the search result that was blocked.
 msgid "Images for %s blocked by safe search"
-msgstr ""
-"Изображения по запросу «%1$s» заблокированы в рамках безопасного поиска."
+msgstr "Изображения по запросу «%1$s» заблокированы в рамках безопасного поиска."
 
 # smartling.placeholder_format=C
 #. Title for the section that showcases the image results for a certain query, ex. Images for <b>beach</b>
@@ -11805,8 +11790,7 @@ msgstr "Подробнее об активной защите конфиденц
 # smartling.placeholder_format=C
 msgctxt "showcase_newsletter"
 msgid "Learn about online privacy right in your inbox."
-msgstr ""
-"Получайте рекомендации о защите персональных данных на электронную почту."
+msgstr "Получайте рекомендации о защите персональных данных на электронную почту."
 
 # smartling.placeholder_format=C
 #. Link to a page with more information about how DuckDuckGo settings are managed.
@@ -11860,8 +11844,7 @@ msgstr "Подробнее о работе этой функции"
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
 msgid "Learn why reducing online tracking is important."
-msgstr ""
-"Узнайте, почему важно ограничивать отслеживание ваших действий в интернете."
+msgstr "Узнайте, почему важно ограничивать отслеживание ваших действий в интернете."
 
 # smartling.placeholder_format=C
 #. A link that takes users to a page where they can learn more about the dangers of online tracking.
@@ -12007,7 +11990,7 @@ msgstr "Ссылка истекает через 7 дней."
 #. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days. People can save a chat copy."
-msgstr ""
+msgstr "Ссылка истекает через 7 дней. Другие пользователи могут сохранить копию чата."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14134,7 +14117,7 @@ msgstr "Хорошо, понятно!"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "OPTIONAL"
-msgstr ""
+msgstr "НЕОБЯЗАТЕЛЬНО"
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -14264,8 +14247,7 @@ msgstr "Оман"
 #. http://i.imgur.com/zQWKLIm.png
 msgctxt "settings"
 msgid "Omits objectionable (mostly adult) material"
-msgstr ""
-"Исключает из выдачи нежелательные материалы (в основном — \"для взрослых\")"
+msgstr "Исключает из выдачи нежелательные материалы (в основном — \"для взрослых\")"
 
 # smartling.placeholder_format=C
 msgid "On"
@@ -14462,8 +14444,7 @@ msgstr "Открыть сайт %1$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr ""
-"Убедитесь, что %1$sгеолокация%2$s (в одноименном разделе) %3$sвключена%4$s."
+msgstr "Убедитесь, что %1$sгеолокация%2$s (в одноименном разделе) %3$sвключена%4$s."
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -14632,8 +14613,7 @@ msgstr "Открыть панель «Как работает Duck.ai»"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Откройте меню Safari и выберите пункт «%1$sНастройки для DuckDuckGo...%2$s»"
+msgstr "Откройте меню Safari и выберите пункт «%1$sНастройки для DuckDuckGo...%2$s»"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -16158,8 +16138,7 @@ msgstr "Приватные чаты без сохранения"
 #. The device location shared is is not logged by us
 msgctxt "precise_user_location"
 msgid "Private to us and secured on your device"
-msgstr ""
-"Ваши данные остаются конфиденциальными и надежно хранятся на вашем устройстве"
+msgstr "Ваши данные остаются конфиденциальными и надежно хранятся на вашем устройстве"
 
 # smartling.placeholder_format=C
 #. Heading above the group of Pro-tier locked models in the model picker dropdown, when the user is on the Plus tier.
@@ -16268,7 +16247,7 @@ msgstr "Защищено"
 #. Headline in sync-enabled chat history about modals explaining encrypted server storage.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Protected with end-to-end encryption"
-msgstr ""
+msgstr "Защищено сквозным шифрованием"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -16407,7 +16386,7 @@ msgstr "Рейтинги"
 #. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
 msgctxt "star rating on a product"
 msgid "Rated %s out of %s"
-msgstr ""
+msgstr "Оценка: %1$s из %2$s"
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -16500,22 +16479,19 @@ msgstr "Аналитическая ИИ-модель со средним уро�
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr ""
-"Рассуждения позволяют получить более обдуманные ответы на сложные вопросы."
+msgstr "Рассуждения позволяют получить более обдуманные ответы на сложные вопросы."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
-msgstr ""
-"Более глубокие рассуждения, но лимиты достигаются в 2–5 раз быстрее. %1$s"
+msgstr "Более глубокие рассуждения, но лимиты достигаются в 2–5 раз быстрее. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr ""
-"Более глубокие рассуждения, но лимиты расходуются в 2–5 раз быстрее. %1$s"
+msgstr "Более глубокие рассуждения, но лимиты расходуются в 2–5 раз быстрее. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -17648,7 +17624,7 @@ msgstr "Чаты сохраняются на всех устройствах."
 #. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
 msgctxt "Chat history about modal list item headline"
 msgid "Save your chats on this device"
-msgstr ""
+msgstr "Сохраняй чаты на этом устройстве"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
@@ -17860,7 +17836,7 @@ msgctxt ""
 "Placeholder and accessibility label for the search input in the tab picker "
 "dialog"
 msgid "Search"
-msgstr ""
+msgstr "Поиск"
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18232,8 +18208,7 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr ""
-"Надежно хранится на сервере DuckDuckGo с применением сквозного шифрования."
+msgstr "Надежно хранится на сервере DuckDuckGo с применением сквозного шифрования."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -18417,8 +18392,7 @@ msgstr "Выберите %1$sDuckDuckGo%2$s и нажмите %3$sУстанов
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr ""
-"Выберите %1$sDuckDuckGo%2$s поисковой системой по умолчанию в выпадающем меню"
+msgstr "Выберите %1$sDuckDuckGo%2$s поисковой системой по умолчанию в выпадающем меню"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
@@ -18438,8 +18412,7 @@ msgstr "Выберите %1$sDuckDuckGo%2$s в списке поисковых �
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr ""
-"Выберите %1$sDuckDuckGo%2$s в разделе%3$sПоисковая система по умолчанию%4$s"
+msgstr "Выберите %1$sDuckDuckGo%2$s в разделе%3$sПоисковая система по умолчанию%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -18524,8 +18497,7 @@ msgstr "Выберите %1$sНастройки%2$s, затем %3$sДополн
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr ""
-"Выберите %1$sНастройки%2$s, а затем %3$sПоисковая система по умолчанию%4$s"
+msgstr "Выберите %1$sНастройки%2$s, а затем %3$sПоисковая система по умолчанию%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -18621,8 +18593,7 @@ msgstr "Выбранный текст со страницы %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr ""
-"Выделенный текст слишком длинный. Попробуйте выбрать фрагмент покороче."
+msgstr "Выделенный текст слишком длинный. Попробуйте выбрать фрагмент покороче."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -18873,8 +18844,7 @@ msgstr "Поделиться"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Поделитесь DuckDuckGo и помогите друзьям вернуть свою конфиденциальность!"
+msgstr "Поделитесь DuckDuckGo и помогите друзьям вернуть свою конфиденциальность!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -19047,7 +19017,7 @@ msgstr "За покупками"
 #. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
 msgctxt "Button in the merchandise logo modal (mobile)"
 msgid "Shop Now"
-msgstr ""
+msgstr "За покупками"
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -19471,8 +19441,7 @@ msgstr "Показывает поисковые подсказки при вво
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr ""
-"Показывает преимущества приватного поиска с DuckDuckGo на стартовой странице"
+msgstr "Показывает преимущества приватного поиска с DuckDuckGo на стартовой странице"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19566,8 +19535,7 @@ msgstr "Поиск по сайту временно недоступен. Мы �
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"Сайты, которые ты заблокируешь, будут скрыты из всех твоих результатов поиска"
+msgstr "Сайты, которые ты заблокируешь, будут скрыты из всех твоих результатов поиска"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19720,8 +19688,7 @@ msgstr "Произошла ошибка при загрузке этого об�
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr ""
-"Что-то пошло не так при сохранении на сервер, пожалуйста, попробуйте снова."
+msgstr "Что-то пошло не так при сохранении на сервер, пожалуйста, попробуйте снова."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
@@ -19823,8 +19790,7 @@ msgctxt "noresults"
 msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
-msgstr ""
-"При отображении результатов произошла ошибка. %1$sПовторить попытку%2$s"
+msgstr "При отображении результатов произошла ошибка. %1$sПовторить попытку%2$s"
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
@@ -20710,6 +20676,8 @@ msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
 msgstr ""
+"Sync & Backup сохраняет больше ваших чатов и синхронизирует их на всех ваших "
+"устройствах."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20831,7 +20799,7 @@ msgstr "Чаты синхронизируются на всех устройст
 #. Headline in sync-enabled chat history about modals explaining cross-device sync.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Sync your chats across all your devices"
-msgstr ""
+msgstr "Синхронизируйте чаты на всех ваших устройствах"
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -20916,8 +20884,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
-"Берите Duck.ai с собой повсюду. Получайте быстрый доступ к чату с ИИ-"
-"помощником прямо в нашем бесплатном приложении — где бы вы ни находились."
+"Берите Duck.ai с собой повсюду. Получайте быстрый доступ к чату с "
+"ИИ-помощником прямо в нашем бесплатном приложении — где бы вы ни находились."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20926,8 +20894,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
-"Берите Duck.ai с собой повсюду. Получайте быстрый доступ к чату с ИИ-"
-"помощником прямо в нашем бесплатном браузере — где бы вы ни находились."
+"Берите Duck.ai с собой повсюду. Получайте быстрый доступ к чату с "
+"ИИ-помощником прямо в нашем бесплатном браузере — где бы вы ни находились."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -21238,8 +21206,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider does not save this chat or any associated data on their "
 "servers."
-msgstr ""
-"Поставщик не хранит этот чат и связанные с ним данные на своих серверах."
+msgstr "Поставщик не хранит этот чат и связанные с ним данные на своих серверах."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -21374,8 +21341,7 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr ""
-"Эта ИИ-модель больше недоступна. Попробуйте запустить чат с другой моделью."
+msgstr "Эта ИИ-модель больше недоступна. Попробуйте запустить чат с другой моделью."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -21420,12 +21386,14 @@ msgid ""
 "This chat and its generated images become public when you create and copy "
 "the link."
 msgstr ""
+"Этот чат и созданные в нём изображения станут общедоступными, когда ты "
+"создашь и скопируешь ссылку."
 
 # smartling.placeholder_format=C
 #. Explains that creating and copying a share link makes the selected chat content public.
 msgctxt "Share modal info bullet about public access"
 msgid "This chat becomes public when you create and copy the link."
-msgstr ""
+msgstr "Этот чат становится общедоступным, когда ты создаёшь и копируешь ссылку."
 
 # smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
@@ -21577,8 +21545,7 @@ msgstr ""
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr ""
-"Формат не поддерживается. Прикрепите изображение в JPG, PNG, WebP или GIF."
+msgstr "Формат не поддерживается. Прикрепите изображение в JPG, PNG, WebP или GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -21657,8 +21624,7 @@ msgstr "Для нормальной работы данной странице �
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Содержимое страницы будет отправлено в Duck.ai вместе с вашим сообщением."
+msgstr "Содержимое страницы будет отправлено в Duck.ai вместе с вашим сообщением."
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21746,8 +21712,7 @@ msgstr "Здесь это видео пока недоступно. Его мо�
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Эта страница не использует безопасное зашифрованное соединение (HTTPS)."
+msgstr "Эта страница не использует безопасное зашифрованное соединение (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21894,8 +21859,7 @@ msgstr ""
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to Duck.ai’s %s and %s"
-msgstr ""
-"Чтобы продолжить, примите положения разделов «%1$s» и «%2$s» сервиса Duck.ai."
+msgstr "Чтобы продолжить, примите положения разделов «%1$s» и «%2$s» сервиса Duck.ai."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to AI Chat Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to DuckDuckGo AI Chat’s Privacy Policy and Terms of Service'
@@ -21968,7 +21932,7 @@ msgstr "Сегодня"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
-msgstr ""
+msgstr "Переключитесь на приватный чат с ИИ или %1$sотключите его в настройках%2$s."
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -22324,13 +22288,11 @@ msgstr "Чтобы не получать подобные сообщения, п
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Попробуйте %1$s — нашу первую ИИ-модель с нулевой видимостью для поставщика."
+msgstr "Попробуйте %1$s — нашу первую ИИ-модель с нулевой видимостью для поставщика."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
-msgstr ""
-"Попробуйте %1$sDuck.ai%2$s — приватный чат с искусственным интеллектом:"
+msgstr "Попробуйте %1$sDuck.ai%2$s — приватный чат с искусственным интеллектом:"
 
 # smartling.placeholder_format=C
 #. Button text to retry loading an explore more question that failed
@@ -22467,16 +22429,14 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Для более точных результатов попробуйте использовать анонимную геопозицию."
+msgstr "Для более точных результатов попробуйте использовать анонимную геопозицию."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Попробуйте поэкспериментировать с каждой моделью: они дадут разные ответы."
+msgstr "Попробуйте поэкспериментировать с каждой моделью: они дадут разные ответы."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -22664,8 +22624,7 @@ msgstr "Новинки платформы: ИИ-модели с открытым
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
-msgstr ""
-"Попробуйте начать с готовых запросов или введите собственный вариант ниже."
+msgstr "Попробуйте начать с готовых запросов или введите собственный вариант ниже."
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -22855,8 +22814,7 @@ msgstr "Активировать переключатель Duck.ai"
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Precise Location” for more accurate results."
-msgstr ""
-"Для получения более точных результатов выберите вариант «Точная геопозиция»."
+msgstr "Для получения более точных результатов выберите вариант «Точная геопозиция»."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -23063,15 +23021,14 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"Под %1$sОткрыть с%2$s выберите %3$sОпределенная страница или страницы%4$s"
+msgstr "Под %1$sОткрыть с%2$s выберите %3$sОпределенная страница или страницы%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"В меню %1$sПри запуске > Домашняя страница%2$s введите: https://duckduckgo."
-"com"
+"В меню %1$sПри запуске > Домашняя страница%2$s введите: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23081,16 +23038,15 @@ msgstr "В меню %1$sНастройки поиска%2$s выберите %3$
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr ""
-"В разделе %1$sпоиска в адресной строке%2$s выберите %3$sДобавить новый%4$s"
+msgstr "В разделе %1$sпоиска в адресной строке%2$s выберите %3$sДобавить новый%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"Под разделом %1$sПоиск%2$s нажмите на %3$sУправление поисковыми системами..."
-"%4$s"
+"Под разделом %1$sПоиск%2$s нажмите на %3$sУправление поисковыми "
+"системами...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -23104,8 +23060,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr ""
-"В разделе поиска нажмите на выпадающий список и выберите %1$sDuckDuckGo%2$s"
+msgstr "В разделе поиска нажмите на выпадающий список и выберите %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -23346,8 +23301,8 @@ msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
 msgstr ""
-"Чтобы активировать подписку в Duck.ai и пользоваться продвинутыми ИИ-"
-"моделями, обновите браузер DuckDuckGo."
+"Чтобы активировать подписку в Duck.ai и пользоваться продвинутыми "
+"ИИ-моделями, обновите браузер DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -23589,8 +23544,7 @@ msgstr "Используйте DuckDuckGo Private Search"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"Пользуйтесь DuckDuckGo Private Search на вашем iPad, iPhone, или Android!"
+msgstr "Пользуйтесь DuckDuckGo Private Search на вашем iPad, iPhone, или Android!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -23724,8 +23678,7 @@ msgstr "Видеоролики заблокированы в рамках без
 # smartling.placeholder_format=C
 #. A label that indicates a specific search result for videos has been blocked by the safe search filter. The placeholder value is the name of the search result that was blocked.
 msgid "Videos for %s blocked by safe search"
-msgstr ""
-"Видеоролики по запросу «%1$s» заблокированы в рамках безопасного поиска."
+msgstr "Видеоролики по запросу «%1$s» заблокированы в рамках безопасного поиска."
 
 # smartling.placeholder_format=C
 #. Title for the section that showcases the video results for a certain query, ex. Videos for <b>japan</b>
@@ -23820,6 +23773,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Yelp's ad network."
 msgstr ""
+"DuckDuckGo защищает конфиденциальность пользователей при просмотре рекламных "
+"объявлений. За переходы по объявлениям отвечает рекламная сеть компании Yelp."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -24252,8 +24207,7 @@ msgstr "Мы не отслеживаем вас. Никогда."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr ""
-"Никакой слежки за вами. Вот краткий обзор нашей Политики конфиденциальности."
+msgstr "Никакой слежки за вами. Вот краткий обзор нашей Политики конфиденциальности."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -24294,8 +24248,7 @@ msgstr "Мы не следим за вами, ни в режиме приват�
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr ""
-"Мы не шпионим за вами. Вот краткий обзор нашей политики конфиденциальности…"
+msgstr "Мы не шпионим за вами. Вот краткий обзор нашей политики конфиденциальности…"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -24401,8 +24354,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr ""
-"Пока вы гуляете по Интернету, мы не даем трекерам собирать ваши данные."
+msgstr "Пока вы гуляете по Интернету, мы не даем трекерам собирать ваши данные."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
@@ -24809,8 +24761,7 @@ msgstr "Чему я научусь на этом курсе?"
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr ""
-"Каковы основные контраргументы или критические замечания по этому поводу?"
+msgstr "Каковы основные контраргументы или критические замечания по этому поводу?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
@@ -25088,8 +25039,7 @@ msgstr "На какие бренды обратить внимание нови�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"При активации этой настройки Duck.ai будет показывать быстрые ответы в чате."
+msgstr "При активации этой настройки Duck.ai будет показывать быстрые ответы в чате."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -25297,6 +25247,8 @@ msgid ""
 "With chat history on, up to %s of your most recent chats will be saved on "
 "this device."
 msgstr ""
+"Если история чатов включена, на этом устройстве будет сохраняться до %1$s "
+"последних чатов."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline in the About Chat History modal.
@@ -25304,6 +25256,8 @@ msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, your most recent chats will be saved on this device."
 msgstr ""
+"Если история чатов включена, последние чаты будут сохраняться на этом "
+"устройстве."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -25629,8 +25583,7 @@ msgstr ""
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
-msgstr ""
-"Сервис %1$sDuck.ai%2$s также умеет отвечать на вопросы и резюмировать текст."
+msgstr "Сервис %1$sDuck.ai%2$s также умеет отвечать на вопросы и резюмировать текст."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -25659,8 +25612,7 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr ""
-"Вы в любой момент можете изменить свой выбор в %1$sнастройках поиска%2$s"
+msgstr "Вы в любой момент можете изменить свой выбор в %1$sнастройках поиска%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
@@ -25705,8 +25657,7 @@ msgstr "Вы можете продолжить чат, используя сво
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Теперь на этом устройстве можно хранить до 100 чатов. Общайтесь больше!"
+msgstr "Теперь на этом устройстве можно хранить до 100 чатов. Общайтесь больше!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -25724,29 +25675,25 @@ msgstr "Число файлов, прикрепляемых к одной бес
 #. Error message displayed when the user has select more images than are allowed to be uploaded. Placeholder is the number of images that are allowed. E.g. You can only attach 3 images per chat
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach %s images at a time"
-msgstr ""
-"Число изображений, прикрепляемых за один раз, ограничено: максимум %1$s."
+msgstr "Число изображений, прикрепляемых за один раз, ограничено: максимум %1$s."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded. Placeholder is the number of images that are allowed. E.g. You can only attach 3 images per chat
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach %s images at a time."
-msgstr ""
-"Число изображений, прикрепляемых за один раз, ограничено: максимум %1$s."
+msgstr "Число изображений, прикрепляемых за один раз, ограничено: максимум %1$s."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more images across the conversation than allowed. Placeholder is the maximum number of images. E.g. You can only attach 5 images per conversation
 msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation"
-msgstr ""
-"Число изображений, прикрепляемых к одной беседе, ограничено: максимум %1$s."
+msgstr "Число изображений, прикрепляемых к одной беседе, ограничено: максимум %1$s."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more images across the conversation than allowed. Placeholder is the maximum number of images. E.g. You can only attach 5 images per conversation
 msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
-msgstr ""
-"Число изображений, прикрепляемых к одной беседе, ограничено: максимум %1$s."
+msgstr "Число изображений, прикрепляемых к одной беседе, ограничено: максимум %1$s."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
@@ -25999,8 +25946,7 @@ msgstr "Вы исчерпали голосовой лимит на сегодн�
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"Вы достигли лимита использования функции диктовки. Повторите попытку позже."
+msgstr "Вы достигли лимита использования функции диктовки. Повторите попытку позже."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -26068,8 +26014,7 @@ msgstr ""
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr ""
-"Ваши чаты Duck.ai синхронизируются с использованием сквозного шифрования."
+msgstr "Ваши чаты Duck.ai синхронизируются с использованием сквозного шифрования."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -26191,8 +26136,7 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr ""
-"Ваши чаты сохраняются в секрете и не используются для обучения моделей ИИ"
+msgstr "Ваши чаты сохраняются в секрете и не используются для обучения моделей ИИ"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -26214,8 +26158,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"Ваши чаты конфиденциальны. Мы не храним их и не используем для обучения ИИ-"
-"моделей."
+"Ваши чаты конфиденциальны. Мы не храним их и не используем для обучения "
+"ИИ-моделей."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -26249,8 +26193,8 @@ msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
 msgstr ""
-"Ваши чаты импортированы. Продолжай с того места, где ты остановился, в Duck."
-"ai."
+"Ваши чаты импортированы. Продолжай с того места, где ты остановился, в "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -26708,7 +26652,7 @@ msgstr "мин."
 #. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the chat options menu button"
 msgid "menu"
-msgstr ""
+msgstr "меню"
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/sc_IT/LC_MESSAGES/duckduckgo.po
+++ b/locales/sc_IT/LC_MESSAGES/duckduckgo.po
@@ -980,6 +980,11 @@ msgstr "A subra de nois"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1083,6 +1088,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "Publitzidade suspetosa"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Agiunghe DuckDuckGo"
@@ -1105,6 +1122,24 @@ msgstr "Agiunghe DuckDuckGo che a motore de chirca"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Agiunghe DuckDuckGo a %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1143,6 +1178,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1215,6 +1264,11 @@ msgstr "Cumplementos"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1462,6 +1516,11 @@ msgstr "Totu is colores"
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2829,6 +2888,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3234,9 +3300,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3252,6 +3328,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4553,6 +4636,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr "Sèrie atuale"
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4837,6 +4925,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5175,6 +5268,11 @@ msgstr "Iscarta sempre"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6087,6 +6185,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6268,6 +6371,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6946,6 +7054,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7364,6 +7477,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8360,6 +8478,11 @@ msgid "How is it anonymous?"
 msgstr "Comente est anònimu?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9547,6 +9670,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11290,6 +11418,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "AB, cumprèndidu!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -13016,6 +13149,11 @@ msgstr "Ampara is datos tuos in totu is dispositivos."
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -13122,6 +13260,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -14115,6 +14258,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14280,6 +14428,13 @@ msgstr "Chirca"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15237,6 +15392,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16590,6 +16750,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16670,6 +16837,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -17140,6 +17312,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17547,6 +17733,11 @@ msgstr "Oe"
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -19027,6 +19218,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -20199,6 +20397,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21307,6 +21518,11 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "m"
 msgstr "m"
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.
 msgctxt "Aria label for the menu button"

--- a/locales/si_LK/LC_MESSAGES/duckduckgo.po
+++ b/locales/si_LK/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: si_LK\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1210,6 +1210,12 @@ msgid "About our ads"
 msgstr "අපගේ දැන්වීම් ගැන"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1339,6 +1345,20 @@ msgid "Ad is suspicious"
 msgstr "දැන්වීම සැක සහිතයි"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "DuckDuckGo එකතු කරන්න"
@@ -1364,6 +1384,27 @@ msgstr "DuckDuckGo සෙවුම් පද්ධතියක් ලෙස එ�
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "%1$s වෙත DuckDuckGo එක් කරන්න"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1409,6 +1450,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "පිටු අන්තර්ගතය එක් කරන්න"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1494,6 +1551,12 @@ msgstr "ඇඩෝන"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "අවසන් සැරසීම් එකතු කිරීම"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1792,6 +1855,12 @@ msgstr "සියලු වර්ණ"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "සියල්ල සම්පූර්ණයි!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3477,6 +3546,14 @@ msgid "Cancel"
 msgstr "අවලංගු කරන්න"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3967,10 +4044,22 @@ msgid "Chat response is offensive"
 msgstr "මෙම පරිවර්තනය අහිතකරය"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "%1$s සමඟ කතාබස් කරන්න"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3989,6 +4078,14 @@ msgstr "කතාබස්"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "කතාබස්"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5575,6 +5672,12 @@ msgid "Current Streak"
 msgstr "වත්මන් රේඛාව"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5920,6 +6023,12 @@ msgstr "මකා දැමූ කතාබස්"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "දින 30කට වඩා පැරණි කතාබස් මකන්න"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6333,6 +6442,12 @@ msgstr "හැමදාටම නැති කරන්න"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "ප්‍රවර්ධනය ඉවත ලන්න"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7486,6 +7601,12 @@ msgid "Edit Prompt"
 msgstr "විමසුම සංස්කරණය කරන්න"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7704,6 +7825,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "ගුප්ත කේතිත ආකෘතිය"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8522,6 +8649,12 @@ msgid "Follow-up question"
 msgstr "පසු විපරම් ප්‍රශ්නය"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9032,6 +9165,12 @@ msgstr ""
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr "DuckDuckGo VPN, උසස් Duck.ai, සහ Identity Theft Restoration ලබා ගන්න."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10256,6 +10395,12 @@ msgstr "කෙසේද එය නිර්නාමික වන්නේ?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "එය ක්‍රියා කරන ආකාරය"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11688,6 +11833,12 @@ msgstr "ප්‍රතිවාදී සීමාවෙන් පන්දු 
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "සබැඳිය දින 7කින් කල් ඉකුත් වේ."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13804,6 +13955,12 @@ msgid "OK, got it!"
 msgstr "හරි, දැනුවත් උනා!"
 
 # smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -15903,6 +16060,12 @@ msgid "Protected"
 msgstr "ආරක්ෂිතයි"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "ආරක්ෂාව. පෞද්ගලිකත්වය. සිතේ සාමය."
@@ -16034,6 +16197,12 @@ msgstr "වැසි"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "ශ්රේණිගත කිරීම්"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17255,6 +17424,12 @@ msgid "Save your chats across all your devices."
 msgstr "ඔබගේ සියලු උපාංග හරහා ඔබේ කතාබස් සුරකින්න."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17453,6 +17628,14 @@ msgstr "සොයන්න"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "සොයන්න"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18613,6 +18796,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "සාප්පු සවාරි යාම"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20250,6 +20439,14 @@ msgstr ""
 "Sync & Backup දත්ත මාස 18ක කාලයක් තිස්සේ අකර්මණ්‍යව තිබූ පසු ඒවා ප්‍රතිසාධනය කළ නොහැක."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20361,6 +20558,12 @@ msgstr "සමීපස්ථ උපාංගයක් සමඟ සමමුහ
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "ඔබේ කතාබස් ඔබගේ සියලු උපාංග අතර සමමුහුර්ත කරන්න."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -20938,6 +21141,22 @@ msgid "This Week"
 msgstr "මේ සතියේ"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21451,6 +21670,12 @@ msgstr "අද"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "අද"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23259,6 +23484,14 @@ msgstr ""
 "දැන්වීම් ජාලය විසින් කළමනාකරණය කරනු ලැබේ."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "වර්ජින් දූපත්"
 
@@ -24712,6 +24945,21 @@ msgstr ""
 "නොකෙරේ. '%1$s' මෙනුව තුළ ඕනෑම වේලාවක එය සක්‍රිය හෝ අක්‍රිය කරන්න."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26076,6 +26324,12 @@ msgstr "විනා"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "විනා"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/si_LK/LC_MESSAGES/duckduckgo.po
+++ b/locales/si_LK/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: si_LK\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -191,8 +191,8 @@ msgid ""
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
 "%1$s ලබා ගත හැක්කේ Pro සමඟ පමණි. කතාබහ දිගටම කරගෙන යාමට මෙම බ්‍රවුසරයේ ඔබේ "
-"DuckDuckGo ග්‍රාහකත්වය නැවත උත්ශ්‍රේණිගත කරන්න, නැතහොත් Plus හෝ නොමිලේ ප්‍රකාරයකට මාරු "
-"වන්න."
+"DuckDuckGo ග්‍රාහකත්වය නැවත උත්ශ්‍රේණිගත කරන්න, නැතහොත් Plus හෝ නොමිලේ "
+"ප්‍රකාරයකට මාරු වන්න."
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -203,8 +203,8 @@ msgid ""
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
 "%1$s ලබා ගත හැක්කේ Pro සමඟ පමණි. කතාබහ දිගටම කරගෙන යාමට මෙම බ්‍රවුසරයේ ඔබේ "
-"DuckDuckGo ග්‍රාහකත්වය නැවත උත්ශ්‍රේණිගත කරන්න, නැතහොත් Plus හෝ නොමිලේ ප්‍රකාරයකට මාරු "
-"වන්න."
+"DuckDuckGo ග්‍රාහකත්වය නැවත උත්ශ්‍රේණිගත කරන්න, නැතහොත් Plus හෝ නොමිලේ "
+"ප්‍රකාරයකට මාරු වන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -221,7 +221,8 @@ msgid ""
 "model."
 msgstr ""
 "%1$s ලබා ගත හැක්කේ DuckDuckGo දායකත්වයක් සමඟ පමණි. චැට් දිගටම කරගෙන යාමට මෙම "
-"බ්‍රව්සරයේ ඔබේ දායකත්වය නැවත සක්‍රිය කරන්න, නැත්නම් නොමිලේ ආකෘතියකට මාරු වන්න."
+"බ්‍රව්සරයේ ඔබේ දායකත්වය නැවත සක්‍රිය කරන්න, නැත්නම් නොමිලේ ආකෘතියකට මාරු "
+"වන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -230,8 +231,8 @@ msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
 msgstr ""
-"%1$s තාවකාලිකව ලබා ගත නොහැක. කරුණාකර වෙනත් ආකෘතියකට මාරු වන්න නැතිනම් පසුව නැවත උත්සාහ "
-"කරන්න."
+"%1$s තාවකාලිකව ලබා ගත නොහැක. කරුණාකර වෙනත් ආකෘතියකට මාරු වන්න නැතිනම් පසුව "
+"නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -328,9 +329,9 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$s ක් රියාත්මක වන්නේ විශ්වාසදායක ක් රියාත්මක කිරීමේ පරිසරයක ය. මෙයින් අදහස් කරන්නේ ආකෘති "
-"සපයන්නාට පවා ඔබේ විමසීම් හෝ ආකෘතියේ ප්‍රතිචාර දැකීමට හෝ මෙම කතාබහ ඔවුන්ගේ සර්වරවල සුරැකීමට "
-"නොහැකි බවයි."
+"%1$s ක් රියාත්මක වන්නේ විශ්වාසදායක ක් රියාත්මක කිරීමේ පරිසරයක ය. මෙයින් "
+"අදහස් කරන්නේ ආකෘති සපයන්නාට පවා ඔබේ විමසීම් හෝ ආකෘතියේ ප්‍රතිචාර දැකීමට හෝ "
+"මෙම කතාබහ ඔවුන්ගේ සර්වරවල සුරැකීමට නොහැකි බවයි."
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -416,8 +417,8 @@ msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
 msgstr ""
-"%1$s දින %2$sකින් (%3$s) Duck.ai හැර යනු ඇත. ඊට පසු, ඔබට මෙම කතාබහ දිගටම කරගෙන "
-"යාමට ආකෘති මාරු කළ හැකි ය."
+"%1$s දින %2$sකින් (%3$s) Duck.ai හැර යනු ඇත. ඊට පසු, ඔබට මෙම කතාබහ දිගටම "
+"කරගෙන යාමට ආකෘති මාරු කළ හැකි ය."
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -428,8 +429,8 @@ msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
 msgstr ""
-"%1$s දින 1කින් Duck.ai හැර යනු ඇත (%2$s). ඊට පසු, ඔබට මෙම කතාබහ දිගටම කරගෙන යාමට "
-"ආකෘති මාරු කළ හැකි ය."
+"%1$s දින 1කින් Duck.ai හැර යනු ඇත (%2$s). ඊට පසු, ඔබට මෙම කතාබහ දිගටම කරගෙන "
+"යාමට ආකෘති මාරු කළ හැකි ය."
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -442,8 +443,8 @@ msgstr "%1$s වචන"
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$sක්ලික් කරන්න %2$sඑක් කරන්න%3$sපරීක්ෂා කරන්න %4$sඉඩ දෙන්න%5$s, අනතුරුව %6$sහරි%7$sක්ලික් "
-"කරන්න"
+"%1$sක්ලික් කරන්න %2$sඑක් කරන්න%3$sපරීක්ෂා කරන්න %4$sඉඩ දෙන්න%5$s, අනතුරුව "
+"%6$sහරි%7$sක්ලික් කරන්න"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -451,8 +452,8 @@ msgstr ""
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$sAllow%2$s %3$sක්ලික් කරන්න %4$sAdd%5$s ක්ලික් කරන්න %6$sAllow%7$s මත හරි ලකුණ "
-"දමන්න, ඉන්පසුව %8$sOkay%9$s ක්ලික් කරන්න"
+"%1$sAllow%2$s %3$sක්ලික් කරන්න %4$sAdd%5$s ක්ලික් කරන්න %6$sAllow%7$s මත හරි "
+"ලකුණ දමන්න, ඉන්පසුව %8$sOkay%9$s ක්ලික් කරන්න"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -472,7 +473,8 @@ msgid ""
 "%sClick here%s to try again, if you think there should be results for this "
 "search."
 msgstr ""
-"මෙයට ප්‍රතිඵලයක් තිබෙන්නටම අවශ්‍යයැයි සිතෙනවානම්, නැවත් උත්සාහ කිරීමට %1$sමෙතන ක්ලික් කරන්න%2$s."
+"මෙයට ප්‍රතිඵලයක් තිබෙන්නටම අවශ්‍යයැයි සිතෙනවානම්, නැවත් උත්සාහ කිරීමට "
+"%1$sමෙතන ක්ලික් කරන්න%2$s."
 
 # smartling.placeholder_format=C
 #. Header for a page with information about sharing DuckDuckGo.
@@ -505,7 +507,8 @@ msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
 msgstr ""
-"%1$sDuckDuckGo සර්වරයේ කතාබස් පෞද්ගලිකව ගබඩා වන ආකාරය පිළිබඳ%2$s වැඩිදුර ඉගෙන ගන්න."
+"%1$sDuckDuckGo සර්වරයේ කතාබස් පෞද්ගලිකව ගබඩා වන ආකාරය පිළිබඳ%2$s වැඩිදුර "
+"ඉගෙන ගන්න."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -524,8 +527,8 @@ msgstr "මුල් තිරයේ ඇති DuckDuckGo යෙදුම් න
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
 msgstr ""
-"%1$sඅපොයි!%2$s%3$sකුමක් හෝ වැරැද්දක් සිදු විය. කරුණාකර %4$sනැවුම් කරන්න%5$s සහ නැවත "
-"උත්සාහ කරන්න."
+"%1$sඅපොයි!%2$s%3$sකුමක් හෝ වැරැද්දක් සිදු විය. කරුණාකර %4$sනැවුම් කරන්න%5$s "
+"සහ නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -877,7 +880,8 @@ msgstr "පැය 6ක පරිශීලන සීමාවට ළඟා වී
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
 msgstr ""
-"පැය 6ක පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබට %1$sට පසුව මෙම කතාබහ දිගටම කරගෙන යා හැක."
+"පැය 6ක පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබට %1$sට පසුව මෙම කතාබහ දිගටම කරගෙන යා "
+"හැක."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -885,8 +889,8 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "6-hour usage limit reached. You can keep chatting by using your daily limit."
 msgstr ""
-"පැය 6ක පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබේ දෛනික සීමාව භාවිතා කිරීමෙන් ඔබට දිගට ම කතාබස් කළ "
-"හැකි ය."
+"පැය 6ක පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබේ දෛනික සීමාව භාවිතා කිරීමෙන් ඔබට දිගට "
+"ම කතාබස් කළ හැකි ය."
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes abbreviation
@@ -940,8 +944,8 @@ msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
 msgstr ""
-"ජාල ගැටලුවක් හේතුවෙන් Search Assist මගින් පිළිතුරක් ජනනය කිරීම වැළකී ඇත. කරුණාකර ඔබේ "
-"සම්බන්ධතාව පරීක්ෂා කර නැවත උත්සාහ කරන්න."
+"ජාල ගැටලුවක් හේතුවෙන් Search Assist මගින් පිළිතුරක් ජනනය කිරීම වැළකී ඇත. "
+"කරුණාකර ඔබේ සම්බන්ධතාව පරීක්ෂා කර නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
@@ -949,8 +953,8 @@ msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
 msgstr ""
-"AI Chat හි නව අනුවාදයක් ලබා ගත හැකි ය! දිගටම කරගෙන යාමට කරුණාකර මෙම පිටුව නැවත නැවුම් "
-"කරන්න."
+"AI Chat හි නව අනුවාදයක් ලබා ගත හැකි ය! දිගටම කරගෙන යාමට කරුණාකර මෙම පිටුව "
+"නැවත නැවුම් කරන්න."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
@@ -958,8 +962,8 @@ msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
 msgstr ""
-"Duck.ai හි නව අනුවාදයක් ලබා ගත හැකි ය! දිගටම කරගෙන යාමට කරුණාකර මෙම පිටුව නැවත නැවුම් "
-"කරන්න."
+"Duck.ai හි නව අනුවාදයක් ලබා ගත හැකි ය! දිගටම කරගෙන යාමට කරුණාකර මෙම පිටුව "
+"නැවත නැවුම් කරන්න."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1003,9 +1007,10 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"AI Chat ඔබට 3පාර්ශවයේ AI Chat ආකෘති සමඟ නිර්නාමික සංවාද පැවැත්වීමට ඉඩ සලසයි. මෙය "
-"ක්‍රියා විරහිත කිරීමෙන් DuckDuckGo Search AI Chat විශේෂාංගය සඟවනු ඇත. මෙම සැකසුම ක්‍රියා "
-"විරහිත වූ විට ඔබට තවමත් %1$sduckduckgo.com/aichat%2$s AI Chat වෙත ප්‍රවේශ විය හැකිය."
+"AI Chat ඔබට 3පාර්ශවයේ AI Chat ආකෘති සමඟ නිර්නාමික සංවාද පැවැත්වීමට ඉඩ සලසයි. "
+"මෙය ක්‍රියා විරහිත කිරීමෙන් DuckDuckGo Search AI Chat විශේෂාංගය සඟවනු ඇත. "
+"මෙම සැකසුම ක්‍රියා විරහිත වූ විට ඔබට තවමත් %1$sduckduckgo.com/aichat%2$s AI "
+"Chat වෙත ප්‍රවේශ විය හැකිය."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1066,10 +1071,10 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"AI සහය සහිත පිළිතුරු දැනට සෘජුවම පසු විපරම් ප්‍රශ්නවලට සහය නොදක්වයි. කෙසේ වෙතත්, අපි පසු විපරම් "
-"ප්‍රශ්න සඳහා %1$sDuck.ai%2$s පිරිනමමු, තවද බොහෝ විට එය වෙත සබැඳෙමු, එය OpenAI සහ "
-"Anthropic, සහ තවත් දෑ වෙතින් චැට් ආකෘති සඳහා සහය දක්වන අපගේ පෞද්ගලික AI බලයෙන් "
-"ක්‍රියාත්මක වන චැට් සේවාවක් වේ."
+"AI සහය සහිත පිළිතුරු දැනට සෘජුවම පසු විපරම් ප්‍රශ්නවලට සහය නොදක්වයි. කෙසේ "
+"වෙතත්, අපි පසු විපරම් ප්‍රශ්න සඳහා %1$sDuck.ai%2$s පිරිනමමු, තවද බොහෝ විට එය "
+"වෙත සබැඳෙමු, එය OpenAI සහ Anthropic, සහ තවත් දෑ වෙතින් චැට් ආකෘති සඳහා සහය "
+"දක්වන අපගේ පෞද්ගලික AI බලයෙන් ක්‍රියාත්මක වන චැට් සේවාවක් වේ."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1213,7 +1218,7 @@ msgstr "අපගේ දැන්වීම් ගැන"
 #. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
 msgctxt "Modal header for chat history with sync information"
 msgid "About Chat History with Sync & Backup"
-msgstr ""
+msgstr "Sync & Backup සම්බන්ධ කතාබස් ඉතිහාසය පිළිබඳව"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
@@ -1260,8 +1265,8 @@ msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
 msgstr ""
-"චැට් දිගටම කරගෙන යාමට මෙම බ්රව්සරයේ ඔබේ %1$s නැවත සක්රිය කරන්න, නැත්නම් නොමිලේ ආකෘතියකට "
-"මාරු වන්න."
+"චැට් දිගටම කරගෙන යාමට මෙම බ්රව්සරයේ ඔබේ %1$s නැවත සක්රිය කරන්න, නැත්නම් "
+"නොමිලේ ආකෘතියකට මාරු වන්න."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1297,8 +1302,8 @@ msgstr "දැන්වීම"
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
 msgstr ""
-"වෙළඳ දැන්වීම් ක්ලික් කිරීම් කළමනාකරණය කරනු ලබන්නේ %1$sහි වෙළඳ දැන්වීම් ජාලය මගින් වන අතර ඒවා "
-"ඔබේ හැසිරීම මත පදනම්ව තීරණ ගැනීමට භාවිත කරනු නොලැබේ."
+"වෙළඳ දැන්වීම් ක්ලික් කිරීම් කළමනාකරණය කරනු ලබන්නේ %1$sහි වෙළඳ දැන්වීම් ජාලය "
+"මගින් වන අතර ඒවා ඔබේ හැසිරීම මත පදනම්ව තීරණ ගැනීමට භාවිත කරනු නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
@@ -1306,8 +1311,8 @@ msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
 msgstr ""
-"දැන්වීම් ක්ලික් කිරීම් කළමනාකරණය කරනු ලබන්නේ Microsoft හි දැන්වීම් ජාලය විසිනි, ඒවා ඔබව පැතිකඩ "
-"කිරීමට භාවිතා නොකෙරේ."
+"දැන්වීම් ක්ලික් කිරීම් කළමනාකරණය කරනු ලබන්නේ Microsoft හි දැන්වීම් ජාලය "
+"විසිනි, ඒවා ඔබව පැතිකඩ කිරීමට භාවිතා නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1348,7 +1353,7 @@ msgstr "දැන්වීම සැක සහිතයි"
 #. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
 msgctxt "Button to open menu for attaching images or page context to AI chat"
 msgid "Add"
-msgstr ""
+msgstr "එක් කරන්න"
 
 # smartling.placeholder_format=C
 #. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
@@ -1356,7 +1361,7 @@ msgctxt ""
 "Primary button that attaches the tabs the user checked in the tab picker "
 "dialog"
 msgid "Add"
-msgstr ""
+msgstr "එක් කරන්න"
 
 # smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
@@ -1372,7 +1377,8 @@ msgstr "DuckDuckGo දිගුව එක් කරන්න"
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
 msgstr ""
-"එක් බාගැනීමකින් DuckDuckGo Privacy Essentials ඔබේ බ්‍රවුසරය වෙත නොමිලේ එක් කරන්න:"
+"එක් බාගැනීමකින් DuckDuckGo Privacy Essentials ඔබේ බ්‍රවුසරය වෙත නොමිලේ එක් "
+"කරන්න:"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1390,13 +1396,13 @@ msgstr "%1$s වෙත DuckDuckGo එක් කරන්න"
 msgctxt ""
 "Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
 msgid "Add File"
-msgstr ""
+msgstr "ගොනුව එක් කරන්න"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
 msgid "Add Image"
-msgstr ""
+msgstr "රූපය එක් කරන්න"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
@@ -1404,7 +1410,7 @@ msgctxt ""
 "Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
 "item)"
 msgid "Add Image or File"
-msgstr ""
+msgstr "රූපය හෝ ගොනුව එක් කරන්න"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1457,7 +1463,7 @@ msgctxt ""
 "Open the tab picker to attach browser tab content to the AI chat message "
 "(attach dropdown menu item)"
 msgid "Add Tabs"
-msgstr ""
+msgstr "ටැබ එක් කරන්න"
 
 # smartling.placeholder_format=C
 #. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
@@ -1465,7 +1471,7 @@ msgctxt ""
 "Title and accessible name of the tab-picker dialog opened from the attach "
 "dropdown menu"
 msgid "Add Tabs"
-msgstr ""
+msgstr "ටැබ එක් කරන්න"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1556,7 +1562,7 @@ msgstr "අවසන් සැරසීම් එකතු කිරීම"
 #. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
 msgctxt "Aria label for the additional instructions textarea"
 msgid "Additional instructions"
-msgstr ""
+msgstr "අමතර උපදෙස්"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1649,7 +1655,8 @@ msgctxt ""
 msgid ""
 "Advanced models can reach usage limits 2–5x sooner than other models. %s"
 msgstr ""
-"උසස් ආකෘති අනෙකුත් ආකෘතිවලට වඩා 2–5 ගුණයක් වේගයෙන් පරිශීලන සීමාවලට ළඟා විය හැක. %1$s"
+"උසස් ආකෘති අනෙකුත් ආකෘතිවලට වඩා 2–5 ගුණයක් වේගයෙන් පරිශීලන සීමාවලට ළඟා විය "
+"හැක. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
@@ -1657,7 +1664,9 @@ msgctxt ""
 "Always-visible warning banner shown above the recommended models in the "
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
-msgstr "උසස් ආකෘති අනෙකුත් ආකෘතිවලට වඩා 2-5 ගුණයකින් වේගයෙන් සීමාවන් භාවිතා කළ හැක. %1$s"
+msgstr ""
+"උසස් ආකෘති අනෙකුත් ආකෘතිවලට වඩා 2-5 ගුණයකින් වේගයෙන් සීමාවන් භාවිතා කළ හැක. "
+"%1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1835,8 +1844,8 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
-"සියලුම කතාබස් DuckDuckGo විසින් නිර්නාමික කර ඇති අතර, ඔබේ සංවාද DuckDuckGo හෝ ආකෘති "
-"සැපයුම්කරුවන් විසින් චැට් ආකෘති පුහුණු කිරීමට භාවිත කරනු නොලැබේ"
+"සියලුම කතාබස් DuckDuckGo විසින් නිර්නාමික කර ඇති අතර, ඔබේ සංවාද DuckDuckGo "
+"හෝ ආකෘති සැපයුම්කරුවන් විසින් චැට් ආකෘති පුහුණු කිරීමට භාවිත කරනු නොලැබේ"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1860,7 +1869,7 @@ msgstr "සියල්ල සම්පූර්ණයි!"
 #. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the read-only textarea listing all AI instructions"
 msgid "All instructions"
-msgstr ""
+msgstr "සියලුම උපදෙස්"
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -1889,8 +1898,8 @@ msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
 msgstr ""
-"AI සැපයුම්කරුට කතාබහක් යැවීමට පෙර සියලුම පුද්ගලික පාර-දත්ත (උදාහරණයක් ලෙස, ඔබගේ IP ලිපිනය) "
-"ඉවත් කරනු ලැබේ."
+"AI සැපයුම්කරුට කතාබහක් යැවීමට පෙර සියලුම පුද්ගලික පාර-දත්ත (උදාහරණයක් ලෙස, "
+"ඔබගේ IP ලිපිනය) ඉවත් කරනු ලැබේ."
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1929,7 +1938,8 @@ msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
 msgstr ""
-"හඬ කතාබස් භාවිතා කිරීමට පද්ධති සැකසීම් තුළ DuckDuckGo මයික්‍රෆෝනයට ප්‍රවේශය ලබා දෙන්න."
+"හඬ කතාබස් භාවිතා කිරීමට පද්ධති සැකසීම් තුළ DuckDuckGo මයික්‍රෆෝනයට ප්‍රවේශය "
+"ලබා දෙන්න."
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1961,9 +1971,10 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"අදාළ විමසීම්වලට ප්‍රතිචාර වැඩි දියුණු කිරීම සඳහා වෙබයේ සෙවීමට %1$s හට ඉඩ දෙයි. සීමිත දත්ත "
-"රඳවා ගැනීමක් සහිත සෙවුම් යන්ත්‍රයකට AI-ජනනය කරන ලද විමසුම් පමණක් යවයි. %2$s සහිත විමසීම් සහ "
-"ප්‍රතිචාර වලට තවමත් %3$sසැපයුම්කරුගේ දෘශ්‍යතාව ශුන්‍ය වේ%4$s."
+"අදාළ විමසීම්වලට ප්‍රතිචාර වැඩි දියුණු කිරීම සඳහා වෙබයේ සෙවීමට %1$s හට ඉඩ "
+"දෙයි. සීමිත දත්ත රඳවා ගැනීමක් සහිත සෙවුම් යන්ත්‍රයකට AI-ජනනය කරන ලද විමසුම් "
+"පමණක් යවයි. %2$s සහිත විමසීම් සහ ප්‍රතිචාර වලට තවමත් %3$sසැපයුම්කරුගේ "
+"දෘශ්‍යතාව ශුන්‍ය වේ%4$s."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -1971,7 +1982,8 @@ msgid ""
 "Allows Cloud Save key to be stored locally on device (required to use Cloud "
 "Save)"
 msgstr ""
-"Cloud Save යතුර උපාංගයේ දේශීයව ගබඩා කිරීමට ඉඩ දෙයි (Cloud Save භාවිතා කිරීමට අවශ්‍ය වේ)"
+"Cloud Save යතුර උපාංගයේ දේශීයව ගබඩා කිරීමට ඉඩ දෙයි (Cloud Save භාවිතා කිරීමට "
+"අවශ්‍ය වේ)"
 
 # smartling.placeholder_format=C
 #. Pending title indicating near completion.
@@ -2109,7 +2121,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"%1$s, %2$s සහ විවෘත මූලාශ්ර %3$s සහ %4$sඇතුළු ජනප්රිය AI ආකෘති සඳහා නිර්නාමික ප්රවේශය."
+"%1$s, %2$s සහ විවෘත මූලාශ්ර %3$s සහ %4$sඇතුළු ජනප්රිය AI ආකෘති සඳහා "
+"නිර්නාමික ප්රවේශය."
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -2118,7 +2131,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"%1$s, %2$s සහ විවෘත මූලාශ්ර %3$s සහ %4$sඇතුළු ජනප්රිය AI ආකෘති සඳහා නිර්නාමික ප්රවේශය."
+"%1$s, %2$s සහ විවෘත මූලාශ්ර %3$s සහ %4$sඇතුළු ජනප්රිය AI ආකෘති සඳහා "
+"නිර්නාමික ප්රවේශය."
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -2132,8 +2146,9 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
-"වෙබ් අන්තර්ගතය මත පදනම්ව සෙවුම් විමසුම් සඳහා නිර්නාමිකව පිළිතුරු ජනනය කරයි. එය කොපමණ වාර ගණනක් "
-"පෙනී සිටීමට අවශ්‍යද යන්න තෝරන්න, නැතහොත් එය සම්පූර්ණයෙන්ම අක්‍රිය කරන්න."
+"වෙබ් අන්තර්ගතය මත පදනම්ව සෙවුම් විමසුම් සඳහා නිර්නාමිකව පිළිතුරු ජනනය කරයි. "
+"එය කොපමණ වාර ගණනක් පෙනී සිටීමට අවශ්‍යද යන්න තෝරන්න, නැතහොත් එය සම්පූර්ණයෙන්ම "
+"අක්‍රිය කරන්න."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2180,8 +2195,8 @@ msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
 msgstr ""
-"Duck.ai අනුගමනය කිරීමට ඔයාට අවශ්‍ය ඕනෑම අමතර උපදෙසක්. උදා. තාරාවන් ගැන හැම විටම කරුණු "
-"මට කියන්න"
+"Duck.ai අනුගමනය කිරීමට ඔයාට අවශ්‍ය ඕනෑම අමතර උපදෙසක්. උදා. තාරාවන් ගැන හැම "
+"විටම කරුණු මට කියන්න"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2301,7 +2316,8 @@ msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
 msgstr ""
-"ඔබට ඉතිහාසය අක්‍රිය කිරීමට අවශ්‍ය බව විශ්වාසද? මෙය පින් කළ කතා ඇතුළුව, සියලුම කතා මකා දමනු ඇත."
+"ඔබට ඉතිහාසය අක්‍රිය කිරීමට අවශ්‍ය බව විශ්වාසද? මෙය පින් කළ කතා ඇතුළුව, "
+"සියලුම කතා මකා දමනු ඇත."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2310,8 +2326,8 @@ msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
 msgstr ""
-"ඔබට මෑත කාලීන කතාබස් අක්‍රිය කළ යුතු බවට ඔබට විශ්වාස ද? මෙය දැනට සුරකින ලද ඕනෑම මෑත "
-"කාලීන කතාබස් ද මකා දමනු ඇත."
+"ඔබට මෑත කාලීන කතාබස් අක්‍රිය කළ යුතු බවට ඔබට විශ්වාස ද? මෙය දැනට සුරකින ලද "
+"ඕනෑම මෑත කාලීන කතාබස් ද මකා දමනු ඇත."
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2349,8 +2365,9 @@ msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
 msgstr ""
-"අපගේ රහස්‍යතා ප්‍රතිපත්තියට අනුව, අපි කිසිදු පෞද්ගලික තොරතුරක් අප විසින්ම රැස්කර හෝ හුවමාරුකර "
-"නොගන්නෙමු. මෙම සියලු රහස්‍යතා ආරක්ෂාව ඔබගේ උපාංගයේ සිදු වේ."
+"අපගේ රහස්‍යතා ප්‍රතිපත්තියට අනුව, අපි කිසිදු පෞද්ගලික තොරතුරක් අප විසින්ම "
+"රැස්කර හෝ හුවමාරුකර නොගන්නෙමු. මෙම සියලු රහස්‍යතා ආරක්ෂාව ඔබගේ උපාංගයේ සිදු "
+"වේ."
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2492,12 +2509,14 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assist යනු අදාළ වෙබ් අන්තර්ගතය සාරාංශ කිරීම මත පදනම්ව සමහර සෙවුම් සඳහා AI-සහය සහිත "
-"පිළිතුරු නිර්නාමිකව ජනනය කළ හැකි සේවාවකි. ඔබට කොපමණ වාරයක් Assist පෙනී සිටීමට අවශ්‍ය දැ යි "
-"ඔබට තෝරා ගත හැකිය: කිසි විටෙකත් (සෙවුම් ප්‍රතිඵලවලින් Assist UI සම්පූර්ණයෙන්ම ඉවත් කරයි), ඉල්ලුම "
-"මත (ඔබ Assist බොත්තම ක්ලික් කළහොත් AI-සහාය සහිත පිළිතුරු පමණක් පෙන්වයි), සමහර විට (ඉහළ "
-"අදාළ වන විට AI-සහය සහිත පිළිතුරු පමණක් පෙන්වයි), හෝ බොහෝ විට (පුළුල් පරාසයක සෙවුම් මත නිතර "
-"පෙන්වයි). දැනට, AI සහය සහිත පිළිතුරු ලබා ගත හැක්කේ එක්සත් ජනපද (ඉංග්‍රීසි) කලාපයේ පමණි."
+"Assist යනු අදාළ වෙබ් අන්තර්ගතය සාරාංශ කිරීම මත පදනම්ව සමහර සෙවුම් සඳහා "
+"AI-සහය සහිත පිළිතුරු නිර්නාමිකව ජනනය කළ හැකි සේවාවකි. ඔබට කොපමණ වාරයක් "
+"Assist පෙනී සිටීමට අවශ්‍ය දැ යි ඔබට තෝරා ගත හැකිය: කිසි විටෙකත් (සෙවුම් "
+"ප්‍රතිඵලවලින් Assist UI සම්පූර්ණයෙන්ම ඉවත් කරයි), ඉල්ලුම මත (ඔබ Assist "
+"බොත්තම ක්ලික් කළහොත් AI-සහාය සහිත පිළිතුරු පමණක් පෙන්වයි), සමහර විට (ඉහළ "
+"අදාළ වන විට AI-සහය සහිත පිළිතුරු පමණක් පෙන්වයි), හෝ බොහෝ විට (පුළුල් පරාසයක "
+"සෙවුම් මත නිතර පෙන්වයි). දැනට, AI සහය සහිත පිළිතුරු ලබා ගත හැක්කේ එක්සත් "
+"ජනපද (ඉංග්‍රීසි) කලාපයේ පමණි."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2509,11 +2528,12 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති විකල්ප විශේෂාංගයක් වන අතර එයට නිර්නාමික ව සෙවුම් විමසුම් "
-"සඳහා AI සහය සහිත පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා "
-"වෙබ් ස්කෑන් කරන අතර පසුව සොයාගත් අදාළ තොරතුරු මත පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI-"
-"බලැති ස්වාභාවික භාෂා තාක්ෂණය භාවිත කරයි. ප්රතිචාර උපුටා දක්වන ලද මූලාශ්රවලින් ස්වයංක්රීයව "
-"ජනනය වන අතර %1$sවෙබ් කැටි ගැසීම%2$s මත පදනම් වන බව මතක තබා ගැනීම වැදගත්ය."
+"Assist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති විකල්ප විශේෂාංගයක් වන අතර එයට "
+"නිර්නාමික ව සෙවුම් විමසුම් සඳහා AI සහය සහිත පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු "
+"කිරීම සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා වෙබ් ස්කෑන් කරන අතර පසුව සොයාගත් අදාළ "
+"තොරතුරු මත පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI-බලැති ස්වාභාවික භාෂා "
+"තාක්ෂණය භාවිත කරයි. ප්රතිචාර උපුටා දක්වන ලද මූලාශ්රවලින් ස්වයංක්රීයව ජනනය වන "
+"අතර %1$sවෙබ් කැටි ගැසීම%2$s මත පදනම් වන බව මතක තබා ගැනීම වැදගත්ය."
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2539,8 +2559,8 @@ msgid ""
 "At the café, airport, or hotel, DuckDuckGo VPN encrypts your connection and "
 "hides your IP address on Wi-Fi."
 msgstr ""
-"DuckDuckGo VPN මගින් අවන්හලක, ගුවන් තොටුපළක හෝ හෝටලයක දී, ඔබේ සම්බන්ධතාවය ගුප්ත කේතනය "
-"කර Wi-Fi මත ඔබේ IP ලිපිනය සඟවයි."
+"DuckDuckGo VPN මගින් අවන්හලක, ගුවන් තොටුපළක හෝ හෝටලයක දී, ඔබේ සම්බන්ධතාවය "
+"ගුප්ත කේතනය කර Wi-Fi මත ඔබේ IP ලිපිනය සඟවයි."
 
 # smartling.placeholder_format=C
 #. In the context of the National Hockey League (NHL), label for teams belonging to the Atlantic division
@@ -2661,7 +2681,9 @@ msgstr "ලැයිස්තුගත මූලාශ්‍ර මත පදන
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
-msgstr "ලැයිස්තුගත මූලාශ්‍ර මත පදනම්ව ස්වයංක්‍රීයව ජනනය වේ. ප්‍රතිචාරවල සාවද්‍ය තැන් තිබිය හැක."
+msgstr ""
+"ලැයිස්තුගත මූලාශ්‍ර මත පදනම්ව ස්වයංක්‍රීයව ජනනය වේ. ප්‍රතිචාරවල සාවද්‍ය තැන් "
+"තිබිය හැක."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
@@ -2686,9 +2708,9 @@ msgid ""
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
 msgstr ""
-"අදාළ සෙවීම් සඳහා ස්වයංක්‍රීයව Assist පෙන්වයි. Assist හට නිර්නාමිකව සමහර සෙවීම් වලට ප්‍රතිචාර "
-"වශයෙන් තොරතුරු සොයා බලා සාරාංශගත කළ හැක. දැනට, Assist ලබා ගත හැක්කේ ඉංග්‍රීසි කලාපවල "
-"පමණි."
+"අදාළ සෙවීම් සඳහා ස්වයංක්‍රීයව Assist පෙන්වයි. Assist හට නිර්නාමිකව සමහර "
+"සෙවීම් වලට ප්‍රතිචාර වශයෙන් තොරතුරු සොයා බලා සාරාංශගත කළ හැක. දැනට, Assist "
+"ලබා ගත හැක්කේ ඉංග්‍රීසි කලාපවල පමණි."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2697,15 +2719,17 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"අදාළ සෙවීම් සඳහා ස්වයංක්‍රීයව DuckAssist පෙන්වයි. DuckAssist හට නිර්නාමිකව සමහර සෙවීම් "
-"වලට ප්‍රතිචාර වශයෙන් තොරතුරු සොයා බලා සාරාංශගත කළ හැක. දැනට, DuckAssist ලබා ගත "
-"හැක්කේ ඉංග්‍රීසි කලාපවල පමණි."
+"අදාළ සෙවීම් සඳහා ස්වයංක්‍රීයව DuckAssist පෙන්වයි. DuckAssist හට නිර්නාමිකව "
+"සමහර සෙවීම් වලට ප්‍රතිචාර වශයෙන් තොරතුරු සොයා බලා සාරාංශගත කළ හැක. දැනට, "
+"DuckAssist ලබා ගත හැක්කේ ඉංග්‍රීසි කලාපවල පමණි."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Autoplay short, silent video previews when you hover over video results."
-msgstr "ඔබ වීඩියෝ ප්‍රතිඵල මත සැරිසරන විට කෙටි, නිහඬ වීඩියෝ පෙරදසුන් ස්වයංක්‍රීයව ධාවනය කරන්න."
+msgstr ""
+"ඔබ වීඩියෝ ප්‍රතිඵල මත සැරිසරන විට කෙටි, නිහඬ වීඩියෝ පෙරදසුන් ස්වයංක්‍රීයව "
+"ධාවනය කරන්න."
 
 # smartling.placeholder_format=C
 #. Title for the menu listing free/degraded models available after the advanced-model usage limit has been reached.
@@ -2905,8 +2929,8 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
-"මෙම වාර්තාව ගබඩා කිරීමට පෙර, DuckDuckGo විසින් නම්, ඊමේල් ලිපින සහ හඳුනාගත හැකි පාරදත්ත "
-"වැනි PII ඉවත් කිරීම මගින් ඔබගේ සංවාදය නිර්නාමික කරනු ඇත."
+"මෙම වාර්තාව ගබඩා කිරීමට පෙර, DuckDuckGo විසින් නම්, ඊමේල් ලිපින සහ හඳුනාගත "
+"හැකි පාරදත්ත වැනි PII ඉවත් කිරීම මගින් ඔබගේ සංවාදය නිර්නාමික කරනු ඇත."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3036,8 +3060,8 @@ msgid ""
 "Block harmful sites, hide your IP address, plus get more premium protections "
 "with our subscription."
 msgstr ""
-"හානිකර වෙබ් අඩවි අවහිර කරන්න, ඔබේ IP ලිපිනය සඟවන්න, තව ද අපගේ ග්‍රාහකත්වය සමඟ තවත් වාරික "
-"ආරක්ෂණ ලබා ගන්න."
+"හානිකර වෙබ් අඩවි අවහිර කරන්න, ඔබේ IP ලිපිනය සඟවන්න, තව ද අපගේ ග්‍රාහකත්වය "
+"සමඟ තවත් වාරික ආරක්ෂණ ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
@@ -3297,16 +3321,18 @@ msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"අපි රහස්‍යතා ආරක්ෂාව එක් කරන තුරු සාමාන්‍ය පරිදි බ්‍රවුස් කරන්න. අපි අපේ සෙවුම් යාන්ත්‍රණය, නිරික්සු "
-"අවහිරය හා ගුප්ත කේතන බලාත්කුරුව එක් %1$s%2$s දිගුවක්%3$s වෙත ගොනු කර ඇත්තෙමු."
+"අපි රහස්‍යතා ආරක්ෂාව එක් කරන තුරු සාමාන්‍ය පරිදි බ්‍රවුස් කරන්න. අපි අපේ "
+"සෙවුම් යාන්ත්‍රණය, නිරික්සු අවහිරය හා ගුප්ත කේතන බලාත්කුරුව එක් %1$s%2$s "
+"දිගුවක්%3$s වෙත ගොනු කර ඇත්තෙමු."
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"සාමාන්‍ය පරිදි බ්‍රවුස්කරන්න, අපි අනික්වා ගැන බලා ගන්නෙමු. අපි අපේ සෙවුම් යාන්ත්‍රණය, නිරික්සු "
-"අවහිරකාරකය හා ගුප්ත කේතන බලාත්කාරකය එක් %1$s%2$s දිගුවක%3$sට සම්පිණ්ඩනය කළෙමු."
+"සාමාන්‍ය පරිදි බ්‍රවුස්කරන්න, අපි අනික්වා ගැන බලා ගන්නෙමු. අපි අපේ සෙවුම් "
+"යාන්ත්‍රණය, නිරික්සු අවහිරකාරකය හා ගුප්ත කේතන බලාත්කාරකය එක් %1$s%2$s "
+"දිගුවක%3$sට සම්පිණ්ඩනය කළෙමු."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3314,8 +3340,9 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"සාමාන්‍ය පරිදි බ්‍රවුස්කරන්න, අපි අනික්වා ගැන බලා ගන්නෙමු. %1$sප්‍රධාන බ්‍රවුසර්%2$s සඳහා පුද්ගලික "
-"සෙවුම, නිරික්සුව අවහිර කිරීම හා අඩවි ගුප්ත කේතනය යන සියල්ල එකම බාගැනීමකින් ලබාගන්න."
+"සාමාන්‍ය පරිදි බ්‍රවුස්කරන්න, අපි අනික්වා ගැන බලා ගන්නෙමු. %1$sප්‍රධාන "
+"බ්‍රවුසර්%2$s සඳහා පුද්ගලික සෙවුම, නිරික්සුව අවහිර කිරීම හා අඩවි ගුප්ත කේතනය "
+"යන සියල්ල එකම බාගැනීමකින් ලබාගන්න."
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3422,10 +3449,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"පෙරනිමියෙන් සැකසීම් පුද්ගලික නොවන බ්‍රව්සර් කුකීස් තුළ ගබඩා කර ඇත (ඔබගේ බ්‍රව්සරයේ). ඔබේ සැකසීම් "
-"වඩාත් ස්ථිර ආකාරයකින් ගබඩා කිරීමට ඔබට නිර්ණාමික Cloud Save භාවිතා කළ හැකිය (ක්ලවුඩයේ ඇති "
-"දුරස්ථ සර්වරයක). පුද්ගලිකව හඳුනාගත හැකි තොරතුරු ක්ලවුඩය තුළ ගබඩා නොවන අතර ඔබගේ මුර පදය කිසි "
-"විටෙකත් ඔබගේ බ්‍රව්සරයෙන් ඉවත් නොවේ."
+"පෙරනිමියෙන් සැකසීම් පුද්ගලික නොවන බ්‍රව්සර් කුකීස් තුළ ගබඩා කර ඇත (ඔබගේ "
+"බ්‍රව්සරයේ). ඔබේ සැකසීම් වඩාත් ස්ථිර ආකාරයකින් ගබඩා කිරීමට ඔබට නිර්ණාමික "
+"Cloud Save භාවිතා කළ හැකිය (ක්ලවුඩයේ ඇති දුරස්ථ සර්වරයක). පුද්ගලිකව හඳුනාගත "
+"හැකි තොරතුරු ක්ලවුඩය තුළ ගබඩා නොවන අතර ඔබගේ මුර පදය කිසි විටෙකත් ඔබගේ "
+"බ්‍රව්සරයෙන් ඉවත් නොවේ."
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
@@ -3433,8 +3461,8 @@ msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"කියවන විට ලිවීම සක්‍රීය කිරීමෙන්, මෙම විශේෂාංගය භාවිතා කිරීම සඳහා ඔබගේ හඬ දත්ත OpenAI වෙත "
-"යැවීමට ඔබ එකඟ වෙයි. ආරම්භ කිරීමට පෙර අපේ %1$s බලන්න."
+"කියවන විට ලිවීම සක්‍රීය කිරීමෙන්, මෙම විශේෂාංගය භාවිතා කිරීම සඳහා ඔබගේ හඬ "
+"දත්ත OpenAI වෙත යැවීමට ඔබ එකඟ වෙයි. ආරම්භ කිරීමට පෙර අපේ %1$s බලන්න."
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3443,8 +3471,8 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"හඬ කතාබස් සක්‍රීය කිරීමෙන්, මෙම විශේෂාංගය භාවිතා කිරීම සඳහා ඔයාගේ හඬ දත්ත OpenAI වෙත "
-"යැවීමට ඔයා එකඟ වෙනවා. ආරම්භ කිරීමට පෙර අපේ %1$s බලන්න."
+"හඬ කතාබස් සක්‍රීය කිරීමෙන්, මෙම විශේෂාංගය භාවිතා කිරීම සඳහා ඔයාගේ හඬ දත්ත "
+"OpenAI වෙත යැවීමට ඔයා එකඟ වෙනවා. ආරම්භ කිරීමට පෙර අපේ %1$s බලන්න."
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3479,7 +3507,9 @@ msgstr "කැමරූන්"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr "කුකුළු මස්, බ්‍රොකොලි සහ සහල් භාවිත කරමින් සරල වට්ටෝරු කිහිපයක් නිර්මාණය කළ හැකිද?"
+msgstr ""
+"කුකුළු මස්, බ්‍රොකොලි සහ සහල් භාවිත කරමින් සරල වට්ටෝරු කිහිපයක් නිර්මාණය කළ "
+"හැකිද?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3551,7 +3581,7 @@ msgctxt ""
 "Secondary button that dismisses the tab picker dialog without attaching "
 "anything"
 msgid "Cancel"
-msgstr ""
+msgstr "අවලංගු කරන්න"
 
 # smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
@@ -3936,11 +3966,11 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"චැට් (අපගේ Duck.ai සේවාව හරහා) ඔබට 3 වන පාර්ශවයේ AI චැට් ආකෘති සමඟ නිර්නාමික සංවාද "
-"කිරීමට ඉඩ සලසයි, එය OpenAI, Anthropic සහ තවත් ආකෘති සඳහා සහය දක්වයි. මෙම සැකසුම අක්‍රිය "
-"කිරීමෙන් DuckDuckGo Search හි චැට් බොත්තම් සහ සබැඳි සඟවනු ඇත. කෙසේ වෙතත්, මෙම සැකසුම "
-"ක්‍රියා විරහිත වූ විට ඔබට තවමත් %1$shttps://duck.ai%2$s වෙත පිවිසීමෙන් සෘජුව චැට් වෙත "
-"ප්‍රවේශ විය හැකිය."
+"චැට් (අපගේ Duck.ai සේවාව හරහා) ඔබට 3 වන පාර්ශවයේ AI චැට් ආකෘති සමඟ නිර්නාමික "
+"සංවාද කිරීමට ඉඩ සලසයි, එය OpenAI, Anthropic සහ තවත් ආකෘති සඳහා සහය දක්වයි. "
+"මෙම සැකසුම අක්‍රිය කිරීමෙන් DuckDuckGo Search හි චැට් බොත්තම් සහ සබැඳි සඟවනු "
+"ඇත. කෙසේ වෙතත්, මෙම සැකසුම ක්‍රියා විරහිත වූ විට ඔබට තවමත් "
+"%1$shttps://duck.ai%2$s වෙත පිවිසීමෙන් සෘජුව චැට් වෙත ප්‍රවේශ විය හැකිය."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3996,7 +4026,8 @@ msgstr "පෞද්ගලිකව චැට් කරන්න"
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
 msgstr ""
-"අපගේ ගාස්තු රහිත බ්රවුසරයේ ඇති Duck.ai සමඟ ඕනෑම වෙබ් අඩවියක පෞද්ගලිකව කතාබහේ යෙදෙන්න."
+"අපගේ ගාස්තු රහිත බ්රවුසරයේ ඇති Duck.ai සමඟ ඕනෑම වෙබ් අඩවියක පෞද්ගලිකව කතාබහේ "
+"යෙදෙන්න."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
@@ -4004,8 +4035,8 @@ msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
 msgstr ""
-"අපගේ ගාස්තු රහිත බ්‍රවුසරයේ ඇති Duck.ai පැති තීරුව සමඟ ඕනෑම වෙබ් අඩවියක පුද්ගලිකව කතාබහේ "
-"යෙදෙන්න."
+"අපගේ ගාස්තු රහිත බ්‍රවුසරයේ ඇති Duck.ai පැති තීරුව සමඟ ඕනෑම වෙබ් අඩවියක "
+"පුද්ගලිකව කතාබහේ යෙදෙන්න."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4047,7 +4078,7 @@ msgstr "මෙම පරිවර්තනය අහිතකරය"
 #. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
 msgctxt "Chat history about modal list item headline"
 msgid "Chat storage varies by browser"
-msgstr ""
+msgstr "කතාබස් ආචයනය බ්‍රව්සරය අනුව වෙනස් වේ"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4059,7 +4090,7 @@ msgstr "%1$s සමඟ කතාබස් කරන්න"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Chat with popular AI models, anonymized by us."
-msgstr ""
+msgstr "අප විසින් නිර්නාමික කර ඇති ජනප්‍රිය AI ආකෘති සමග කතාබස් කරන්න."
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4086,6 +4117,8 @@ msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
 msgstr ""
+"කතාබස් DuckDuckGo සර්වරයේ මුල සිට අග දක්වා ගුප්ත කේතනය සමඟ ආරක්ෂිතව ගබඩා කර "
+"ඇත. ඔබට හැර වෙන කිසිවෙකුට, අපට පවා, ඔබගේ දත්ත දැකිය නොහැක."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4094,8 +4127,8 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"ඔබේ උපාංගයේ DuckDuckGo සර්වර හෝ වෙනත් දුරස්ථ සර්වර මත වෙනුවට දේශීයව චැට් ගබඩා කර ඇත. "
-"කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ කතාබස් මකා දැමෙනු ඇත."
+"ඔබේ උපාංගයේ DuckDuckGo සර්වර හෝ වෙනත් දුරස්ථ සර්වර මත වෙනුවට දේශීයව චැට් "
+"ගබඩා කර ඇත. කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ කතාබස් මකා දැමෙනු ඇත."
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -4107,10 +4140,11 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"කතාබස් ඔබගේ උපාංගයේ දේශීයව ගබඩා කර ඇත. ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති වුවහොත් කතාබහක් "
-"නැවත ලබා ගැනීමට උපකාර කිරීම සඳහා, නව විමසීම් සහ ප්‍රතිචාර සංකේතනය කර යැවීමෙන් පසු "
-"තාවකාලිකව DuckDuckGo සේවාදායකයක ගබඩා කරනු ලැබේ. කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ "
-"කතාබස් මැකෙනු ඇති අතර නව විමසීම් සහ ප්‍රතිචාර තාවකාලිකව ගබඩා කිරීම අක්‍රිය කරනු ඇත."
+"කතාබස් ඔබගේ උපාංගයේ දේශීයව ගබඩා කර ඇත. ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති "
+"වුවහොත් කතාබහක් නැවත ලබා ගැනීමට උපකාර කිරීම සඳහා, නව විමසීම් සහ ප්‍රතිචාර "
+"සංකේතනය කර යැවීමෙන් පසු තාවකාලිකව DuckDuckGo සේවාදායකයක ගබඩා කරනු ලැබේ. "
+"කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ කතාබස් මැකෙනු ඇති අතර නව විමසීම් සහ "
+"ප්‍රතිචාර තාවකාලිකව ගබඩා කිරීම අක්‍රිය කරනු ඇත."
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -4133,8 +4167,9 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"%1$s සමඟ කතාබස්වලට සැපයුම්කරු දෘශ්‍යතාව නොමැත, නමුත් Duck.ai වෙත උඩුගත කරන සියලුම ගොනු "
-"%2$s සඳහා අන්තර්ගත මධ්‍යස්ථකරණ සැපයුම්කරුවෙකු විසින් නිර්නාමිකව සමාලෝචනය කරනු ලැබේ."
+"%1$s සමඟ කතාබස්වලට සැපයුම්කරු දෘශ්‍යතාව නොමැත, නමුත් Duck.ai වෙත උඩුගත කරන "
+"සියලුම ගොනු %2$s සඳහා අන්තර්ගත මධ්‍යස්ථකරණ සැපයුම්කරුවෙකු විසින් නිර්නාමිකව "
+"සමාලෝචනය කරනු ලැබේ."
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -4142,8 +4177,8 @@ msgctxt "Sync file storage inline disclaimer body"
 msgid ""
 "Chats with attachments have stopped syncing. Free up storage to resume Sync."
 msgstr ""
-"ඇමුණුම් සහිත කතාබස් සමමුහුර්ත වීම නැවතී ඇත. සමමුහුර්ත වීම නැවත ආරම්භ කිරීමට ගබඩාවේ ඉඩ නිදහස් "
-"කරගන්න."
+"ඇමුණුම් සහිත කතාබස් සමමුහුර්ත වීම නැවතී ඇත. සමමුහුර්ත වීම නැවත ආරම්භ කිරීමට "
+"ගබඩාවේ ඉඩ නිදහස් කරගන්න."
 
 # smartling.placeholder_format=C
 #. Message shown when we have no data from upstream to display
@@ -4299,8 +4334,8 @@ msgid ""
 "Choose from 40+ server locations worldwide to help block harmful sites and "
 "scams."
 msgstr ""
-"හානිකර අඩවි සහ වංචා අවහිර කිරීමට උපකාරී වන ලොව පුරා පවතින සේවාදායක ස්ථාන 40කට වඩා වැඩි "
-"ගණනකින් තෝරා ගන්න."
+"හානිකර අඩවි සහ වංචා අවහිර කිරීමට උපකාරී වන ලොව පුරා පවතින සේවාදායක ස්ථාන "
+"40කට වඩා වැඩි ගණනකින් තෝරා ගන්න."
 
 # smartling.placeholder_format=C
 #. The title of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -4317,7 +4352,9 @@ msgstr "සේවාවක් තෝරන්න"
 msgctxt "settings"
 msgid ""
 "Choose which app to use when you need directions for a location search result"
-msgstr "ඔබට ස්ථාන සෙවුම් ප්‍රතිඵලයක් සඳහා උපදෙස් අවශ්‍ය විට භාවිත කළ යුතු යෙදුම තෝරන්න"
+msgstr ""
+"ඔබට ස්ථාන සෙවුම් ප්‍රතිඵලයක් සඳහා උපදෙස් අවශ්‍ය විට භාවිත කළ යුතු යෙදුම "
+"තෝරන්න"
 
 # smartling.placeholder_format=C
 #. Accessible label for the citations popover dialog in Duck.ai chat responses.
@@ -4498,9 +4535,9 @@ msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
-"බ්‍රවුසර දත්ත මකා දැමීමෙන් කතාබස් මකා දමනු ලැබේ. සමහර බ්‍රවුසර මෑත කාලීන කතාබස් කාලය "
-"නොසලකා තබා ගන්නා හෝ AI Chat භාවිත නොකිරීමෙන් දින 7කට පසු ඒවා ස්වයංක්‍රීයව මකා දැමිය හැකි "
-"ය."
+"බ්‍රවුසර දත්ත මකා දැමීමෙන් කතාබස් මකා දමනු ලැබේ. සමහර බ්‍රවුසර මෑත කාලීන "
+"කතාබස් කාලය නොසලකා තබා ගන්නා හෝ AI Chat භාවිත නොකිරීමෙන් දින 7කට පසු ඒවා "
+"ස්වයංක්‍රීයව මකා දැමිය හැකි ය."
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4510,8 +4547,9 @@ msgid ""
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
 msgstr ""
-"බ්‍රවුසර දත්ත මකා දැමීම මෑත කතාබස් මකා දමයි. Duck.ai භාවිත නොකර දින 7කට පසු, ඔබේ "
-"බ්‍රව්සරය මත පදනම්ව මෑත කතාබස් දින නියමයක් නොමැතිව සුරැකීමට හෝ ස්වයංක්‍රීයව මකා දැමිය හැකිය."
+"බ්‍රවුසර දත්ත මකා දැමීම මෑත කතාබස් මකා දමයි. Duck.ai භාවිත නොකර දින 7කට පසු, "
+"ඔබේ බ්‍රව්සරය මත පදනම්ව මෑත කතාබස් දින නියමයක් නොමැතිව සුරැකීමට හෝ "
+"ස්වයංක්‍රීයව මකා දැමිය හැකිය."
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4520,8 +4558,8 @@ msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
 msgstr ""
-"බ්රව්සර් දත්ත ඉවත් කිරීමෙන් ඔබගේ අවහිර කරන ලද වෙබ් අඩවි යළි සැකසේ. ඔබගේ අවහිර ලැයිස්තුව අපගේ "
-"ගාස්තු රහිත බ්‍රවුසරයේ"
+"බ්රව්සර් දත්ත ඉවත් කිරීමෙන් ඔබගේ අවහිර කරන ලද වෙබ් අඩවි යළි සැකසේ. ඔබගේ "
+"අවහිර ලැයිස්තුව අපගේ ගාස්තු රහිත බ්‍රවුසරයේ"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4530,9 +4568,9 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"මාතෘකාවක් පිළිබඳව වැඩිදුරටත් විමසා බලන්න \"තවත්\" මත ක්ලික් කරන්න, සහ %1$sDuck.ai%2$s "
-"හරහා පසු විපරම් ප්‍රශ්න අසන්න OpenAI, Anthropic සහ තවත් බොහෝ ආයතනවලින් චැට් ආකෘතිවලට සහය "
-"දක්වන අපගේ පෞද්ගලික AI චැට් සේවය."
+"මාතෘකාවක් පිළිබඳව වැඩිදුරටත් විමසා බලන්න \"තවත්\" මත ක්ලික් කරන්න, සහ "
+"%1$sDuck.ai%2$s හරහා පසු විපරම් ප්‍රශ්න අසන්න OpenAI, Anthropic සහ තවත් බොහෝ "
+"ආයතනවලින් චැට් ආකෘතිවලට සහය දක්වන අපගේ පෞද්ගලික AI චැට් සේවය."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4606,8 +4644,8 @@ msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
 msgstr ""
-"ඉහළ මෙනුවෙන් %1$sSafari%2$s මත ක්ලික් කරන්න (වින්ඩෝව්ස් වලදී, ඉහළ මෙනුවේ දකුණු පස "
-"%3$sgears icon%4$s මත ක්ලික් කරන්න)"
+"ඉහළ මෙනුවෙන් %1$sSafari%2$s මත ක්ලික් කරන්න (වින්ඩෝව්ස් වලදී, ඉහළ මෙනුවේ "
+"දකුණු පස %3$sgears icon%4$s මත ක්ලික් කරන්න)"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4637,7 +4675,8 @@ msgstr "%1$sYes%2$s කලික් කරන්න"
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
 msgstr ""
-"Chrom උපකරණ කොටුවේ (ඉහළ දකුණ) %1$ssettings/hamburger icon %2$s මත ක්ලික් කරන්න."
+"Chrom උපකරණ කොටුවේ (ඉහළ දකුණ) %1$ssettings/hamburger icon %2$s මත ක්ලික් "
+"කරන්න."
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4699,8 +4738,9 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
 msgstr ""
-"%1$sමගේ දත්ත මකන්න%2$s ක්ලික් කරන්න හෝ තට්ටු කරන්න. මෙය ක්ලවුඩවලින් දත්ත ඉවත් කරන නමුදු, ඔබ "
-"විසින් %3$sසියලුම සැකසුම් යළි පිහිටුවන්න%4$s ක්ලික්/තට්ටු කරන තෙක් ඔබේ බ්‍රවුසරයේ පවතී."
+"%1$sමගේ දත්ත මකන්න%2$s ක්ලික් කරන්න හෝ තට්ටු කරන්න. මෙය ක්ලවුඩවලින් දත්ත "
+"ඉවත් කරන නමුදු, ඔබ විසින් %3$sසියලුම සැකසුම් යළි පිහිටුවන්න%4$s ක්ලික්/තට්ටු "
+"කරන තෙක් ඔබේ බ්‍රවුසරයේ පවතී."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4711,8 +4751,9 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
 msgstr ""
-"%1$sමගේ දත්ත මකන්න%2$s ක්ලික් කරන්න හෝ තට්ටු කරන්න. මෙය ක්ලවුඩවලින් දත්ත ඉවත් කරන නමුදු, ඔබ "
-"විසින් %3$sසියලුම සැකසුම් යළි පිහිටුවන්න%4$s ක්ලික්/තට්ටු කරන තෙක් ඔබේ බ්‍රවුසරයේ පවතී."
+"%1$sමගේ දත්ත මකන්න%2$s ක්ලික් කරන්න හෝ තට්ටු කරන්න. මෙය ක්ලවුඩවලින් දත්ත "
+"ඉවත් කරන නමුදු, ඔබ විසින් %3$sසියලුම සැකසුම් යළි පිහිටුවන්න%4$s ක්ලික්/තට්ටු "
+"කරන තෙක් ඔබේ බ්‍රවුසරයේ පවතී."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4781,8 +4822,8 @@ msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
 msgstr ""
-"ලිපින තීරුව %1$sහි භාවිතා කර ඇති සෙවුම් යන්ත්‍රය%2$s අසල ඇති ඩ්‍රොප් ඩවුන් මෙනුව ක්ලික් කර "
-"%3$sDuckDuckGo%4$s තෝරන්න."
+"ලිපින තීරුව %1$sහි භාවිතා කර ඇති සෙවුම් යන්ත්‍රය%2$s අසල ඇති ඩ්‍රොප් ඩවුන් "
+"මෙනුව ක්ලික් කර %3$sDuckDuckGo%4$s තෝරන්න."
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
@@ -4790,8 +4831,8 @@ msgid ""
 "Click the icon of the ad blocker extension. It's usually in the upper right "
 "hand corner of your browser."
 msgstr ""
-"Ad blocker කිරීමේ දිගුවේ අයිකනය ක්ලික් කරන්න. එය සාමාන්යයෙන් ඔබේ බ්‍රව්සරයේ ඉහළ දකුණු කෙළවරේ "
-"තියෙනවා."
+"Ad blocker කිරීමේ දිගුවේ අයිකනය ක්ලික් කරන්න. එය සාමාන්යයෙන් ඔබේ බ්‍රව්සරයේ "
+"ඉහළ දකුණු කෙළවරේ තියෙනවා."
 
 #  Safari default search engine instruction
 # smartling.placeholder_format=C
@@ -4992,8 +5033,8 @@ msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
 msgstr ""
-"මුරවදනක් ඇතුලත් කිරීම මඟින් ඔබගේ සැකසුම් ක්ලව්ඩයේ සුරෑකීම වඩාත් තහවුරු කිරීමට හැකියාව Cloud "
-"Save. එය සම්පූර්ණයෙන්ම ඔබගේ තේරීමකි."
+"මුරවදනක් ඇතුලත් කිරීම මඟින් ඔබගේ සැකසුම් ක්ලව්ඩයේ සුරෑකීම වඩාත් තහවුරු "
+"කිරීමට හැකියාව Cloud Save. එය සම්පූර්ණයෙන්ම ඔබගේ තේරීමකි."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -5265,8 +5306,8 @@ msgstr "දැන්වීම් අවහිර කිරීම දිගටම
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
 msgstr ""
-"මෑත කාලීන කතාබස් මෙතැනින් දිගටම කරගෙන යන්න. නැතහොත් Fire Button භාවිතයෙන් ඒවා මකා "
-"දමන්න."
+"මෑත කාලීන කතාබස් මෙතැනින් දිගටම කරගෙන යන්න. නැතහොත් Fire Button භාවිතයෙන් "
+"ඒවා මකා දමන්න."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5437,8 +5478,8 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
-"වෙනත් උපාංගයකින් කේතය පිටපත් කරගන්න. %1$sDuck.ai සැකසුම් › කතාබස් › Sync & Backup › "
-"වෙනත් උපාංගයක් සමඟ සමමුහුර්ත කරන්න%2$s වෙත ගොස් නැවත උත්සාහ කරන්න."
+"වෙනත් උපාංගයකින් කේතය පිටපත් කරගන්න. %1$sDuck.ai සැකසුම් › කතාබස් › Sync & "
+"Backup › වෙනත් උපාංගයක් සමඟ සමමුහුර්ත කරන්න%2$s වෙත ගොස් නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5491,7 +5532,8 @@ msgstr "කොස්ටාරිකාව"
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
 msgstr ""
-"ඔබේ ප් රතිසාධන කේතය පූරණය කළ නොහැකි විය. කරුණාකර මෙය වසා දාලා නැවත උත්සාහ කරන්න."
+"ඔබේ ප් රතිසාධන කේතය පූරණය කළ නොහැකි විය. කරුණාකර මෙය වසා දාලා නැවත උත්සාහ "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5592,7 +5634,8 @@ msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
 msgstr ""
-"සබැඳියක් සෑදීමෙන් කතාබස්හි පිටපතක් සෑදෙන අතර, එය විවෘත කරන ඕනෑම අයෙකුට එය බැලිය හැකිය."
+"සබැඳියක් සෑදීමෙන් කතාබස්හි පිටපතක් සෑදෙන අතර, එය විවෘත කරන ඕනෑම අයෙකුට එය "
+"බැලිය හැකිය."
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5675,7 +5718,7 @@ msgstr "වත්මන් රේඛාව"
 #. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
 msgctxt "Suffix label indicating a tab is the currently active browser tab"
 msgid "Current Tab"
-msgstr ""
+msgstr "වත්මන් ටැබය"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
@@ -5838,7 +5881,8 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Daily usage limit reached. You can keep chatting by using your weekly limit."
 msgstr ""
-"දෛනික පරිශීලන සීමාවට ළඟා විය. ඔබට ඔබේ සතිපතා සීමාව භාවිතා කරමින් කතාබස් කරගෙන යා හැකිය."
+"දෛනික පරිශීලන සීමාවට ළඟා විය. ඔබට ඔබේ සතිපතා සීමාව භාවිතා කරමින් කතාබස් "
+"කරගෙන යා හැකිය."
 
 # smartling.placeholder_format=C
 #. The name of the Danish language
@@ -6028,7 +6072,7 @@ msgstr "දින 30කට වඩා පැරණි කතාබස් මක�
 #. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
 msgctxt "Button text in the modal for deleting all recent chats"
 msgid "Delete Chats and Shared Links"
-msgstr ""
+msgstr "කතාබස් සහ බෙදාගත් සබැඳි මකන්න"
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6155,8 +6199,8 @@ msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
 msgstr ""
-"සබැඳියක් මකා දැමීමෙන් එය ක්‍රියා කිරීම නවත්වයි. සංවාදය විවෘත කර ඔවුන්ගේ කතාබස් වෙත එක් කර ඇති "
-"පුද්ගලයින් ඔවුන්ගේම පිටපතක් තබා ගනු ඇත."
+"සබැඳියක් මකා දැමීමෙන් එය ක්‍රියා කිරීම නවත්වයි. සංවාදය විවෘත කර ඔවුන්ගේ "
+"කතාබස් වෙත එක් කර ඇති පුද්ගලයින් ඔවුන්ගේම පිටපතක් තබා ගනු ඇත."
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6253,8 +6297,8 @@ msgstr "Duck.ai අසා ලිවීම"
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
 msgstr ""
-"කියවන විට ලිවීම අප විසින් නිර්නාමික කර ඇති අතර, එය AI ආකෘති පුහුණු කිරීමට කිසිවිටෙකත් භාවිතා කරනු "
-"නොලැබේ."
+"කියවන විට ලිවීම අප විසින් නිර්නාමික කර ඇති අතර, එය AI ආකෘති පුහුණු කිරීමට "
+"කිසිවිටෙකත් භාවිතා කරනු නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6272,8 +6316,8 @@ msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
 msgstr ""
-"කථනය පාඨ බවට පරිවර්තනය කිරීම සඳහා “කියවන විට ලිවීම“ OpenAI ආකෘතියක් භාවිතා කරන බැවින්, "
-"ටයිප් නොකර Duck.ai මත කතාබස් කිරීමට ඔබට පුළුවන."
+"කථනය පාඨ බවට පරිවර්තනය කිරීම සඳහා “කියවන විට ලිවීම“ OpenAI ආකෘතියක් භාවිතා "
+"කරන බැවින්, ටයිප් නොකර Duck.ai මත කතාබස් කිරීමට ඔබට පුළුවන."
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6447,7 +6491,7 @@ msgstr "ප්‍රවර්ධනය ඉවත ලන්න"
 #. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the close button on the survey banner"
 msgid "Dismiss survey"
-msgstr ""
+msgstr "සමීක්ෂණය ඉවතලන්න"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6598,8 +6642,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
-"AI අවශ්‍ය නැද්ද? %1$snoai.duckduckgo.com%2$s කිසිදු AI විශේෂාංග ලබා නොදෙන අතර AI-"
-"ජනනය කරන ලද රූප පෙරහන් කරයි. %3$sවැඩිදුර දැනගන්න%4$s"
+"AI අවශ්‍ය නැද්ද? %1$snoai.duckduckgo.com%2$s කිසිදු AI විශේෂාංග ලබා නොදෙන "
+"අතර AI-ජනනය කරන ලද රූප පෙරහන් කරයි. %3$sවැඩිදුර දැනගන්න%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6608,8 +6652,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"AI අවශ්‍ය නැද්ද? %1$snoai.duckduckgo.com%2$s වෙත යන්න AI විශේෂාංග නොමැතිව සහ AI රූප "
-"පෙරහන් කර සෙවීම සඳහා. %3$sවැඩිදුර දැනගන්න%4$s"
+"AI අවශ්‍ය නැද්ද? %1$snoai.duckduckgo.com%2$s වෙත යන්න AI විශේෂාංග නොමැතිව සහ "
+"AI රූප පෙරහන් කර සෙවීම සඳහා. %3$sවැඩිදුර දැනගන්න%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6725,8 +6769,8 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for "
 "ceiling fan repair services."
 msgstr ""
-"සිවිලිම් විදුලි පංකා අළුත්වැඩියා සේවා සඳහා උපුටා දැක්වීමක් ඉල්ලා සිටින විකුණුම්කරුවෙකුට සංක්ෂිප්ත හා "
-"සවිස්තරාත්මක විද්‍යුත් තැපෑලක් කෙටුම්පත් කරන්න."
+"සිවිලිම් විදුලි පංකා අළුත්වැඩියා සේවා සඳහා උපුටා දැක්වීමක් ඉල්ලා සිටින "
+"විකුණුම්කරුවෙකුට සංක්ෂිප්ත හා සවිස්තරාත්මක විද්‍යුත් තැපෑලක් කෙටුම්පත් කරන්න."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion asking for an email draft to a vendor requesting a quote for home refrigerator repair services.
@@ -6735,8 +6779,8 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
 msgstr ""
-"ගෘහ ශීතකරණ අළුත්වැඩියා සේවා සඳහා මිල කැඳවීමක් ඉල්ලා සිටින විකුණුම්කරුවෙකුට සංක්ෂිප්ත හා "
-"සවිස්තරාත්මක විද්‍යුත් තැපෑලක් කෙටුම්පත් කරන්න."
+"ගෘහ ශීතකරණ අළුත්වැඩියා සේවා සඳහා මිල කැඳවීමක් ඉල්ලා සිටින විකුණුම්කරුවෙකුට "
+"සංක්ෂිප්ත හා සවිස්තරාත්මක විද්‍යුත් තැපෑලක් කෙටුම්පත් කරන්න."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -6757,8 +6801,8 @@ msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
 msgstr ""
-"මගේ ඉදිරි සාදයට පුද්ගලයන්ට ආරාධනා කරන සමාජ මාධ්‍ය පළ කිරීමක් සඳහා විකල්ප කිහිපයක් කෙටුම්පත් "
-"කරන්න."
+"මගේ ඉදිරි සාදයට පුද්ගලයන්ට ආරාධනා කරන සමාජ මාධ්‍ය පළ කිරීමක් සඳහා විකල්ප "
+"කිහිපයක් කෙටුම්පත් කරන්න."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6767,8 +6811,8 @@ msgid ""
 "Draft a few options for a title of a post I’m writing about strategies to "
 "increase team collaboration."
 msgstr ""
-"කණ්ඩායම් සහයෝගීතාව වැඩි කිරීම සඳහා උපාය මාර්ග ගැන මම ලියන තනතුරක මාතෘකාවක් සඳහා විකල්ප "
-"කිහිපයක් කෙටුම්පත් කරන්න."
+"කණ්ඩායම් සහයෝගීතාව වැඩි කිරීම සඳහා උපාය මාර්ග ගැන මම ලියන තනතුරක මාතෘකාවක් "
+"සඳහා විකල්ප කිහිපයක් කෙටුම්පත් කරන්න."
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for drafting a social media post.
@@ -6900,8 +6944,9 @@ msgid ""
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
 msgstr ""
-"ඔබ නරඹන පිටුව පිළිබඳ ප්‍රශ්නවලට පිළිතුරු දීමට Duck.ai හට දැන් උදව් කළ හැක. සැකසුම් තුළ පිටු "
-"ස්වයංක්‍රීයව ඇමිණීමට ඔබ තෝරා නොගන්නේ නම්, පිටු අන්තර්ගතය ඇතුළත් වන්නේ ඔබ එය අමුණන විට පමණි."
+"ඔබ නරඹන පිටුව පිළිබඳ ප්‍රශ්නවලට පිළිතුරු දීමට Duck.ai හට දැන් උදව් කළ හැක. "
+"සැකසුම් තුළ පිටු ස්වයංක්‍රීයව ඇමිණීමට ඔබ තෝරා නොගන්නේ නම්, පිටු අන්තර්ගතය "
+"ඇතුළත් වන්නේ ඔබ එය අමුණන විට පමණි."
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6911,8 +6956,9 @@ msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
 msgstr ""
-"ඔබගේ කතාබස් සුරැකීම සඳහා Duck.ai දේශීය ගබඩාවට පිවිසිය නොහැක. කරුණාකර ඔබගේ බ්‍රවුසර "
-"සැකසුම් පරීක්ෂා කරන්න, නැතහොත් කිනම් හෝ දිගුවක් වේ නම්, එය අක්‍රිය කර නැවත උත්සාහ කරන්න."
+"ඔබගේ කතාබස් සුරැකීම සඳහා Duck.ai දේශීය ගබඩාවට පිවිසිය නොහැක. කරුණාකර ඔබගේ "
+"බ්‍රවුසර සැකසුම් පරීක්ෂා කරන්න, නැතහොත් කිනම් හෝ දිගුවක් වේ නම්, එය අක්‍රිය "
+"කර නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6921,8 +6967,8 @@ msgid ""
 "Duck.ai has reached the maximum number of messages for one day. Please "
 "continue this chat tomorrow."
 msgstr ""
-"Duck.ai එක් දිනක් සඳහා උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වී ඇත. කරුණාකර හෙට මෙම කතාබස් දිගටම "
-"කරගෙන යන්න."
+"Duck.ai එක් දිනක් සඳහා උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වී ඇත. කරුණාකර හෙට මෙම "
+"කතාබස් දිගටම කරගෙන යන්න."
 
 # smartling.placeholder_format=C
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
@@ -6938,9 +6984,9 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
-"Duck.ai නිර්මාණය කර ඇත්තේ DuckDuckGo විසිනි. තම පුද්ගලික තොරතූරුවල පාලනය නැවතත් සියතට "
-"ගැනීමට උවමනා ඔ්නෑම අයකු සඳහා සේවය කරන අන්තර්ජාල ආරක්ෂාව සලසන ස්වාධීන සමාගමක් ලෙස අපි "
-"කටයුතු කරමු."
+"Duck.ai නිර්මාණය කර ඇත්තේ DuckDuckGo විසිනි. තම පුද්ගලික තොරතූරුවල පාලනය "
+"නැවතත් සියතට ගැනීමට උවමනා ඔ්නෑම අයකු සඳහා සේවය කරන අන්තර්ජාල ආරක්ෂාව සලසන "
+"ස්වාධීන සමාගමක් ලෙස අපි කටයුතු කරමු."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6955,8 +7001,8 @@ msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
 msgstr ""
-"Duck.ai තවමත් DuckDuckGo නිෂ්පාදනයක්, නමුත් දැන් මතක තබා ගැනීමට පහසු මුල් පිටුවක් සමගින් "
-"අන්තර්ජාලයේ: https://duck.ai"
+"Duck.ai තවමත් DuckDuckGo නිෂ්පාදනයක්, නමුත් දැන් මතක තබා ගැනීමට පහසු මුල් "
+"පිටුවක් සමගින් අන්තර්ජාලයේ: https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6971,8 +7017,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai තාවකාලිකව ලබා ගත නොහැක. මෙය දිගටම පවතින්නේ නම්, කරුණාකර මෙම %1$s නිර්නාමික "
-"කේතය %2$s වෙත ඊමේල් කරන්න"
+"Duck.ai තාවකාලිකව ලබා ගත නොහැක. මෙය දිගටම පවතින්නේ නම්, කරුණාකර මෙම %1$s "
+"නිර්නාමික කේතය %2$s වෙත ඊමේල් කරන්න"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6993,9 +7039,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"Duck.ai මගින් ඔබට ජනප්‍රිය AI ආකෘති සමඟ පෞද්ගලිකව කතාබස් කිරීමට ඉඩ ලබා දේ. එය අක්‍රිය "
-"කිරීමෙන් Duck.ai බොත්තම් සහ සබැඳි සැඟවෙනු ඇති නමුත් ඔබට තවමත්ඍජුව ම %1$sduck.ai%2$s වෙත "
-"පිවිසිය හැකි ය."
+"Duck.ai මගින් ඔබට ජනප්‍රිය AI ආකෘති සමඟ පෞද්ගලිකව කතාබස් කිරීමට ඉඩ ලබා දේ. "
+"එය අක්‍රිය කිරීමෙන් Duck.ai බොත්තම් සහ සබැඳි සැඟවෙනු ඇති නමුත් ඔබට තවමත්ඍජුව "
+"ම %1$sduck.ai%2$s වෙත පිවිසිය හැකි ය."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7006,10 +7052,11 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai මඟින් OpenAI, Anthropic සහ වෙනත් අයගේ ආකෘති ඇතුළුව 3වන පාර්ශවීය AI චැට් ආකෘති "
-"සමඟ නිර්නාමික සංවාද කිරීමට ඔබට ඉඩ සලසයි. මෙම සැකසුම අක්‍රිය කිරීමෙන් DuckDuckGo Search හි "
-"Duck.ai බොත්තම් සහ සබැඳි සඟවනු ඇත. කෙසේ වෙතත්, මෙම සැකසුම ක්‍රියා විරහිත වූ විටත් ඔබට "
-"%1$shttps://duck.ai%2$s වෙත පිවිසීමෙන් Duck.ai වෙත ප්‍රවේශ විය හැක හැකිය."
+"Duck.ai මඟින් OpenAI, Anthropic සහ වෙනත් අයගේ ආකෘති ඇතුළුව 3වන පාර්ශවීය AI "
+"චැට් ආකෘති සමඟ නිර්නාමික සංවාද කිරීමට ඔබට ඉඩ සලසයි. මෙම සැකසුම අක්‍රිය "
+"කිරීමෙන් DuckDuckGo Search හි Duck.ai බොත්තම් සහ සබැඳි සඟවනු ඇත. කෙසේ වෙතත්, "
+"මෙම සැකසුම ක්‍රියා විරහිත වූ විටත් ඔබට %1$shttps://duck.ai%2$s වෙත "
+"පිවිසීමෙන් Duck.ai වෙත ප්‍රවේශ විය හැක හැකිය."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -7024,8 +7071,8 @@ msgid ""
 "Duck.ai might have lost your recent chats. You can still use Duck.ai as "
 "usual."
 msgstr ""
-"Duck.ai තුළ ඔබේ මෑත කතාබස් නොතිබීමට ඉඩ ඇත. ඔයාට තවමත් සාමාන්‍ය පරිදි Duck.ai භාවිතා "
-"කරන්න පුළුවන්."
+"Duck.ai තුළ ඔබේ මෑත කතාබස් නොතිබීමට ඉඩ ඇත. ඔයාට තවමත් සාමාන්‍ය පරිදි Duck.ai "
+"භාවිතා කරන්න පුළුවන්."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -7039,7 +7086,8 @@ msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
 msgstr ""
-"Duck.ai ප්‍රතිචාර විශේෂිත මූලාශ්‍ර මත පදනම් නොවී ඇත හෝ නිරවද්‍යතාව සඳහා පරීක්ෂා කර නැත."
+"Duck.ai ප්‍රතිචාර විශේෂිත මූලාශ්‍ර මත පදනම් නොවී ඇත හෝ නිරවද්‍යතාව සඳහා "
+"පරීක්ෂා කර නැත."
 
 # smartling.placeholder_format=C
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
@@ -7073,9 +7121,10 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, පුද්ගලික AI චැට්බොට්, නොමිලේ AI කතාබස්, නිර්නාමික AI කතාබහ, "
-"ලියාපදිංචි වීමක් නොමැති AI කතාබස්, OpenAI, Anthropic, Llama, Mistral, විවෘත මූලාශ්‍ර AI "
-"ආකෘති, පෞද්ගලිකත්වය කේන්ද්‍ර කරගත් AI, ගිණුමක් නොමැති AI කතාබස්"
+"Duck.ai, DuckDuckGo AI, පුද්ගලික AI චැට්බොට්, නොමිලේ AI කතාබස්, නිර්නාමික AI "
+"කතාබහ, ලියාපදිංචි වීමක් නොමැති AI කතාබස්, OpenAI, Anthropic, Llama, Mistral, "
+"විවෘත මූලාශ්‍ර AI ආකෘති, පෞද්ගලිකත්වය කේන්ද්‍ර කරගත් AI, ගිණුමක් නොමැති AI "
+"කතාබස්"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7103,12 +7152,13 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"DuckAssist හට නිර්නාමිකව සමහර සෙවීම් වලට ප්‍රතිචාර වශයෙන් තොරතුරු සොයා බලා සාරාංශගත කළ "
-"හැක. කොපමණ වාරයක් DuckAssist පෙනී සිටීමට අවශ්‍ය දැ යි ඔබට තෝරා ගත හැකිය: කිසි විටෙකත් "
-"(සෙවුම් ප්‍රතිඵලවලින් DuckAssist UI සම්පූර්ණයෙන්ම ඉවත් කරයි), On-demand (ඔබ සහාය බොත්තම "
-"ක්ලික් කළහොත් පමණක් පෙන්වයි), සමහර විට (ඉතා අදාළ වන විට පමණක් පෙන්වයි), හෝ බොහෝ විට (පුළුල් "
-"පරාසයක සෙවුම් මත නිතර නිතර පෙන්වයි). දැනට, DuckAssist ලබා ගත හැක්කේ එක්සත් ජනපද "
-"(ඉංග්‍රීසි) කලාපයේ පමණි."
+"DuckAssist හට නිර්නාමිකව සමහර සෙවීම් වලට ප්‍රතිචාර වශයෙන් තොරතුරු සොයා බලා "
+"සාරාංශගත කළ හැක. කොපමණ වාරයක් DuckAssist පෙනී සිටීමට අවශ්‍ය දැ යි ඔබට තෝරා "
+"ගත හැකිය: කිසි විටෙකත් (සෙවුම් ප්‍රතිඵලවලින් DuckAssist UI සම්පූර්ණයෙන්ම "
+"ඉවත් කරයි), On-demand (ඔබ සහාය බොත්තම ක්ලික් කළහොත් පමණක් පෙන්වයි), සමහර විට "
+"(ඉතා අදාළ වන විට පමණක් පෙන්වයි), හෝ බොහෝ විට (පුළුල් පරාසයක සෙවුම් මත නිතර "
+"නිතර පෙන්වයි). දැනට, DuckAssist ලබා ගත හැක්කේ එක්සත් ජනපද (ඉංග්‍රීසි) කලාපයේ "
+"පමණි."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7117,9 +7167,10 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist ට පසුවිපරම් ප්‍රශ්නවලට පිළිතුරු දිය නොහැක, කෙසේ වෙතත්, අපි %1$sDuckDuckGo AI "
-"Chat%2$s සේවය ද ලබා දෙන්නෙමු, එය OpenAI සහ Anthropic වෙතින් වන චැට් ආකෘති සඳහා සහය "
-"දක්වන පෞද්ගලික AI බලයෙන් ක්‍රියාත්මක වන චැට් සේවාවක් වේ."
+"DuckAssist ට පසුවිපරම් ප්‍රශ්නවලට පිළිතුරු දිය නොහැක, කෙසේ වෙතත්, අපි "
+"%1$sDuckDuckGo AI Chat%2$s සේවය ද ලබා දෙන්නෙමු, එය OpenAI සහ Anthropic "
+"වෙතින් වන චැට් ආකෘති සඳහා සහය දක්වන පෞද්ගලික AI බලයෙන් ක්‍රියාත්මක වන චැට් "
+"සේවාවක් වේ."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7128,9 +7179,10 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist ට පසුවිපරම් ප්‍රශ්නවලට පිළිතුරු දිය නොහැක, කෙසේ වෙතත්, අපි DuckDuckGo %1$sAI "
-"Chat%2$s සේවය ද ලබා දෙන්නෙමු, එය OpenAI සහ Anthropic වෙතින් වන චැට් ආකෘති සඳහා සහය "
-"දක්වන පෞද්ගලික AI බලයෙන් ක්‍රියාත්මක වන චැට් සේවාවක් වේ."
+"DuckAssist ට පසුවිපරම් ප්‍රශ්නවලට පිළිතුරු දිය නොහැක, කෙසේ වෙතත්, අපි "
+"DuckDuckGo %1$sAI Chat%2$s සේවය ද ලබා දෙන්නෙමු, එය OpenAI සහ Anthropic "
+"වෙතින් වන චැට් ආකෘති සඳහා සහය දක්වන පෞද්ගලික AI බලයෙන් ක්‍රියාත්මක වන චැට් "
+"සේවාවක් වේ."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7142,11 +7194,12 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති නව විශේෂාංගයක් වන අතර එයට නිර්නාමික ව සෙවුම් "
-"විමසුම් සඳහා පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා විකිපීඩියාව "
-"සහ ඒ ආශ්‍රිත අඩවි පිරික්සන අතර පසුව එම තොරතුරු වල සාරාංශයක් ජනනය කිරීම සඳහා AI බලයෙන් "
-"ක්‍රියාත්මක වන ස්වාභාවික භාෂා තාක්ෂණය භාවිතා කරයි. එහි ප්‍රතිචාර දැනට විකිපීඩියාව සහ අදාළ "
-"අන්තර්ගතයන් මත පදනම් වී ඇති අතර නිරවද්‍යතාව සඳහා පරීක්ෂා කර නොමැති බව කරුණාවෙන් සලකන්න."
+"DuckAssist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති නව විශේෂාංගයක් වන අතර එයට "
+"නිර්නාමික ව සෙවුම් විමසුම් සඳහා පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු කිරීම සඳහා, "
+"එය අදාළ අන්තර්ගතයන් සඳහා විකිපීඩියාව සහ ඒ ආශ්‍රිත අඩවි පිරික්සන අතර පසුව එම "
+"තොරතුරු වල සාරාංශයක් ජනනය කිරීම සඳහා AI බලයෙන් ක්‍රියාත්මක වන ස්වාභාවික භාෂා "
+"තාක්ෂණය භාවිතා කරයි. එහි ප්‍රතිචාර දැනට විකිපීඩියාව සහ අදාළ අන්තර්ගතයන් මත "
+"පදනම් වී ඇති අතර නිරවද්‍යතාව සඳහා පරීක්ෂා කර නොමැති බව කරුණාවෙන් සලකන්න."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7160,13 +7213,15 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති නව විශේෂාංගයක් වන අතර එයට නිර්නාමික ව සෙවුම් "
-"විමසුම් සඳහා පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා වෙබ් ස්කෑන් "
-"කරන අතර පසුව සොයාගත් අදාළ තොරතුරු මත පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI-බලැති "
-"ස්වාභාවික භාෂා තාක්ෂණය භාවිත කරයි. DuckAssist ප්‍රතිචාර සෑම විටම මූලාශ්‍ර එකකට හෝ දෙකකට "
-"සෘජුවම සම්බන්ධ වන අතර, පිළිතුර පැමිණි ස්ථානය උපුටා දක්වයි, එබැවින් ඔබට පහසුවෙන් ගොස් වඩාත් "
-"සවිස්තරාත්මක තොරතුරු ලබා ගත හැකිය. ප්රතිචාර උපුටා දක්වන ලද මූලාශ්රවලින් ස්වයංක්රීයව ජනනය වන "
-"අතර %1$sවෙබ් කැටි ගැසීම%2$s මත පදනම් වන බව මතක තබා ගැනීම වැදගත්ය."
+"DuckAssist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති නව විශේෂාංගයක් වන අතර එයට "
+"නිර්නාමික ව සෙවුම් විමසුම් සඳහා පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු කිරීම සඳහා, "
+"එය අදාළ අන්තර්ගතයන් සඳහා වෙබ් ස්කෑන් කරන අතර පසුව සොයාගත් අදාළ තොරතුරු මත "
+"පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI-බලැති ස්වාභාවික භාෂා තාක්ෂණය භාවිත "
+"කරයි. DuckAssist ප්‍රතිචාර සෑම විටම මූලාශ්‍ර එකකට හෝ දෙකකට සෘජුවම සම්බන්ධ වන "
+"අතර, පිළිතුර පැමිණි ස්ථානය උපුටා දක්වයි, එබැවින් ඔබට පහසුවෙන් ගොස් වඩාත් "
+"සවිස්තරාත්මක තොරතුරු ලබා ගත හැකිය. ප්රතිචාර උපුටා දක්වන ලද මූලාශ්රවලින් "
+"ස්වයංක්රීයව ජනනය වන අතර %1$sවෙබ් කැටි ගැසීම%2$s මත පදනම් වන බව මතක තබා ගැනීම "
+"වැදගත්ය."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -7174,8 +7229,8 @@ msgid ""
 "DuckAssist responses are auto-generated based on listed sources and not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist ප්‍රතිචාර ලැයිස්තුගත මූලාශ්‍ර මත පදනම්ව ස්වයංක්‍රීයව ජනනය වන අතර නිරවද්‍යතාව සඳහා "
-"පරීක්‍ෂා කර නොමැත."
+"DuckAssist ප්‍රතිචාර ලැයිස්තුගත මූලාශ්‍ර මත පදනම්ව ස්වයංක්‍රීයව ජනනය වන අතර "
+"නිරවද්‍යතාව සඳහා පරීක්‍ෂා කර නොමැත."
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -7184,8 +7239,8 @@ msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
 msgstr ""
-"DuckDuckGo AI Chat එක දවසකට උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වෙලා ඇත. කරුණාකර හෙට මෙම "
-"කතාබස් දිගටම කරගෙන යන්න."
+"DuckDuckGo AI Chat එක දවසකට උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වෙලා ඇත. කරුණාකර හෙට "
+"මෙම කතාබස් දිගටම කරගෙන යන්න."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7194,8 +7249,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat පුද්ගලික AI බලැති චැට් සේවාවක් වන අතර එය දැනට %1$s %2$s සහ %3$s "
-"%4$s චැට් මාදිලි සඳහා සහාය දක්වයි."
+"DuckDuckGo AI Chat පුද්ගලික AI බලැති චැට් සේවාවක් වන අතර එය දැනට %1$s %2$s "
+"සහ %3$s %4$s චැට් මාදිලි සඳහා සහාය දක්වයි."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7204,8 +7259,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat පුද්ගලික AI බලැති චැට් සේවාවක් වන අතර එය දැනට %1$s %2$s සහ %3$s "
-"%4$s චැට් මාදිලි සඳහා සහාය දක්වයි."
+"DuckDuckGo AI Chat පුද්ගලික AI බලැති චැට් සේවාවක් වන අතර එය දැනට %1$s %2$s "
+"සහ %3$s %4$s චැට් මාදිලි සඳහා සහාය දක්වයි."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -7231,7 +7286,9 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr "DuckDuckGo AI Chat තාවකාලිකව නොමැත. කරුණාකර පිටුව නැවුම් කර නැවත උත්සාහ කරන්න."
+msgstr ""
+"DuckDuckGo AI Chat තාවකාලිකව නොමැත. කරුණාකර පිටුව නැවුම් කර නැවත උත්සාහ "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7387,8 +7444,8 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"DuckDuckGo නම, විද්‍යුත් තැපැල් ලිපින, දුරකථන අංක සහ හඳුනාගත හැකි පාර-දත්ත වැනි PII "
-"ස්වයංක්‍රීයව ඉවත් කිරීමෙන් මෙම වාර්තා නිර්නාමික කරයි."
+"DuckDuckGo නම, විද්‍යුත් තැපැල් ලිපින, දුරකථන අංක සහ හඳුනාගත හැකි පාර-දත්ත "
+"වැනි PII ස්වයංක්‍රීයව ඉවත් කිරීමෙන් මෙම වාර්තා නිර්නාමික කරයි."
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -7396,8 +7453,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo ඔබගේ කතාබස් නිර්නාමික කරයි. '%1$s' ක්ලික් කිරීමෙන් ඔබ Duck.ai %2$s වෙත එකඟ "
-"වෙයි."
+"DuckDuckGo ඔබගේ කතාබස් නිර්නාමික කරයි. '%1$s' ක්ලික් කිරීමෙන් ඔබ Duck.ai "
+"%2$s වෙත එකඟ වෙයි."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7406,7 +7463,8 @@ msgctxt ""
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
 msgstr ""
-"DuckDuckGo ඔබගේ කතාබස් නිර්නාමික කරයි. '%1$s' ක්ලික් කිරීමෙන් ඔබ අපගේ %2$s වෙත එකඟ වෙයි."
+"DuckDuckGo ඔබගේ කතාබස් නිර්නාමික කරයි. '%1$s' ක්ලික් කිරීමෙන් ඔබ අපගේ %2$s "
+"වෙත එකඟ වෙයි."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7415,8 +7473,9 @@ msgid ""
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
 msgstr ""
-"ගූගල් සහ ෆේස්බුක් වැනි සමාගම්වල ට්‍රැකර් ඇතුළු ඔබ පිවිසෙන වෙබ් අඩවි වල DuckDuckGo ට්‍රැකර් අවහිර "
-"කරයි, බොහෝ විට වෙනත් වෙබ් අඩවි වල ඔබව නිරීක්ෂණය කිරීමට උත්සාහ කරයි."
+"ගූගල් සහ ෆේස්බුක් වැනි සමාගම්වල ට්‍රැකර් ඇතුළු ඔබ පිවිසෙන වෙබ් අඩවි වල "
+"DuckDuckGo ට්‍රැකර් අවහිර කරයි, බොහෝ විට වෙනත් වෙබ් අඩවි වල ඔබව නිරීක්ෂණය "
+"කිරීමට උත්සාහ කරයි."
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7428,11 +7487,11 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo සැලසුම අනුව පුද්ගලිකයි. ඔබ ස්ථානය සක්‍රීය කරන විට, එය ඔබේ දේශීය උපාංගයේ පමණක් "
-"ගබඩා වේ. ඔබ සොයන විට, ඔබේ උපාංගය එය අප වෙත යවයි, එම සෙවුමේ ප්‍රතිඵල වැඩි දියුණු කිරීම "
-"සඳහා අපි එය භාවිතා කරමු, පසුව ඔබ නිර්නාමික වන පරිදි අපි එය වහාම ඉවත දමමු. %1$sඔබේ "
-"පුද්ගලිකත්වය ආරක්ෂා කිරීමට අප මෙම තාක්ෂණය කෙසේ නිර්මාණය කර ඇතිදැයි යන්න තවදුරටත් ඉගෙන "
-"ගන්න%2$s."
+"DuckDuckGo සැලසුම අනුව පුද්ගලිකයි. ඔබ ස්ථානය සක්‍රීය කරන විට, එය ඔබේ දේශීය "
+"උපාංගයේ පමණක් ගබඩා වේ. ඔබ සොයන විට, ඔබේ උපාංගය එය අප වෙත යවයි, එම සෙවුමේ "
+"ප්‍රතිඵල වැඩි දියුණු කිරීම සඳහා අපි එය භාවිතා කරමු, පසුව ඔබ නිර්නාමික වන "
+"පරිදි අපි එය වහාම ඉවත දමමු. %1$sඔබේ පුද්ගලිකත්වය ආරක්ෂා කිරීමට අප මෙම "
+"තාක්ෂණය කෙසේ නිර්මාණය කර ඇතිදැයි යන්න තවදුරටත් ඉගෙන ගන්න%2$s."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -7452,8 +7511,8 @@ msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
 msgstr ""
-"DuckDuckGo භාවිතා කරන්නේ ඔබගේ ආසන්න ස්ථානය පමණි. ඔබට වඩා සමීප හොඳ ප්‍රතිඵල ලබා දීමට "
-"අපට අවශ්‍ය වන්නේ එපමණයි. %1$sතවත් ඉගෙන ගන්න%2$s."
+"DuckDuckGo භාවිතා කරන්නේ ඔබගේ ආසන්න ස්ථානය පමණි. ඔබට වඩා සමීප හොඳ ප්‍රතිඵල "
+"ලබා දීමට අපට අවශ්‍ය වන්නේ එපමණයි. %1$sතවත් ඉගෙන ගන්න%2$s."
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7545,9 +7604,9 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"ඔබ මුරපද යෝජනාවක් ඉල්ලා සිටින සෑම අවස්ථාවකම, DuckDuckGo සර්වර වලින් අපට දිගු අහඹු වචන "
-"ලැයිස්තුවක් ලැබේ. බ්‍රව්සරයේ දී, අපි එම ලැයිස්තුවෙන් අහඹු වචන 4-5 ක් තෝරා ගනිමු, මුරපදය අවම "
-"වශයෙන් අක්ෂර 18-20 ක් වත් ඇති බව සහතික කරමු."
+"ඔබ මුරපද යෝජනාවක් ඉල්ලා සිටින සෑම අවස්ථාවකම, DuckDuckGo සර්වර වලින් අපට දිගු "
+"අහඹු වචන ලැයිස්තුවක් ලැබේ. බ්‍රව්සරයේ දී, අපි එම ලැයිස්තුවෙන් අහඹු වචන 4-5 "
+"ක් තෝරා ගනිමු, මුරපදය අවම වශයෙන් අක්ෂර 18-20 ක් වත් ඇති බව සහතික කරමු."
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7604,7 +7663,7 @@ msgstr "විමසුම සංස්කරණය කරන්න"
 #. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the message-editing text area"
 msgid "Edit message"
-msgstr ""
+msgstr "පණිවිඩය සංස්කරණය කරන්න"
 
 # smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
@@ -7623,7 +7682,9 @@ msgstr "රූපය සංස්කරණය කෙරේ..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr "ඔබේ පණිවිඩය සංස්කරණය කිරීමෙන් පහත ප්‍රතිචාරය ඉවත් කර නව ප්‍රතිචාරයක් ජනනය කරයි."
+msgstr ""
+"ඔබේ පණිවිඩය සංස්කරණය කිරීමෙන් පහත ප්‍රතිචාරය ඉවත් කර නව ප්‍රතිචාරයක් ජනනය "
+"කරයි."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7761,8 +7822,8 @@ msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
 msgstr ""
-"වඩාත් නිවැරදි ප්‍රතිඵල සඳහා නිර්නාමික ස්ථානය සක්‍රීය කරන්න. ඔබට පසුව සෑම විටම ඔබේ අදහස වෙනස් "
-"කළ හැකිය."
+"වඩාත් නිවැරදි ප්‍රතිඵල සඳහා නිර්නාමික ස්ථානය සක්‍රීය කරන්න. ඔබට පසුව සෑම "
+"විටම ඔබේ අදහස වෙනස් කළ හැකිය."
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7773,7 +7834,9 @@ msgstr "Duck.ai මත අසා ලිවීම සක් රීය කරන�
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr "නිර්නාමික පිහිටීම භාවිතා කිරීම සඳහා ඔබේ උපාංගය මත පිහිටීම් සැකසුම් සක්‍රිය කරන්න"
+msgstr ""
+"නිර්නාමික පිහිටීම භාවිතා කිරීම සඳහා ඔබේ උපාංගය මත පිහිටීම් සැකසුම් සක්‍රිය "
+"කරන්න"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -7805,8 +7868,8 @@ msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
 msgstr ""
-"නිර්නාමික ස්ථානය සක්‍රිය කිරීම වඩාත් නිවැරදි ප්‍රතිඵල ලබා දෙන නමුත් ඉන් තවමත් ඔබේ සෙවුම් සහ නිශ්චිත "
-"ස්ථානය DuckDuckGo වෙත පෞද්ගලිකව තබා ගනී."
+"නිර්නාමික ස්ථානය සක්‍රිය කිරීම වඩාත් නිවැරදි ප්‍රතිඵල ලබා දෙන නමුත් ඉන් "
+"තවමත් ඔබේ සෙවුම් සහ නිශ්චිත ස්ථානය DuckDuckGo වෙත පෞද්ගලිකව තබා ගනී."
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7830,7 +7893,7 @@ msgstr "ගුප්ත කේතිත ආකෘතිය"
 #. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
 msgctxt "Share modal info bullet about encryption"
 msgid "Encrypted so DuckDuckGo can't read your chat."
-msgstr ""
+msgstr "DuckDuckGo හට ඔබගේ කතාබස කියවිය නොහැකි වන පරිදි ගුප්ත කේතිත කර ඇත."
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -7974,8 +8037,8 @@ msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
 msgstr ""
-"නව මුරපදයක් ඇතුලත් කර %1$sසැකසුම් සුරකින්න%2$s ක්ලික්/තට්ටු කරන්න. මෙය ඔබගේ නව මුරදය යටතේ "
-"ඔබගේ දත්ත සුරකිනු ඇත."
+"නව මුරපදයක් ඇතුලත් කර %1$sසැකසුම් සුරකින්න%2$s ක්ලික්/තට්ටු කරන්න. මෙය ඔබගේ "
+"නව මුරදය යටතේ ඔබගේ දත්ත සුරකිනු ඇත."
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -8102,7 +8165,9 @@ msgstr "සිතියම පුළුල් කරන්න"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr "පෞද්ගලිකත්වය ගැන සැලකිල්ලක් දක්වන අය සඳහා විශේෂඥ ලෙස නිර්මාණය කරන ලද නිෂ්පාදන."
+msgstr ""
+"පෞද්ගලිකත්වය ගැන සැලකිල්ලක් දක්වන අය සඳහා විශේෂඥ ලෙස නිර්මාණය කරන ලද "
+"නිෂ්පාදන."
 
 # smartling.placeholder_format=C
 #. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
@@ -8190,7 +8255,9 @@ msgstr "මෙය සරලව පැහැදිලි කරන්න"
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
-msgstr "මෙම සංචිතය කරන්නේ කුමක් ද යන්න සහ එය භාවිතා කරන්නේ කෙසේ ද යන්න පැහැදිලි කරන්න."
+msgstr ""
+"මෙම සංචිතය කරන්නේ කුමක් ද යන්න සහ එය භාවිතා කරන්නේ කෙසේ ද යන්න පැහැදිලි "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -8385,7 +8452,9 @@ msgstr "ප්‍රතිපෝෂණය සාර්ථකව යවන ලද
 msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
-msgstr "ඔබේ වැනි ප්‍රතිචාර සෘජුවම අපගේ නිෂ්පාදන යාවත්කාලීන කිරීම් සහ වැඩිදියුණු කිරීම් බලපායි."
+msgstr ""
+"ඔබේ වැනි ප්‍රතිචාර සෘජුවම අපගේ නිෂ්පාදන යාවත්කාලීන කිරීම් සහ වැඩිදියුණු "
+"කිරීම් බලපායි."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8394,15 +8463,18 @@ msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
 msgstr ""
-"ඔබේ වැනි ප්‍රතිචාර අපගේ නිෂ්පාදන යාවත්කාලීන කිරීම් සහ වැඩිදියුණු කිරීම් සෘජුවම බලපායි. ඔබ බෙදාගත් "
-"ගැටලුවටත් අපට විසඳුමක් සොයාගත හැකි යැයි මම බලාපොරොත්තු වෙමි."
+"ඔබේ වැනි ප්‍රතිචාර අපගේ නිෂ්පාදන යාවත්කාලීන කිරීම් සහ වැඩිදියුණු කිරීම් "
+"සෘජුවම බලපායි. ඔබ බෙදාගත් ගැටලුවටත් අපට විසඳුමක් සොයාගත හැකි යැයි මම "
+"බලාපොරොත්තු වෙමි."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
 msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
-msgstr "පහත සැකසුම් සකස් කිරීමට නිදහස් වන්න. ඉන්පසු කේතය ඔබේ වෙබ් අඩවියට පිටපත් කරන්න."
+msgstr ""
+"පහත සැකසුම් සකස් කිරීමට නිදහස් වන්න. ඉන්පසු කේතය ඔබේ වෙබ් අඩවියට පිටපත් "
+"කරන්න."
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8492,7 +8564,8 @@ msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
 msgstr ""
-"රූප සෙවුම් ප්‍රතිඵලවලින් දන්නා AI අයාචිත අඩවි පෙරහන් කර ඉවත් කරයි. %1$sවැඩිදුර දැනගන්න%2$s"
+"රූප සෙවුම් ප්‍රතිඵලවලින් දන්නා AI අයාචිත අඩවි පෙරහන් කර ඉවත් කරයි. "
+"%1$sවැඩිදුර දැනගන්න%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8570,7 +8643,9 @@ msgstr "ඔබට සමීප ප්‍රතිඵල සොයා ගන්�
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr "ඔබට අසල ප්‍රතිඵල සොයා ගන්න. %1$sඔබේ ස්ථානය පුද්ගලිකව, ආරක්ෂිතව සහ නිර්නාමිකව පවතී."
+msgstr ""
+"ඔබට අසල ප්‍රතිඵල සොයා ගන්න. %1$sඔබේ ස්ථානය පුද්ගලිකව, ආරක්ෂිතව සහ නිර්නාමිකව "
+"පවතී."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8634,8 +8709,8 @@ msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
 msgstr ""
-"DuckDuckGo සඳහා දැන්වීම් අවහිරකරණය අක්‍රීය කිරීමට උපදෙස් අනුගමනය කරන්න. ඔයාට මෙනු විකල්පයක් "
-"තෝරන්න හෝ බොත්තමක් ක්ලික් කරන්න වෙන්න පුළුවන්."
+"DuckDuckGo සඳහා දැන්වීම් අවහිරකරණය අක්‍රීය කිරීමට උපදෙස් අනුගමනය කරන්න. ඔයාට "
+"මෙනු විකල්පයක් තෝරන්න හෝ බොත්තමක් ක්ලික් කරන්න වෙන්න පුළුවන්."
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8652,7 +8727,7 @@ msgstr "පසු විපරම් ප්‍රශ්නය"
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
-msgstr ""
+msgstr "පසු විපරම් පෞද්ගලිකව පවතී."
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8870,8 +8945,8 @@ msgid ""
 "strong>."
 msgstr ""
 "Mac හි යෙදුම් මෙනු තීරුවෙන්, <strong>DuckDuckGo</strong> තෝරන්න &gt; "
-"<strong>යාවත්කාලීන සඳහා පරීක්ෂා කරන්න...</strong>, ඉන්පසු <strong>යාවත්කාලීන ස්ථාපනය "
-"කරන්න</strong> තෝරන්න."
+"<strong>යාවත්කාලීන සඳහා පරීක්ෂා කරන්න...</strong>, ඉන්පසු <strong>යාවත්කාලීන "
+"ස්ථාපනය කරන්න</strong> තෝරන්න."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9157,8 +9232,8 @@ msgid ""
 "Get DuckDuckGo VPN, advanced Duck.ai, Personal Info Removal, and Identity "
 "Theft Restoration."
 msgstr ""
-"DuckDuckGo VPN, උසස් Duck.ai ලබා ගන්න පුද්ගලික තොරතුරු ඉවත් කිරීම සහ Identity Theft "
-"Restoration."
+"DuckDuckGo VPN, උසස් Duck.ai ලබා ගන්න පුද්ගලික තොරතුරු ඉවත් කිරීම සහ "
+"Identity Theft Restoration."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
@@ -9170,7 +9245,7 @@ msgstr "DuckDuckGo VPN, උසස් Duck.ai, සහ Identity Theft Restoration 
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
 msgctxt "Tooltip on the header logo for sunglasses searches"
 msgid "Get DuckDuckGo sunglasses and other gear."
-msgstr ""
+msgstr "DuckDuckGo අව් කණ්ණාඩි සහ අනෙකුත් වෙළඳ භාණ්ඩ ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9250,8 +9325,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, Personal Info Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"වේගවත්, ලොග් වීම අනවශ්‍ය VPN, විකල්ප උසස් AI කතාබහ, Personal info Removal, සහ "
-"Identity Theft Restoration ලබා ගන්න."
+"වේගවත්, ලොග් වීම අනවශ්‍ය VPN, විකල්ප උසස් AI කතාබහ, Personal info Removal, "
+"සහ Identity Theft Restoration ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; 'advanced AI chat' refers to Duck.ai; Identity Theft Restoration is a bundled feature.
@@ -9260,8 +9335,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, and Identity Theft "
 "Restoration."
 msgstr ""
-"වේගවත්, ලොග් වීම අනවශ්‍ය VPN එකක්, විකල්ප උසස් AI චැට් එකක් සහ Identity Theft "
-"Restoration ලබා ගන්න."
+"වේගවත්, ලොග් වීම අනවශ්‍ය VPN එකක්, විකල්ප උසස් AI චැට් එකක් සහ Identity "
+"Theft Restoration ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. Description for the subscription modal where users can update their subscription to DuckDuckGo.
@@ -9270,8 +9345,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"අපගේ VPN සහ අනෙකුත් ප්‍රිමියම් පෞද්ගලිකත්ව ආරක්ෂණ ඇතුළත් වන DuckDuckGo වෙත දායක වීමෙන් Duck."
-"ai හි උසස් AI ආකෘති වෙත ප්‍රවේශය ලබා ගන්න."
+"අපගේ VPN සහ අනෙකුත් ප්‍රිමියම් පෞද්ගලිකත්ව ආරක්ෂණ ඇතුළත් වන DuckDuckGo වෙත "
+"දායක වීමෙන් Duck.ai හි උසස් AI ආකෘති වෙත ප්‍රවේශය ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -9282,8 +9357,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"අපගේ VPN සහ අනෙකුත් ප්‍රිමියම් පෞද්ගලිකත්ව ආරක්ෂණ ද ඇතුළත් වන DuckDuckGo දායකත්වයක් සමඟ "
-"Duck.ai හි උසස් AI ආකෘති වෙත ප්‍රවේශය ලබා ගන්න."
+"අපගේ VPN සහ අනෙකුත් ප්‍රිමියම් පෞද්ගලිකත්ව ආරක්ෂණ ද ඇතුළත් වන DuckDuckGo "
+"දායකත්වයක් සමඟ Duck.ai හි උසස් AI ආකෘති වෙත ප්‍රවේශය ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9327,8 +9402,8 @@ msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
 msgstr ""
-"අපගේ වේගවත්, ලොග් වීම අනවශ්‍ය VPN එක, ඉහළ චැට් සීමාවන් සහිත උසස් AI මාදිලි සඳහා විකල්ප "
-"ප්‍රවේශය සහ තවත් ප්‍රිමියම් ආරක්ෂණ ලබා ගන්න."
+"අපගේ වේගවත්, ලොග් වීම අනවශ්‍ය VPN එක, ඉහළ චැට් සීමාවන් සහිත උසස් AI මාදිලි "
+"සඳහා විකල්ප ප්‍රවේශය සහ තවත් ප්‍රිමියම් ආරක්ෂණ ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9337,8 +9412,8 @@ msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, Personal Information Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"අපගේ ආරක්ෂිත, ලොග් වීම අනවශ්‍ය VPN, උසස් Duck.ai ලබා ගන්න, Personal Information "
-"Removal සහ Identity Theft Restoration."
+"අපගේ ආරක්ෂිත, ලොග් වීම අනවශ්‍ය VPN, උසස් Duck.ai ලබා ගන්න, Personal "
+"Information Removal සහ Identity Theft Restoration."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
@@ -9346,8 +9421,8 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
-"අපගේ ආරක්ෂිත, ලොග් වීම අනවශ්‍ය VPN, උසස් Duck.ai, සහ Identity Theft Restoration ලබා "
-"ගන්න."
+"අපගේ ආරක්ෂිත, ලොග් වීම අනවශ්‍ය VPN, උසස් Duck.ai, සහ Identity Theft "
+"Restoration ලබා ගන්න."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -9388,7 +9463,9 @@ msgstr "යෙදුම ලබා ගන්න"
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
-msgstr "YouTube මත දැන්වීම් අවහිර කිරීමට %1$sනොමිලේ DuckDuckGo බ්‍රවුසරය ලබා ගන්න.%2$s"
+msgstr ""
+"YouTube මත දැන්වීම් අවහිර කිරීමට %1$sනොමිලේ DuckDuckGo බ්‍රවුසරය ලබා "
+"ගන්න.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9447,9 +9524,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රවුසරයේ %1$sDuck.ai සැකසුම්%2$s වෙත යන්න, නැතහොත් DuckDuckGo යෙදුම වෙත "
-"ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත කරන්න › පාඨමය කේතය "
-"පිටපත් කරන්න%4$sවෙත යන්න"
+"ඔබගේ අනෙක් බ්‍රවුසරයේ %1$sDuck.ai සැකසුම්%2$s වෙත යන්න, නැතහොත් DuckDuckGo "
+"යෙදුම වෙත ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත "
+"කරන්න › පාඨමය කේතය පිටපත් කරන්න%4$sවෙත යන්න"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9458,8 +9535,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රව්සරයෙන් හෝ DuckDuckGo යෙදුමෙන් %1$sDuck.ai සැකසුම්%2$s වෙත ගොස් "
-"%3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත කරන්න%4$sවෙත යන්න."
+"ඔබගේ අනෙක් බ්‍රව්සරයෙන් හෝ DuckDuckGo යෙදුමෙන් %1$sDuck.ai සැකසුම්%2$s වෙත "
+"ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත කරන්න%4$sවෙත "
+"යන්න."
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9469,9 +9547,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රවුසරයේ %1$sDuck.ai සැකසුම්%2$s වෙත යන්න, නැතහොත් DuckDuckGo යෙදුම වෙත "
-"ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත කරන්න%4$s වෙත ගොස් මෙම "
-"කේතය ස්කෑන් කරන්න:"
+"ඔබගේ අනෙක් බ්‍රවුසරයේ %1$sDuck.ai සැකසුම්%2$s වෙත යන්න, නැතහොත් DuckDuckGo "
+"යෙදුම වෙත ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත "
+"කරන්න%4$s වෙත ගොස් මෙම කේතය ස්කෑන් කරන්න:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9481,9 +9559,10 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රවුසරයේ %1$sDuck.ai සැකසුම්%2$s වෙත යන්න, නැතහොත් DuckDuckGo යෙදුම වෙත "
-"ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත කරන්න%4$s වෙත යන්න. "
-"නැතහොත් ඔබගේ ප්‍රතිසාධන PDF ගොනුවේ ඇති QR කේතය ස්කෑන් කරන්න."
+"ඔබගේ අනෙක් බ්‍රවුසරයේ %1$sDuck.ai සැකසුම්%2$s වෙත යන්න, නැතහොත් DuckDuckGo "
+"යෙදුම වෙත ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත "
+"කරන්න%4$s වෙත යන්න. නැතහොත් ඔබගේ ප්‍රතිසාධන PDF ගොනුවේ ඇති QR කේතය ස්කෑන් "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Path to the pairing code on the other device. Bold segments are UI path labels.
@@ -9492,8 +9571,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
 msgstr ""
-"%1$sDuck.ai සැකසුම්%2$s › %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත "
-"කරන්න%4$s වෙත යන්න."
+"%1$sDuck.ai සැකසුම්%2$s › %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග "
+"සමමුහුර්ත කරන්න%4$s වෙත යන්න."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9508,8 +9587,8 @@ msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
 msgstr ""
-"%1$sසැකසුම්> පෞද්ගලිකත්වය සහ ආරක්ෂාව > ස්ථාන සේවා%2$s වෙත ගොස් \"ස්ථාන සේවා\" සක්‍රිය කර "
-"ඇති බවට වග බලා ගන්න."
+"%1$sසැකසුම්> පෞද්ගලිකත්වය සහ ආරක්ෂාව > ස්ථාන සේවා%2$s වෙත ගොස් \"ස්ථාන "
+"සේවා\" සක්‍රිය කර ඇති බවට වග බලා ගන්න."
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -9518,8 +9597,8 @@ msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
 msgstr ""
-"%1$sසැකසුම් > පෞද්ගලිකත්වය > අවසර කළමනාකරු > ස්ථාන%2$s වෙත ගොස් %3$sDuckDuckGo%4$s "
-"වෙත පහළට අනුචලනය කරන්න."
+"%1$sසැකසුම් > පෞද්ගලිකත්වය > අවසර කළමනාකරු > ස්ථාන%2$s වෙත ගොස් "
+"%3$sDuckDuckGo%4$s වෙත පහළට අනුචලනය කරන්න."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -10208,8 +10287,8 @@ msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
 msgstr ""
-"වැදගත් තොරතුරු වේගයෙන් සොයා ගැනීමට ඔබට උපකාර කිරීම සඳහා Search Assist පිළිතුරුවල ප්‍රධාන "
-"කරුණු ඉස්මතු කරයි."
+"වැදගත් තොරතුරු වේගයෙන් සොයා ගැනීමට ඔබට උපකාර කිරීම සඳහා Search Assist "
+"පිළිතුරුවල ප්‍රධාන කරුණු ඉස්මතු කරයි."
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -10236,8 +10315,8 @@ msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
 msgstr ""
-"ඔබගේ යතුරුපුවරුවේ %1$sReturn%2$s බොත්තම ඔබා %3$sDuckDuckGo ලැයිස්තුවේ සුරකින්න."
-"%4$sඉන්පසුව %5$sMake Default%6$s මත ක්ලික් කරන්න"
+"ඔබගේ යතුරුපුවරුවේ %1$sReturn%2$s බොත්තම ඔබා %3$sDuckDuckGo ලැයිස්තුවේ "
+"සුරකින්න.%4$sඉන්පසුව %5$sMake Default%6$s මත ක්ලික් කරන්න"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -10251,8 +10330,8 @@ msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
 msgstr ""
-"නවත්වන්න! එය නැවත වෙනස් කිරීමෙන් DuckDuckGo දිගුව අක්‍රීය වන අතර ඔබට අපගේ රහස්‍යතා ආරක්ෂාව "
-"අහිමි වේ."
+"නවත්වන්න! එය නැවත වෙනස් කිරීමෙන් DuckDuckGo දිගුව අක්‍රීය වන අතර ඔබට අපගේ "
+"රහස්‍යතා ආරක්ෂාව අහිමි වේ."
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -10302,8 +10381,8 @@ msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
 msgstr ""
-"හෝටල් දැන්වීම් ක්ලික් කිරීම් Tripadvisor හි දැන්වීම් ජාලය මගින් කළමනාකරණය කරනු ලබන අතර ඔබව "
-"පැතිකඩ කිරීමට භාවිත නොකෙරේ."
+"හෝටල් දැන්වීම් ක්ලික් කිරීම් Tripadvisor හි දැන්වීම් ජාලය මගින් කළමනාකරණය "
+"කරනු ලබන අතර ඔබව පැතිකඩ කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -10400,7 +10479,7 @@ msgstr "එය ක්‍රියා කරන ආකාරය"
 #. Headline in chat history about modals for the temporary encrypted server storage explanation.
 msgctxt "Chat history about modal list item headline"
 msgid "How it works"
-msgstr ""
+msgstr "එය ක්‍රියා කරන ආකාරය"
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -10451,8 +10530,8 @@ msgid ""
 "How should I tactfully approach a colleague about their constant pencil "
 "tapping and what should I say?"
 msgstr ""
-"ඔවුන්ගේ නිරන්තර පැන්සල් තට්ටු කිරීම ගැන සගයෙකුට උපායශීලීව ප්‍රවේශ විය යුත්තේ කෙසේද සහ මා කුමක් "
-"කිව යුතුද?"
+"ඔවුන්ගේ නිරන්තර පැන්සල් තට්ටු කිරීම ගැන සගයෙකුට උපායශීලීව ප්‍රවේශ විය යුත්තේ "
+"කෙසේද සහ මා කුමක් කිව යුතුද?"
 
 # smartling.placeholder_format=C
 #. The title for a feedback prompt that includes thumbs up and thumbs down buttons
@@ -10574,8 +10653,8 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"සුළඟේ නම කියන පොතට මම කැමතියි. තවත් හොඳ පොත්/කතා මාලා කිහිපයක් එයට වඩාත්ම කැමති මොනවාද "
-"සහ ඇයි?"
+"සුළඟේ නම කියන පොතට මම කැමතියි. තවත් හොඳ පොත්/කතා මාලා කිහිපයක් එයට වඩාත්ම "
+"කැමති මොනවාද සහ ඇයි?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -10610,8 +10689,8 @@ msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
 msgstr ""
-"බ්‍රවුසර් පිහිටීම දිගටම ලද නොහැකි නම්, %1$sසැකසුම් > සාමාන්‍ය > යළි සකසන්න > 'පිහිටීම හා "
-"රහස්‍යතාව යළි සකසන්න'%2$s වෙත යන්න."
+"බ්‍රවුසර් පිහිටීම දිගටම ලද නොහැකි නම්, %1$sසැකසුම් > සාමාන්‍ය > යළි සකසන්න > "
+"'පිහිටීම හා රහස්‍යතාව යළි සකසන්න'%2$s වෙත යන්න."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10621,8 +10700,9 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"බ්‍රවුසර් පිහිටීම දිගටම ලද නොහැකි නම්, ඔබේ බ්‍රවුසරයෙන් %1$s⋮ > මෙනුව > සැකසුම් > අඩවි සැකසුම් > "
-"පිහිටීම%2$s වෙත ගොස්, DuckDuckGo වෙත ප්‍රවේශය සඳහා අවසර දී ඇති ද යන්න දැනගන්න."
+"බ්‍රවුසර් පිහිටීම දිගටම ලද නොහැකි නම්, ඔබේ බ්‍රවුසරයෙන් %1$s⋮ > මෙනුව > "
+"සැකසුම් > අඩවි සැකසුම් > පිහිටීම%2$s වෙත ගොස්, DuckDuckGo වෙත ප්‍රවේශය සඳහා "
+"අවසර දී ඇති ද යන්න දැනගන්න."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10637,8 +10717,8 @@ msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
 msgstr ""
-"ඔබට %1$sDuckDuckGo%2$s දැක ගැනීමට නොහැකිනම්, ඔබට සිදුවෙනවා එය %3$sOther Search "
-"Engines%4$s ලැයිස්තුවට එකතු කරන්න"
+"ඔබට %1$sDuckDuckGo%2$s දැක ගැනීමට නොහැකිනම්, ඔබට සිදුවෙනවා එය %3$sOther "
+"Search Engines%4$s ලැයිස්තුවට එකතු කරන්න"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -10647,8 +10727,8 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"අපගේ චැට් සපයන්නන් හෝ කිසියම් විශේෂිත චැට් ප්‍රතිචාරයක් ගැන ඔබට කනස්සල්ලක් ඇත්නම්, ඔබට කෙලින්ම "
-"%1$s සහ %2$s සහාය පිටු වෙත ළඟා විය හැකිය."
+"අපගේ චැට් සපයන්නන් හෝ කිසියම් විශේෂිත චැට් ප්‍රතිචාරයක් ගැන ඔබට කනස්සල්ලක් "
+"ඇත්නම්, ඔබට කෙලින්ම %1$s සහ %2$s සහාය පිටු වෙත ළඟා විය හැකිය."
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10657,14 +10737,17 @@ msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
 msgstr ""
-"ඔබට ඔබගේ උපාංගවලට ප්‍රවේශය අහිමි වුවහොත්, ඔබගේ සුරකින ලද කතාබස් නැවත ලබා ගැනීමට මෙම "
-"කේතය අවශ්‍ය වනු ඇත. ඔබට මෙම කේතය ඔබගේ උපාංගයට පෙළ ගොනුවක් ලෙස සුරැකිය හැකි ය."
+"ඔබට ඔබගේ උපාංගවලට ප්‍රවේශය අහිමි වුවහොත්, ඔබගේ සුරකින ලද කතාබස් නැවත ලබා "
+"ගැනීමට මෙම කේතය අවශ්‍ය වනු ඇත. ඔබට මෙම කේතය ඔබගේ උපාංගයට පෙළ ගොනුවක් ලෙස "
+"සුරැකිය හැකි ය."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "ඔබට තවමත් අවශ්‍යයනම් අපිට උදවු කරන්න, %1$sDuckDuckGo ව්‍යාප්ත කරන්න උදවු කරන්න%2$s"
+msgstr ""
+"ඔබට තවමත් අවශ්‍යයනම් අපිට උදවු කරන්න, %1$sDuckDuckGo ව්‍යාප්ත කරන්න උදවු "
+"කරන්න%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10674,15 +10757,17 @@ msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
 msgstr ""
-"ඔබට DuckDuckGo ජාවාස්ක්‍රිප්ට් නැතුව භාවිතා කිරීමට අවශ්‍යයනම්, කරුණාකර අපගේ %1$s හෝ %2$s "
-"යන පිටපත් භාවිතා කරන්න."
+"ඔබට DuckDuckGo ජාවාස්ක්‍රිප්ට් නැතුව භාවිතා කිරීමට අවශ්‍යයනම්, කරුණාකර අපගේ "
+"%1$s හෝ %2$s යන පිටපත් භාවිතා කරන්න."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
-msgstr "ඔබට අවශ්‍යයනම්, අලුත් කවුළු හා ටැබ් සඳහා මුල් පිටුවක් තෝරා ගන්න (සමග විවෘත කරන්න)."
+msgstr ""
+"ඔබට අවශ්‍යයනම්, අලුත් කවුළු හා ටැබ් සඳහා මුල් පිටුවක් තෝරා ගන්න (සමග විවෘත "
+"කරන්න)."
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -10811,7 +10896,8 @@ msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
 msgstr ""
-"යාවත්කාලීන කළ URL ආකෘතිය, ස්ථානගත කිරීම සහ වර්ණය සමඟ ප්‍රතිඵල වලංගු භාවය වැඩි දියුණු කරයි"
+"යාවත්කාලීන කළ URL ආකෘතිය, ස්ථානගත කිරීම සහ වර්ණය සමඟ ප්‍රතිඵල වලංගු භාවය "
+"වැඩි දියුණු කරයි"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -10824,8 +10910,8 @@ msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
 msgstr ""
-"සමහර පැරණි බ්‍රව්සර් වලදී, සෙවුම් කාන්දු වීම වැළැක්වීම සඳහා ඔබේ ක්ලික් කිරීම් අපගේ සර්වරය හරහා "
-"හරවා යැවීම අවශ්‍ය වේ. %1$sතවත් ඉගෙන ගන්න%2$s."
+"සමහර පැරණි බ්‍රව්සර් වලදී, සෙවුම් කාන්දු වීම වැළැක්වීම සඳහා ඔබේ ක්ලික් "
+"කිරීම් අපගේ සර්වරය හරහා හරවා යැවීම අවශ්‍ය වේ. %1$sතවත් ඉගෙන ගන්න%2$s."
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -10836,8 +10922,8 @@ msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
 msgstr ""
-"DuckDuckGo බ්‍රවුසරයේ, සැකසුම් › Sync & Backup වෙත ගොස්, පසුව “වෙනත් උපාංගයක් සමග "
-"සමමුහුර්ත කරන්න” වෙත යන්න."
+"DuckDuckGo බ්‍රවුසරයේ, සැකසුම් › Sync & Backup වෙත ගොස්, පසුව “වෙනත් "
+"උපාංගයක් සමග සමමුහුර්ත කරන්න” වෙත යන්න."
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -10852,8 +10938,8 @@ msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
 msgstr ""
-"විනිවිදභාවය පිළිබඳ උනන්දුව නිසා, මෙම දත්ත කේතනය වී නැත: ඔබට නිසැකයෙන්ම දැන ගැනීමට හැකියි අප "
-"ගබඩා කරන්නේ කුමන දත්තද කියා."
+"විනිවිදභාවය පිළිබඳ උනන්දුව නිසා, මෙම දත්ත කේතනය වී නැත: ඔබට නිසැකයෙන්ම දැන "
+"ගැනීමට හැකියි අප ගබඩා කරන්නේ කුමන දත්තද කියා."
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -10864,8 +10950,8 @@ msgstr "ඉහළ ඇති මෙනුවෙන් %1$sTools%2$s > %3$sSetting
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
 msgstr ""
-"උද්දීපනය වන කොටුවෙන්, %1$sMake this my default search provider%2$s මත හරි සලකුණ "
-"යොදන්න"
+"උද්දීපනය වන කොටුවෙන්, %1$sMake this my default search provider%2$s මත හරි "
+"සලකුණ යොදන්න"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -11192,7 +11278,8 @@ msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
 msgstr ""
-"මේ ස්ථානය හොඳ ද? සමාලෝචන සහ ශ්‍රේණිගත කිරීම් මත පදනම්ව එහි කීර්තිනාමය සාරාංශගත කරන්න."
+"මේ ස්ථානය හොඳ ද? සමාලෝචන සහ ශ්‍රේණිගත කිරීම් මත පදනම්ව එහි කීර්තිනාමය "
+"සාරාංශගත කරන්න."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -11261,9 +11348,10 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"ඔබගේ සෙවුම් පද වලට අදාලත්වය මත අයිතම ශ්‍රේණිගත කර ඇති අතර Microsoft හි දැන්වීම් ජාලය "
-"හරහා බෙදා හරිනු ලැබේ. ක්ලික් කිරීම් සෘජුවම වෙළෙන්දා පිවිසීමේ පිටු වෙත යොමු කරන අතර දැන්වීම් මෙන් "
-"නොව, DuckDuckGo මෙම ප්‍රතිඵල සඳහා හිලවු නොකෙරේ."
+"ඔබගේ සෙවුම් පද වලට අදාලත්වය මත අයිතම ශ්‍රේණිගත කර ඇති අතර Microsoft හි "
+"දැන්වීම් ජාලය හරහා බෙදා හරිනු ලැබේ. ක්ලික් කිරීම් සෘජුවම වෙළෙන්දා පිවිසීමේ "
+"පිටු වෙත යොමු කරන අතර දැන්වීම් මෙන් නොව, DuckDuckGo මෙම ප්‍රතිඵල සඳහා හිලවු "
+"නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -11272,7 +11360,8 @@ msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
 msgstr ""
-"අහඹු අකුරු සහ අංක 10 ට වඩා වචන 4-5 මතක තබා ගැනීම පහසු වන අතර, වඩාත් ආරක්ෂිත වේ."
+"අහඹු අකුරු සහ අංක 10 ට වඩා වචන 4-5 මතක තබා ගැනීම පහසු වන අතර, වඩාත් ආරක්ෂිත "
+"වේ."
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -11344,7 +11433,9 @@ msgstr "උපාංග දෙකෙහිම Sync & Backup විවෘතව �
 msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Keep all your apps and online activity private on up to 5 devices at once."
-msgstr "එකවර උපාංග 5ක් දක්වා ඔබගේ සියලුම යෙදුම් සහ මාර්ගගත ක්‍රියාකාරකම් පුද්ගලිකව තබා ගන්න."
+msgstr ""
+"එකවර උපාංග 5ක් දක්වා ඔබගේ සියලුම යෙදුම් සහ මාර්ගගත ක්‍රියාකාරකම් පුද්ගලිකව "
+"තබා ගන්න."
 
 # smartling.placeholder_format=C
 #. An instruction to state that a list of companies/trackers will be updated with continued use
@@ -11838,7 +11929,7 @@ msgstr "සබැඳිය දින 7කින් කල් ඉකුත් ව
 #. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days. People can save a chat copy."
-msgstr ""
+msgstr "සබැඳිය දින 7කින් කල් ඉකුත් වේ. මිනිසුන්ට කතාබස්වල පිටපතක් සුරැකිය හැක."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11965,7 +12056,9 @@ msgstr "අනුචලනය කරන විට තවත් පින්ත�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr "අනුචලනය කරන විට පින්තූර, වීඩියෝ හා සාප්පු සවාරි තුළ වැඩිපුර ප්‍රතිඵල පූරණය කරයි"
+msgstr ""
+"අනුචලනය කරන විට පින්තූර, වීඩියෝ හා සාප්පු සවාරි තුළ වැඩිපුර ප්‍රතිඵල පූරණය "
+"කරයි"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -12151,8 +12244,7 @@ msgstr "සියළුම වචන වල අක්ෂර වින්‍ය�
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr ""
-"%1$s\"Make this my default search provider\"%2$s මත හරි ලකුණ දැමුවාදැයි බලන්න"
+msgstr "%1$s\"Make this my default search provider\"%2$s මත හරි ලකුණ දැමුවාදැයි බලන්න"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -12511,7 +12603,9 @@ msgstr "මයික්රොනීසියාව"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr "මයික්‍රෆෝන ප්‍රවේශය ප්‍රතික්ෂේප විය. කරුණාකර මයික්‍රෆෝන ප්‍රවේශය ඉඩ දී නැවත උත්සාහ කරන්න."
+msgstr ""
+"මයික්‍රෆෝන ප්‍රවේශය ප්‍රතික්ෂේප විය. කරුණාකර මයික්‍රෆෝන ප්‍රවේශය ඉඩ දී නැවත "
+"උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -12742,7 +12836,9 @@ msgstr "මාසික සීමාවට ළඟා විය"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr "මාසික පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබට %1$sට පසුව මෙම කතාබහ දිගටම කරගෙන යා හැක."
+msgstr ""
+"මාසික පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබට %1$sට පසුව මෙම කතාබහ දිගටම කරගෙන යා "
+"හැක."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -13295,10 +13391,10 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති වුවහොත් කතාබහක් නැවත ලබා ගැනීමට උපකාර කිරීම සඳහා, නව "
-"විමසීම් සහ ප්‍රතිචාර සංකේතනය කර යැවීමෙන් පසු තාවකාලිකව DuckDuckGo සේවාදායකයක ගබඩා කරනු "
-"ලැබේ. කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ කතාබස් මැකෙනු ඇති අතර නව විමසීම් සහ ප්‍රතිචාර "
-"තාවකාලිකව ගබඩා කිරීම අක්‍රිය කරනු ඇත."
+"ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති වුවහොත් කතාබහක් නැවත ලබා ගැනීමට උපකාර කිරීම "
+"සඳහා, නව විමසීම් සහ ප්‍රතිචාර සංකේතනය කර යැවීමෙන් පසු තාවකාලිකව DuckDuckGo "
+"සේවාදායකයක ගබඩා කරනු ලැබේ. කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ කතාබස් "
+"මැකෙනු ඇති අතර නව විමසීම් සහ ප්‍රතිචාර තාවකාලිකව ගබඩා කිරීම අක්‍රිය කරනු ඇත."
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -13958,7 +14054,7 @@ msgstr "හරි, දැනුවත් උනා!"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "OPTIONAL"
-msgstr ""
+msgstr "විකල්ප"
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -14126,8 +14222,8 @@ msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
 msgstr ""
-"මැක් වල, %1$sClick Maxthon > Preferences%2$s, වින්ඩෝව්ස් වල, %3$sClick the %4$s "
-"icon > Settings%5$s"
+"මැක් වල, %1$sClick Maxthon > Preferences%2$s, වින්ඩෝව්ස් වල, %3$sClick the "
+"%4$s icon > Settings%5$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -14157,8 +14253,8 @@ msgid ""
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
 "වෙනත් උපාංගයක %1$sDuck.ai සැකසුම්%2$s › %3$sකතාබස් › Sync & Backup › වෙනත් "
-"උපාංගයක් සමග සමමුහුර්ත කරන්න%4$s වෙත යන්න. නැතහොත් ඔබගේ ප්‍රතිසාධන PDF ගොනුවේ ඇති QR "
-"කේතය ස්කෑන් කරන්න."
+"උපාංගයක් සමග සමමුහුර්ත කරන්න%4$s වෙත යන්න. නැතහොත් ඔබගේ ප්‍රතිසාධන PDF "
+"ගොනුවේ ඇති QR කේතය ස්කෑන් කරන්න."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14186,8 +14282,8 @@ msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
 msgstr ""
-"අමුණා ඇති ගොනුවලින් එකක අපට ක්‍රියාත්මක කළ හැකි ප්‍රමාණයට වඩා පිටු තිබේ. පිටු %1$s ක් හෝ ඊට අඩු "
-"පිටු ඇති ගොනු උඩුගත කරන්න."
+"අමුණා ඇති ගොනුවලින් එකක අපට ක්‍රියාත්මක කළ හැකි ප්‍රමාණයට වඩා පිටු තිබේ. "
+"පිටු %1$s ක් හෝ ඊට අඩු පිටු ඇති ගොනු උඩුගත කරන්න."
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -14213,7 +14309,9 @@ msgctxt "cloudsave"
 msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
-msgstr "ඔබ වෙනස් කර ඇති සැකසුම් පමණයි. ඒවා %1$sURL පරාමිතීන්%2$s පිටුවේ සවිස්තරව දක්වා ඇත."
+msgstr ""
+"ඔබ වෙනස් කර ඇති සැකසුම් පමණයි. ඒවා %1$sURL පරාමිතීන්%2$s පිටුවේ සවිස්තරව "
+"දක්වා ඇත."
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -14228,7 +14326,8 @@ msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
 msgstr ""
-"අපොයි! මෙම පෙළ පරිවර්තනය කිරීමේදී අනපේක්ෂිත දෝෂයක් ඇතිවිය. කරුණාකර පසුව නැවත උත්සාහ කරන්න."
+"අපොයි! මෙම පෙළ පරිවර්තනය කිරීමේදී අනපේක්ෂිත දෝෂයක් ඇතිවිය. කරුණාකර පසුව නැවත "
+"උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -14551,8 +14650,8 @@ msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
 msgstr ""
-"ඔබ පුද්ගලික ගවේෂණ මාදිලියේ සිටියදී පවා වෙනත් සෙවුම් යන්ත්‍ර ඔබගේ සෙවීම් නිරීක්ෂණය කරයි. අපි ඔබව "
-"කාල පරිච්ඡේද — ක් නිරීක්ෂණය නොකරමු."
+"ඔබ පුද්ගලික ගවේෂණ මාදිලියේ සිටියදී පවා වෙනත් සෙවුම් යන්ත්‍ර ඔබගේ සෙවීම් "
+"නිරීක්ෂණය කරයි. අපි ඔබව කාල පරිච්ඡේද — ක් නිරීක්ෂණය නොකරමු."
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -14566,8 +14665,8 @@ msgid ""
 "Our fast, no-log VPN comes with smarter AI chats with higher limits, plus "
 "more premium protections. All in one subscription."
 msgstr ""
-"අපගේ වේගවත්, ලොග් වීම අනවශ්‍ය VPN, ඉහළ සීමාවන් සහිත වඩා සුහුරු AI චැට් සහ තවත් ප්‍රිමියම් "
-"ආරක්ෂණ සමඟින් පැමිණේ.‍ සියල්ල ඇතුළත් එකම ග්‍රාහකත්වයක්."
+"අපගේ වේගවත්, ලොග් වීම අනවශ්‍ය VPN, ඉහළ සීමාවන් සහිත වඩා සුහුරු AI චැට් සහ "
+"තවත් ප්‍රිමියම් ආරක්ෂණ සමඟින් පැමිණේ.‍ සියල්ල ඇතුළත් එකම ග්‍රාහකත්වයක්."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -14575,8 +14674,8 @@ msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
 msgstr ""
-"අපගේ පෞද්ගලිකත්වය සමිබන්ද ප්‍රතිපත්තිය සරලයි: අපි ඔබගේ පෞද්ගලික තොරතුරු එකතු කරන්නේ හෝ බෙදා "
-"හරින්නේ නැත."
+"අපගේ පෞද්ගලිකත්වය සමිබන්ද ප්‍රතිපත්තිය සරලයි: අපි ඔබගේ පෞද්ගලික තොරතුරු එකතු "
+"කරන්නේ හෝ බෙදා හරින්නේ නැත."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -14584,8 +14683,9 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"ජංගම දුරකථන සඳහා වන අපගේ පුද්ගලික බ්‍රවුසරය අපගේ සෙවුම් යාන්ත්‍රණය, නිරික්සු අවහිරකාරකය, "
-"ගුප්තකේතන බලාත්කාරකය හා තවත් දැයින් සන්නද්ධව තිබේ. %1$siOS & Android%2$sහි ලද හැක."
+"ජංගම දුරකථන සඳහා වන අපගේ පුද්ගලික බ්‍රවුසරය අපගේ සෙවුම් යාන්ත්‍රණය, නිරික්සු "
+"අවහිරකාරකය, ගුප්තකේතන බලාත්කාරකය හා තවත් දැයින් සන්නද්ධව තිබේ. %1$siOS & "
+"Android%2$sහි ලද හැක."
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14838,8 +14938,8 @@ msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
 msgstr ""
-"අපි ඔබගේ IP ලිපිනය, බ්‍රව්සර් ඇඟිලි සලකුණු හෝ වෙනත් තොරතුරු ගොනුව සමඟ සම්බන්ධ නොකරන බැවින් මුරපද "
-"යථාවත් කර ගත නොහැක."
+"අපි ඔබගේ IP ලිපිනය, බ්‍රව්සර් ඇඟිලි සලකුණු හෝ වෙනත් තොරතුරු ගොනුව සමඟ "
+"සම්බන්ධ නොකරන බැවින් මුරපද යථාවත් කර ගත නොහැක."
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -14995,8 +15095,9 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
-"Personal Information Removal මගින් ඔබේ තොරතුරු ඒවා අලෙවි කරන දත්ත තැරැව්කාර අඩවිවලින් "
-"සොයා ගනියි. අනතුරුව අපි ඔබ වෙනුවෙන් ඒවා ඉවත් කර ගැනීමට කටයුතු කරන්නෙමු."
+"Personal Information Removal මගින් ඔබේ තොරතුරු ඒවා අලෙවි කරන දත්ත තැරැව්කාර "
+"අඩවිවලින් සොයා ගනියි. අනතුරුව අපි ඔබ වෙනුවෙන් ඒවා ඉවත් කර ගැනීමට කටයුතු "
+"කරන්නෙමු."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15067,9 +15168,10 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙසත් සම්පූර්ණ වාක්‍යයකින් ලියා ඇති විට AI-සහය සහිත පිළිතුරු ස්වයංක්‍රීයව දිස්වීමේ "
-"ඉඩකඩ වැඩි වන අතර බොහෝ විට හොඳ පිළිතුරු ලැබේ. ඒවා ක්‍රියා විරහිත කිරීමට සහ Assist බොත්තම "
-"සැඟවීමට %1$sසෙවුම් සැකසුම්%2$s වෙත පිවිසෙන්න."
+"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙසත් සම්පූර්ණ වාක්‍යයකින් ලියා ඇති විට AI-සහය සහිත "
+"පිළිතුරු ස්වයංක්‍රීයව දිස්වීමේ ඉඩකඩ වැඩි වන අතර බොහෝ විට හොඳ පිළිතුරු ලැබේ. "
+"ඒවා ක්‍රියා විරහිත කිරීමට සහ Assist බොත්තම සැඟවීමට %1$sසෙවුම් සැකසුම්%2$s "
+"වෙත පිවිසෙන්න."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15078,9 +15180,10 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙස සහ සම්පූර්ණ වාක්‍යයක් තුළ වාක්‍ය කණ්ඩ කිරීමෙන් DuckAssist දිස්වීමට වැඩි "
-"ඉඩක් ඇති අතර බොහෝ විට වඩා හොඳ පිළිතුරු ලබා දෙයි. මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් "
-"කිරීමට හෝ එය ක්‍රියා විරහිත කිරීමට,%1$sDuckAssist%2$s සැකසුම් වෙත පිවිසෙන්න."
+"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙස සහ සම්පූර්ණ වාක්‍යයක් තුළ වාක්‍ය කණ්ඩ කිරීමෙන් "
+"DuckAssist දිස්වීමට වැඩි ඉඩක් ඇති අතර බොහෝ විට වඩා හොඳ පිළිතුරු ලබා දෙයි. "
+"මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය ක්‍රියා විරහිත "
+"කිරීමට,%1$sDuckAssist%2$s සැකසුම් වෙත පිවිසෙන්න."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15090,9 +15193,10 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙස සහ සම්පූර්ණ වාක්‍යයක් තුළ වාක්‍ය කණ්ඩ කිරීමෙන් DuckAssist දිස්වීමට වැඩි "
-"ඉඩක් ඇති අතර බොහෝ විට වඩා හොඳ පිළිතුරු ලබා දෙයි. එය නිවා දැමීමට සහ Assist බොත්තම සැඟවීමට "
-"%1$sDuckAssist සැකසුම්%2$s වෙත පිවිසෙන්න."
+"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙස සහ සම්පූර්ණ වාක්‍යයක් තුළ වාක්‍ය කණ්ඩ කිරීමෙන් "
+"DuckAssist දිස්වීමට වැඩි ඉඩක් ඇති අතර බොහෝ විට වඩා හොඳ පිළිතුරු ලබා දෙයි. එය "
+"නිවා දැමීමට සහ Assist බොත්තම සැඟවීමට %1$sDuckAssist සැකසුම්%2$s වෙත "
+"පිවිසෙන්න."
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -15125,7 +15229,8 @@ msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
 msgstr ""
-"GPT-5 mini, Claude Haiku 4.5, Mistral වැනි ජනප්‍රිය AI එකක් සමඟ කතාබස් කිරීමට තෝරන්න."
+"GPT-5 mini, Claude Haiku 4.5, Mistral වැනි ජනප්‍රිය AI එකක් සමඟ කතාබස් "
+"කිරීමට තෝරන්න."
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -15134,7 +15239,8 @@ msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, "
 "Mistral, etc."
 msgstr ""
-"කතාබස් කිරීම සඳහා GPT-5 mini, Claude Haiku 4.5, Mistral වැනි ජනප්‍රිය AI එකක් තෝරන්න."
+"කතාබස් කිරීම සඳහා GPT-5 mini, Claude Haiku 4.5, Mistral වැනි ජනප්‍රිය AI "
+"එකක් තෝරන්න."
 
 # smartling.placeholder_format=C
 #. The description of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -15155,8 +15261,8 @@ msgstr "විශේෂ වූ ප්‍රශ්නයක් තෝරා ග�
 msgid ""
 "Pick your ad blocker and follow the instructions to allow ads on DuckDuckGo."
 msgstr ""
-"ඔබේ දැන්වීම් අවහිරකාරකය තෝරාගෙන DuckDuckGo හි දැන්වීම්වලට ඉඩ දීම සඳහා උපදෙස් අනුගමනය "
-"කරන්න."
+"ඔබේ දැන්වීම් අවහිරකාරකය තෝරාගෙන DuckDuckGo හි දැන්වීම්වලට ඉඩ දීම සඳහා උපදෙස් "
+"අනුගමනය කරන්න."
 
 # smartling.placeholder_format=C
 #. Text for a button that pins a chat, as in it will it will add the chat to the pinned chats list.
@@ -15244,7 +15350,9 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr "මෙම සෙවුම මිනිසෙකු විසින් කරන ලද බව තහවුරු කිරීමට කරුණාකර පහත අභියෝගය සම්පූර්ණ කරන්න."
+msgstr ""
+"මෙම සෙවුම මිනිසෙකු විසින් කරන ලද බව තහවුරු කිරීමට කරුණාකර පහත අභියෝගය "
+"සම්පූර්ණ කරන්න."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -15252,19 +15360,25 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr "මෙම සෙවුම මිනිසෙකු විසින් කරන ලද බව තහවුරු කිරීමට කරුණාකර පහත අභියෝගය සම්පූර්ණ කරන්න."
+msgstr ""
+"මෙම සෙවුම මිනිසෙකු විසින් කරන ලද බව තහවුරු කිරීමට කරුණාකර පහත අභියෝගය "
+"සම්පූර්ණ කරන්න."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr "කතාබස් ප්‍රතිචාරය හානිකර හෝ නීතිවිරෝධී වන්නේ මන්ද යන්න පැහැදිලි කරන්න. (විකල්ප)"
+msgstr ""
+"කතාබස් ප්‍රතිචාරය හානිකර හෝ නීතිවිරෝධී වන්නේ මන්ද යන්න පැහැදිලි කරන්න. "
+"(විකල්ප)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr "කතාබස් ප්‍රතිචාරය නීතිවිරෝධී හෝ හානිකර වන්නේ මන්ද යන්න පැහැදිලි කරන්න. (විකල්ප)"
+msgstr ""
+"කතාබස් ප්‍රතිචාරය නීතිවිරෝධී හෝ හානිකර වන්නේ මන්ද යන්න පැහැදිලි කරන්න. "
+"(විකල්ප)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -15285,7 +15399,8 @@ msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
 msgstr ""
-"කරුණාකර සලකන්න: ඕනෑම ආකෘතියක් සමඟ නව චැට් ආරම්භ කිරීම ඔබේ වර්තමාන චැට් සැසිය මකා දමනු ඇත."
+"කරුණාකර සලකන්න: ඕනෑම ආකෘතියක් සමඟ නව චැට් ආරම්භ කිරීම ඔබේ වර්තමාන චැට් සැසිය "
+"මකා දමනු ඇත."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15294,8 +15409,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
-"කරුණාකර ඔබේ පණිවිඩය සහ ගැටලුකාරී ප්‍රතිදානය (ඕනෑම පුද්ගලික තොරතුරක් ඉවත් කර) අලවා අන්තර්ගතය "
-"හානිකර හෝ නීති විරෝධී වන්නේ මන්දැ යි යන්න විස්තර කරන්න."
+"කරුණාකර ඔබේ පණිවිඩය සහ ගැටලුකාරී ප්‍රතිදානය (ඕනෑම පුද්ගලික තොරතුරක් ඉවත් කර) "
+"අලවා අන්තර්ගතය හානිකර හෝ නීති විරෝධී වන්නේ මන්දැ යි යන්න විස්තර කරන්න."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15304,8 +15419,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
 msgstr ""
-"කරුණාකර ඔබේ පණිවිඩය සහ ගැටලුකාරී ප්‍රතිදානය (ඕනෑම පුද්ගලික තොරතුරක් ඉවත් කර) අලවා අන්තර්ගතය "
-"නීති විරෝධී හෝ හානිකර වන්නේ මන්දැ යි යන්න විස්තර කරන්න."
+"කරුණාකර ඔබේ පණිවිඩය සහ ගැටලුකාරී ප්‍රතිදානය (ඕනෑම පුද්ගලික තොරතුරක් ඉවත් කර) "
+"අලවා අන්තර්ගතය නීති විරෝධී හෝ හානිකර වන්නේ මන්දැ යි යන්න විස්තර කරන්න."
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -15519,7 +15634,9 @@ msgstr "දුර්වල ආකෘතිකරණය"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
-msgstr "ජනප්‍රිය AI ආකෘති ලබා ගත හැක. ගිණුමක් අවශ්‍ය නොවේ. කතාබස් අප විසින් නිර්නාමික කර ඇත."
+msgstr ""
+"ජනප්‍රිය AI ආකෘති ලබා ගත හැක. ගිණුමක් අවශ්‍ය නොවේ. කතාබස් අප විසින් "
+"නිර්නාමික කර ඇත."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -16063,7 +16180,7 @@ msgstr "ආරක්ෂිතයි"
 #. Headline in sync-enabled chat history about modals explaining encrypted server storage.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Protected with end-to-end encryption"
-msgstr ""
+msgstr "මුල සිට අග දක්වා ගුප්තකේතනයෙන් ආරක්ෂා කර ඇත"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -16077,8 +16194,8 @@ msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
 msgstr ""
-"පහත දැක්වෙන පාඨය වඩාත් සංක්ෂිප්ත කිරීම සඳහා යෝජනා කිහිපයක් ලබා දෙන්න. [ඔබේම පෙළ මෙහි "
-"ඇතුලත් කරන්න.]"
+"පහත දැක්වෙන පාඨය වඩාත් සංක්ෂිප්ත කිරීම සඳහා යෝජනා කිහිපයක් ලබා දෙන්න. [ඔබේම "
+"පෙළ මෙහි ඇතුලත් කරන්න.]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -16202,7 +16319,7 @@ msgstr "ශ්රේණිගත කිරීම්"
 #. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
 msgctxt "star rating on a product"
 msgid "Rated %s out of %s"
-msgstr ""
+msgstr "%2$sන් %1$s ලෙස ශ්‍රේණිගත කර ඇත"
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -16301,7 +16418,9 @@ msgstr "තර්කනය මඟින් සංකීර්ණ ප්‍රශ
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
-msgstr "තර්කනය වඩාත් සවිස්තරාත්මකයි, නමුත් 2-5 ගුණයක් වේගයෙන් පරිශීලන සීමාවන්ට ළඟා වේ. %1$s"
+msgstr ""
+"තර්කනය වඩාත් සවිස්තරාත්මකයි, නමුත් 2-5 ගුණයක් වේගයෙන් පරිශීලන සීමාවන්ට ළඟා "
+"වේ. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
@@ -16357,8 +16476,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"මෑත කාලීන කතාබස් DuckDuckGo සේවාදායකයන් හෝ වෙනත් දුරස්ථ සේවාදායකයන් මත වෙනුවට ඔබේ "
-"උපාංගයේ දේශීයව ගබඩා කර ඇත."
+"මෑත කාලීන කතාබස් DuckDuckGo සේවාදායකයන් හෝ වෙනත් දුරස්ථ සේවාදායකයන් මත "
+"වෙනුවට ඔබේ උපාංගයේ දේශීයව ගබඩා කර ඇත."
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -16367,8 +16486,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"මෑත කාලීන කතාබස් DuckDuckGo සේවාදායකයන් හෝ වෙනත් දුරස්ථ සේවාදායකයන් මත වෙනුවට ඔබේ "
-"උපාංගයේ දේශීයව ගබඩා කර ඇත."
+"මෑත කාලීන කතාබස් DuckDuckGo සේවාදායකයන් හෝ වෙනත් දුරස්ථ සේවාදායකයන් මත "
+"වෙනුවට ඔබේ උපාංගයේ දේශීයව ගබඩා කර ඇත."
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -16378,9 +16497,9 @@ msgid ""
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
 msgstr ""
-"මෑත කතාබස් ඔබගේ උපාංගයේ දේශීයව ගබඩා කර ඇත. ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති වුවහොත් "
-"කතාබහක් නැවත ලබා ගැනීමට උපකාර කිරීම සඳහා, නව විමසීම් සහ ප්‍රතිචාර සංකේතනය කර යැවීමෙන් පසු "
-"තාවකාලිකව DuckDuckGo සේවාදායකයක ගබඩා කරනු ලැබේ."
+"මෑත කතාබස් ඔබගේ උපාංගයේ දේශීයව ගබඩා කර ඇත. ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති "
+"වුවහොත් කතාබහක් නැවත ලබා ගැනීමට උපකාර කිරීම සඳහා, නව විමසීම් සහ ප්‍රතිචාර "
+"සංකේතනය කර යැවීමෙන් පසු තාවකාලිකව DuckDuckGo සේවාදායකයක ගබඩා කරනු ලැබේ."
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -16521,7 +16640,9 @@ msgctxt "settings"
 msgid ""
 "Reduces extra space in and around results and reduces size of result title "
 "text"
-msgstr "ප්‍රතිඵල තුළ සහ අවට අමතර ඉඩ අඩු කරමින් ප්‍රතිඵල මාතෘකාවේ පෙළ ප්‍රමාණය අඩු කරයි"
+msgstr ""
+"ප්‍රතිඵල තුළ සහ අවට අමතර ඉඩ අඩු කරමින් ප්‍රතිඵල මාතෘකාවේ පෙළ ප්‍රමාණය අඩු "
+"කරයි"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'Refer to me as John'
@@ -16662,8 +16783,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"උපදෙස් අනුගමනය කරමින් හෝ ඔබේ බ්‍රවුසරයේ &quot;Refresh&quot; හෝ &quot;Reload&quot; "
-"බොත්තම ක්ලික් කරමින් DuckDuckGo නැවත පූරණය කරන්න."
+"උපදෙස් අනුගමනය කරමින් හෝ ඔබේ බ්‍රවුසරයේ &quot;Refresh&quot; හෝ "
+"&quot;Reload&quot; බොත්තම ක්ලික් කරමින් DuckDuckGo නැවත පූරණය කරන්න."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16771,8 +16892,8 @@ msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
 msgstr ""
-"අදාළ සෙවීම් වලට ප්‍රතිචාර වශයෙන් පිළිතුරු ස්වයංක්‍රීයව දිස්වන පරිදි \"Ask\" බොත්තම ඉවත් කරයි. "
-"හැඹිලි සහිත පිළිතුරු සෑම විටම ස්වයංක්‍රීයව දර්ශනය වේ."
+"අදාළ සෙවීම් වලට ප්‍රතිචාර වශයෙන් පිළිතුරු ස්වයංක්‍රීයව දිස්වන පරිදි \"Ask\" "
+"බොත්තම ඉවත් කරයි. හැඹිලි සහිත පිළිතුරු සෑම විටම ස්වයංක්‍රීයව දර්ශනය වේ."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16780,8 +16901,9 @@ msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
 msgstr ""
-"අදාළ සෙවීම් වලට ප්‍රතිචාර වශයෙන් පිළිතුරු ස්වයංක්‍රීයව දිස්වන පරිදි \"Generate\" බොත්තම ඉවත් "
-"කරයි. හැඹිලි සහිත පිළිතුරු සෑම විටම ස්වයංක්‍රීයව දර්ශනය වේ."
+"අදාළ සෙවීම් වලට ප්‍රතිචාර වශයෙන් පිළිතුරු ස්වයංක්‍රීයව දිස්වන පරිදි "
+"\"Generate\" බොත්තම ඉවත් කරයි. හැඹිලි සහිත පිළිතුරු සෑම විටම ස්වයංක්‍රීයව "
+"දර්ශනය වේ."
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -16839,9 +16961,9 @@ msgid ""
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
 msgstr ""
-"වාර්තා නිර්නාමික වන අතර අපගේ සෙවුම් සේවාව වැඩිදියුණු කිරීමට උදවු කිරීමට DuckDuckGo වෙත යවනු "
-"ලැබේ. ඔබේ නිර්නාමික ප්‍රතිපෝෂණය ඔවුන්ගේ සේවා වැඩිදියුණු කිරීමට උදවු කිරීමට %1$s සමඟ ද බෙදා ගනු "
-"ලැබේ."
+"වාර්තා නිර්නාමික වන අතර අපගේ සෙවුම් සේවාව වැඩිදියුණු කිරීමට උදවු කිරීමට "
+"DuckDuckGo වෙත යවනු ලැබේ. ඔබේ නිර්නාමික ප්‍රතිපෝෂණය ඔවුන්ගේ සේවා වැඩිදියුණු "
+"කිරීමට උදවු කිරීමට %1$s සමඟ ද බෙදා ගනු ලැබේ."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16849,8 +16971,8 @@ msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo වෙත යවන වාර්තා නිර්නාමික වේ. කරුණාකර ඔබේ ප්‍රතිචාරයේ කිසිදු පුද්ගලික හෝ හඳුනාගත "
-"හැකි තොරතුරු ඇතුළත් නොකරන්න."
+"DuckDuckGo වෙත යවන වාර්තා නිර්නාමික වේ. කරුණාකර ඔබේ ප්‍රතිචාරයේ කිසිදු "
+"පුද්ගලික හෝ හඳුනාගත හැකි තොරතුරු ඇතුළත් නොකරන්න."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16859,9 +16981,9 @@ msgid ""
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo වෙත යවන වාර්තා වලට මෙම පිටු පැටවීමේදී ඔබ අපෙන් පරිවර්තනය කිරීමට ඉල්ලා ඇති සියලු "
-"පෙළ ඇතුළත් වන අතර, ඒවා නිර්නාමික වේ. කරුණාකර ඔබේ ප්‍රතිචාරයේ කිසිදු පුද්ගලික හෝ හඳුනාගත හැකි "
-"තොරතුරු ඇතුළත් නොකරන්න."
+"DuckDuckGo වෙත යවන වාර්තා වලට මෙම පිටු පැටවීමේදී ඔබ අපෙන් පරිවර්තනය කිරීමට "
+"ඉල්ලා ඇති සියලු පෙළ ඇතුළත් වන අතර, ඒවා නිර්නාමික වේ. කරුණාකර ඔබේ ප්‍රතිචාරයේ "
+"කිසිදු පුද්ගලික හෝ හඳුනාගත හැකි තොරතුරු ඇතුළත් නොකරන්න."
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -16953,8 +17075,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
-"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන හෝ වෙනත් වෘත්තීය "
-"උපදෙස් ලෙස අදහස් නොකෙරේ. AI-සහය සහිත පිළිතුරු අපගේ %1$sසේවා කොන්දේසි%2$s යටතේ පවතී."
+"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන "
+"හෝ වෙනත් වෘත්තීය උපදෙස් ලෙස අදහස් නොකෙරේ. AI-සහය සහිත පිළිතුරු අපගේ %1$sසේවා "
+"කොන්දේසි%2$s යටතේ පවතී."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16963,8 +17086,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
 msgstr ""
-"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන හෝ වෙනත් වෘත්තීය "
-"උපදෙස් ලෙස අදහස් නොකෙරේ. DuckAssist අපගේ %1$sසේවා කොන්දේසි%2$s යටතේ පවතී."
+"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන "
+"හෝ වෙනත් වෘත්තීය උපදෙස් ලෙස අදහස් නොකෙරේ. DuckAssist අපගේ %1$sසේවා "
+"කොන්දේසි%2$s යටතේ පවතී."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16974,9 +17098,10 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන හෝ වෙනත් වෘත්තීය "
-"උපදෙස් ලෙස අදහස් නොකෙරේ. ඒවා වෙබ් අන්තර්ගතය මත පදනම්ව ජනනය කර ඇති අතර සාවද්‍යතා අඩංගු "
-"විය හැක. Search Assist අපගේ %1$sසේවා කොන්දේසි%2$s යටතේ පවතී."
+"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන "
+"හෝ වෙනත් වෘත්තීය උපදෙස් ලෙස අදහස් නොකෙරේ. ඒවා වෙබ් අන්තර්ගතය මත පදනම්ව ජනනය "
+"කර ඇති අතර සාවද්‍යතා අඩංගු විය හැක. Search Assist අපගේ %1$sසේවා කොන්දේසි%2$s "
+"යටතේ පවතී."
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -17401,8 +17526,8 @@ msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
 msgstr ""
-"ගුප්ත කේතිත ආචයනය සමඟ තවත් බොහෝ දේ සඳහා විකල්පය සමඟින්, ඔබගේ උපාංගයේ ඔබගේ මෑත කාලීන "
-"කතාබස් 30ක් දක්වා ස්ථානීයව සුරකින්න."
+"ගුප්ත කේතිත ආචයනය සමඟ තවත් බොහෝ දේ සඳහා විකල්පය සමඟින්, ඔබගේ උපාංගයේ ඔබගේ "
+"මෑත කාලීන කතාබස් 30ක් දක්වා ස්ථානීයව සුරකින්න."
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -17427,7 +17552,7 @@ msgstr "ඔබගේ සියලු උපාංග හරහා ඔබේ ක�
 #. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
 msgctxt "Chat history about modal list item headline"
 msgid "Save your chats on this device"
-msgstr ""
+msgstr "ඔබගේ කතාබස් මෙම උපාංගයේ සුරකින්න"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
@@ -17575,8 +17700,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
 msgstr ""
-"පහලට අනුචලනය කර %1$sSearch in the address bar%2$s සොයන්න. ඉන්පසු %3$sChange%4$s "
-"ක්ලික් කරන්න (හෝ %5$sAdd new%6$s)"
+"පහලට අනුචලනය කර %1$sSearch in the address bar%2$s සොයන්න. ඉන්පසු "
+"%3$sChange%4$s ක්ලික් කරන්න (හෝ %5$sAdd new%6$s)"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17585,8 +17710,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
 msgstr ""
-"පහලට අනුචලනය කර %1$sලිපින තීරුව සොයන්න%2$s සොයා ගන්න. %3$sවෙනස් කරන්න%4$s මත ක්ලික් කරන්න "
-"(හෝ %5$sඅළුතින්%6$s එකතු කරන්න)."
+"පහලට අනුචලනය කර %1$sලිපින තීරුව සොයන්න%2$s සොයා ගන්න. %3$sවෙනස් කරන්න%4$s මත "
+"ක්ලික් කරන්න (හෝ %5$sඅළුතින්%6$s එකතු කරන්න)."
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -17635,7 +17760,7 @@ msgctxt ""
 "Placeholder and accessibility label for the search input in the tab picker "
 "dialog"
 msgid "Search"
-msgstr ""
+msgstr "සොයන්න"
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -17672,12 +17797,13 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist යනු සෙවුම් විමසුම් සඳහා නිර්නාමිකව පිළිතුරු ජනනය කරන විශේෂාංගයකි. මෙය සිදු කිරීම "
-"සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා වෙබ් ස්කෑන් කරන අතර පසුව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI "
-"භාවිත කරයි. ඔබට එය කොපමණ වාර ගණනක් පෙනී සිටීමට අවශ්‍යද යන්න තෝරා ගත හැක: කිසි විටෙකත්, "
-"ඉල්ලූ-විට (Assist ක්ලික් කළ විට පමණක්), සමහර විට (දැඩිව අදාළ වන විට), හෝ බොහෝ විට (පුළුල් "
-"පරාසයක සෙවුම් මත). දැනට, Search Assist ලබා ගත හැක්කේ ඉංග්‍රීසි කතා කරන කලාපවල උප "
-"කණ්ඩායමක පමණි."
+"Search Assist යනු සෙවුම් විමසුම් සඳහා නිර්නාමිකව පිළිතුරු ජනනය කරන "
+"විශේෂාංගයකි. මෙය සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා වෙබ් ස්කෑන් කරන "
+"අතර පසුව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI භාවිත කරයි. ඔබට එය කොපමණ වාර "
+"ගණනක් පෙනී සිටීමට අවශ්‍යද යන්න තෝරා ගත හැක: කිසි විටෙකත්, ඉල්ලූ-විට (Assist "
+"ක්ලික් කළ විට පමණක්), සමහර විට (දැඩිව අදාළ වන විට), හෝ බොහෝ විට (පුළුල් "
+"පරාසයක සෙවුම් මත). දැනට, Search Assist ලබා ගත හැක්කේ ඉංග්‍රීසි කතා කරන "
+"කලාපවල උප කණ්ඩායමක පමණි."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -17685,8 +17811,8 @@ msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
 msgstr ""
-"මෙම ප්‍රශ්නය සඳහා පිළිතුරක් උත්පාදනය කිරීම සඳහා ප්‍රමාණවත් විශ්වාසදායක තොරතුරු සොයාගැනීමට "
-"Search Assist හට නොහැකි විය. තවත් සෙවීමක් කරන්න."
+"මෙම ප්‍රශ්නය සඳහා පිළිතුරක් උත්පාදනය කිරීම සඳහා ප්‍රමාණවත් විශ්වාසදායක "
+"තොරතුරු සොයාගැනීමට Search Assist හට නොහැකි විය. තවත් සෙවීමක් කරන්න."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -17695,9 +17821,10 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist යනු නිර්නාමිකව සෙවුම් විමසුම් සඳහා පිළිතුරු ජනනය කරන විකල්ප විශේෂාංගයකි. "
-"%1$sමෙය%2$s සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතය සඳහා වෙබ් ස්කෑන් කර පසුව සොයාගත් තොරතුරු "
-"මත පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI භාවිත කරයි."
+"Search Assist යනු නිර්නාමිකව සෙවුම් විමසුම් සඳහා පිළිතුරු ජනනය කරන විකල්ප "
+"විශේෂාංගයකි. %1$sමෙය%2$s සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතය සඳහා වෙබ් ස්කෑන් "
+"කර පසුව සොයාගත් තොරතුරු මත පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI භාවිත "
+"කරයි."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -17818,8 +17945,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"%1$s කෙටිමං භාවිතයෙන් වෙනත් අඩවි සොයන්න: ”!w ducks” සෙවීමකින් විකිපීඩියාවේ “ducks” සෘජුවම "
-"සොයාගත හැක."
+"%1$s කෙටිමං භාවිතයෙන් වෙනත් අඩවි සොයන්න: ”!w ducks” සෙවීමකින් විකිපීඩියාවේ "
+"“ducks” සෘජුවම සොයාගත හැක."
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -17838,8 +17965,8 @@ msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
-"අපගේ යෙදුම හෝ දිගුව භාවිතයෙන් සොයන්න, ඔබේ ප්‍රියතම බ්‍රවුසරයට පුද්ගලික වෙබ් සෙවුම එක් කරන්න, "
-"නැතහොත් %1$sduckduckgo.com%2$s වෙතින් ඍජුවම සෙවීම් කරන්න."
+"අපගේ යෙදුම හෝ දිගුව භාවිතයෙන් සොයන්න, ඔබේ ප්‍රියතම බ්‍රවුසරයට පුද්ගලික වෙබ් "
+"සෙවුම එක් කරන්න, නැතහොත් %1$sduckduckgo.com%2$s වෙතින් ඍජුවම සෙවීම් කරන්න."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -17847,7 +17974,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"සෙවුම් විමසුම් URL එකෙහි අන්තර්ගතයි (සංවෘත කර ඇත්නම්, සෙවුම් POST ඉල්ලීම් භාවිතා කරනු ඇත)"
+"සෙවුම් විමසුම් URL එකෙහි අන්තර්ගතයි (සංවෘත කර ඇත්නම්, සෙවුම් POST ඉල්ලීම් "
+"භාවිතා කරනු ඇත)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -17859,10 +17987,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"සෙවුම් සැකසුම් ඔබේ බ්‍රව්සරයේ පුද්ගලික නොවන බ්‍රව්සර් කුකීස් සහ අභ්‍යන්තර ගබඩා තුළ ගබඩා කර ඇත, "
-"නමුත් ඔබට ඔබගේ සැකසුම් නිර්නාමිකව ක්ලවුඩයේ ඇති දුරස්ථ සර්වරයක ගබඩා කිරීමට Cloud Save භාවිත "
-"කළ හැක. පුද්ගලිකව හඳුනාගත හැකි තොරතුරු ක්ලවුඩය තුළ ගබඩා නොවන අතර, ඔබේ මුරපදය කිසි විටෙකත් "
-"ඔබේ බ්‍රව්සරයෙන් ඉවත් නොවේ."
+"සෙවුම් සැකසුම් ඔබේ බ්‍රව්සරයේ පුද්ගලික නොවන බ්‍රව්සර් කුකීස් සහ අභ්‍යන්තර "
+"ගබඩා තුළ ගබඩා කර ඇත, නමුත් ඔබට ඔබගේ සැකසුම් නිර්නාමිකව ක්ලවුඩයේ ඇති දුරස්ථ "
+"සර්වරයක ගබඩා කිරීමට Cloud Save භාවිත කළ හැක. පුද්ගලිකව හඳුනාගත හැකි තොරතුරු "
+"ක්ලවුඩය තුළ ගබඩා නොවන අතර, ඔබේ මුරපදය කිසි විටෙකත් ඔබේ බ්‍රව්සරයෙන් ඉවත් "
+"නොවේ."
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -17965,8 +18094,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"මුල සිට අග දක්වා ම සංකේතනය භාවිතා කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් ආරක්ෂිතව ගබඩා "
-"කර, ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වෙන්න."
+"මුල සිට අග දක්වා ම සංකේතනය භාවිතා කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් "
+"ආරක්ෂිතව ගබඩා කර, ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වෙන්න."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -17975,8 +18104,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"මුල සිට අග දක්වා ම සංකේතනය භාවිතා කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් ආරක්ෂිතව ගබඩා "
-"කර, ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වෙන්න."
+"මුල සිට අග දක්වා ම සංකේතනය භාවිතා කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් "
+"ආරක්ෂිතව ගබඩා කර, ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වෙන්න."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17985,8 +18114,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-"මුල සිට අග දක්වා ම සංකේතනය භාවිත කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් ආරක්ෂිතව ගබඩා "
-"කර, ඔබ සමකාලීන කරන ලද සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වන්න."
+"මුල සිට අග දක්වා ම සංකේතනය භාවිත කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් "
+"ආරක්ෂිතව ගබඩා කර, ඔබ සමකාලීන කරන ලද සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වන්න."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17995,8 +18124,8 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"මුල සිට අග දක්වා ම සංකේතනය භාවිත කර ඔබේ කතාබස් ආරක්ෂිතව අපගේ සේවාදායකයේ ගබඩා කර, "
-"ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වන්න."
+"මුල සිට අග දක්වා ම සංකේතනය භාවිත කර ඔබේ කතාබස් ආරක්ෂිතව අපගේ සේවාදායකයේ ගබඩා "
+"කර, ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වන්න."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -18011,8 +18140,8 @@ msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
 msgstr ""
-"DuckDuckGo සර්වරයේ මුල සිට අග දක්වා ගුප්ත කේතනය සමඟ ආරක්ෂිතව ගබඩා කර ඇත. ඔබට හැර වෙන "
-"කිසිවෙකුට ඔබගේ දත්ත දැකිය නොහැක, අපටවත් නොවේ."
+"DuckDuckGo සර්වරයේ මුල සිට අග දක්වා ගුප්ත කේතනය සමඟ ආරක්ෂිතව ගබඩා කර ඇත. ඔබට "
+"හැර වෙන කිසිවෙකුට ඔබගේ දත්ත දැකිය නොහැක, අපටවත් නොවේ."
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
@@ -18236,8 +18365,8 @@ msgstr ""
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
 msgstr ""
-"%1$sOpera > Preferences%2$s (මැක් වල) හෝ %3$sOpera > Options%4$s (වින්ඩෝව්ස් වල) "
-"තෝරන්න"
+"%1$sOpera > Preferences%2$s (මැක් වල) හෝ %3$sOpera > Options%4$s (වින්ඩෝව්ස් "
+"වල) තෝරන්න"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -18302,8 +18431,8 @@ msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
 msgstr ""
-"%1$sUse this webpage as your only home page%2$s තෝරන්න (හෝ ඔබ කැමතිනම් අනෙකුත් "
-"විකල්ප වලින් එකක් තෝරන්න)"
+"%1$sUse this webpage as your only home page%2$s තෝරන්න (හෝ ඔබ කැමතිනම් "
+"අනෙකුත් විකල්ප වලින් එකක් තෝරන්න)"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
@@ -18425,8 +18554,8 @@ msgid ""
 "respond. These instructions will apply to all of your conversations going "
 "forward."
 msgstr ""
-"ඔබේ පණිවිඩ සහ ප්‍රතිචාර දැක්විය යුතු ආකාරය පිළිබඳ උපදෙස් සමඟ AI ආකෘති වෙත විමසුමක් යවයි. මෙම "
-"උපදෙස් ඔබේ සියලුම සංවාද සඳහා ඉදිරියට අදාළ වනු ඇත."
+"ඔබේ පණිවිඩ සහ ප්‍රතිචාර දැක්විය යුතු ආකාරය පිළිබඳ උපදෙස් සමඟ AI ආකෘති වෙත "
+"විමසුමක් යවයි. මෙම උපදෙස් ඔබේ සියලුම සංවාද සඳහා ඉදිරියට අදාළ වනු ඇත."
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -18549,8 +18678,8 @@ msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
 msgstr ""
-"ඔබේ කතාබස් උපාංග අතර සමමුහුර්තව තබා ගැනීමට කතාබස් ඉතිහාසය ක්‍රියාත්මක කිරීමෙන් පසු Sync & "
-"Backup පිහිටුුවන්න."
+"ඔබේ කතාබස් උපාංග අතර සමමුහුර්තව තබා ගැනීමට කතාබස් ඉතිහාසය ක්‍රියාත්මක "
+"කිරීමෙන් පසු Sync & Backup පිහිටුුවන්න."
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -18657,8 +18786,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"අදාළත්වය වැඩි දියුණු කිරීම සඳහා AI ආකෘති සමඟ නගර මට්ටමේ ස්ථානයක් බෙදා ගන්න. Duck.ai කිසි "
-"විටෙකත් ඔබේ නිශ්චිත ස්ථානය අපට හෝ AI ආකෘතිවලට හෙළි නොකරයි."
+"අදාළත්වය වැඩි දියුණු කිරීම සඳහා AI ආකෘති සමඟ නගර මට්ටමේ ස්ථානයක් බෙදා ගන්න. "
+"Duck.ai කිසි විටෙකත් ඔබේ නිශ්චිත ස්ථානය අපට හෝ AI ආකෘතිවලට හෙළි නොකරයි."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -18754,8 +18883,8 @@ msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
 msgstr ""
-"ඔබේ කඩිනම් සහ කතාබස් ප්‍රතිචාරය DuckDuckGo සමග බෙදා ගන්න (නීති විරෝධී සහ හානිකර වාර්තා "
-"සඳහා අවශ්‍ය වේ)"
+"ඔබේ කඩිනම් සහ කතාබස් ප්‍රතිචාරය DuckDuckGo සමග බෙදා ගන්න (නීති විරෝධී සහ "
+"හානිකර වාර්තා සඳහා අවශ්‍ය වේ)"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -18782,8 +18911,9 @@ msgid ""
 "Shield your online activity with our no-log, fast VPN. Simple to set up and "
 "easy to turn on and off anytime."
 msgstr ""
-"අපගේ ලොග් වීම අනවශ්‍ය, වේගවත් VPN සමඟ ඔබේ අන්තර්ජාල ක්‍රියාකාරකම් ආරක්ෂා කරගන්න. සැකසීමට "
-"සරල වන අතර ඕනෑම වේලාවක ක්‍රියාත්මක කිරීමට සහ අක්‍රිය කිරීමට පහසුය."
+"අපගේ ලොග් වීම අනවශ්‍ය, වේගවත් VPN සමඟ ඔබේ අන්තර්ජාල ක්‍රියාකාරකම් ආරක්ෂා "
+"කරගන්න. සැකසීමට සරල වන අතර ඕනෑම වේලාවක ක්‍රියාත්මක කිරීමට සහ අක්‍රිය කිරීමට "
+"පහසුය."
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -18801,7 +18931,7 @@ msgstr "සාප්පු සවාරි යාම"
 #. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
 msgctxt "Button in the merchandise logo modal (mobile)"
 msgid "Shop Now"
-msgstr ""
+msgstr "දැන් සාප්පු යන්න"
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -18910,7 +19040,8 @@ msgstr "DuckAssist <sup>BETA</sup> පෙන්වන්න"
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
 msgstr ""
-"DuckAssist නිතර නිතර පෙන්වන්න. (ඔබට සම්පූර්ණයෙන්ම %1$sඑය ක්‍රියා විරහිත කිරීමටද%2$s හැකිය.)"
+"DuckAssist නිතර නිතර පෙන්වන්න. (ඔබට සම්පූර්ණයෙන්ම %1$sඑය ක්‍රියා විරහිත "
+"කිරීමටද%2$s හැකිය.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -19148,8 +19279,8 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
 msgstr ""
-"DuckDuckGo හි සෙවීම් සැමවිටම පුද්ගලික බව මතක් කිරීමක් පෙන්වයි. මෙය අක්‍රිය කිරීම මතක් කිරීම සඟවයි "
-"සහ සෙවුම් පෞද්ගලිකත්වයට කිසි විටෙකත් බලපාන්නේ නැත."
+"DuckDuckGo හි සෙවීම් සැමවිටම පුද්ගලික බව මතක් කිරීමක් පෙන්වයි. මෙය අක්‍රිය "
+"කිරීම මතක් කිරීම සඟවයි සහ සෙවුම් පෞද්ගලිකත්වයට කිසි විටෙකත් බලපාන්නේ නැත."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19157,8 +19288,8 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
 msgstr ""
-"DuckDuckGo හි සෙවීම් සැමවිටම ආරක්ෂිත බව මතක් කිරීමක් පෙන්වයි. මෙය අක්‍රිය කිරීම මතක් කිරීම සඟවන "
-"අතර සෙවුම් ආරක්ෂාවට කිසි විටෙකත් බලපාන්නේ නැත."
+"DuckDuckGo හි සෙවීම් සැමවිටම ආරක්ෂිත බව මතක් කිරීමක් පෙන්වයි. මෙය අක්‍රිය "
+"කිරීම මතක් කිරීම සඟවන අතර සෙවුම් ආරක්ෂාවට කිසි විටෙකත් බලපාන්නේ නැත."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19196,7 +19327,8 @@ msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
 msgstr ""
-"DuckDuckGo පෞදගලිකත්වය සම්බන්ධ පුවත් ලිපි සඳහා ලියපදිංචිය ඉඳහිට මතක් කරන පණිවුඩ පෙන්වන්න"
+"DuckDuckGo පෞදගලිකත්වය සම්බන්ධ පුවත් ලිපි සඳහා ලියපදිංචිය ඉඳහිට මතක් කරන "
+"පණිවුඩ පෙන්වන්න"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19537,7 +19669,8 @@ msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
 msgstr ""
-"කනගාටුයි, උඩුගත කළ රූපය සැකසිය නොහැකි විය. කරුණාකර වෙනස් රූපයක් හෝ ආකෘතියක් උත්සාහ කරන්න."
+"කනගාටුයි, උඩුගත කළ රූපය සැකසිය නොහැකි විය. කරුණාකර වෙනස් රූපයක් හෝ ආකෘතියක් "
+"උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -19546,16 +19679,16 @@ msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
 msgstr ""
-"කනගාටුයි, මෙම කේතය අවලංගු වේ. කරුණාකර නිවැරදි කේතය ඇතුළත් කර හෝ ස්කෑන් කර ඇති බවට වග "
-"බලා ගන්න."
+"කනගාටුයි, මෙම කේතය අවලංගු වේ. කරුණාකර නිවැරදි කේතය ඇතුළත් කර හෝ ස්කෑන් කර "
+"ඇති බවට වග බලා ගන්න."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid ""
 "Sorry, we couldn't generate a richer answer. You can try asking Duck.ai."
 msgstr ""
-"කණගාටුයි, අපට වඩාත් පොහොසත් පිළිතුරක් නිර්මාණය කරන්නට නොහැකි විය. ඔබට Duck.ai එකෙන් අහන්න "
-"උත්සාහ කළ හැක."
+"කණගාටුයි, අපට වඩාත් පොහොසත් පිළිතුරක් නිර්මාණය කරන්නට නොහැකි විය. ඔබට "
+"Duck.ai එකෙන් අහන්න උත්සාහ කළ හැක."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and that they could try to refresh the page to resolve the error. Placeholders are for markup, please ignore.
@@ -19564,15 +19697,16 @@ msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
 msgstr ""
-"කණගාටුයි, මෙම ප්‍රතිඵල පෙන්වීමේදී අපට දෝෂයක් ඇති විය. නැවත උත්සාහ කිරීමට%1$sමෙහි ක්ලික් "
-"කරන්න%2$s ."
+"කණගාටුයි, මෙම ප්‍රතිඵල පෙන්වීමේදී අපට දෝෂයක් ඇති විය. නැවත උත්සාහ "
+"කිරීමට%1$sමෙහි ක්ලික් කරන්න%2$s ."
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
 msgstr ""
-"සමාවන්න, අපට ඔබේ ප්‍රතිපෝෂණ ඉදිරිපත් කිරීමට නොහැකි විය. කරුණාකර පසුව නැවත උත්සාහ කරන්න."
+"සමාවන්න, අපට ඔබේ ප්‍රතිපෝෂණ ඉදිරිපත් කිරීමට නොහැකි විය. කරුණාකර පසුව නැවත "
+"උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19976,8 +20110,8 @@ msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
 msgstr ""
-"Duck.ai තුළ ඇති ඉහළ සීමාවන් අගුළු හැර ගැනීමට DuckDuckGo වෙත ග්‍රාහකත්වය ලබාගන්න, නැතහොත් "
-"තවත් රූප නිර්මාණය කිරීමට පසුව නැවත එන්න."
+"Duck.ai තුළ ඇති ඉහළ සීමාවන් අගුළු හැර ගැනීමට DuckDuckGo වෙත ග්‍රාහකත්වය "
+"ලබාගන්න, නැතහොත් තවත් රූප නිර්මාණය කිරීමට පසුව නැවත එන්න."
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -20045,7 +20179,9 @@ msgctxt "Full sentence for composing a card"
 msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
-msgstr "සැත්කමකින් සුවය ලැබූ කෙනෙකුට get-well කාඩ්පතක ලිවීමට වාක්ය ඛණ්ඩයක් යෝජනා කරනවාද?"
+msgstr ""
+"සැත්කමකින් සුවය ලැබූ කෙනෙකුට get-well කාඩ්පතක ලිවීමට වාක්ය ඛණ්ඩයක් යෝජනා "
+"කරනවාද?"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
@@ -20381,7 +20517,9 @@ msgstr "%1$sවෙත මාරු විය"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr "ආකෘතිය මාරු කිරීමෙන්, ඔබේ කතාබහ සපයන්නාගේ දෘශ්‍යතාව ශුන්‍ය නොවන ආකෘතියකට යවනු ඇත"
+msgstr ""
+"ආකෘතිය මාරු කිරීමෙන්, ඔබේ කතාබහ සපයන්නාගේ දෘශ්‍යතාව ශුන්‍ය නොවන ආකෘතියකට "
+"යවනු ඇත"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -20436,7 +20574,8 @@ msgstr "Sync & Backup සක්‍රිය කරන ලදී!"
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
-"Sync & Backup දත්ත මාස 18ක කාලයක් තිස්සේ අකර්මණ්‍යව තිබූ පසු ඒවා ප්‍රතිසාධනය කළ නොහැක."
+"Sync & Backup දත්ත මාස 18ක කාලයක් තිස්සේ අකර්මණ්‍යව තිබූ පසු ඒවා ප්‍රතිසාධනය "
+"කළ නොහැක."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
@@ -20445,6 +20584,8 @@ msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
 msgstr ""
+"Sync & Backup ඔබේ කතාබස්වල වැඩි ප්‍රමාණයක් සුරකින අතර ඒවා ඔබගේ සියලු උපාංග "
+"හරහා සමමුහුර්ත කරයි."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20493,9 +20634,9 @@ msgid ""
 msgstr ""
 "ප්‍රතිසාධන කේතය සමමුහුර්ත කරන්න\n"
 "\n"
-"ප්‍රතිසාධන කේතය මඟින් ඔබේ මුරපද, ස්වයංක්‍රීය පිරවීම් දත්ත සහ Duck.ai කතාබස් උපාංග කිහිපයක් අතර "
-"සමමුහුර්ත කිරීමට ඉඩ සලසන අතර, උපාංගයකට ප්‍රවේශය අහිමි වුවහොත් ඔබේ සමමුහුර්ත දත්ත ප්‍රතිසාධනය "
-"කර ගනී.\n"
+"ප්‍රතිසාධන කේතය මඟින් ඔබේ මුරපද, ස්වයංක්‍රීය පිරවීම් දත්ත සහ Duck.ai කතාබස් "
+"උපාංග කිහිපයක් අතර සමමුහුර්ත කිරීමට ඉඩ සලසන අතර, උපාංගයකට ප්‍රවේශය අහිමි "
+"වුවහොත් ඔබේ සමමුහුර්ත දත්ත ප්‍රතිසාධනය කර ගනී.\n"
 "\n"
 "මෙම තොරතුරු ආරක්ෂිතව තබා ගන්න.\n"
 "මෙම කේතයට ප්‍රවේශය ඇති ඕනෑම අයෙකුට ඔබේ සමමුහුර්ත දත්ත වෙත ප්‍රවේශ විය හැක.\n"
@@ -20504,12 +20645,14 @@ msgstr ""
 "\n"
 "මෙම කේතය ක්‍රියා කරන්නේ කෙසේ ද?\n"
 "1. ඔබේ බ්‍රවුසරයෙන් Duck.ai වෙත ගොස් Duck.ai සැකසුම් විවෘත කරන්න.\n"
-"2. \"Sync & Backup සක්‍රීය කරන්න, තෝරා, ඉන්පසු \"සමමුහුර්ත දත්ත ප්‍රතිසාධනය කරන්න\" තෝරන්න\n"
-"3. ඉහත ප්‍රතිසාධන කේතය පිටපත් කර \"මෙහි ඔබේ කේතය අලවන්න\" යනුවෙන් දැක්වෙන ස්ථානයේ "
-"අලවන්න\n"
+"2. \"Sync & Backup සක්‍රීය කරන්න, තෝරා, ඉන්පසු \"සමමුහුර්ත දත්ත ප්‍රතිසාධනය "
+"කරන්න\" තෝරන්න\n"
+"3. ඉහත ප්‍රතිසාධන කේතය පිටපත් කර \"මෙහි ඔබේ කේතය අලවන්න\" යනුවෙන් දැක්වෙන "
+"ස්ථානයේ අලවන්න\n"
 "\n"
-"ඔබ DuckDuckGo බ්‍රවුසරය Sync & Backup සක්‍රීය කර නොමැතිව මාස 18 කට වැඩි කාලයක් භාවිතා "
-"නොකරන්නේ නම්, ඔබගේ දත්ත සර්වරයෙන් මනා දමනු ලබන අතර ප්‍රතිසාධනය කළ නොහැක."
+"ඔබ DuckDuckGo බ්‍රවුසරය Sync & Backup සක්‍රීය කර නොමැතිව මාස 18 කට වැඩි "
+"කාලයක් භාවිතා නොකරන්නේ නම්, ඔබගේ දත්ත සර්වරයෙන් මනා දමනු ලබන අතර ප්‍රතිසාධනය "
+"කළ නොහැක."
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -20563,7 +20706,7 @@ msgstr "ඔබේ කතාබස් ඔබගේ සියලු උපාං�
 #. Headline in sync-enabled chat history about modals explaining cross-device sync.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Sync your chats across all your devices"
-msgstr ""
+msgstr "ඔබේ කතාබස් ඔබේ සියලු උපාංග අතර සමමුහුර්ත කරන්න"
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -20648,8 +20791,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
-"සෑම තැනකම ඔබ සමඟ Duck.ai රැගෙන යන්න. ඔබ කොතැනක සිටියත්, වඩාත් වේගවත් ප්‍රවේශයක් සඳහා "
-"එය අපගේ නොමිලේ යෙදුම තුළම ලබා ගන්න."
+"සෑම තැනකම ඔබ සමඟ Duck.ai රැගෙන යන්න. ඔබ කොතැනක සිටියත්, වඩාත් වේගවත් "
+"ප්‍රවේශයක් සඳහා එය අපගේ නොමිලේ යෙදුම තුළම ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20658,8 +20801,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
-"සෑම තැනකම ඔබ සමඟ Duck.ai රැගෙන යන්න. ඔබ කොතැනක සිට බ්‍රවුස් කළ ද වඩාත් වේගවත් "
-"ප්‍රවේශයක් සඳහා එය අපගේ නොමිලේ ලබා දෙන බ්‍රවුසරය තුළට ඇතුළත් කරගන්න."
+"සෑම තැනකම ඔබ සමඟ Duck.ai රැගෙන යන්න. ඔබ කොතැනක සිට බ්‍රවුස් කළ ද වඩාත් "
+"වේගවත් ප්‍රවේශයක් සඳහා එය අපගේ නොමිලේ ලබා දෙන බ්‍රවුසරය තුළට ඇතුළත් කරගන්න."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20683,7 +20826,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
-"Duck.ai වඩා හොඳ කළ හැක්කේ කෙසේදැයි අපව දැනුවත් කිරීමට මෙම නිර්නාමික සමීක්ෂණයට සහභාගි වන්න."
+"Duck.ai වඩා හොඳ කළ හැක්කේ කෙසේදැයි අපව දැනුවත් කිරීමට මෙම නිර්නාමික "
+"සමීක්ෂණයට සහභාගි වන්න."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -20904,9 +21048,9 @@ msgid ""
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
 msgstr ""
-"එයින් අදහස් වන්නේ ඔබගේ උපාංගය සහ මෙම සබැඳිය පිටුපස ඇති වෙබ් පිටුව අතර යවන ලද තොරතුරු තෙවන "
-"පාර්ශවයක් විසින් වළක්වාලීමේ අවදානම වැඩි බවයි. දුර්ලභ අවස්ථාවන්හි මුරපද හෝ ගෙවීම් විස්තර මෙයට "
-"ඇතුළත් වේ."
+"එයින් අදහස් වන්නේ ඔබගේ උපාංගය සහ මෙම සබැඳිය පිටුපස ඇති වෙබ් පිටුව අතර යවන ලද "
+"තොරතුරු තෙවන පාර්ශවයක් විසින් වළක්වාලීමේ අවදානම වැඩි බවයි. දුර්ලභ "
+"අවස්ථාවන්හි මුරපද හෝ ගෙවීම් විස්තර මෙයට ඇතුළත් වේ."
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -20915,8 +21059,8 @@ msgid ""
 "The Cloud Save bookmarklet allows any changes you make to your settings to "
 "automatically save in the cloud."
 msgstr ""
-"වලාකුළු තුළ ස්වයංක්‍රීයව සුරැකීමට ඔබගේ සැකසුම් වල සිදුකරන ඕනෑම වෙනස්කමක් Cloud Save කුඩා පිටු "
-"සලකුණු මඟින් ඉඩ දෙයි."
+"වලාකුළු තුළ ස්වයංක්‍රීයව සුරැකීමට ඔබගේ සැකසුම් වල සිදුකරන ඕනෑම වෙනස්කමක් "
+"Cloud Save කුඩා පිටු සලකුණු මඟින් ඉඩ දෙයි."
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -20946,8 +21090,8 @@ msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
 msgstr ""
-"සංකේතාංකන යතුර ඔබගේ බ්‍රවුසරයේ දේශීය ගබඩාවේ පමණක් සුරකින අතර, ඊට ප්‍රවේශ විය හැක්කේ ඔබට "
-"පමණි."
+"සංකේතාංකන යතුර ඔබගේ බ්‍රවුසරයේ දේශීය ගබඩාවේ පමණක් සුරකින අතර, ඊට ප්‍රවේශ විය "
+"හැක්කේ ඔබට පමණි."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider deletes all chat data within 30 days.
@@ -20968,7 +21112,9 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider does not save this chat or any associated data on their "
 "servers."
-msgstr "ආකෘති සපයන්නා මෙම කතාබස් හෝ ඒ ආශ්‍රිත කිසිදු දත්තයක් ඔවුන්ගේ සර්වරවල සුරකින්නේ නැත."
+msgstr ""
+"ආකෘති සපයන්නා මෙම කතාබස් හෝ ඒ ආශ්‍රිත කිසිදු දත්තයක් ඔවුන්ගේ සර්වරවල "
+"සුරකින්නේ නැත."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -21027,8 +21173,8 @@ msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
 msgstr ""
-"මෙම කතාබහ අභ්‍යන්තරව සුරැකීමේදී දෝෂයක් සිදු විය. අභ්‍යන්තර දත්ත ගබඩා සක්‍රිය කර ඇති බවට වග බලා "
-"ගැනීම සඳහා කරුණාකර ඔබේ බ්‍රව්සර් සැකසුම් පරීක්ෂා කරන්න."
+"මෙම කතාබහ අභ්‍යන්තරව සුරැකීමේදී දෝෂයක් සිදු විය. අභ්‍යන්තර දත්ත ගබඩා සක්‍රිය "
+"කර ඇති බවට වග බලා ගැනීම සඳහා කරුණාකර ඔබේ බ්‍රව්සර් සැකසුම් පරීක්ෂා කරන්න."
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -21043,8 +21189,8 @@ msgid ""
 "There was still an error displaying the search results. Please wait a few "
 "minutes before you try again."
 msgstr ""
-"සෙවුම් ප්‍රතිඵල පෙන්වීමේ දෝෂයක් තවමත් පැවතිණි. ඔබ නැවත උත්සාහ කිරීමට පෙර කරුණාකර මිනිත්තු කිහිපයක් "
-"රැඳී සිටින්න."
+"සෙවුම් ප්‍රතිඵල පෙන්වීමේ දෝෂයක් තවමත් පැවතිණි. ඔබ නැවත උත්සාහ කිරීමට පෙර "
+"කරුණාකර මිනිත්තු කිහිපයක් රැඳී සිටින්න."
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
@@ -21063,9 +21209,9 @@ msgid ""
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
 msgstr ""
-"සැඟවුණු ට්‍රැකර් අවහිර කිරීමෙන්, හැකි සෑම තැනකම සම්බන්ධතා සංකේතනය කිරීමෙන් සහ DuckDuckGo "
-"ඔබේ සුපුරුදු සෙවුම් යන්ත්‍රය බවට පත් කිරීමෙන් ඔබ පිවිසෙන වෙබ් අඩවි වලට පෞද්ගලිකත්වය එක් කිරීමට මෙම "
-"බ්‍රව්සර් අවසර භාවිතා කරයි."
+"සැඟවුණු ට්‍රැකර් අවහිර කිරීමෙන්, හැකි සෑම තැනකම සම්බන්ධතා සංකේතනය කිරීමෙන් "
+"සහ DuckDuckGo ඔබේ සුපුරුදු සෙවුම් යන්ත්‍රය බවට පත් කිරීමෙන් ඔබ පිවිසෙන වෙබ් "
+"අඩවි වලට පෞද්ගලිකත්වය එක් කිරීමට මෙම බ්‍රව්සර් අවසර භාවිතා කරයි."
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -21103,8 +21249,8 @@ msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
 msgstr ""
-"මෙම AI ආකෘතිය තවදුරටත් ලබා ගත නොහැක. වෙනස් ආකෘතියක් සමඟ නව කතාබස් ආරම්භ කිරීමට උත්සාහ "
-"කරන්න."
+"මෙම AI ආකෘතිය තවදුරටත් ලබා ගත නොහැක. වෙනස් ආකෘතියක් සමඟ නව කතාබස් ආරම්භ "
+"කිරීමට උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -21113,8 +21259,8 @@ msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
 msgstr ""
-"මෙම AI ආකෘති අනුවාදය තවදුරටත් සහය නොදක්වයි. මෙම ආකෘතියේ නවතම අනුවාදය සමඟ නව කතාබහක් "
-"ආරම්භ කරන්න."
+"මෙම AI ආකෘති අනුවාදය තවදුරටත් සහය නොදක්වයි. මෙම ආකෘතියේ නවතම අනුවාදය සමඟ නව "
+"කතාබහක් ආරම්භ කරන්න."
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -21148,13 +21294,13 @@ msgctxt ""
 msgid ""
 "This chat and its generated images become public when you create and copy "
 "the link."
-msgstr ""
+msgstr "සබැඳිය තනා පිටපත් කළ විට මෙම කතාබහ සහ එහි ජනනය කළ පින්තූර සියල්ලන්ට විවෘත වේ."
 
 # smartling.placeholder_format=C
 #. Explains that creating and copying a share link makes the selected chat content public.
 msgctxt "Share modal info bullet about public access"
 msgid "This chat becomes public when you create and copy the link."
-msgstr ""
+msgstr "සබැඳිය තනා පිටපත් කළ විට මෙම කතාබහ සියල්ලන්ට විවෘත වේ."
 
 # smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
@@ -21169,8 +21315,9 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"මෙම සංවාදය Duck.ai (%1$s) සමඟ ජනනය කරන ලද්දේ %2$sගේ %3$s ආකෘතිය භාවිත කරමිනි. AI "
-"කතාබස් සාවද්‍ය හෝ අපහාසාත්මක තොරතුරු ප්‍රදර්ශනය කළ හැකිය (වැඩි විස්තර සඳහා %4$s බලන්න)."
+"මෙම සංවාදය Duck.ai (%1$s) සමඟ ජනනය කරන ලද්දේ %2$sගේ %3$s ආකෘතිය භාවිත "
+"කරමිනි. AI කතාබස් සාවද්‍ය හෝ අපහාසාත්මක තොරතුරු ප්‍රදර්ශනය කළ හැකිය (වැඩි "
+"විස්තර සඳහා %4$s බලන්න)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21180,8 +21327,8 @@ msgid ""
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"බහු කතාබස් ආකෘති භාවිත කරමින් Duck.ai (%1$s) සමඟ මෙම සංවාදය ජනනය කරන ලදී. AI කතාබස් "
-"සාවද්‍ය හෝ අහිතකර තොරතුරු පෙන්විය හැකිය (වැඩි විස්තර සඳහා %2$s බලන්න)."
+"බහු කතාබස් ආකෘති භාවිත කරමින් Duck.ai (%1$s) සමඟ මෙම සංවාදය ජනනය කරන ලදී. AI "
+"කතාබස් සාවද්‍ය හෝ අහිතකර තොරතුරු පෙන්විය හැකිය (වැඩි විස්තර සඳහා %2$s බලන්න)."
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21190,8 +21337,8 @@ msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
 msgstr ""
-"මෙම සංවාදය Duck.ai හඬ කතාබස් (%1$s) සමඟින් ජනනය කරන ලදී. AI මඟින් සාවද්‍ය හෝ අහිතකර "
-"තොරතුරු සැපයිය හැකිය. (වැඩිදුර තොරතුරු සඳහා %2$s බලන්න)."
+"මෙම සංවාදය Duck.ai හඬ කතාබස් (%1$s) සමඟින් ජනනය කරන ලදී. AI මඟින් සාවද්‍ය හෝ "
+"අහිතකර තොරතුරු සැපයිය හැකිය. (වැඩිදුර තොරතුරු සඳහා %2$s බලන්න)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -21202,8 +21349,8 @@ msgid ""
 "more info)."
 msgstr ""
 "මෙම සංවාදය DuckDuckGo AI Chat (%1$s) සමඟ ජනනය කරන ලද්දේ %2$sහි %3$s ආකෘතිය "
-"භාවිතා කරමිනි. AI කතාබස් සාවද්‍ය හෝ වැරදිසහගත තොරතුරු ප්‍රදර්ශනය කළ හැකිය (වැඩි විස්තර සඳහා "
-"%4$s බලන්න)."
+"භාවිතා කරමිනි. AI කතාබස් සාවද්‍ය හෝ වැරදිසහගත තොරතුරු ප්‍රදර්ශනය කළ හැකිය "
+"(වැඩි විස්තර සඳහා %4$s බලන්න)."
 
 # smartling.placeholder_format=C
 #. Renders to the right of the device name for the row that matches this device's id.
@@ -21220,8 +21367,8 @@ msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
 msgstr ""
-"මෙම උපාංගයට අනෙකුත් උපාංගවල ඔබගේ සමමුහුර්ත දත්ත වෙත තවදුරටත් ප්‍රවේශ වීමට නොහැකි වනු ඇත. "
-"අවසාන කතාබස් %1$s තවමත් ස්ථානීය ගබඩාවේ පවතිනු ඇත."
+"මෙම උපාංගයට අනෙකුත් උපාංගවල ඔබගේ සමමුහුර්ත දත්ත වෙත තවදුරටත් ප්‍රවේශ වීමට "
+"නොහැකි වනු ඇත. අවසාන කතාබස් %1$s තවමත් ස්ථානීය ගබඩාවේ පවතිනු ඇත."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21319,8 +21466,8 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
-"මෙය හුදෙක් ආදර්ශ කතාබහක් පමණි. එහි මෙනුව (තිත් තුන) විවෘත කර, එය ඔබේ කතාබස්වල ඉහළින්ම තබා "
-"ගැනීමට පින් කරන්න තෝරන්න!"
+"මෙය හුදෙක් ආදර්ශ කතාබහක් පමණි. එහි මෙනුව (තිත් තුන) විවෘත කර, එය ඔබේ "
+"කතාබස්වල ඉහළින්ම තබා ගැනීමට පින් කරන්න තෝරන්න!"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -21329,7 +21476,8 @@ msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
 msgstr ""
-"මෙය හුදෙක් ආදර්ශ කතාබහක් පමණි. එය මකා දැමීමට පැති මෙනුවේ ඇති Fire Button භාවිතා කරන්න!"
+"මෙය හුදෙක් ආදර්ශ කතාබහක් පමණි. එය මකා දැමීමට පැති මෙනුවේ ඇති Fire Button "
+"භාවිතා කරන්න!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -21350,8 +21498,8 @@ msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
 msgstr ""
-"මෙම ආකෘති සැපයුම්කරු දින 30ක් ඇතුළත මෙම කතාබහ හා සම්බන්ධ දත්ත මකා දමයි. අනෙකුත් ආකෘති "
-"සපයන්නන් ශුන්‍ය දත්ත රඳවා ගැනීමේ ආකෘතියක් අනුගමනය කරයි."
+"මෙම ආකෘති සැපයුම්කරු දින 30ක් ඇතුළත මෙම කතාබහ හා සම්බන්ධ දත්ත මකා දමයි. "
+"අනෙකුත් ආකෘති සපයන්නන් ශුන්‍ය දත්ත රඳවා ගැනීමේ ආකෘතියක් අනුගමනය කරයි."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -21360,8 +21508,8 @@ msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
 msgstr ""
-"මෙම ආකෘති සැපයුම්කරු මෙම කතාබහ හා සම්බන්ධ කිසිදු දත්තයක් ගබඩා නොකරයි. අනෙකුත් ආකෘති සපයන්නන් "
-"සීමිත දත්ත රඳවා ගැනීමේ ආකෘතියක් අනුගමනය කරයි."
+"මෙම ආකෘති සැපයුම්කරු මෙම කතාබහ හා සම්බන්ධ කිසිදු දත්තයක් ගබඩා නොකරයි. "
+"අනෙකුත් ආකෘති සපයන්නන් සීමිත දත්ත රඳවා ගැනීමේ ආකෘතියක් අනුගමනය කරයි."
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -21398,8 +21546,8 @@ msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
 msgstr ""
-"මෙය DuckDuckGo ආරක්ෂිත සේවාදායකයේ ඔබේ කතාබස් මුල සිට අග දක්වා ගුප්ත කේතනය සමඟ සුරකින "
-"අතර පසුව ඕනෑම බ්රවුසරයකින් ඒවාට ප්රවේශ විය හැකිය."
+"මෙය DuckDuckGo ආරක්ෂිත සේවාදායකයේ ඔබේ කතාබස් මුල සිට අග දක්වා ගුප්ත කේතනය "
+"සමඟ සුරකින අතර පසුව ඕනෑම බ්රවුසරයකින් ඒවාට ප්රවේශ විය හැකිය."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21408,8 +21556,8 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"මෙම සැකසුම ඔබේ බ්‍රව්සරයේ ගබඩා වේ, එයින් අදහස් වන්නේ ඔබ duckduckgo.com බ්‍රව්සර දත්ත මකා "
-"දැමුවහොත්, ඔබට නැවත AI සහාය සහිත පිළිතුරු දැකිය හැක."
+"මෙම සැකසුම ඔබේ බ්‍රව්සරයේ ගබඩා වේ, එයින් අදහස් වන්නේ ඔබ duckduckgo.com "
+"බ්‍රව්සර දත්ත මකා දැමුවහොත්, ඔබට නැවත AI සහාය සහිත පිළිතුරු දැකිය හැක."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21419,9 +21567,9 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"මෙම සැකසුම ඔබේ බ්‍රව්සරයේ ගබඩා වේ, එයින් අදහස් වන්නේ ඔබ duckduckgo.com බ්‍රව්සර දත්ත මකා "
-"දැමුවහොත්, ඔබට නැවත AI සහාය සහිත පිළිතුරු දැකිය හැක. කෙසේ වෙතත්, අපට %1$s හි AI-සහය "
-"සහිත පිළිතුරු කිසිවිටෙකත් පෙන්වන ආරම්භක පිටුවක් ඇත."
+"මෙම සැකසුම ඔබේ බ්‍රව්සරයේ ගබඩා වේ, එයින් අදහස් වන්නේ ඔබ duckduckgo.com "
+"බ්‍රව්සර දත්ත මකා දැමුවහොත්, ඔබට නැවත AI සහාය සහිත පිළිතුරු දැකිය හැක. කෙසේ "
+"වෙතත්, අපට %1$s හි AI-සහය සහිත පිළිතුරු කිසිවිටෙකත් පෙන්වන ආරම්භක පිටුවක් ඇත."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
@@ -21472,9 +21620,9 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"මින් ඔබගේ සියලුම Duck.ai කතාබස් මෙම බ්‍රව්සරයෙන් මකා දමා Sync & Backup විසන්ධි කරයි. Sync "
-"& Backup ට සම්බන්ධ කර ඇති අනෙකුත් බ්‍රව්සර්වලින් ඔයාට තවමත් ඔයාගේ කතාබස් වෙත ප්‍රවේශ වීමට "
-"හැකි වනු ඇත."
+"මින් ඔබගේ සියලුම Duck.ai කතාබස් මෙම බ්‍රව්සරයෙන් මකා දමා Sync & Backup "
+"විසන්ධි කරයි. Sync & Backup ට සම්බන්ධ කර ඇති අනෙකුත් බ්‍රව්සර්වලින් ඔයාට "
+"තවමත් ඔයාගේ කතාබස් වෙත ප්‍රවේශ වීමට හැකි වනු ඇත."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -21483,7 +21631,8 @@ msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
 msgstr ""
-"මෙය ඔයාගේ මෑත කාලීන කතාබස් සියල්ල මකා දමයි, ඒවා අමුණලා නැත්නම්. මෙය ආපසු හැරවිය නොහැක."
+"මෙය ඔයාගේ මෑත කාලීන කතාබස් සියල්ල මකා දමයි, ඒවා අමුණලා නැත්නම්. මෙය ආපසු "
+"හැරවිය නොහැක."
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -21621,8 +21770,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"දිශාවන් මුද්‍රණය කිරීම සඳහා:%1$sසිතියම වෙත ආපසු යන්න.%2$sඔබට මුද්‍රණය කිරීමට අවශ්‍ය මාර්ගය "
-"තෝරන්න.%3$sමුද්‍රණ නිරූපකය ක්ලික් කරන්න.%4$s"
+"දිශාවන් මුද්‍රණය කිරීම සඳහා:%1$sසිතියම වෙත ආපසු යන්න.%2$sඔබට මුද්‍රණය කිරීමට "
+"අවශ්‍ය මාර්ගය තෝරන්න.%3$sමුද්‍රණ නිරූපකය ක්ලික් කරන්න.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -21632,9 +21781,9 @@ msgid ""
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
 msgstr ""
-"ඔබේ සමමුහුර්ත කළ දත්ත ප්‍රතිසාධනය කිරීම සඳහා ඔබ විසින් පළමු වරට සමමුහුර්ත කිරීම සැකසීමේ දී සුරකින "
-"ලද ප්‍රතිසාධන කේතය අවශ්‍ය වනු ඇත. මෙම කේතය ඔබ මුල් වරට සමමුහු සැකසීමට භාවිතා කළ උපාංගයේ "
-"PDF ගොනුවක් ලෙස සුරැකී තිබිය හැකිය."
+"ඔබේ සමමුහුර්ත කළ දත්ත ප්‍රතිසාධනය කිරීම සඳහා ඔබ විසින් පළමු වරට සමමුහුර්ත "
+"කිරීම සැකසීමේ දී සුරකින ලද ප්‍රතිසාධන කේතය අවශ්‍ය වනු ඇත. මෙම කේතය ඔබ මුල් "
+"වරට සමමුහු සැකසීමට භාවිතා කළ උපාංගයේ PDF ගොනුවක් ලෙස සුරැකී තිබිය හැකිය."
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -21643,8 +21792,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"ඔබේ කතාබස් ඉතිහාසය Duck.ai වෙත මාරු කිරීමට, කරුණාකර ඔබේ DuckDuckGo බ්‍රවුසරය නවතම "
-"අනුවාදයට යාවත්කාලීන කර නැවත උත්සාහ කරන්න."
+"ඔබේ කතාබස් ඉතිහාසය Duck.ai වෙත මාරු කිරීමට, කරුණාකර ඔබේ DuckDuckGo බ්‍රවුසරය "
+"නවතම අනුවාදයට යාවත්කාලීන කර නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -21652,8 +21801,8 @@ msgid ""
 "To use dictation, allow your browser to access the microphone in your system "
 "settings."
 msgstr ""
-"අසා ලිවීම භාවිත කිරීමට, ඔබේ පද්ධති සැකසුම් තුළින් මයික්‍රොෆෝනය වෙත ප්‍රවේශ වීමට ඔබේ බ්‍රවුසරයට ඉඩ "
-"දෙන්න."
+"අසා ලිවීම භාවිත කිරීමට, ඔබේ පද්ධති සැකසුම් තුළින් මයික්‍රොෆෝනය වෙත ප්‍රවේශ "
+"වීමට ඔබේ බ්‍රවුසරයට ඉඩ දෙන්න."
 
 # smartling.placeholder_format=C
 msgid "Today"
@@ -21676,14 +21825,16 @@ msgstr "අද"
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
+"පුද්ගලික AI කතාබස් සඳහා ටොගල් කරන්න, නැතහොත් %1$sසැකසුම් තුළින් අක්‍රිය "
+"කරන්න%2$s."
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
-"පුද්ගලික AI කතාබස් උත්සාහ කිරීමට ටොගල් කරන්න, නැතහොත් %1$s %2$s මෙනුව තුළින් එය අක්‍රිය කරන්න."
-"%3$s"
+"පුද්ගලික AI කතාබස් උත්සාහ කිරීමට ටොගල් කරන්න, නැතහොත් %1$s %2$s මෙනුව තුළින් "
+"එය අක්‍රිය කරන්න.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21857,8 +22008,8 @@ msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
 msgstr ""
-"DuckDuckGo විසින් අවහිර කළ නිරීක්ෂණය කිරීමේ ප්‍රයත්න මෙහි දිස් වේ.අපි කොපමණ ප්‍රමාණයක් අවහිර "
-"කරනවාදැයි බැලීමට බ්‍රවුස් කරන්න."
+"DuckDuckGo විසින් අවහිර කළ නිරීක්ෂණය කිරීමේ ප්‍රයත්න මෙහි දිස් වේ.අපි කොපමණ "
+"ප්‍රමාණයක් අවහිර කරනවාදැයි බැලීමට බ්‍රවුස් කරන්න."
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -21906,8 +22057,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"මෙම ඉංග්‍රීසි වාක්‍යය ප්‍රංශ භාෂාවට පරිවර්තනය කරන්න: \"මම ළඟම ඇති චිත්‍රපට ශාලාවට යන්නේ "
-"කෙසේද?\""
+"මෙම ඉංග්‍රීසි වාක්‍යය ප්‍රංශ භාෂාවට පරිවර්තනය කරන්න: \"මම ළඟම ඇති චිත්‍රපට "
+"ශාලාවට යන්නේ කෙසේද?\""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -21916,8 +22067,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"මෙම ඉංග්‍රීසි වාක්‍යය ප්‍රංශ භාෂාවට පරිවර්තනය කරන්න: \"මම ළඟම ඇති චිත්‍රපට ශාලාවට යන්නේ "
-"කෙසේද?\""
+"මෙම ඉංග්‍රීසි වාක්‍යය ප්‍රංශ භාෂාවට පරිවර්තනය කරන්න: \"මම ළඟම ඇති චිත්‍රපට "
+"ශාලාවට යන්නේ කෙසේද?\""
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -22164,7 +22315,9 @@ msgstr "වෙනත් වචන සමග උත්සාහ කරන්න."
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr "තවත් ප්‍රතිඵල දැකීමට DuckDuckGo හි ඔබේ දැන්වීම් අවහිරකරණය අබල කිරීමට උත්සාහ කරන්න."
+msgstr ""
+"තවත් ප්‍රතිඵල දැකීමට DuckDuckGo හි ඔබේ දැන්වීම් අවහිරකරණය අබල කිරීමට උත්සාහ "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
@@ -22177,7 +22330,9 @@ msgstr "වඩාත් නිවැරදි ප්‍රතිඵල සඳහ
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "එක් එක් ආකෘතිය සමඟ අත්හදා බැලීමට උත්සාහ කරන්න - ඔවුන් විවිධ ප්‍රතිචාර ලබා දෙනු ඇත."
+msgstr ""
+"එක් එක් ආකෘතිය සමඟ අත්හදා බැලීමට උත්සාහ කරන්න - ඔවුන් විවිධ ප්‍රතිචාර ලබා "
+"දෙනු ඇත."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -22395,8 +22550,8 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"AI විශේෂාංග අක්‍රීය කිරීමට උත්සාහ කරනවා ද? ඔයාගේ සැකසුම් මතක තබා ගැනීමට %1$sDuckDuckGo "
-"No AI%2$s සෙවුම් දිගුව ස්ථාපනය කරන්න. %3$sවැඩිදුර දැනගන්න%4$s"
+"AI විශේෂාංග අක්‍රීය කිරීමට උත්සාහ කරනවා ද? ඔයාගේ සැකසුම් මතක තබා ගැනීමට "
+"%1$sDuckDuckGo No AI%2$s සෙවුම් දිගුව ස්ථාපනය කරන්න. %3$sවැඩිදුර දැනගන්න%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -22405,8 +22560,8 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"AI විශේෂාංග අක්‍රීය කිරීමට උත්සාහ කරනවා ද? ඔබේ සැකසුම් මතක තබා ගැනීමට %1$sDuckDuckGo "
-"No AI%2$s සෙවුම් දිගුව වෙත මාරු වෙන්න. %3$sවැඩිදුර දැනගන්න%4$s"
+"AI විශේෂාංග අක්‍රීය කිරීමට උත්සාහ කරනවා ද? ඔබේ සැකසුම් මතක තබා ගැනීමට "
+"%1$sDuckDuckGo No AI%2$s සෙවුම් දිගුව වෙත මාරු වෙන්න. %3$sවැඩිදුර දැනගන්න%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -22607,8 +22762,8 @@ msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
 msgstr ""
-"DuckAssist පිළිතුරු උත්පාදනය වන විට ඒවා ටයිප් කරයි. මෙය ක්‍රියාවිරහිත කිරීමෙන් සෙවීමක් සහ "
-"ප්‍රදර්ශනය වන පිළිතුර අතර කෙටි ප්‍රමාදයක් ඇති විය හැක."
+"DuckAssist පිළිතුරු උත්පාදනය වන විට ඒවා ටයිප් කරයි. මෙය ක්‍රියාවිරහිත "
+"කිරීමෙන් සෙවීමක් සහ ප්‍රදර්ශනය වන පිළිතුර අතර කෙටි ප්‍රමාදයක් ඇති විය හැක."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -22738,8 +22893,8 @@ msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
 msgstr ""
-"%1$sOn startup%2$s වලට පහළින්, %3$sOpen a specific page%4$s ක්ලික් කර %5$sSet "
-"Pages%6$s මත ක්ලික් කරන්න."
+"%1$sOn startup%2$s වලට පහළින්, %3$sOpen a specific page%4$s ක්ලික් කර "
+"%5$sSet Pages%6$s මත ක්ලික් කරන්න."
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
@@ -22747,8 +22902,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"%1$sOn startup%2$s වලට පහළීන් ඇති, %3$sHomepage%4$s තෝරාගෙන ඇතුළු කරන්න: https://"
-"duckduckgo.com"
+"%1$sOn startup%2$s වලට පහළීන් ඇති, %3$sHomepage%4$s තෝරාගෙන ඇතුළු කරන්න: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -22864,8 +23019,8 @@ msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
 msgstr ""
-"Pro වෙත උත්ශ්‍රේණිගත කිරීමෙන් %1$s, වඩා ඉහළ AI තර්කනයක් සහ Plus සැලැස්මට වඩා 2 ගුණයක් "
-"ඉහළ AI පරිශීලන සීමා අගුළු හැර ගන්න."
+"Pro වෙත උත්ශ්‍රේණිගත කිරීමෙන් %1$s, වඩා ඉහළ AI තර්කනයක් සහ Plus සැලැස්මට වඩා "
+"2 ගුණයක් ඉහළ AI පරිශීලන සීමා අගුළු හැර ගන්න."
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -23023,8 +23178,8 @@ msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
 msgstr ""
-"Duck.ai හි ඔබේ දායකත්වය සක්රිය කිරීමට සහ උසස් ආකෘති වෙත ප්‍රවේශ වීමට DuckDuckGo බ්‍රවුසරය "
-"යාවත්කාලීන කරන්න"
+"Duck.ai හි ඔබේ දායකත්වය සක්රිය කිරීමට සහ උසස් ආකෘති වෙත ප්‍රවේශ වීමට "
+"DuckDuckGo බ්‍රවුසරය යාවත්කාලීන කරන්න"
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -23149,15 +23304,16 @@ msgid ""
 "Upgrade to Pro to unlock 2x higher limits than Plus, or come back later to "
 "create more images."
 msgstr ""
-"Plus ප්‍රකාරයට වඩා දෙගුණයකින් ඉහළ සීමාවන් අගුළු ඇරීමට Pro වෙත උත්ශ්‍රේණිගත කරන්න, නැත්නම් තවත් "
-"රූප නිර්මාණය කිරීමට පසුව නැවත එන්න."
+"Plus ප්‍රකාරයට වඩා දෙගුණයකින් ඉහළ සීමාවන් අගුළු ඇරීමට Pro වෙත උත්ශ්‍රේණිගත "
+"කරන්න, නැත්නම් තවත් රූප නිර්මාණය කිරීමට පසුව නැවත එන්න."
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
 msgstr ""
-"Plus ප්‍රකාරයට වඩා දෙගුණයකින් පුළුල් පරිශීලන සීමා අගුළු හැර ගැනීමට Pro වෙත උත්ශ්‍රේණිගත කරන්න"
+"Plus ප්‍රකාරයට වඩා දෙගුණයකින් පුළුල් පරිශීලන සීමා අගුළු හැර ගැනීමට Pro වෙත "
+"උත්ශ්‍රේණිගත කරන්න"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -23253,9 +23409,9 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"ChatGPT, Claude, සහ අනෙකුත් AI පද්ධති පුද්ගලිකව භාවිත කරන්න. හැකර්වරුන්, වංචාකරුවන් සහ "
-"සමාගම් වලින් ඔබේ කතාබස් ආරක්ෂා කරගන්න. තොරතුරු රහසිගතව තබා ගන්න. ගාස්තු රහිතයි. ගිණුමක් අවශ්‍ය "
-"නොවේ."
+"ChatGPT, Claude, සහ අනෙකුත් AI පද්ධති පුද්ගලිකව භාවිත කරන්න. හැකර්වරුන්, "
+"වංචාකරුවන් සහ සමාගම් වලින් ඔබේ කතාබස් ආරක්ෂා කරගන්න. තොරතුරු රහසිගතව තබා "
+"ගන්න. ගාස්තු රහිතයි. ගිණුමක් අවශ්‍ය නොවේ."
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -23310,8 +23466,8 @@ msgid ""
 "Use this code to restore your data if you lose access to your devices. Keep "
 "it safe."
 msgstr ""
-"ඔබේ උපාංගවලට ප්‍රවේශය අහිමි වුණොත් ඔබේ දත්ත ප්‍රතිසාධනය කිරීමට මේ කේතය භාවිතා කරන්න. එය "
-"ආරක්ෂිතව තබා ගන්න."
+"ඔබේ උපාංගවලට ප්‍රවේශය අහිමි වුණොත් ඔබේ දත්ත ප්‍රතිසාධනය කිරීමට මේ කේතය "
+"භාවිතා කරන්න. එය ආරක්ෂිතව තබා ගන්න."
 
 # smartling.placeholder_format=C
 #. First sentence of the recovery section. The 18-month inactivity notice is rendered by the component using DUCKCHAT_SYNC_RECOVERY_INACTIVITY_NOTICE so both surfaces stay consistent.
@@ -23319,8 +23475,8 @@ msgctxt "Description for the recovery section inside Manage"
 msgid ""
 "Use this code to restore your saved chats if you lose access to your devices."
 msgstr ""
-"ඔබේ උපාංගවලට ප්‍රවේශය අහිමි වුණොත් ඔබේ සුරකින ලද කතාබස් ප්‍රතිසාධනය කිරීමට මේ කේතය භාවිතා "
-"කරන්න."
+"ඔබේ උපාංගවලට ප්‍රවේශය අහිමි වුණොත් ඔබේ සුරකින ලද කතාබස් ප්‍රතිසාධනය කිරීමට "
+"මේ කේතය භාවිතා කරන්න."
 
 # smartling.placeholder_format=C
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
@@ -23470,8 +23626,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
 msgstr ""
-"දැන්වීම් බැලීම DuckDuckGo මගින් පුද්ගලිකත්වය ආරක්ෂා කරයි. දැන්වීම් ක්ලික් කිරීම් කළමනාකරණය කරනු "
-"ලබන්නේ Microsoftහි දැන්වීම් ජාලය විසිනි"
+"දැන්වීම් බැලීම DuckDuckGo මගින් පුද්ගලිකත්වය ආරක්ෂා කරයි. දැන්වීම් ක්ලික් "
+"කිරීම් කළමනාකරණය කරනු ලබන්නේ Microsoftහි දැන්වීම් ජාලය විසිනි"
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -23480,8 +23636,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
 msgstr ""
-"දැන්වීම් බැලීම DuckDuckGo මගින් පුද්ගලිකත්වය ආරක්ෂා කරයි. දැන්වීම් ක්ලික් කිරීම් TripAdvisor හි "
-"දැන්වීම් ජාලය විසින් කළමනාකරණය කරනු ලැබේ."
+"දැන්වීම් බැලීම DuckDuckGo මගින් පුද්ගලිකත්වය ආරක්ෂා කරයි. දැන්වීම් ක්ලික් "
+"කිරීම් TripAdvisor හි දැන්වීම් ජාලය විසින් කළමනාකරණය කරනු ලැබේ."
 
 # smartling.placeholder_format=C
 #. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
@@ -23490,6 +23646,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Yelp's ad network."
 msgstr ""
+"වෙළෙඳ දැන්වීම් බැලීමේ පුද්ගලිකත්වය DuckDuckGo මගින් ආරක්ෂා කරයි. වෙළෙඳ "
+"දැන්වීම් මත ක්ලික් කිරීම් Yelp ප්‍රචාරණ ජාලය විසින් කළමනාකරණය කරනු ලැබේ."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -23501,8 +23659,8 @@ msgctxt "duckassist"
 msgid ""
 "Visit %sAssist Settings%s to adjust how this feature works or turn it off."
 msgstr ""
-"මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය අක්‍රිය කිරීමට %1$sAssist සැකසුම්%2$s "
-"වෙත පිවිසෙන්න."
+"මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය අක්‍රිය කිරීමට %1$sAssist "
+"සැකසුම්%2$s වෙත පිවිසෙන්න."
 
 # smartling.placeholder_format=C
 #. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
@@ -23511,8 +23669,8 @@ msgid ""
 "Visit %sDuckAssist Settings%s to adjust how this feature works or turn it "
 "off."
 msgstr ""
-"මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය අක්‍රිය කිරීමට %1$sDuckAssist "
-"සැකසුම්%2$s වෙත පිවිසෙන්න."
+"මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය අක්‍රිය කිරීමට "
+"%1$sDuckAssist සැකසුම්%2$s වෙත පිවිසෙන්න."
 
 # smartling.placeholder_format=C
 #. Prompt to visit DuckDuckGo on another device.
@@ -23521,8 +23679,8 @@ msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
 msgstr ""
-"%1$sDuckDuckGo.com%2$s වෙතට ඔබගේ දුරකථනයෙන් හෝ ටැබ්ලට් එකෙන් පැමිණ සපයා ඇති උපදෙස් "
-"පිළිපදින්න."
+"%1$sDuckDuckGo.com%2$s වෙතට ඔබගේ දුරකථනයෙන් හෝ ටැබ්ලට් එකෙන් පැමිණ සපයා ඇති "
+"උපදෙස් පිළිපදින්න."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -23537,9 +23695,9 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රව්සරයෙන් Duck.ai වෙත පිවිස %1$sDuck.ai සැකසීම්%2$s > %3$sSync & "
-"Backup%4$s > %5$sකළමනාකරණය කරන්න%6$s වෙත ගොස් %7$sවෙනත් උපාංගයක් සමඟ සමමුහුර්ත "
-"කරන්න%8$s තෝරන්න."
+"ඔබගේ අනෙක් බ්‍රව්සරයෙන් Duck.ai වෙත පිවිස %1$sDuck.ai සැකසීම්%2$s > %3$sSync "
+"& Backup%4$s > %5$sකළමනාකරණය කරන්න%6$s වෙත ගොස් %7$sවෙනත් උපාංගයක් සමඟ "
+"සමමුහුර්ත කරන්න%8$s තෝරන්න."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23549,9 +23707,9 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රවුසරයෙන් Duck.ai වෙත පිවිස Duck.ai සැකසුම් විවෘත කරන්න. “Turn On” තෝරන්න "
-"Sync & Backup යටතේ, “තවත් උපාංගයක් සමඟ සමමුහුර්ත කරන්න” තෝරන්න. නැතහොත් ඔබගේ ප්‍රතිසාධන "
-"PDF එකේ QR ස්කෑන් කරන්න."
+"ඔබගේ අනෙක් බ්‍රවුසරයෙන් Duck.ai වෙත පිවිස Duck.ai සැකසුම් විවෘත කරන්න. “Turn "
+"On” තෝරන්න Sync & Backup යටතේ, “තවත් උපාංගයක් සමඟ සමමුහුර්ත කරන්න” තෝරන්න. "
+"නැතහොත් ඔබගේ ප්‍රතිසාධන PDF එකේ QR ස්කෑන් කරන්න."
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -23573,9 +23731,10 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රවුසරයෙන් හෝ DuckDuckGo යෙදුමෙන් Duck.ai වෙත පිවිස Duck.ai සැකසුම් විවෘත "
-"කරන්න. “ක්‍රියාත්මක කරන්න” තෝරා Sync & Backup යටතේ, “තවත් උපාංගයක් සමග සමමුහුර්ත කරන්න” "
-"තෝරන්න. නැතහොත් ඔබගේ ප්‍රතිසාධන PDF ගොනුවේ QR කේතය ස්කෑන් කරන්න."
+"ඔබගේ අනෙක් බ්‍රවුසරයෙන් හෝ DuckDuckGo යෙදුමෙන් Duck.ai වෙත පිවිස Duck.ai "
+"සැකසුම් විවෘත කරන්න. “ක්‍රියාත්මක කරන්න” තෝරා Sync & Backup යටතේ, “තවත් "
+"උපාංගයක් සමග සමමුහුර්ත කරන්න” තෝරන්න. නැතහොත් ඔබගේ ප්‍රතිසාධන PDF ගොනුවේ QR "
+"කේතය ස්කෑන් කරන්න."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23628,7 +23787,8 @@ msgstr "හඬ කතාබහ අවසන්"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"හඬ කතාබස් අපි නිර්නාමික කරලා තියෙනවා, AI ආකෘති පුහුණු කිරීමට කිසි විටෙකත් භාවිතා කරන්නේ නැහැ."
+"හඬ කතාබස් අපි නිර්නාමික කරලා තියෙනවා, AI ආකෘති පුහුණු කිරීමට කිසි විටෙකත් "
+"භාවිතා කරන්නේ නැහැ."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -23772,8 +23932,8 @@ msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
-"YouTube හි පුද්ගලාරෝපිත දැන්වීම් අවහිර කිරීමට සහ යූ ටියුබ් නිර්දේශයන්ට බලපෑම් කිරීමෙන් ඔබේ නැරඹීමේ "
-"ක්රියාකාරකම් වළක්වා ගැනීමට Duck Player හි නරඹන්න."
+"YouTube හි පුද්ගලාරෝපිත දැන්වීම් අවහිර කිරීමට සහ යූ ටියුබ් නිර්දේශයන්ට "
+"බලපෑම් කිරීමෙන් ඔබේ නැරඹීමේ ක්රියාකාරකම් වළක්වා ගැනීමට Duck Player හි නරඹන්න."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -23793,9 +23953,10 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"මෙහි වීඩියෝවක් නැරඹීම යන්නෙන් අදහස් කරන්නේ එහි සත්කාරකත්වය දරන වෙබ් අඩවියට ඔබව නිරීක්ෂණය කළ "
-"හැකි බව වන අතර, ඊට හේතුව අප එහි සිට අන්තර්ගතය විකාශය කළ යුතු වීමයි. DuckDuckGo යනු ස්වාධීන "
-"සමාගමක් වන අතර බොහෝ වීඩියෝ දර්ශන සත්කාරකත්වය සපයන YouTube සමඟ කිසිදු සම්බන්ධයක් නොමැත."
+"මෙහි වීඩියෝවක් නැරඹීම යන්නෙන් අදහස් කරන්නේ එහි සත්කාරකත්වය දරන වෙබ් අඩවියට "
+"ඔබව නිරීක්ෂණය කළ හැකි බව වන අතර, ඊට හේතුව අප එහි සිට අන්තර්ගතය විකාශය කළ "
+"යුතු වීමයි. DuckDuckGo යනු ස්වාධීන සමාගමක් වන අතර බොහෝ වීඩියෝ දර්ශන "
+"සත්කාරකත්වය සපයන YouTube සමඟ කිසිදු සම්බන්ධයක් නොමැත."
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -23807,7 +23968,9 @@ msgstr "අපි නිර්නාමික කරමු"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr "ඔබට වඩාත් නිවැරදි ප්‍රතිඵල පෙන්වීමට අපට%1$s ඔබේ ස්ථානය%2$s නිර්නාමික කළ හැකිය."
+msgstr ""
+"ඔබට වඩාත් නිවැරදි ප්‍රතිඵල පෙන්වීමට අපට%1$s ඔබේ ස්ථානය%2$s නිර්නාමික කළ "
+"හැකිය."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -23819,9 +23982,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
-"අපට පෙනෙන දේ පමණක් නිවැරදි කළ හැකි ය. හානිකර හෝ නීති විරෝධී ප්‍රතිචාරයක් වාර්තා කිරීමට, "
-"කරුණාකර මෙම සංවාදය DuckDuckGo සමඟ බෙදා ගන්න, එවිට අපට ගැටලුව විමර්ශනය කර විසඳා ගත "
-"හැකිය."
+"අපට පෙනෙන දේ පමණක් නිවැරදි කළ හැකි ය. හානිකර හෝ නීති විරෝධී ප්‍රතිචාරයක් "
+"වාර්තා කිරීමට, කරුණාකර මෙම සංවාදය DuckDuckGo සමඟ බෙදා ගන්න, එවිට අපට ගැටලුව "
+"විමර්ශනය කර විසඳා ගත හැකිය."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -23833,15 +23996,17 @@ msgid ""
 "please share your prompt and response so we can investigate and address the "
 "issue."
 msgstr ""
-"අපට පෙනෙන දේ පමණක් නිවැරදි කළ හැකි ය. හානිකර හෝ නීති විරෝධී ප්‍රතිචාරයක් වාර්තා කිරීමට, "
-"කරුණාකර ඔයාගේ ක්ෂණික පණිවිඩය සහ ප්‍රතිචාරය බෙදා ගන්න එවිට අපට ගැටලුව විමර්ශනය කර විසඳා ගත "
-"හැකිය."
+"අපට පෙනෙන දේ පමණක් නිවැරදි කළ හැකි ය. හානිකර හෝ නීති විරෝධී ප්‍රතිචාරයක් "
+"වාර්තා කිරීමට, කරුණාකර ඔයාගේ ක්ෂණික පණිවිඩය සහ ප්‍රතිචාරය බෙදා ගන්න එවිට අපට "
+"ගැටලුව විමර්ශනය කර විසඳා ගත හැකිය."
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can use your anonymous%s location%s to show you nearby results."
-msgstr "ඔබට ආසන්න ප්‍රතිඵල පෙන්වීම සඳහා අපට ඔබේ නිර්නාමික%1$s පිහිටීම%2$s භාවිතා කළ හැකිය."
+msgstr ""
+"ඔබට ආසන්න ප්‍රතිඵල පෙන්වීම සඳහා අපට ඔබේ නිර්නාමික%1$s පිහිටීම%2$s භාවිතා කළ "
+"හැකිය."
 
 # smartling.placeholder_format=C
 #. Error message displayed when one or more attached files are encrypted and cannot be read.
@@ -23849,7 +24014,8 @@ msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
 msgstr ""
-"අමුණා ඇති ගොනුවලින් යටත් පිරිසෙයින් එකක් හෝ සංකේතනය කර ඇති නිසා, අපට ඒවා කියවිය නොහැක."
+"අමුණා ඇති ගොනුවලින් යටත් පිරිසෙයින් එකක් හෝ සංකේතනය කර ඇති නිසා, අපට ඒවා "
+"කියවිය නොහැක."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23865,7 +24031,9 @@ msgstr "අපි පරිශීලක නාම හෝ පුද්ගලි�
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr "කවදාවත් අප ඔබගේ පෞද්ගලික දත්ත ගබඩා කරන්නේ හෝ ඔබව අනවසරයෙන් පරීක්ෂා කරන්නේද නැත."
+msgstr ""
+"කවදාවත් අප ඔබගේ පෞද්ගලික දත්ත ගබඩා කරන්නේ හෝ ඔබව අනවසරයෙන් පරීක්ෂා කරන්නේද "
+"නැත."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23877,8 +24045,8 @@ msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
 msgstr ""
-"අපි ඔබේ පුද්ගලික තතු ගබඩා කර නොගන්නෙමු. අපි වෙළෙඳ දැන්වීම්වලින් ඔබව කරදරයට පත් නොකරන්නෙමු. "
-"අපි ඔබව නිරික්සන්නේ නැත. කවදත්."
+"අපි ඔබේ පුද්ගලික තතු ගබඩා කර නොගන්නෙමු. අපි වෙළෙඳ දැන්වීම්වලින් ඔබව කරදරයට "
+"පත් නොකරන්නෙමු. අපි ඔබව නිරික්සන්නේ නැත. කවදත්."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23892,8 +24060,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
 msgstr ""
-"අපි ඔබව අනවසරයෙන් පරීක්ෂා කරන්නේ නැත, ඉතින් අද ඔබව මෙහි ගෙන ආවේ කුමක්ද යැයි පැවසුවහොත් එය "
-"අපට උපකාරී වීමට හැක:"
+"අපි ඔබව අනවසරයෙන් පරීක්ෂා කරන්නේ නැත, ඉතින් අද ඔබව මෙහි ගෙන ආවේ කුමක්ද යැයි "
+"පැවසුවහොත් එය අපට උපකාරී වීමට හැක:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -23902,8 +24070,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
 msgstr ""
-"අපි ඔබව ලුහුබැඳ නොයන්නෙමු, එබැවින් අද අපව අත්හදා බැලීමට ඔබට ඒත්තු ගැන්වූ දේ අපට පැවසීමට "
-"ඔබගේ උදව් භාවිතා කළ හැකිය:"
+"අපි ඔබව ලුහුබැඳ නොයන්නෙමු, එබැවින් අද අපව අත්හදා බැලීමට ඔබට ඒත්තු ගැන්වූ දේ "
+"අපට පැවසීමට ඔබගේ උදව් භාවිතා කළ හැකිය:"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23943,8 +24111,8 @@ msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
 msgstr ""
-"අප ඔබගේ සෙවුම් ඉතිහාසය ගබඩා කරන්නේ නැත. එම නිසා අපට අන්තර්ජාලය හරහා දැන්වීම වලට විකිණීමට "
-"කිසිවක් නැත."
+"අප ඔබගේ සෙවුම් ඉතිහාසය ගබඩා කරන්නේ නැත. එම නිසා අපට අන්තර්ජාලය හරහා දැන්වීම "
+"වලට විකිණීමට කිසිවක් නැත."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -23970,8 +24138,8 @@ msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
 msgstr ""
-"අපි දත්ත තැරැව්කාර අඩවිවලින් ඔබේ පුද්ගලික තොරතුරු සොයාගෙන ඉවත් කරන්නෙමු. ඊට අමතරව VPN එකක් "
-"සහ තවත් දේ ලබා ගන්න."
+"අපි දත්ත තැරැව්කාර අඩවිවලින් ඔබේ පුද්ගලික තොරතුරු සොයාගෙන ඉවත් කරන්නෙමු. ඊට "
+"අමතරව VPN එකක් සහ තවත් දේ ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -23980,8 +24148,8 @@ msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
 msgstr ""
-"ඔබගේ කතාබස් AI පුහුණු කිරීම සඳහා භාවිතා නොකිරීමට අපි සියලුම AI සපයන්නන් සමඟ ගිවිසුම් ඇති කරගෙන "
-"ඇත්තෙමු."
+"ඔබගේ කතාබස් AI පුහුණු කිරීම සඳහා භාවිතා නොකිරීමට අපි සියලුම AI සපයන්නන් සමඟ "
+"ගිවිසුම් ඇති කරගෙන ඇත්තෙමු."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -24006,8 +24174,8 @@ msgid ""
 "We make money from %sprivacy-respecting search ads%s, not by exploiting your "
 "data."
 msgstr ""
-"අපි %1$sපෞද්ගලිකත්වයට ගරු කරන සෙවුම් දැන්වීම්%2$s මගින් මුදල් උපයන්නෙමු, ඔබේ දත්ත සූරාකෑමෙන් "
-"නොවේ."
+"අපි %1$sපෞද්ගලිකත්වයට ගරු කරන සෙවුම් දැන්වීම්%2$s මගින් මුදල් උපයන්නෙමු, ඔබේ "
+"දත්ත සූරාකෑමෙන් නොවේ."
 
 # smartling.placeholder_format=C
 #. Message describing how DuckDuckGo users location access anonymously to provide better search results.
@@ -24016,8 +24184,8 @@ msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
 msgstr ""
-"අපි ඔබට වඩා ආසන්නයෙන් ඇති, වඩා හොඳ ප්‍රතිඵල ලබා දීම සඳහා පමණක් ඔබේ නිර්නාමික පිහිටීම භාවිතා "
-"කරන්නෙමු. ඔබට ඕනෑම මොහොතක පසුව ඔබේ අදහස වෙනස් කරගත හැක."
+"අපි ඔබට වඩා ආසන්නයෙන් ඇති, වඩා හොඳ ප්‍රතිඵල ලබා දීම සඳහා පමණක් ඔබේ නිර්නාමික "
+"පිහිටීම භාවිතා කරන්නෙමු. ඔබට ඕනෑම මොහොතක පසුව ඔබේ අදහස වෙනස් කරගත හැක."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
@@ -24026,15 +24194,16 @@ msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
 msgstr ""
-"ඔබේ පෞද්ගලික තොරතුරු සඳහා අපි දත්ත තැරැව්කාර අඩවි නිතිපතා ස්කෑන් කරන අතර, භාවිතයට පහසු "
-"උපකරණ පුවරුවකින් අපගේ ප්‍රගතිය ඔබ සමඟ බෙදා ගන්නෙමු."
+"ඔබේ පෞද්ගලික තොරතුරු සඳහා අපි දත්ත තැරැව්කාර අඩවි නිතිපතා ස්කෑන් කරන අතර, "
+"භාවිතයට පහසු උපකරණ පුවරුවකින් අපගේ ප්‍රගතිය ඔබ සමඟ බෙදා ගන්නෙමු."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
 msgstr ""
-"අපි DuckDuckGo සෑම කෙනෙකුටම වඩා හොඳ කිරීම සඳහා ඔබේ නිර්නාමික ප්‍රතිචාර මත රඳා සිටිමු."
+"අපි DuckDuckGo සෑම කෙනෙකුටම වඩා හොඳ කිරීම සඳහා ඔබේ නිර්නාමික ප්‍රතිචාර මත "
+"රඳා සිටිමු."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -24055,13 +24224,15 @@ msgid ""
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
 msgstr ""
-"DuckDuckGo වැඩි දියුණු කිරීම සඳහා අපි මෙවැනි ප්‍රතිපෝෂණ භාවිතා කරමු. %1$s හි අභිමතය පරිදි "
-"යෝජනා ඇතුළත් කෙරේ. නිවැරදි කිරීම් වහාම ප්‍රතිඵලවල නොපෙන්වයි."
+"DuckDuckGo වැඩි දියුණු කිරීම සඳහා අපි මෙවැනි ප්‍රතිපෝෂණ භාවිතා කරමු. %1$s හි "
+"අභිමතය පරිදි යෝජනා ඇතුළත් කෙරේ. නිවැරදි කිරීම් වහාම ප්‍රතිඵලවල නොපෙන්වයි."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr "ඔබ බ්‍රවුස් කරන විට ඔබගේ දත්ත රැස් කිරීමට උත්සාහ කරන ට්‍රැකර් අපි අවහිර කරන්නෙමු."
+msgstr ""
+"ඔබ බ්‍රවුස් කරන විට ඔබගේ දත්ත රැස් කිරීමට උත්සාහ කරන ට්‍රැකර් අපි අවහිර "
+"කරන්නෙමු."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
@@ -24070,8 +24241,8 @@ msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
 msgstr ""
-"අපි ඔබේ විද්‍යුත් තැපෑල, නම, ලිපිනය සහ තවත් දේ සඳහා දත්ත තැරැව්කාර අඩවි ස්කෑන් කර, ඔබ ගැන "
-"සොයා ගන්නා ඕනෑම දෙයක් ඉවත් කිරීමට කටයුතු කරන්නෙමු."
+"අපි ඔබේ විද්‍යුත් තැපෑල, නම, ලිපිනය සහ තවත් දේ සඳහා දත්ත තැරැව්කාර අඩවි "
+"ස්කෑන් කර, ඔබ ගැන සොයා ගන්නා ඕනෑම දෙයක් ඉවත් කිරීමට කටයුතු කරන්නෙමු."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24080,8 +24251,8 @@ msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
 msgstr ""
-"අපි මෙම ගැටලුව පිළිබඳව දන්නා අතර දැනට එය විසඳීමට කටයුතු කරමින් සිටිමු. ඔබට මෙම දෝෂය දිගටම "
-"පෙනේ නම්, කරුණාකර %1$s වෙත සම්බන්ධ වන්න."
+"අපි මෙම ගැටලුව පිළිබඳව දන්නා අතර දැනට එය විසඳීමට කටයුතු කරමින් සිටිමු. ඔබට "
+"මෙම දෝෂය දිගටම පෙනේ නම්, කරුණාකර %1$s වෙත සම්බන්ධ වන්න."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -24090,8 +24261,8 @@ msgid ""
 "We're aware of this issue and are currently working to resolve it. Sometimes "
 "clearing your browser's cache can help."
 msgstr ""
-"අපි මෙම ගැටලුව පිළිබඳව දන්නා අතර දැනට එය විසඳීමට කටයුතු කරමින් සිටිමු. සමහර විට ඔබගේ "
-"බ්‍රවුසරයේ හැඹිලිය හිස් කිරීම උපකාරී විය හැක."
+"අපි මෙම ගැටලුව පිළිබඳව දන්නා අතර දැනට එය විසඳීමට කටයුතු කරමින් සිටිමු. සමහර "
+"විට ඔබගේ බ්‍රවුසරයේ හැඹිලිය හිස් කිරීම උපකාරී විය හැක."
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -24106,7 +24277,8 @@ msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
 msgstr ""
-"අප මේ අපහසුතාව ගැන කනගාටුව ප්‍රකාශ කරමු. ඔබේ අත්දැකීම වඩා හොඳ කිරීමට අපි මහන්සි වෙමින් සිටිමු."
+"අප මේ අපහසුතාව ගැන කනගාටුව ප්‍රකාශ කරමු. ඔබේ අත්දැකීම වඩා හොඳ කිරීමට අපි "
+"මහන්සි වෙමින් සිටිමු."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -24115,7 +24287,8 @@ msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
 msgstr ""
-"අපි Duck.ai සේවාව යාවත්කාලීන කළෙමු. වෙනස ක්‍රියාත්මක වීමට, අප පිටුව නැවත පූරණය කළ යුතුය."
+"අපි Duck.ai සේවාව යාවත්කාලීන කළෙමු. වෙනස ක්‍රියාත්මක වීමට, අප පිටුව නැවත "
+"පූරණය කළ යුතුය."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -24224,8 +24397,8 @@ msgid ""
 "Weekly usage limit reached. You can keep chatting by using your monthly "
 "limit."
 msgstr ""
-"සතිපතා පරිශීලන සීමාවට ළඟා වී ඇත. ඔබේ මාසික සීමාව භාවිතා කිරීමෙන් ඔබට දිගටම කතාබහේ යෙදිය "
-"හැකි ය."
+"සතිපතා පරිශීලන සීමාවට ළඟා වී ඇත. ඔබේ මාසික සීමාව භාවිතා කිරීමෙන් ඔබට දිගටම "
+"කතාබහේ යෙදිය හැකි ය."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -24239,8 +24412,8 @@ msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
 msgstr ""
-"Duck.ai වෙත සාදරයෙන් පිළිගනිමු! මෙහි ඇති ඔබගේ සියලු කතාබස් පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර "
-"ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත නොකෙරේ."
+"Duck.ai වෙත සාදරයෙන් පිළිගනිමු! මෙහි ඇති ඔබගේ සියලු කතාබස් පුද්ගලිකයි, අප "
+"විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -24249,8 +24422,9 @@ msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat වෙත සාදරයෙන් පිළිගනිමු! මෙහි ඇති ඔබගේ සියලු කතාබස් පුද්ගලිකයි, අප විසින් "
-"නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත නොකෙරේ."
+"DuckDuckGo AI Chat වෙත සාදරයෙන් පිළිගනිමු! මෙහි ඇති ඔබගේ සියලු කතාබස් "
+"පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත "
+"නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -24260,15 +24434,17 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat වෙත සාදරයෙන් පිළිගනිමු! මෙම කතාබස් සැසිය බලගන්වන්නේ %1$sගේ %2$s "
-"විසිනි. මෙහි ඔබගේ සියලු කතාබස් පෞද්ගලික වන අතර, කිසි විටෙකත් DuckDuckGo විසින් ගබඩා කර හෝ AI "
-"ආකෘති පුහුණු කිරීම සඳහා භාවිත නොකෙරේ."
+"DuckDuckGo AI Chat වෙත සාදරයෙන් පිළිගනිමු! මෙම කතාබස් සැසිය බලගන්වන්නේ "
+"%1$sගේ %2$s විසිනි. මෙහි ඔබගේ සියලු කතාබස් පෞද්ගලික වන අතර, කිසි විටෙකත් "
+"DuckDuckGo විසින් ගබඩා කර හෝ AI ආකෘති පුහුණු කිරීම සඳහා භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr "නව Duck.ai වෙත සාදරයෙන් පිළිගනිමු! දැන් ඔයාට බාගත කරගත් කතාබස් ආයාත කරන්න පුළුවන්."
+msgstr ""
+"නව Duck.ai වෙත සාදරයෙන් පිළිගනිමු! දැන් ඔයාට බාගත කරගත් කතාබස් ආයාත කරන්න "
+"පුළුවන්."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24336,8 +24512,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"අපිට ඇත්තටම කණගාටුයි, නමුත් Duck.ai පූරණය කිරීමේදී ගැටලුවක් ඇතිවූ බව පෙනේ. පිටුව නැවත "
-"ප්‍රවේශනය කර උත්සාහ කරන්න."
+"අපිට ඇත්තටම කණගාටුයි, නමුත් Duck.ai පූරණය කිරීමේදී ගැටලුවක් ඇතිවූ බව පෙනේ. "
+"පිටුව නැවත ප්‍රවේශනය කර උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -24352,7 +24528,8 @@ msgid ""
 "What are some arguments, counter-arguments, and rebuttals to the concept of "
 "a plant-based diet?"
 msgstr ""
-"ශාක පදනම් කරගත් ආහාරයක් පිළිබඳ සංකල්පයට සමහර තර්ක, ප්‍රති-තර්ක සහ ප්‍රතිවිරෝධතා මොනවාද?"
+"ශාක පදනම් කරගත් ආහාරයක් පිළිබඳ සංකල්පයට සමහර තර්ක, ප්‍රති-තර්ක සහ "
+"ප්‍රතිවිරෝධතා මොනවාද?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
@@ -24373,8 +24550,8 @@ msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
 msgstr ""
-"“අපි ඇත්තටම වඩා හොඳ කරන්න ඕන” යන සන්දර්භය තුළ 'වඩා හොඳ' යන වචනය සඳහා සමහර විකල්ප "
-"මොනවාද."
+"“අපි ඇත්තටම වඩා හොඳ කරන්න ඕන” යන සන්දර්භය තුළ 'වඩා හොඳ' යන වචනය සඳහා සමහර "
+"විකල්ප මොනවාද."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -24399,10 +24576,11 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"Duck.ai භාවිතා කිරීමට උනන්දුවක් දක්වන කෙනෙකුට DuckDuckGo බ්‍රව්සරය බාගැනීමේ ප්‍රතිලාභ මොනවා "
-"ද? නිල DuckDuckGo මූලාශ්‍ර පමණක් යොමු කරන්න. Duck.ai ඒකාබද්ධ කිරීම් සහ රහස්‍යතා ආරක්ෂණ "
-"කෙරෙහි අවධානය යොමු කරමින්, ප්‍රතිචාරය මාතෘකා සහිත පැහැදිලි කොටස්වලට බෙදන්න. AI හෝ තාක්ෂණික "
-"අත්දැකීම් ඇති හෝ නැති අයට එය තරමක් කෙටි, සරල සහ තේරුම් ගැනීමට පහසු වන පරිදි සකසන්න."
+"Duck.ai භාවිතා කිරීමට උනන්දුවක් දක්වන කෙනෙකුට DuckDuckGo බ්‍රව්සරය බාගැනීමේ "
+"ප්‍රතිලාභ මොනවා ද? නිල DuckDuckGo මූලාශ්‍ර පමණක් යොමු කරන්න. Duck.ai ඒකාබද්ධ "
+"කිරීම් සහ රහස්‍යතා ආරක්ෂණ කෙරෙහි අවධානය යොමු කරමින්, ප්‍රතිචාරය මාතෘකා සහිත "
+"පැහැදිලි කොටස්වලට බෙදන්න. AI හෝ තාක්ෂණික අත්දැකීම් ඇති හෝ නැති අයට එය තරමක් "
+"කෙටි, සරල සහ තේරුම් ගැනීමට පහසු වන පරිදි සකසන්න."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24638,7 +24816,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Cloud Save පොත් සලකුණු යනු කුමක්ද සහ එය URL පරාමිති පොත් සලකුණු වලින් වෙනස් වන්නේ කෙසේද?"
+"Cloud Save පොත් සලකුණු යනු කුමක්ද සහ එය URL පරාමිති පොත් සලකුණු වලින් වෙනස් "
+"වන්නේ කෙසේද?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -24739,8 +24918,8 @@ msgid ""
 "When buying an electric guitar for a beginner, what are the top product "
 "brands I should consider?"
 msgstr ""
-"ආරම්භකයෙකු සඳහා විදුලි ගිටාරයක් මිලදී ගැනීමේදී, මා සලකා බැලිය යුතු ඉහළම නිෂ්පාදන වෙළඳ නාම "
-"මොනවාද?"
+"ආරම්භකයෙකු සඳහා විදුලි ගිටාරයක් මිලදී ගැනීමේදී, මා සලකා බැලිය යුතු ඉහළම "
+"නිෂ්පාදන වෙළඳ නාම මොනවාද?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -24941,8 +25120,9 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
-"Duck.ai සමඟින්, ඔබගේ කතාබස් නිර්නාමික කර ඇති අතර ඒවා කිසි විටෙකත් AI පුහුණු කිරීමට භාවිත "
-"නොකෙරේ. '%1$s' මෙනුව තුළ ඕනෑම වේලාවක එය සක්‍රිය හෝ අක්‍රිය කරන්න."
+"Duck.ai සමඟින්, ඔබගේ කතාබස් නිර්නාමික කර ඇති අතර ඒවා කිසි විටෙකත් AI පුහුණු "
+"කිරීමට භාවිත නොකෙරේ. '%1$s' මෙනුව තුළ ඕනෑම වේලාවක එය සක්‍රිය හෝ අක්‍රිය "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
@@ -24951,6 +25131,8 @@ msgid ""
 "With chat history on, up to %s of your most recent chats will be saved on "
 "this device."
 msgstr ""
+"කතාබස් ඉතිහාසය ක්‍රියාත්මක කර ඇති විට, ඔබේ වඩාත්ම මෑත කාලීන කතාබස්වලින් "
+"%1$sක් දක්වා මෙම උපාංගයේ සුරැකෙනු ඇත."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline in the About Chat History modal.
@@ -24958,6 +25140,8 @@ msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, your most recent chats will be saved on this device."
 msgstr ""
+"කතාබස් ඉතිහාසය ක්‍රියාත්මක කර ඇති විට, ඔබේ වඩාත්ම මෑත කාලීන කතාබස් මෙම "
+"උපාංගයේ සුරැකෙනු ඇත."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24972,8 +25156,8 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
-"ඔබේ විද්‍යුත් තැපැල් ලිපිනය, නම, ලිපිනය සහ තවත් දේ දත්ත තැරැව්කාර අඩවිවලින් ඉවත් කිරීමට ඔබේ "
-"උපාංගයෙන්ම ක්‍රියා කරයි."
+"ඔබේ විද්‍යුත් තැපැල් ලිපිනය, නම, ලිපිනය සහ තවත් දේ දත්ත තැරැව්කාර අඩවිවලින් "
+"ඉවත් කිරීමට ඔබේ උපාංගයෙන්ම ක්‍රියා කරයි."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25240,7 +25424,9 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr "ඔබට එය %1$sහි නැරඹිය හැකිය. AI කතාබස් සාවද්ය හෝ අමනාපකාරී තොරතුරු පෙන්විය හැකිය."
+msgstr ""
+"ඔබට එය %1$sහි නැරඹිය හැකිය. AI කතාබස් සාවද්ය හෝ අමනාපකාරී තොරතුරු පෙන්විය "
+"හැකිය."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -25249,8 +25435,8 @@ msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
 msgstr ""
-"ඔබට %2$s සෙවුම් කෙටිමං භාවිත කරමින් DuckDuckGo වෙතින් වෙනත් සෙවුම් යන්ත්‍ර මත කඍජුව %1$s හෝ "
-"සෙවිය හැකිය."
+"ඔබට %2$s සෙවුම් කෙටිමං භාවිත කරමින් DuckDuckGo වෙතින් වෙනත් සෙවුම් යන්ත්‍ර "
+"මත කඍජුව %1$s හෝ සෙවිය හැකිය."
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -25264,8 +25450,8 @@ msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
 msgstr ""
-"ඔබට %1$s ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ ඕනෑම වේලාවක %2$sසෙවුම් සැකසුම්%3$s තුළ එය "
-"අක්‍රිය කළ හැකිය."
+"ඔබට %1$s ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ ඕනෑම වේලාවක %2$sසෙවුම් සැකසුම්%3$s "
+"තුළ එය අක්‍රිය කළ හැකිය."
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -25274,21 +25460,22 @@ msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
 msgstr ""
-"ඔබට %1$sසෙවුම් සැකසීම්%2$s තුළ ඕනෑම වේලාවක Assist ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය "
-"අක්‍රිය කිරීමට හැකිය."
+"ඔබට %1$sසෙවුම් සැකසීම්%2$s තුළ ඕනෑම වේලාවක Assist ක්‍රියා කරන ආකාරය සකස් "
+"කිරීමට හෝ එය අක්‍රිය කිරීමට හැකිය."
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
 msgstr ""
-"ප්‍රශ්නවලට පිළිතුරු දීමට හෝ පෙළ සාරාංශ කිරීමට ඔබට %1$sDuck.ai%2$s ද භාවිත කළ හැකිය."
+"ප්‍රශ්නවලට පිළිතුරු දීමට හෝ පෙළ සාරාංශ කිරීමට ඔබට %1$sDuck.ai%2$s ද භාවිත කළ "
+"හැකිය."
 
 # smartling.placeholder_format=C
 msgid ""
 "You can also use %sDuckDuckGo AI Chat%s to answer questions or summarize "
 "text."
 msgstr ""
-"ඔබට ප්‍රශ්නවලට පිළිතුරු දීමට හෝ පෙළ සාරාංශ කිරීමට %1$sDuckDuckGo AI Chat%2$s ද භාාවිත "
-"කළ හැකිය."
+"ඔබට ප්‍රශ්නවලට පිළිතුරු දීමට හෝ පෙළ සාරාංශ කිරීමට %1$sDuckDuckGo AI Chat%2$s "
+"ද භාාවිත කළ හැකිය."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach more text selections than are allowed. Placeholder is the maximum number of text selections. E.g. You can attach up to 5 text selections.
@@ -25302,8 +25489,8 @@ msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
 msgstr ""
-"ඔබට %1$sසෙවුම් සැකසුම්%2$s තුළ Search Assist දකින වාර ගණන වෙනස් කළ හැකි අතර, එය "
-"සම්පූර්ණයෙන්ම අක්‍රිය කළ හැකිය."
+"ඔබට %1$sසෙවුම් සැකසුම්%2$s තුළ Search Assist දකින වාර ගණන වෙනස් කළ හැකි අතර, "
+"එය සම්පූර්ණයෙන්ම අක්‍රිය කළ හැකිය."
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -25324,8 +25511,8 @@ msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
 msgstr ""
-"වෙනස් මුර පදයක් යටතේ ඔබගේ සැකසුම් සුරැකීමෙන් ඔබට මෙය කළ හැකිය, විකල්පයක් ලෙස පළමු සමූහය "
-"මකනවා."
+"වෙනස් මුර පදයක් යටතේ ඔබගේ සැකසුම් සුරැකීමෙන් ඔබට මෙය කළ හැකිය, විකල්පයක් ලෙස "
+"පළමු සමූහය මකනවා."
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -25418,8 +25605,8 @@ msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
 msgstr ""
-"ඔබට අවහිර කළ හැක්කේ අඩවි %1$s දක්වා පමණි. %2$s අවහිර කිරීමට, ඔබ මුලින්ම වෙනත් වෙබ් අඩවියක් "
-"අහිතකර කිරීමට අවශ්ය වේ."
+"ඔබට අවහිර කළ හැක්කේ අඩවි %1$s දක්වා පමණි. %2$s අවහිර කිරීමට, ඔබ මුලින්ම "
+"වෙනත් වෙබ් අඩවියක් අහිතකර කිරීමට අවශ්ය වේ."
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -25483,8 +25670,8 @@ msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
 msgstr ""
-"ඔබට දැන් %1$s වෙත ප් රවේශය, ඉහළ AI තර්කනය සහ Plus ප්‍රකාරයට වඩා දෙගුණයක් පුළුල් පරිශීලන "
-"සීමාවන් ඇත."
+"ඔබට දැන් %1$s වෙත ප් රවේශය, ඉහළ AI තර්කනය සහ Plus ප්‍රකාරයට වඩා දෙගුණයක් "
+"පුළුල් පරිශීලන සීමාවන් ඇත."
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -25493,8 +25680,8 @@ msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
 msgstr ""
-"ඔබට දැන් උසස් AI ආකෘති වෙත ප්‍රවේශය ඇත. ඔබට DuckDuckGo බ්‍රවුසරයේ VPN සහ අනෙකුත් "
-"DuckDuckGo දායකත්ව ආරක්ෂණ වෙත ප්‍රවේශ විය හැක."
+"ඔබට දැන් උසස් AI ආකෘති වෙත ප්‍රවේශය ඇත. ඔබට DuckDuckGo බ්‍රවුසරයේ VPN සහ "
+"අනෙකුත් DuckDuckGo දායකත්ව ආරක්ෂණ වෙත ප්‍රවේශ විය හැක."
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -25516,9 +25703,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"මෙම බ්‍රව්සරයෙන් ඔබගේ සුරකින ලද කතාබස් වෙත ප්‍රවේශ වීමට ඔබට තවදුරටත් නොහැකි වනු ඇත. අවසාන "
-"කතාබස් 30 තවමත් දේශීය ගබඩාවේ පවතිනු ඇත. මින් ඔබේ කතාබස් සංකේතනය කළ සර්වරයෙන් මකා දමනු "
-"නොලැබේ."
+"මෙම බ්‍රව්සරයෙන් ඔබගේ සුරකින ලද කතාබස් වෙත ප්‍රවේශ වීමට ඔබට තවදුරටත් නොහැකි "
+"වනු ඇත. අවසාන කතාබස් 30 තවමත් දේශීය ගබඩාවේ පවතිනු ඇත. මින් ඔබේ කතාබස් "
+"සංකේතනය කළ සර්වරයෙන් මකා දමනු නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -25528,9 +25715,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"මෙම බ්‍රව්සරයෙන් ඔබගේ සුරකින ලද කතාබස් වෙත ප්‍රවේශ වීමට ඔබට තවදුරටත් නොහැකි වනු ඇත. අවසාන "
-"කතාබස් 30 තවමත් ස්ථානීය ගබඩාවේ පවතිනු ඇත. මින් ඔබේ කතාබස් සංකේතනය කළ සර්වරයෙන් මකා දමනු "
-"නොලැබේ."
+"මෙම බ්‍රව්සරයෙන් ඔබගේ සුරකින ලද කතාබස් වෙත ප්‍රවේශ වීමට ඔබට තවදුරටත් නොහැකි "
+"වනු ඇත. අවසාන කතාබස් 30 තවමත් ස්ථානීය ගබඩාවේ පවතිනු ඇත. මින් ඔබේ කතාබස් "
+"සංකේතනය කළ සර්වරයෙන් මකා දමනු නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -25543,7 +25730,9 @@ msgctxt "Update browser banner"
 msgid ""
 "You'll receive automatic DuckDuckGo app updates once you have the latest "
 "version."
-msgstr "ඔබට නවතම අනුවාදය ලැබුණු පසු ඔබට ස්වයංක්‍රීය DuckDuckGo යෙදුම් යාවත්කාලීන ලැබෙනු ඇත."
+msgstr ""
+"ඔබට නවතම අනුවාදය ලැබුණු පසු ඔබට ස්වයංක්‍රීය DuckDuckGo යෙදුම් යාවත්කාලීන "
+"ලැබෙනු ඇත."
 
 # smartling.placeholder_format=C
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
@@ -25558,8 +25747,8 @@ msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
 msgstr ""
-"දැන් ඔබ Chromeහි පුද්ගලිකව සොයමින් සිටී. පුද්ගලිකව පිරික්සීමටත් Chrome වෙනුවට අපගේ යෙදුම භාවිතා "
-"කරන්න. එය දැනටමත් ස්ථාපනය කර ඇති අතර හැකියාව ඇත්තේ:"
+"දැන් ඔබ Chromeහි පුද්ගලිකව සොයමින් සිටී. පුද්ගලිකව පිරික්සීමටත් Chrome "
+"වෙනුවට අපගේ යෙදුම භාවිතා කරන්න. එය දැනටමත් ස්ථාපනය කර ඇති අතර හැකියාව ඇත්තේ:"
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -25572,8 +25761,8 @@ msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
 msgstr ""
-"ඔබ දැන් පෞද්ගලිකත්වයෙන් යුතුව සොයයි. %1$sඔබගේ පා සටහන් තව දුරටත් අවම කර ගැනීමට ඉඟි ලබා "
-"ගන්න."
+"ඔබ දැන් පෞද්ගලිකත්වයෙන් යුතුව සොයයි. %1$sඔබගේ පා සටහන් තව දුරටත් අවම කර "
+"ගැනීමට ඉඟි ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -25649,8 +25838,9 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"ඔබට ඇමුණුම් සහිත Duck.ai කතාබස් සඳහා Sync & Backup ඉඩ අවසන් වී ඇත. සමමුහුර්ත කිරීම නැවත "
-"ආරම්භ කිරීමට පැරණිතම කතාබස් %1$s මකන්න. ඇමුණූ කතාබස් මකා දමනු නොලැබේ."
+"ඔබට ඇමුණුම් සහිත Duck.ai කතාබස් සඳහා Sync & Backup ඉඩ අවසන් වී ඇත. සමමුහුර්ත "
+"කිරීම නැවත ආරම්භ කිරීමට පැරණිතම කතාබස් %1$s මකන්න. ඇමුණූ කතාබස් මකා දමනු "
+"නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25660,8 +25850,9 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"ඔබට Duck.ai කතාබස් සඳහා Sync & Backup ඉඩ අවසන් වී ඇත. සමමුහුර්ත කිරීම නැවත ආරම්භ කිරීමට "
-"ඇමුතුම් සමඟ පැරණිතම කතාබස් %1$s මකන්න. ඇමුණූ කතාබස් මකා දමනු නොලැබේ."
+"ඔබට Duck.ai කතාබස් සඳහා Sync & Backup ඉඩ අවසන් වී ඇත. සමමුහුර්ත කිරීම නැවත "
+"ආරම්භ කිරීමට ඇමුතුම් සමඟ පැරණිතම කතාබස් %1$s මකන්න. ඇමුණූ කතාබස් මකා දමනු "
+"නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -25675,8 +25866,9 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"Youtube (Google සතු) ඔබට නිර්නාමිකව වීඩියෝ දර්ශන නැරඹීමට ඉඩ ලබා දෙන්නේ නැහැ. ඒ වගේම, "
-"Youtube වීඩියෝ නැරඹීමේදී Google/Youtube මගින් අනවසරයෙන් පරීක්ෂා කිරීමකට ලක් වෙන්න පුළුවන්."
+"Youtube (Google සතු) ඔබට නිර්නාමිකව වීඩියෝ දර්ශන නැරඹීමට ඉඩ ලබා දෙන්නේ නැහැ. "
+"ඒ වගේම, Youtube වීඩියෝ නැරඹීමේදී Google/Youtube මගින් අනවසරයෙන් පරීක්ෂා "
+"කිරීමකට ලක් වෙන්න පුළුවන්."
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -25736,8 +25928,8 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
 msgstr ""
-"ඔබේ උපස්ථය DuckDuckGo සර්වරයෙන් මකා දැමෙනු ඇත. සියලුම උපාංග සමමුහුර්තකරණයෙන් විසන්ධි වනු "
-"ඇත."
+"ඔබේ උපස්ථය DuckDuckGo සර්වරයෙන් මකා දැමෙනු ඇත. සියලුම උපාංග සමමුහුර්තකරණයෙන් "
+"විසන්ධි වනු ඇත."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25747,8 +25939,9 @@ msgid ""
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
 msgstr ""
-"ඔබේ උපස්ථය DuckDuckGo සර්වරයෙන් මකා දැමෙනු ඇත. සියලුම උපාංග සමමුහුර්තකරණයෙන් විසන්ධි වනු "
-"ඇත. ඔබගේ මෑත කාලීන කතාබස් %1$s මෙම බ්‍රව්සර්වල දේශීය ගබඩාවේ ලබා ගත හැකිය:"
+"ඔබේ උපස්ථය DuckDuckGo සර්වරයෙන් මකා දැමෙනු ඇත. සියලුම උපාංග සමමුහුර්තකරණයෙන් "
+"විසන්ධි වනු ඇත. ඔබගේ මෑත කාලීන කතාබස් %1$s මෙම බ්‍රව්සර්වල දේශීය ගබඩාවේ ලබා "
+"ගත හැකිය:"
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -25758,8 +25951,9 @@ msgid ""
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
 msgstr ""
-"ඔබේ උපස්ථය DuckDuckGo සර්වරයෙන් මකා දැමෙනු ඇත. සියලුම උපාංග සමමුහුර්තකරණයෙන් විසන්ධි වනු "
-"ඇත. ඔබේ මෑත කාලීන කතාබස් 100 මෙම බ්‍රව්සර්වල දේශීය ගබඩාවේ ලබා ගත හැකිය:"
+"ඔබේ උපස්ථය DuckDuckGo සර්වරයෙන් මකා දැමෙනු ඇත. සියලුම උපාංග සමමුහුර්තකරණයෙන් "
+"විසන්ධි වනු ඇත. ඔබේ මෑත කාලීන කතාබස් 100 මෙම බ්‍රව්සර්වල දේශීය ගබඩාවේ ලබා ගත "
+"හැකිය:"
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -25784,8 +25978,8 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"ඔබගේ බ්‍රවුසරය ඔබ වැඩිපුරම නරඹන අඩවි ලැයිස්තුවක් සපයයි. DuckDuckGo වෙත කිසිවිටෙක මෙම දත්ත "
-"වෙත ප්‍රවේශය නොමැත."
+"ඔබගේ බ්‍රවුසරය ඔබ වැඩිපුරම නරඹන අඩවි ලැයිස්තුවක් සපයයි. DuckDuckGo වෙත "
+"කිසිවිටෙක මෙම දත්ත වෙත ප්‍රවේශය නොමැත."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -25793,8 +25987,8 @@ msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
 msgstr ""
-"ඔබගේ බ්‍රව්සරය නිතරම නරඹන අඩවි ලැයිස්තුවක් සපයනවා. නමුත් DuckDuckGo වලට කවදාවත් අවසරයක් "
-"නැහැ ඒ දත්ත වලට."
+"ඔබගේ බ්‍රව්සරය නිතරම නරඹන අඩවි ලැයිස්තුවක් සපයනවා. නමුත් DuckDuckGo වලට "
+"කවදාවත් අවසරයක් නැහැ ඒ දත්ත වලට."
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -25802,7 +25996,9 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
-msgstr "%1$s සමඟ ඔයාගේ චැට් පුද්ගලිකයි. AI චැට් සාවද්‍ය හෝ අමනාපකාරී තොරතුරු පෙන්විය හැකිය."
+msgstr ""
+"%1$s සමඟ ඔයාගේ චැට් පුද්ගලිකයි. AI චැට් සාවද්‍ය හෝ අමනාපකාරී තොරතුරු පෙන්විය "
+"හැකිය."
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -25815,7 +26011,8 @@ msgstr "ඔබගේ කතාබස් දැන් සුරැකෙමින
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"ඔබේ කතාබස් පුද්ගලික වන අතර AI ආකෘති පුහුණු කිරීම සඳහා කිසිවිටෙකත් සුරකිනු හෝ භාවිත නොකෙරේ"
+"ඔබේ කතාබස් පුද්ගලික වන අතර AI ආකෘති පුහුණු කිරීම සඳහා කිසිවිටෙකත් සුරකිනු හෝ "
+"භාවිත නොකෙරේ"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
@@ -25829,7 +26026,8 @@ msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"ඔබගේ කතාබස් පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත නොකෙරේ."
+"ඔබගේ කතාබස් පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු "
+"කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
@@ -25837,7 +26035,8 @@ msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"ඔබගේ කතාබස් පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත නොකෙරේ."
+"ඔබගේ කතාබස් පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු "
+"කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -25845,8 +26044,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"ඔබේ කතාබස් පුද්ගලික වන අතර, අප විසින් කිසි විටෙකත් සුරකින අතර AI ආකෘති පුහුණු කිරීමට භාවිත "
-"නොකෙරේ."
+"ඔබේ කතාබස් පුද්ගලික වන අතර, අප විසින් කිසි විටෙකත් සුරකින අතර AI ආකෘති "
+"පුහුණු කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -25854,8 +26053,8 @@ msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"ඔබේ කතාබස් පුද්ගලික වන අතර, අප විසින් කිසි විටෙකත් සුරකින අතර AI ආකෘති පුහුණු කිරීමට භාවිත "
-"නොකෙරේ."
+"ඔබේ කතාබස් පුද්ගලික වන අතර, අප විසින් කිසි විටෙකත් සුරකින අතර AI ආකෘති "
+"පුහුණු කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -25870,8 +26069,9 @@ msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
 msgstr ""
-"ඔබගේ කතාබස් පුද්ගලික වන අතර ඒ්වා අප විසින් නිර්නාමික කර තිබේ. තව ද ඒ්වා කෘත්‍රිම බුද්ධි ආකෘති "
-"පුහුණු කිරීමට යොදා ගනු නොලැබේ. ඔබේ කතාබස් ඉතිහාසය තබා ගැනීමට මේ පියවර අනුගමනය කරන්න."
+"ඔබගේ කතාබස් පුද්ගලික වන අතර ඒ්වා අප විසින් නිර්නාමික කර තිබේ. තව ද ඒ්වා "
+"කෘත්‍රිම බුද්ධි ආකෘති පුහුණු කිරීමට යොදා ගනු නොලැබේ. ඔබේ කතාබස් ඉතිහාසය තබා "
+"ගැනීමට මේ පියවර අනුගමනය කරන්න."
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -25911,8 +26111,8 @@ msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
 msgstr ""
-"ඔබගේ විද්‍යුත් තැපැල් ලිපිනය බෙදාහැරීමක්, %1$sහෝ නිර්නාමික සෙවුම් සමඟ සම්බන්ධ කිරීමක් සිදු නොවේ. "
-"[%2$sඋදාහරණ පණිවිඩය%3$s]"
+"ඔබගේ විද්‍යුත් තැපැල් ලිපිනය බෙදාහැරීමක්, %1$sහෝ නිර්නාමික සෙවුම් සමඟ "
+"සම්බන්ධ කිරීමක් සිදු නොවේ. [%2$sඋදාහරණ පණිවිඩය%3$s]"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -25955,9 +26155,10 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"%1$sSHA-2%2$s ලෙස හැඳින්වෙන ආරක්ෂිත හැෂ් ඇල්ගොරිතම භාවිතා කිරීමෙන් ඔබගේ මුරපදය 512-bit "
-"යතුරක් ජනනය කරයි.. ඔබගේ බ්‍රව්සරයෙන් පිටවන්නේ යතුර සහ ආශ්‍රිත සැකසුම් ගොනුව පමණි. යතුර නම ලෙස "
-"භාවිතා කර අපි සැකසුම් ගොනුව සුරකිමු. DuckDuckGo කිසි විටෙකත් ඔබේ මුරපදය දන්නේ නැත."
+"%1$sSHA-2%2$s ලෙස හැඳින්වෙන ආරක්ෂිත හැෂ් ඇල්ගොරිතම භාවිතා කිරීමෙන් ඔබගේ "
+"මුරපදය 512-bit යතුරක් ජනනය කරයි.. ඔබගේ බ්‍රව්සරයෙන් පිටවන්නේ යතුර සහ ආශ්‍රිත "
+"සැකසුම් ගොනුව පමණි. යතුර නම ලෙස භාවිතා කර අපි සැකසුම් ගොනුව සුරකිමු. "
+"DuckDuckGo කිසි විටෙකත් ඔබේ මුරපදය දන්නේ නැත."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25972,8 +26173,9 @@ msgid ""
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
 msgstr ""
-"ඔබගේ විමසීම් DuckDuckGo සර්වර හරහා යවනු ලබන අතර ඒවායෙන් පුද්ගලිකව හඳුනාගත හැකි පාර-දත්ත "
-"ඉවත් කරනු ලැබේ, එබැවින් ආකෘති සපයන්නන්ට ඔබගේ සංවාද ඔබ හා නැවත සම්බන්ධ කළ නොහැක."
+"ඔබගේ විමසීම් DuckDuckGo සර්වර හරහා යවනු ලබන අතර ඒවායෙන් පුද්ගලිකව හඳුනාගත "
+"හැකි පාර-දත්ත ඉවත් කරනු ලැබේ, එබැවින් ආකෘති සපයන්නන්ට ඔබගේ සංවාද ඔබ හා නැවත "
+"සම්බන්ධ කළ නොහැක."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25987,8 +26189,8 @@ msgid ""
 "Your recent chats live here! You can refer to your chats or clear them "
 "anytime."
 msgstr ""
-"ඔබගේ මෑත කාලීන කතාබස් මෙහි ඇත! ඔබට ඔබේ කතාබස් වෙත යොමු විය හැකි ය හෝ ඕනෑම වේලාවක "
-"ඒවා ඉවත් කළ හැකි ය."
+"ඔබගේ මෑත කාලීන කතාබස් මෙහි ඇත! ඔබට ඔබේ කතාබස් වෙත යොමු විය හැකි ය හෝ ඕනෑම "
+"වේලාවක ඒවා ඉවත් කළ හැකි ය."
 
 # smartling.placeholder_format=C
 #. Message on a feedback form.
@@ -26020,8 +26222,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
-"ඔබේ සැකසුම් සුරැකෙනු ඇත, නමුත් කුකී මකා දැමීමෙන් ඒවා යළි සැකසෙනු ඇත. එය ස්ථිර කර ගැනීමට "
-"%1$sDuckDuckGo No AI%2$s දිගුව සක්‍රීය කරන්න."
+"ඔබේ සැකසුම් සුරැකෙනු ඇත, නමුත් කුකී මකා දැමීමෙන් ඒවා යළි සැකසෙනු ඇත. එය "
+"ස්ථිර කර ගැනීමට %1$sDuckDuckGo No AI%2$s දිගුව සක්‍රීය කරන්න."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -26030,8 +26232,9 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"ඔබේ සැකසුම් සුරැකෙනු ඇත, නමුත් කුකී මකා දැමීමෙන් ඒවා යළි සැකසෙනු ඇත. එය ස්ථිර කර ගැනීමට "
-"%1$sDuckDuckGo No AI%2$s දිගුව ස්ථාපනය කරන්න. %3$sවැඩිදුර දැනගන්න%4$s"
+"ඔබේ සැකසුම් සුරැකෙනු ඇත, නමුත් කුකී මකා දැමීමෙන් ඒවා යළි සැකසෙනු ඇත. එය "
+"ස්ථිර කර ගැනීමට %1$sDuckDuckGo No AI%2$s දිගුව ස්ථාපනය කරන්න. %3$sවැඩිදුර "
+"දැනගන්න%4$s"
 
 # smartling.placeholder_format=C
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
@@ -26051,8 +26254,8 @@ msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
 msgstr ""
-"දැන් ඔබ Chrome හි පුද්ගලිකව සොයමින් සිටී. වැඩි ආරක්ෂාව සඳහා Chrome වෙනුවට අපේ බ්‍රවුසරය "
-"භාවිත කරන්න. එය දැනටමත් ස්ථාපනය කර ඇති අතර හැකියාව ඇත්තේ:"
+"දැන් ඔබ Chrome හි පුද්ගලිකව සොයමින් සිටී. වැඩි ආරක්ෂාව සඳහා Chrome වෙනුවට "
+"අපේ බ්‍රවුසරය භාවිත කරන්න. එය දැනටමත් ස්ථාපනය කර ඇති අතර හැකියාව ඇත්තේ:"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -26061,7 +26264,8 @@ msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
 msgstr ""
-"ඔබ උපරිම පණිවිඩ ප්‍රමාණය ඉක්මවා ඇත. කරුණාකර ඔබගේ පණිවිඩය කෙටි කර නැවත උත්සාහ කරන්න."
+"ඔබ උපරිම පණිවිඩ ප්‍රමාණය ඉක්මවා ඇත. කරුණාකර ඔබගේ පණිවිඩය කෙටි කර නැවත උත්සාහ "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -26070,8 +26274,8 @@ msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
 msgstr ""
-"ඔබ මෙම සංවාදයේ උපරිම කතාබස් දිගට පැමිණ ඇත. දිගටම කරගෙන යාම සඳහා Fire Button සමඟ "
-"මෙම සංවාදය ඉවත් කරන්න."
+"ඔබ මෙම සංවාදයේ උපරිම කතාබස් දිගට පැමිණ ඇත. දිගටම කරගෙන යාම සඳහා Fire Button "
+"සමඟ මෙම සංවාදය ඉවත් කරන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -26079,7 +26283,9 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Start a new "
 "chat to continue."
-msgstr "ඔබ මෙම සංවාදයේ උපරිම කතාබස් දිගට පැමිණ ඇත. ඉදිරියට යාමට නව කතාබහක් ආරම්භ ගන්න."
+msgstr ""
+"ඔබ මෙම සංවාදයේ උපරිම කතාබස් දිගට පැමිණ ඇත. ඉදිරියට යාමට නව කතාබහක් ආරම්භ "
+"ගන්න."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -26094,8 +26300,8 @@ msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
 msgstr ""
-"ඔබ එක් දිනක් සඳහා උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වී ඇත. කරුණාකර හෙට මෙම කතාබස් දිගටම කරගෙන "
-"යන්න."
+"ඔබ එක් දිනක් සඳහා උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වී ඇත. කරුණාකර හෙට මෙම කතාබස් "
+"දිගටම කරගෙන යන්න."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -26329,7 +26535,7 @@ msgstr "විනා"
 #. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the chat options menu button"
 msgid "menu"
-msgstr ""
+msgstr "මෙනුව"
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/sk_SK/LC_MESSAGES/duckduckgo.po
+++ b/locales/sk_SK/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: sk_SK\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -95,8 +95,7 @@ msgstr "%1$s a %2$s Modely umelej inteligencie"
 #. Message that appears above the search results encouraging them to filter results by domain. The placeholder string would include a the name of a website. E.g. 'Reddit appears in some of the top results for this search.'
 msgctxt "Site filter message"
 msgid "%s appears in some of the top results for this search."
-msgstr ""
-"%1$s sa vyskytuje v niektorých z najlepších výsledkov pre toto vyhľadávanie."
+msgstr "%1$s sa vyskytuje v niektorých z najlepších výsledkov pre toto vyhľadávanie."
 
 # smartling.placeholder_format=C
 #. Number of tracking attempts blocked, when there is more than 1. Eg: '2 attempts' or '302 attempts'
@@ -107,8 +106,7 @@ msgstr "Pokusy: %1$s"
 # smartling.placeholder_format=C
 #. A summary description of how many tracking attempts where blocked, when there was more than 1. Eg: '1,028 attempts blocked by DuckDuckGo in the last 24 hours'
 msgid "%s attempts blocked by DuckDuckGo in the last 24 hours"
-msgstr ""
-"DuckDuckGo za posledných 24 hodín zablokoval nasledujúci počet pokusov: %1$s"
+msgstr "DuckDuckGo za posledných 24 hodín zablokoval nasledujúci počet pokusov: %1$s"
 
 # smartling.placeholder_format=C
 #. A label that indicates a specific search result has been blocked by the safe search filter. The placeholder value is the name of the search result that was blocked.
@@ -232,8 +230,7 @@ msgctxt "Error message for model unavailability"
 msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
-msgstr ""
-"%1$s je dočasne nedostupný. Prejdite na iný model alebo to skúste neskôr."
+msgstr "%1$s je dočasne nedostupný. Prejdite na iný model alebo to skúste neskôr."
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -309,8 +306,7 @@ msgstr "Rebríček %1$s ešte nie je k dispozícii"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits 2-5x faster than other models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
-msgstr ""
-"%1$s dosahuje limity používania 2–5× rýchlejšie ako základné modely. %2$s"
+msgstr "%1$s dosahuje limity používania 2–5× rýchlejšie ako základné modely. %2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -474,8 +470,7 @@ msgctxt "noresults"
 msgid ""
 "%sClick here%s to try again, if you think there should be results for this "
 "search."
-msgstr ""
-"%1$sSkúste to znova%2$s, ak si myslíte, že sa mali nájsť nejaké výsledky."
+msgstr "%1$sSkúste to znova%2$s, ak si myslíte, že sa mali nájsť nejaké výsledky."
 
 # smartling.placeholder_format=C
 #. Header for a page with information about sharing DuckDuckGo.
@@ -507,15 +502,13 @@ msgstr "%1$sZistiť viac%2$s"
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr ""
-"%1$sZisti viac%2$s o tom, ako sú čety súkromne uložené na serveri DuckDuckGo."
+msgstr "%1$sZisti viac%2$s o tom, ako sú čety súkromne uložené na serveri DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr ""
-"%1$sZisti viac%2$s o tom, ako sú chaty súkromne uložené v tvojom zariadení."
+msgstr "%1$sZisti viac%2$s o tom, ako sú chaty súkromne uložené v tvojom zariadení."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -527,8 +520,7 @@ msgstr "%1$sDlho stlačte%2$s ikonu aplikácie DuckDuckGo na úvodnej obrazovke"
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr ""
-"%1$sAch!%2$s%3$sNiečo sa pokazilo. Prosím, %4$sobnov%5$s a skús to znova."
+msgstr "%1$sAch!%2$s%3$sNiečo sa pokazilo. Prosím, %4$sobnov%5$s a skús to znova."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -952,16 +944,14 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"K dispozícii je nová verzia AI Chat! Ak chceš pokračovať, obnov túto stránku."
+msgstr "K dispozícii je nová verzia AI Chat! Ak chceš pokračovať, obnov túto stránku."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"Je k dispozícii nová verzia Duck.ai! Ak chceš pokračovať, obnov túto stránku."
+msgstr "Je k dispozícii nová verzia Duck.ai! Ak chceš pokračovať, obnov túto stránku."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1218,7 +1208,7 @@ msgstr "O našich reklamách"
 #. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
 msgctxt "Modal header for chat history with sync information"
 msgid "About Chat History with Sync & Backup"
-msgstr ""
+msgstr "Informácie o histórii chatu so Sync & Backup"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
@@ -1353,7 +1343,7 @@ msgstr "Reklama je podozrivá"
 #. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
 msgctxt "Button to open menu for attaching images or page context to AI chat"
 msgid "Add"
-msgstr ""
+msgstr "Pridať"
 
 # smartling.placeholder_format=C
 #. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
@@ -1361,7 +1351,7 @@ msgctxt ""
 "Primary button that attaches the tabs the user checked in the tab picker "
 "dialog"
 msgid "Add"
-msgstr ""
+msgstr "Pridať"
 
 # smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
@@ -1396,13 +1386,13 @@ msgstr "Pridať DuckDuckGo do prehliadača %1$s"
 msgctxt ""
 "Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
 msgid "Add File"
-msgstr ""
+msgstr "Pridať súbor"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
 msgid "Add Image"
-msgstr ""
+msgstr "Pridať obrázok"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
@@ -1410,7 +1400,7 @@ msgctxt ""
 "Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
 "item)"
 msgid "Add Image or File"
-msgstr ""
+msgstr "Pridať obrázok alebo súbor"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1463,7 +1453,7 @@ msgctxt ""
 "Open the tab picker to attach browser tab content to the AI chat message "
 "(attach dropdown menu item)"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Pridať karty"
 
 # smartling.placeholder_format=C
 #. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
@@ -1471,7 +1461,7 @@ msgctxt ""
 "Title and accessible name of the tab-picker dialog opened from the attach "
 "dropdown menu"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Pridať karty"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1562,7 +1552,7 @@ msgstr "Pridanie dokončovacích prvkov"
 #. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
 msgctxt "Aria label for the additional instructions textarea"
 msgid "Additional instructions"
-msgstr ""
+msgstr "Ďalšie pokyny"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1664,8 +1654,7 @@ msgctxt ""
 "Always-visible warning banner shown above the recommended models in the "
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
-msgstr ""
-"Pokročilé modely môžu využiť limity 2-5x rýchlejšie než iné modely. %1$s"
+msgstr "Pokročilé modely môžu využiť limity 2-5x rýchlejšie než iné modely. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1871,7 +1860,7 @@ msgstr "Všetko je hotové!"
 #. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the read-only textarea listing all AI instructions"
 msgid "All instructions"
-msgstr ""
+msgstr "Všetky pokyny"
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2017,8 +2006,7 @@ msgstr "Už je to synchronizované."
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Also search privately on your iPad, iPhone, or Android!"
-msgstr ""
-"Vyhľadávajte súkromne aj vo svojom zariadení iPad alebo iPhone či Androide!"
+msgstr "Vyhľadávajte súkromne aj vo svojom zariadení iPad alebo iPhone či Androide!"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -3093,8 +3081,7 @@ msgstr "Zablokovať túto stránku vo všetkých výsledkoch"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr ""
-"Blokujte sledovače a prevezmite späť kontrolu nad svojimi osobnými údajmi"
+msgstr "Blokujte sledovače a prevezmite späť kontrolu nad svojimi osobnými údajmi"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3595,7 +3582,7 @@ msgctxt ""
 "Secondary button that dismisses the tab picker dialog without attaching "
 "anything"
 msgid "Cancel"
-msgstr ""
+msgstr "Zrušiť"
 
 # smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
@@ -4095,7 +4082,7 @@ msgstr "Táto odpoveď chatbota je urážlivá."
 #. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
 msgctxt "Chat history about modal list item headline"
 msgid "Chat storage varies by browser"
-msgstr ""
+msgstr "Úložisko četov sa líši podľa prehliadača"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4107,7 +4094,7 @@ msgstr "Chatovať s %1$s"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Chat with popular AI models, anonymized by us."
-msgstr ""
+msgstr "Četuj s populárnymi modelmi AI, anonymizovanými nami."
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4134,6 +4121,8 @@ msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
 msgstr ""
+"Čety sú bezpečne uložené na serveri DuckDuckGo s end-to-end šifrovaním. "
+"Nikto okrem teba nemôže vidieť tvoje údaje, dokonca ani my."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5323,8 +5312,7 @@ msgstr "Pokračuj v blokovaní reklám"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
-"Tu pokračuj v nedávnych četoch. Alebo ich vymaž pomocou tlačidla Fire Button."
+msgstr "Tu pokračuj v nedávnych četoch. Alebo ich vymaž pomocou tlačidla Fire Button."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5442,8 +5430,7 @@ msgstr "Kopírovať"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"Skopírujte a prilepte %1$sabout:preferences#search%2$s do panela s adresou."
+msgstr "Skopírujte a prilepte %1$sabout:preferences#search%2$s do panela s adresou."
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5734,7 +5721,7 @@ msgstr "Aktuálna šnúra"
 #. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
 msgctxt "Suffix label indicating a tab is the currently active browser tab"
 msgid "Current Tab"
-msgstr ""
+msgstr "Aktuálna záložka"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
@@ -6090,7 +6077,7 @@ msgstr "Vymazať chaty staršie ako 30 dní"
 #. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
 msgctxt "Button text in the modal for deleting all recent chats"
 msgid "Delete Chats and Shared Links"
-msgstr ""
+msgstr "Zmazať čety a zdieľané odkazy"
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6509,7 +6496,7 @@ msgstr "Zrušiť propagáciu"
 #. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the close button on the survey banner"
 msgid "Dismiss survey"
-msgstr ""
+msgstr "Zavrieť prieskum"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6628,8 +6615,7 @@ msgstr "Nevidíte súbor? %1$s%2$s%3$sKliknite sem a stiahnite si ho znova.%4$s
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Don't see the checkbox? %sFollow these steps%s."
-msgstr ""
-"Nevidíte začiarkavacie políčko? %1$sPostupujte podľa týchto krokov%2$s."
+msgstr "Nevidíte začiarkavacie políčko? %1$sPostupujte podľa týchto krokov%2$s."
 
 # smartling.placeholder_format=C
 #. Setting that hides a user's most visited sites when they open a new browser tab.
@@ -6993,8 +6979,7 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"Duck.ai je najlepší v našom súkromnom a bezplatnom prehliadači DuckDuckGo!"
+msgstr "Duck.ai je najlepší v našom súkromnom a bezplatnom prehliadači DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -7301,8 +7286,8 @@ msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
 msgstr ""
-"DuckDuckGo AI Chat je dočasne nedostupný. Ak to bude pretrvávať, pošlite e-"
-"mailom tento anonymný kód %1$s na adresu %2$s"
+"DuckDuckGo AI Chat je dočasne nedostupný. Ak to bude pretrvávať, pošlite "
+"e-mailom tento anonymný kód %1$s na adresu %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7310,15 +7295,13 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr ""
-"DuckDuckGo AI Chat je dočasne nedostupný. Obnovte stránku a skúste to znova."
+msgstr "DuckDuckGo AI Chat je dočasne nedostupný. Obnovte stránku a skúste to znova."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chat je dočasne nedostupný. Prosím, skúste to neskôr znova."
+msgstr "DuckDuckGo AI Chat je dočasne nedostupný. Prosím, skúste to neskôr znova."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7487,8 +7470,7 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr ""
-"DuckDuckGo anonymizuje tvoje chaty. Kliknutím na „%1$s“ súhlasíš s %2$s."
+msgstr "DuckDuckGo anonymizuje tvoje chaty. Kliknutím na „%1$s“ súhlasíš s %2$s."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7688,7 +7670,7 @@ msgstr "Upraviť výzvu"
 #. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the message-editing text area"
 msgid "Edit message"
-msgstr ""
+msgstr "Upraviť správu"
 
 # smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
@@ -7707,8 +7689,7 @@ msgstr "Upravujem obrázok..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr ""
-"Úpravou tvojej správy sa odstráni nižšie uvedená odpoveď, a vytvorí sa nová."
+msgstr "Úpravou tvojej správy sa odstráni nižšie uvedená odpoveď, a vytvorí sa nová."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7917,7 +7898,7 @@ msgstr "Šifrovaný model"
 #. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
 msgctxt "Share modal info bullet about encryption"
 msgid "Encrypted so DuckDuckGo can't read your chat."
-msgstr ""
+msgstr "Šifrované, takže DuckDuckGo nemôže čítať tvoj čet."
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8620,8 +8601,7 @@ msgstr "Finančný poradca"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr ""
-"Nájdite %1$sDuckDuckGo%2$s a kliknite na%3$sNastaviť ako predvolené%4$s."
+msgstr "Nájdite %1$sDuckDuckGo%2$s a kliknite na%3$sNastaviť ako predvolené%4$s."
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8633,8 +8613,7 @@ msgstr "Nájdi <b>%1$s</b> v&nbsp;tvojom priečinku so&nbsp;stiahnutými súborm
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr ""
-"Nájdite DuckDuckGo v zozname a vyberte %1$sNastaviť ako predvolený%2$s."
+msgstr "Nájdite DuckDuckGo v zozname a vyberte %1$sNastaviť ako predvolený%2$s."
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8757,7 +8736,7 @@ msgstr "Doplňujúca otázka"
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
-msgstr ""
+msgstr "Doplňujúce otázky zostávajú súkromné."
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -9115,8 +9094,7 @@ msgstr "Všeobecná umelá inteligencia s vysokou mierou moderovania"
 #. Text with short description for an AI (Artificial Intelligence) Model that has a low moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with low built-in moderation"
-msgstr ""
-"Umelá inteligencia na všeobecné použitie s nízkou vstavanou moderovaním"
+msgstr "Umelá inteligencia na všeobecné použitie s nízkou vstavanou moderovaním"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a medium moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
@@ -9278,7 +9256,7 @@ msgstr "Získaj DuckDuckGo VPN, pokročilé Duck.ai a Identity Theft Restoration
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
 msgctxt "Tooltip on the header logo for sunglasses searches"
 msgid "Get DuckDuckGo sunglasses and other gear."
-msgstr ""
+msgstr "Získaj slnečné okuliare DuckDuckGo a ďalšie vybavenie."
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9499,8 +9477,8 @@ msgstr "Získaj aplikáciu"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"Získaj bezplatný prehliadač DuckDuckGo %1$sna blokovanie reklám na YouTube."
-"%2$s"
+"Získaj bezplatný prehliadač DuckDuckGo %1$sna blokovanie reklám na "
+"YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9612,8 +9590,7 @@ msgstr ""
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr ""
-"Prejsť na %1$sOchrana osobných údajov a zabezpečenie > Lokalizačné služby%2$s"
+msgstr "Prejsť na %1$sOchrana osobných údajov a zabezpečenie > Lokalizačné služby%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -10441,8 +10418,7 @@ msgstr "Otvárací čas chýba"
 #. This is the name of a user setting
 msgctxt "settings"
 msgid "Hover, Module, and Dropdown Background Color"
-msgstr ""
-"Farba pozadia pri ukázaní kurzorom, v moduloch a rozbaľovacích ponukách"
+msgstr "Farba pozadia pri ukázaní kurzorom, v moduloch a rozbaľovacích ponukách"
 
 # smartling.placeholder_format=C
 #. Label for a pill-shaped tab below the empty-state Duck.ai chat input. Clicking it opens a panel that explains how Duck.ai protects user privacy.
@@ -10515,7 +10491,7 @@ msgstr "Ako to funguje"
 #. Headline in chat history about modals for the temporary encrypted server storage explanation.
 msgctxt "Chat history about modal list item headline"
 msgid "How it works"
-msgstr ""
+msgstr "Ako to funguje"
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11314,8 +11290,7 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr ""
-"Je toto miesto dobré? Zhrň jeho reputáciu na základe recenzií a hodnotení."
+msgstr "Je toto miesto dobré? Zhrň jeho reputáciu na základe recenzií a hodnotení."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -11365,8 +11340,7 @@ msgstr "Je to rýchly, bezplatný a poskytuje ti ešte väčšiu ochranu online.
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Občas (naozaj len občas) sa ma môžete spýtať na môj názor na DuckDuckGo"
+msgstr "Občas (naozaj len občas) sa ma môžete spýtať na môj názor na DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11824,8 +11798,7 @@ msgstr "Viac informácií o tom, ako to funguje"
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
 msgid "Learn why reducing online tracking is important."
-msgstr ""
-"Ďalšie informácie o tom, prečo je dôležité obmedziť sledovanie na internete."
+msgstr "Ďalšie informácie o tom, prečo je dôležité obmedziť sledovanie na internete."
 
 # smartling.placeholder_format=C
 #. A link that takes users to a page where they can learn more about the dangers of online tracking.
@@ -11888,8 +11861,8 @@ msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
 msgstr ""
-"Umožní ti prepínať medzi odosielaním vyhľadávacích dopytov a výziev do Duck."
-"ai"
+"Umožní ti prepínať medzi odosielaním vyhľadávacích dopytov a výziev do "
+"Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11971,7 +11944,7 @@ msgstr "Platnosť odkazu vyprší o 7 dní."
 #. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days. People can save a chat copy."
-msgstr ""
+msgstr "Platnosť odkazu vyprší o 7 dní. Ľudia si môžu uložiť kópiu četu."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14096,7 +14069,7 @@ msgstr "OK, rozumiem!"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "OPTIONAL"
-msgstr ""
+msgstr "NEPOVINNÉ"
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -14367,8 +14340,7 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr ""
-"Ajaj! Pri preklade tohto textu došlo k neočakávanej chybe. Skúste to neskôr."
+msgstr "Ajaj! Pri preklade tohto textu došlo k neočakávanej chybe. Skúste to neskôr."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -14447,8 +14419,7 @@ msgstr "Otvorte položku Poloha a uistite sa, že je poloha %1$szapnutá%2$s."
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open 'Privacy', then 'Location Services'."
-msgstr ""
-"Otvorte položku „Ochrana osobných údajov“ a potom „Služby určovania polohy“."
+msgstr "Otvorte položku „Ochrana osobných údajov“ a potom „Služby určovania polohy“."
 
 # smartling.placeholder_format=C
 #. Indicates a business is open 24 hours a day.
@@ -14591,8 +14562,7 @@ msgstr "Otvoriť panel Ako funguje Duck.ai"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Otvorte ponuku Safari a vyberte položku %1$sNastavenia pre DuckDuckGo...%2$s"
+msgstr "Otvorte ponuku Safari a vyberte položku %1$sNastavenia pre DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -15419,8 +15389,7 @@ msgstr "Popíš, prečo je odpoveď v chate škodlivá alebo nezákonná. (nepov
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr ""
-"Popíšte, prečo je odpoveď v chate nelegálna alebo škodlivá. (Nepovinné)"
+msgstr "Popíšte, prečo je odpoveď v chate nelegálna alebo škodlivá. (Nepovinné)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -16228,7 +16197,7 @@ msgstr "Chránené"
 #. Headline in sync-enabled chat history about modals explaining encrypted server storage.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Protected with end-to-end encryption"
-msgstr ""
+msgstr "Chránené end-to-end šifrovaním"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -16367,7 +16336,7 @@ msgstr "Rebríčky"
 #. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
 msgctxt "star rating on a product"
 msgid "Rated %s out of %s"
-msgstr ""
+msgstr "Hodnotenie %1$s z %2$s"
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -16466,8 +16435,7 @@ msgstr "Uvažovanie môže poskytnúť lepšie odpovede na zložité otázky."
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
-msgstr ""
-"Uvažovanie je dôkladnejšie, ale limity používania dosiahne 2–5× skôr. %1$s"
+msgstr "Uvažovanie je dôkladnejšie, ale limity používania dosiahne 2–5× skôr. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
@@ -17590,8 +17558,7 @@ msgstr "Ulož si až 30 svojich najnovších chatov lokálne do svojho zariad
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Ulož si svoje čety Duck.ai medzi zariadeniami pomocou end-to-end šifrovania."
+msgstr "Ulož si svoje čety Duck.ai medzi zariadeniami pomocou end-to-end šifrovania."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17603,7 +17570,7 @@ msgstr "Ulož si svoje chaty na všetkých svojich zariadeniach."
 #. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
 msgctxt "Chat history about modal list item headline"
 msgid "Save your chats on this device"
-msgstr ""
+msgstr "Ulož si svoje čety na tomto zariadení"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
@@ -17788,8 +17755,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr ""
-"Prejdite nadol do časti %1$sSlužby%2$s a vyberte %3$sPanel s adresou%4$s."
+msgstr "Prejdite nadol do časti %1$sSlužby%2$s a vyberte %3$sPanel s adresou%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -17814,7 +17780,7 @@ msgctxt ""
 "Placeholder and accessibility label for the search input in the tab picker "
 "dialog"
 msgid "Search"
-msgstr ""
+msgstr "Vyhľadávať"
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -17953,8 +17919,7 @@ msgstr "Viditeľnosť vyhľadávania"
 # smartling.placeholder_format=C
 #. Message prompting users to download the DuckDuckGo app.
 msgid "Search and browse privately with the DuckDuckGo app."
-msgstr ""
-"Vyhľadávajte a prehľadávajte web súkromne pomocou aplikácie DuckDuckGo."
+msgstr "Vyhľadávajte a prehľadávajte web súkromne pomocou aplikácie DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Category a user can select on a feedback form.
@@ -18090,8 +18055,7 @@ msgstr "Vyhľadávajte cez DuckDuckGo"
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid "Search, browse, and chat privately in our free browser"
-msgstr ""
-"Vyhľadávaj, prehliadaj a chatuj súkromne v našom bezplatnom prehliadači"
+msgstr "Vyhľadávaj, prehliadaj a chatuj súkromne v našom bezplatnom prehliadači"
 
 # smartling.placeholder_format=C
 #. Message displayed sometimes at top of results (for bang syntax), e.g. <a href="https://duckduckgo.com/?q=twitter+test">https://duckduckgo.com/?q=twitter+test</a>
@@ -18141,8 +18105,7 @@ msgstr "Druhý názor"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr ""
-"Bezpečne ukladaj a synchronizuj svoje chaty na všetkých svojich zariadeniach."
+msgstr "Bezpečne ukladaj a synchronizuj svoje chaty na všetkých svojich zariadeniach."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18171,8 +18134,9 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-"Bezpečne ukladaj takmer neobmedzený počet četov na našom serveri pomocou end-"
-"to-end šifrovania a pristupuj k nim zo všetkých synchronizovaných zariadení."
+"Bezpečne ukladaj takmer neobmedzený počet četov na našom serveri pomocou "
+"end-to-end šifrovania a pristupuj k nim zo všetkých synchronizovaných "
+"zariadení."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18376,15 +18340,13 @@ msgstr "Vyberte %1$sDuckDuckGo%2$s a potom %3$sPridať ako predvolené%4$s."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr ""
-"V rozbaľovacej ponuke Predvolený vyhľadávač vyberte %1$sDuckDuckGo%2$s."
+msgstr "V rozbaľovacej ponuke Predvolený vyhľadávač vyberte %1$sDuckDuckGo%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"V zozname vyberte %1$sDuckDuckGo%2$s a %3$spovoľte%4$s prístup k polohe"
+msgstr "V zozname vyberte %1$sDuckDuckGo%2$s a %3$spovoľte%4$s prístup k polohe"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18828,8 +18790,7 @@ msgstr "Zdieľať"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Zdieľajte DuckDuckGo a pomôžte svojim priateľom získať späť ich súkromie!"
+msgstr "Zdieľajte DuckDuckGo a pomôžte svojim priateľom získať späť ich súkromie!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -19001,7 +18962,7 @@ msgstr "Obchod"
 #. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
 msgctxt "Button in the merchandise logo modal (mobile)"
 msgid "Shop Now"
-msgstr ""
+msgstr "Nakupuj teraz"
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -19109,8 +19070,7 @@ msgstr "Zobraziť DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"Zobrazovať DuckAssist častejšie. (Môžete ho tiež úplne %1$svypnúť%2$s.)"
+msgstr "Zobrazovať DuckAssist častejšie. (Môžete ho tiež úplne %1$svypnúť%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -19370,8 +19330,7 @@ msgstr "Zobraziť vodorovné čiary medzi stránkami vo výsledkoch vyhľadávan
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr ""
-"Zobraziť odkazy na návod, ako pridať DuckDuckGo do webového prehliadača"
+msgstr "Zobraziť odkazy na návod, ako pridať DuckDuckGo do webového prehliadača"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -19387,14 +19346,12 @@ msgstr "Zobraziť najnavštevovanejšie odkazy na novej karte"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Zobraziť občasné pripomenutia na pridanie DuckDuckGo do webového prehliadača"
+msgstr "Zobraziť občasné pripomenutia na pridanie DuckDuckGo do webového prehliadača"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Zobraziť občasné pripomenutia na pridanie služby DuckDuckGo do zariadení"
+msgstr "Zobraziť občasné pripomenutia na pridanie služby DuckDuckGo do zariadení"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19425,8 +19382,7 @@ msgstr "Zobrazovať návrhy pod vyhľadávacím poľom pri písaní"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr ""
-"Zobraziť výhody DuckDuckGo v oblasti ochrany súkromia na domovskej stránke"
+msgstr "Zobraziť výhody DuckDuckGo v oblasti ochrany súkromia na domovskej stránke"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19436,8 +19392,7 @@ msgstr "Zobraziť pozadie tlačidla Hľadať"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message on top of the search results page"
-msgstr ""
-"Zobraziť uvítaciu správu v hornej časti stránky s výsledkami vyhľadávania"
+msgstr "Zobraziť uvítaciu správu v hornej časti stránky s výsledkami vyhľadávania"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19748,8 +19703,7 @@ msgctxt "Error message when an uploaded image cannot be decoded or processed"
 msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
-msgstr ""
-"Žiaľ, nahraný obrázok sa nepodarilo spracovať. Skús iný obrázok alebo formát."
+msgstr "Žiaľ, nahraný obrázok sa nepodarilo spracovať. Skús iný obrázok alebo formát."
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -19783,8 +19737,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Ľutujeme, ale nepodarilo sa nám odoslať vašu spätnú väzbu. Skúste to neskôr."
+msgstr "Ľutujeme, ale nepodarilo sa nám odoslať vašu spätnú väzbu. Skúste to neskôr."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19838,8 +19791,7 @@ msgstr "Zdrojový text bol vymazaný"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr ""
-"Zdrojový text je príliš dlhý na zhrnutie. Skús to znova s kratším výberom."
+msgstr "Zdrojový text je príliš dlhý na zhrnutie. Skús to znova s kratším výberom."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -20105,8 +20057,7 @@ msgstr "Zablokujte skryté sledovače, ktoré na vás číhajú na iných weboch
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Zablokujte väčšinu skrytých sledovačov, ktoré na vás číhajú na iných weboch."
+msgstr "Zablokujte väčšinu skrytých sledovačov, ktoré na vás číhajú na iných weboch."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20603,8 +20554,7 @@ msgstr "Prepnuté na %1$s"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr ""
-"Prepnutím sa tvoj chat odošle modelu bez nulovej viditeľnosti poskytovateľa."
+msgstr "Prepnutím sa tvoj chat odošle modelu bez nulovej viditeľnosti poskytovateľa."
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -20669,6 +20619,8 @@ msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
 msgstr ""
+"Sync & Backup ukladá viac tvojich četov a synchronizuje ich na všetkých "
+"tvojich zariadeniach."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20790,7 +20742,7 @@ msgstr "Synchronizuj svoje chaty na všetkých svojich zariadeniach."
 #. Headline in sync-enabled chat history about modals explaining cross-device sync.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Sync your chats across all your devices"
-msgstr ""
+msgstr "Synchronizuj svoje čety na všetkých svojich zariadeniach"
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -20909,8 +20861,7 @@ msgstr "Získajte späť kontrolu nad svojimi osobnými údajmi!"
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr ""
-"Vyplň tento anonymný prieskum a daj nám vedieť, ako môžeme Duck.ai vylepšiť."
+msgstr "Vyplň tento anonymný prieskum a daj nám vedieť, ako môžeme Duck.ai vylepšiť."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -21216,8 +21167,7 @@ msgstr "Uplynul časový limit žiadosti. Skús to znova."
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "The server encountered an error and could not complete your request."
-msgstr ""
-"Na serveri sa vyskytla chyba a server nemohol dokončiť tvoju požiadavku."
+msgstr "Na serveri sa vyskytla chyba a server nemohol dokončiť tvoju požiadavku."
 
 # smartling.placeholder_format=C
 #. Title for the theme menu:
@@ -21336,8 +21286,7 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr ""
-"Tento model AI už nie je k dispozícii. Skúste začať nový chat iným modelom."
+msgstr "Tento model AI už nie je k dispozícii. Skúste začať nový chat iným modelom."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -21382,12 +21331,14 @@ msgid ""
 "This chat and its generated images become public when you create and copy "
 "the link."
 msgstr ""
+"Tento čet a obrázky, ktoré v ňom vytvoríš, sa stanú verejnými, keď vytvoríš "
+"a skopíruješ odkaz."
 
 # smartling.placeholder_format=C
 #. Explains that creating and copying a share link makes the selected chat content public.
 msgctxt "Share modal info bullet about public access"
 msgid "This chat becomes public when you create and copy the link."
-msgstr ""
+msgstr "Tento čet sa stane verejným, keď vytvoríš a skopíruješ odkaz."
 
 # smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
@@ -21697,8 +21648,7 @@ msgstr "Tento preklad je nesprávny"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Toto video tu ešte nie je možné sledovať. Môžete ho sledovať v službe %1$s."
+msgstr "Toto video tu ešte nie je možné sledovať. Môžete ho sledovať v službe %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -21821,8 +21771,8 @@ msgstr "Tipy"
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
 msgstr ""
-"Už vás nebaví, že vás na internete niekto neustále sleduje? %1$sPomôžeme vám."
-"%2$s"
+"Už vás nebaví, že vás na internete niekto neustále sleduje? %1$sPomôžeme "
+"vám.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -21870,8 +21820,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"Tlač návodu:%1$sVráťte sa do mapy.%2$sVyberte trasu, ktorú chcete vytlačiť."
-"%3$sKliknite na ikonu tlače.%4$s"
+"Tlač návodu:%1$sVráťte sa do mapy.%2$sVyberte trasu, ktorú chcete "
+"vytlačiť.%3$sKliknite na ikonu tlače.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -21925,14 +21875,13 @@ msgstr "Dnes"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
-msgstr ""
+msgstr "Prepni na súkromný AI čet alebo ho %1$svypni v nastaveniach%2$s."
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
-msgstr ""
-"Prepnutím vyskúšaj súkromný AI čet alebo ho %1$svypni v ponuke %2$s.%3$s"
+msgstr "Prepnutím vyskúšaj súkromný AI čet alebo ho %1$svypni v ponuke %2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -22415,15 +22364,13 @@ msgstr "Skúste iné kľúčové slová."
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr ""
-"Skús vypnúť blokovanie reklám na DuckDuckGo, aby si videl/-a viac výsledkov."
+msgstr "Skús vypnúť blokovanie reklám na DuckDuckGo, aby si videl/-a viac výsledkov."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Presnejšie výsledky môžete získať povolením anonymného určovania polohy."
+msgstr "Presnejšie výsledky môžete získať povolením anonymného určovania polohy."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
@@ -22788,8 +22735,7 @@ msgstr "Vypnúť:"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on %sPrecise Location%s for more accurate results"
-msgstr ""
-"Ak chcete získať presnejšie výsledky, zapnite možnosť %1$sPresná poloha%2$s"
+msgstr "Ak chcete získať presnejšie výsledky, zapnite možnosť %1$sPresná poloha%2$s"
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -22812,8 +22758,7 @@ msgstr "Presnejšie výsledky môžete získať zapnutím nastavenia „Presná 
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr ""
-"Presnejšie výsledky môžete získať zapnutím nastavenia „Použiť presnú polohu“."
+msgstr "Presnejšie výsledky môžete získať zapnutím nastavenia „Použiť presnú polohu“."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -23019,14 +22964,13 @@ msgstr ""
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"Pod možnosťou %1$sPri spustení > Domovská stránka%2$s napíšte: https://"
-"duckduckgo.com."
+"Pod možnosťou %1$sPri spustení > Domovská stránka%2$s napíšte: "
+"https://duckduckgo.com."
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch Settings%s select %sDuckDuckGo%s"
-msgstr ""
-"Pod možnosťou %1$sNastavenia vyhľadávania%2$s vyberte %3$sDuckDuckGo%4$s."
+msgstr "Pod možnosťou %1$sNastavenia vyhľadávania%2$s vyberte %3$sDuckDuckGo%4$s."
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23039,8 +22983,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr ""
-"Pod sekciou %1$sVyhľadávanie%2$s vyberte %3$sSpravovať vyhľadávače...%4$s."
+msgstr "Pod sekciou %1$sVyhľadávanie%2$s vyberte %3$sSpravovať vyhľadávače...%4$s."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -23054,8 +22997,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr ""
-"V časti Vyhľadávanie vyberte rozbaľovaciu ponuku a potom %1$sDuckDuckGo%2$s."
+msgstr "V časti Vyhľadávanie vyberte rozbaľovaciu ponuku a potom %1$sDuckDuckGo%2$s."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -23764,6 +23706,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Yelp's ad network."
 msgstr ""
+"Prezeranie reklám s ochranou súkromia DuckDuckGo. Kliknutia na reklamy "
+"spravuje reklamná sieť lokality Yelp."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -24670,8 +24614,7 @@ msgctxt "Full sentence for finding a better word"
 msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
-msgstr ""
-"Aké sú niektoré možnosti slova „lepší“ v kontexte „Naozaj musíme byť lepší“."
+msgstr "Aké sú niektoré možnosti slova „lepší“ v kontexte „Naozaj musíme byť lepší“."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -25047,8 +24990,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"Ak je toto povolené, Duck.ai bude v chate zobrazovať okamžité odpovede."
+msgstr "Ak je toto povolené, Duck.ai bude v chate zobrazovať okamžité odpovede."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -25066,8 +25008,7 @@ msgstr "Kde sledovať <strong>%1$s</strong>"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr ""
-"Pri možnosti Domovská stránka vyberte %1$sNastaviť aktuálnu stránku%2$s."
+msgstr "Pri možnosti Domovská stránka vyberte %1$sNastaviť aktuálnu stránku%2$s."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -25107,8 +25048,7 @@ msgstr "Kto sme"
 #. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
-msgstr ""
-"Kto je hlavnom hereckom obsadení a štábe, a čím ďalším sú dané osoby známe?"
+msgstr "Kto je hlavnom hereckom obsadení a štábe, a čím ďalším sú dané osoby známe?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -25256,6 +25196,8 @@ msgid ""
 "With chat history on, up to %s of your most recent chats will be saved on "
 "this device."
 msgstr ""
+"Keď máš zapnutú históriu četov, na tomto zariadení sa uloží až %1$s tvojich "
+"najnovších četov."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline in the About Chat History modal.
@@ -25263,6 +25205,8 @@ msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, your most recent chats will be saved on this device."
 msgstr ""
+"Keď je história chatu zapnutá, tvoje najnovšie čety sa uložia na tomto "
+"zariadení."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -26023,8 +25967,7 @@ msgstr ""
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr ""
-"Tvoje čety Duck.ai sa synchronizujú pomocou šifrovania typu end-to-end."
+msgstr "Tvoje čety Duck.ai sa synchronizujú pomocou šifrovania typu end-to-end."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -26097,8 +26040,7 @@ msgstr "Podľa vášho prehliadača ste tento odkaz už otvorili."
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid "Your browser provides a list of your most-visited sites."
-msgstr ""
-"Váš prehliadač poskytuje zoznam vašich najčastejšie navštevovaných lokalít."
+msgstr "Váš prehliadač poskytuje zoznam vašich najčastejšie navštevovaných lokalít."
 
 # smartling.placeholder_format=C
 #. Used as a description in a menu
@@ -26147,8 +26089,7 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr ""
-"Tvoje rozhovory sú súkromné a nikdy sa nepoužívajú na trénovanie modelov AI"
+msgstr "Tvoje rozhovory sú súkromné a nikdy sa nepoužívajú na trénovanie modelov AI"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -26209,8 +26150,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr ""
-"Tvoje čety boli importované. Pokračuj tam, kde si na Duck.ai skončil/-a."
+msgstr "Tvoje čety boli importované. Pokračuj tam, kde si na Duck.ai skončil/-a."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -26398,8 +26338,7 @@ msgctxt "Error message for input limit"
 msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
-msgstr ""
-"Prekročili ste maximálnu veľkosť správy. Skráťte správu a skúste to znova."
+msgstr "Prekročili ste maximálnu veľkosť správy. Skráťte správu a skúste to znova."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -26669,7 +26608,7 @@ msgstr "min"
 #. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the chat options menu button"
 msgid "menu"
-msgstr ""
+msgstr "Ponuka"
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.
@@ -26743,8 +26682,7 @@ msgstr "oficiálnej webovej stránky"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr ""
-"alebo napíšte kód požadovanej farby, napr. %1$s (%2$s je kódovaný znak %3$s)."
+msgstr "alebo napíšte kód požadovanej farby, napr. %1$s (%2$s je kódovaný znak %3$s)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/sk_SK/LC_MESSAGES/duckduckgo.po
+++ b/locales/sk_SK/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: sk_SK\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1215,6 +1215,12 @@ msgid "About our ads"
 msgstr "O našich reklamách"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1344,6 +1350,20 @@ msgid "Ad is suspicious"
 msgstr "Reklama je podozrivá"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Pridať DuckDuckGo"
@@ -1370,6 +1390,27 @@ msgstr "Pridať DuckDuckGo ako vyhľadávač"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Pridať DuckDuckGo do prehliadača %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1415,6 +1456,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Pridať obsah stránky"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1500,6 +1557,12 @@ msgstr "Doplnky"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Pridanie dokončovacích prvkov"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1803,6 +1866,12 @@ msgstr "Všetky farby"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Všetko je hotové!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3521,6 +3590,14 @@ msgid "Cancel"
 msgstr "Zrušiť"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4015,10 +4092,22 @@ msgid "Chat response is offensive"
 msgstr "Táto odpoveď chatbota je urážlivá."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Chatovať s %1$s"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4037,6 +4126,14 @@ msgstr "Čety"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Čety"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5634,6 +5731,12 @@ msgid "Current Streak"
 msgstr "Aktuálna šnúra"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5982,6 +6085,12 @@ msgstr "Zmazať chaty"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Vymazať chaty staršie ako 30 dní"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6395,6 +6504,12 @@ msgstr "Skryť navždy"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Zrušiť propagáciu"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7570,6 +7685,12 @@ msgid "Edit Prompt"
 msgstr "Upraviť výzvu"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7791,6 +7912,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Šifrovaný model"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8627,6 +8754,12 @@ msgid "Follow-up question"
 msgstr "Doplňujúca otázka"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9140,6 +9273,12 @@ msgstr ""
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr "Získaj DuckDuckGo VPN, pokročilé Duck.ai a Identity Theft Restoration."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10371,6 +10510,12 @@ msgstr "Ako sa zabezpečuje anonymita?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Ako to funguje"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11821,6 +11966,12 @@ msgstr "Vyhrané auty"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "Platnosť odkazu vyprší o 7 dní."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13940,6 +14091,12 @@ msgstr "OK"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "OK, rozumiem!"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16068,6 +16225,12 @@ msgid "Protected"
 msgstr "Chránené"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Ochrana. Súkromie. Pokoj v duši."
@@ -16199,6 +16362,12 @@ msgstr "Dážď"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Rebríčky"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17431,6 +17600,12 @@ msgid "Save your chats across all your devices."
 msgstr "Ulož si svoje chaty na všetkých svojich zariadeniach."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17632,6 +17807,14 @@ msgstr "Vyhľadávanie"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Vyhľadávanie"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18813,6 +18996,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Obchod"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20474,6 +20663,14 @@ msgstr ""
 "nečinnosti."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20588,6 +20785,12 @@ msgstr "Synchronizácia s blízkym zariadením."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Synchronizuj svoje chaty na všetkých svojich zariadeniach."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21171,6 +21374,22 @@ msgid "This Week"
 msgstr "Tento týždeň"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21701,6 +21920,12 @@ msgstr "Dnes"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Dnes"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23533,6 +23758,14 @@ msgstr ""
 "spravuje reklamná sieť lokality TripAdvisor."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Panenské ostrovy"
 
@@ -25017,6 +25250,21 @@ msgstr ""
 "umelej inteligencie. Zapni alebo vypni kedykoľvek v ponuke „%1$s“."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26416,6 +26664,12 @@ msgstr "min"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "min"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/sl_SI/LC_MESSAGES/duckduckgo.po
+++ b/locales/sl_SI/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: sl_SI\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1217,6 +1217,12 @@ msgid "About our ads"
 msgstr "O naših oglasih"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1346,6 +1352,20 @@ msgid "Ad is suspicious"
 msgstr "Oglas je sumljiv"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Dodaj DuckDuckGo"
@@ -1372,6 +1392,27 @@ msgstr "Dodajte DuckDuckGo kot iskalnik"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Dodaj DuckDuckGo v %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1417,6 +1458,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Dodaj vsebino strani"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1502,6 +1559,12 @@ msgstr "Dodatki"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Še zadnji popravki"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1805,6 +1868,12 @@ msgstr "Vse barve"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Končano!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3519,6 +3588,14 @@ msgid "Cancel"
 msgstr "Prekliči"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4013,10 +4090,22 @@ msgid "Chat response is offensive"
 msgstr "Odziv v klepetu je žaljiv"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Klepetajte z modelom %1$s"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4035,6 +4124,14 @@ msgstr "Klepeti"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Klepeti"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5632,6 +5729,12 @@ msgid "Current Streak"
 msgstr "Trenutni niz"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5979,6 +6082,12 @@ msgstr "Izbriši klepete"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Izbriši klepete, starejše od 30 dni"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6398,6 +6507,12 @@ msgstr "Opusti za vedno"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Zavrni promocijo"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7574,6 +7689,12 @@ msgid "Edit Prompt"
 msgstr "Uredi poziv"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7794,6 +7915,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Šifrirani model"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8633,6 +8760,12 @@ msgid "Follow-up question"
 msgstr "Nadaljnje vprašanje"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9148,6 +9281,12 @@ msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
 "Pridobi DuckDuckGo VPN, napredni Duck.ai in zaščito Identity Theft "
 "Restoration."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10384,6 +10523,12 @@ msgstr "Kako je ta storitev anonimna?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Kako deluje"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11832,6 +11977,12 @@ msgstr "Osvojeni lineouti"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "Povezava poteče čez 7 dni."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13953,6 +14104,12 @@ msgstr "V redu"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "V redu, razumem!"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16081,6 +16238,12 @@ msgid "Protected"
 msgstr "Zaščiteno"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Zaščita. Zasebnost. Zaupanje."
@@ -16212,6 +16375,12 @@ msgstr "Dež"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Uvrstitve"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17450,6 +17619,12 @@ msgid "Save your chats across all your devices."
 msgstr "Shrani vaše klepete v vseh vaših napravah."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17654,6 +17829,14 @@ msgstr "Iskanje"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Iskanje"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18829,6 +19012,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Nakup"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20478,6 +20667,14 @@ msgstr ""
 "nedejavnosti."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20590,6 +20787,12 @@ msgstr "Sinhroniziraj z bližnjo napravo."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Sinhronizira vaše klepete v vseh vaših napravah."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21172,6 +21375,22 @@ msgid "This Week"
 msgstr "Ta teden"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21708,6 +21927,12 @@ msgstr "Danes"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Danes"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23539,6 +23764,14 @@ msgstr ""
 "oglaševalsko omrežje družbe TripAdvisor."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Deviški otoki"
 
@@ -25020,6 +25253,21 @@ msgstr ""
 "učenje UI. Kadar koli ga vklopite ali izklopite v meniju »%1$s«."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26416,6 +26664,12 @@ msgstr "min"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "min"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/sl_SI/LC_MESSAGES/duckduckgo.po
+++ b/locales/sl_SI/LC_MESSAGES/duckduckgo.po
@@ -2,16 +2,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: sl_SI\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || "
-"n%100==4 ? 2 : 3;\n"
+"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -523,15 +522,13 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr ""
-"%1$sDolgo pritisnite%2$s ikono aplikacije DuckDuckGo na začetnem zaslonu."
+msgstr "%1$sDolgo pritisnite%2$s ikono aplikacije DuckDuckGo na začetnem zaslonu."
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr ""
-"%1$sUps!%2$s%3$sNekaj je šlo narobe. %4$sOsvežite%5$s in poskusite znova."
+msgstr "%1$sUps!%2$s%3$sNekaj je šlo narobe. %4$sOsvežite%5$s in poskusite znova."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -882,8 +879,7 @@ msgstr "Dosežena je 6-urna omejitev uporabe."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Dosežena je 6-urna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
+msgstr "Dosežena je 6-urna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -963,8 +959,7 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"Na voljo je nova različica Duck.ai! Če želite nadaljevati, osvežite to stran."
+msgstr "Na voljo je nova različica Duck.ai! Če želite nadaljevati, osvežite to stran."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1220,7 +1215,7 @@ msgstr "O naših oglasih"
 #. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
 msgctxt "Modal header for chat history with sync information"
 msgid "About Chat History with Sync & Backup"
-msgstr ""
+msgstr "O zgodovini klepetov s funkcijo Sync & Backup"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
@@ -1355,7 +1350,7 @@ msgstr "Oglas je sumljiv"
 #. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
 msgctxt "Button to open menu for attaching images or page context to AI chat"
 msgid "Add"
-msgstr ""
+msgstr "Dodaj"
 
 # smartling.placeholder_format=C
 #. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
@@ -1363,7 +1358,7 @@ msgctxt ""
 "Primary button that attaches the tabs the user checked in the tab picker "
 "dialog"
 msgid "Add"
-msgstr ""
+msgstr "Dodaj"
 
 # smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
@@ -1398,13 +1393,13 @@ msgstr "Dodaj DuckDuckGo v %1$s"
 msgctxt ""
 "Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
 msgid "Add File"
-msgstr ""
+msgstr "Dodaj datoteko"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
 msgid "Add Image"
-msgstr ""
+msgstr "Dodaj sliko"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
@@ -1412,7 +1407,7 @@ msgctxt ""
 "Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
 "item)"
 msgid "Add Image or File"
-msgstr ""
+msgstr "Dodaj sliko ali datoteko"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1465,7 +1460,7 @@ msgctxt ""
 "Open the tab picker to attach browser tab content to the AI chat message "
 "(attach dropdown menu item)"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Dodaj zavihke"
 
 # smartling.placeholder_format=C
 #. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
@@ -1473,7 +1468,7 @@ msgctxt ""
 "Title and accessible name of the tab-picker dialog opened from the attach "
 "dropdown menu"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Dodaj zavihke"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1564,7 +1559,7 @@ msgstr "Še zadnji popravki"
 #. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
 msgctxt "Aria label for the additional instructions textarea"
 msgid "Additional instructions"
-msgstr ""
+msgstr "Dodatna navodila"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1666,8 +1661,7 @@ msgctxt ""
 "Always-visible warning banner shown above the recommended models in the "
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
-msgstr ""
-"Napredni modeli lahko porabijo omejitve 2–5× hitreje kot drugi modeli. %1$s"
+msgstr "Napredni modeli lahko porabijo omejitve 2–5× hitreje kot drugi modeli. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1873,7 +1867,7 @@ msgstr "Končano!"
 #. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the read-only textarea listing all AI instructions"
 msgid "All instructions"
-msgstr ""
+msgstr "Vsa navodila"
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2314,8 +2308,7 @@ msgstr "Ali ste prepričani, da želite izbrisati ta pogovor in začeti novega?"
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
 msgctxt "Body text for delete chat confirmation modal"
 msgid "Are you sure you want to delete this chat? This cannot be undone."
-msgstr ""
-"Ste prepričani, da želite izbrisati ta klepet? Tega ni mogoče razveljaviti."
+msgstr "Ste prepričani, da želite izbrisati ta klepet? Tega ni mogoče razveljaviti."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable chat history, with a warning that it will also delete currently saved chats including pinned chats.
@@ -2684,8 +2677,7 @@ msgstr "Samodejno odgovarjanje"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr ""
-"Samodejno ustvarjeno na podlagi navedenih virov. Lahko vsebuje netočnosti."
+msgstr "Samodejno ustvarjeno na podlagi navedenih virov. Lahko vsebuje netočnosti."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -3093,8 +3085,7 @@ msgstr "Blokiraj to spletno mesto v vseh rezultatih"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr ""
-"Blokirajte sledilnike in prevzemite nadzor nad svojimi osebnimi podatki"
+msgstr "Blokirajte sledilnike in prevzemite nadzor nad svojimi osebnimi podatki"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3593,7 +3584,7 @@ msgctxt ""
 "Secondary button that dismisses the tab picker dialog without attaching "
 "anything"
 msgid "Cancel"
-msgstr ""
+msgstr "Prekliči"
 
 # smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
@@ -3984,8 +3975,8 @@ msgstr ""
 "klepeta z umetno inteligenco tretjih oseb, ki podpirajo modele OpenAI, "
 "Anthropic in druge. Če to nastavitev izklopiš, bodo gumbi in povezave za "
 "klepet v iskalniku DuckDuckGo skriti. Vendar pa lahko še vedno dostopaš do "
-"klepeta, ko je ta nastavitev izklopljena tako, da obiščeš %1$shttps://duck."
-"ai%2$s neposredno."
+"klepeta, ko je ta nastavitev izklopljena tako, da obiščeš "
+"%1$shttps://duck.ai%2$s neposredno."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4093,7 +4084,7 @@ msgstr "Odziv v klepetu je žaljiv"
 #. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
 msgctxt "Chat history about modal list item headline"
 msgid "Chat storage varies by browser"
-msgstr ""
+msgstr "Shranjevanje klepetov se razlikuje glede na brskalnik"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4106,6 +4097,8 @@ msgstr "Klepetajte z modelom %1$s"
 msgctxt "new tab page"
 msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
+"Klepetajte s priljubljenimi modeli umetne inteligence, za vašo anonimnost "
+"poskrbimo mi."
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4132,6 +4125,8 @@ msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
 msgstr ""
+"Klepeti so varno shranjeni na strežniku DuckDuckGo s celovitim šifriranjem. "
+"Nihče razen vas ne more videti vaših podatkov, niti mi."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4643,8 +4638,7 @@ msgstr "Kliknite %1$stukaj%2$s za prenos razširitve DuckDuckGo"
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr ""
-"Kliknite %1$sOdpri%2$s za prenos in odprite razširitev DuckDuckGo Safari"
+msgstr "Kliknite %1$sOdpri%2$s za prenos in odprite razširitev DuckDuckGo Safari"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4677,8 +4671,7 @@ msgstr "Kliknite %1$sNastavitve%2$s v spustnem meniju."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Kliknite %1$sUporabi trenutne strani%2$s, nato %3$skliknite V redu%4$s."
+msgstr "Kliknite %1$sUporabi trenutne strani%2$s, nato %3$skliknite V redu%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -5321,8 +5314,7 @@ msgstr "Nadaljuj blokiranje oglasov"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
-"Nadaljujte nedavne klepete tukaj. Ali pa jih izbrišite z gumbom Fire Button."
+msgstr "Nadaljujte nedavne klepete tukaj. Ali pa jih izbrišite z gumbom Fire Button."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5440,8 +5432,7 @@ msgstr "Kopiraj"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"Kopirajte in prilepite %1$sabout:preferences#search%2$s v naslovno vrstico"
+msgstr "Kopirajte in prilepite %1$sabout:preferences#search%2$s v naslovno vrstico"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5732,7 +5723,7 @@ msgstr "Trenutni niz"
 #. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
 msgctxt "Suffix label indicating a tab is the currently active browser tab"
 msgid "Current Tab"
-msgstr ""
+msgstr "Trenutni zavihek"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
@@ -5887,8 +5878,7 @@ msgstr "Dosežena je dnevna omejitev"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Dosežena je dnevna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
+msgstr "Dosežena je dnevna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -6087,7 +6077,7 @@ msgstr "Izbriši klepete, starejše od 30 dni"
 #. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
 msgctxt "Button text in the modal for deleting all recent chats"
 msgid "Delete Chats and Shared Links"
-msgstr ""
+msgstr "Izbriši klepete in povezave do deljenih klepetov"
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6512,7 +6502,7 @@ msgstr "Zavrni promocijo"
 #. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the close button on the survey banner"
 msgid "Dismiss survey"
-msgstr ""
+msgstr "Opustite anketo"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6904,8 +6894,7 @@ msgstr "Spustite svoje fotografije ali datoteke PDF"
 # smartling.placeholder_format=C
 #. A title explaining what Duck Player (DDG's feature to watch youtube videos more privately) does
 msgid "Duck Player lets you watch YouTube without targeted ads"
-msgstr ""
-"Predvajalnik Duck Player vam omogoča gledanje YouTuba brez ciljanih oglasov"
+msgstr "Predvajalnik Duck Player vam omogoča gledanje YouTuba brez ciljanih oglasov"
 
 # smartling.placeholder_format=C
 #. This is the DDG version of "Google it", meaning "search it".
@@ -6951,8 +6940,7 @@ msgstr "pogoji storitve Duck.ai"
 #. The HTML <title> for Duck.ai.
 msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
-msgstr ""
-"Duck.ai by DuckDuckGo. Zasebni klepet z umetno inteligenco. Brezplačno."
+msgstr "Duck.ai by DuckDuckGo. Zasebni klepet z umetno inteligenco. Brezplačno."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -6998,8 +6986,7 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"Duck.ai najbolje deluje v našem zasebnem in brezplačnem brskalniku DuckDuckGo"
+msgstr "Duck.ai najbolje deluje v našem zasebnem in brezplačnem brskalniku DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -7135,8 +7122,7 @@ msgstr "Duck.ai je nadgrajen!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.ai najbolje deluje v naši zasebni in brezplačni aplikaciji DuckDuckGo"
+msgstr "Duck.ai najbolje deluje v naši zasebni in brezplačni aplikaciji DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7313,8 +7299,7 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr ""
-"DuckDuckGo AI Chat trenutno ni na voljo. Osvežite stran in poskusite znova."
+msgstr "DuckDuckGo AI Chat trenutno ni na voljo. Osvežite stran in poskusite znova."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7692,7 +7677,7 @@ msgstr "Uredi poziv"
 #. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the message-editing text area"
 msgid "Edit message"
-msgstr ""
+msgstr "Uredi sporočilo"
 
 # smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
@@ -7711,8 +7696,7 @@ msgstr "Urejanje slike ..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr ""
-"Z urejanjem sporočila boste odstranili spodnji odgovor in ustvarili novega."
+msgstr "Z urejanjem sporočila boste odstranili spodnji odgovor in ustvarili novega."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7773,8 +7757,7 @@ msgstr "Omogoči funkcije UI"
 #. Text explaining how to enable the cloud save feature.
 msgctxt "cloudsave"
 msgid "Enable Cloud Save by entering your existing passphrase."
-msgstr ""
-"Omogočite storitev Cloud Save z vnosom svoje obstoječe varnostne fraze."
+msgstr "Omogočite storitev Cloud Save z vnosom svoje obstoječe varnostne fraze."
 
 # smartling.placeholder_format=C
 #. Primary button text in the dictation privacy consent modal to enable dictation.
@@ -7920,7 +7903,7 @@ msgstr "Šifrirani model"
 #. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
 msgctxt "Share modal info bullet about encryption"
 msgid "Encrypted so DuckDuckGo can't read your chat."
-msgstr ""
+msgstr "Šifrirano, tako da DuckDuckGo ne more prebrati vašega klepeta."
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -7992,8 +7975,7 @@ msgstr "Prepričajte se, da so »Lokacijske storitve« %1$somogočene%2$s."
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr ""
-"Prepričajte se, da je možnost »Lokacija« nastavljena na %1$sdovoli%2$s."
+msgstr "Prepričajte se, da je možnost »Lokacija« nastavljena na %1$sdovoli%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -8005,8 +7987,7 @@ msgstr "Preverite, ali je možnost »Lokacija« nastavljena na %1$sdovoli%2$s."
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure Location is set to %sAllow%s"
-msgstr ""
-"Prepričajte se, da je možnost »Lokacija« nastavljena na %1$sDovoli%2$s."
+msgstr "Prepričajte se, da je možnost »Lokacija« nastavljena na %1$sDovoli%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -8030,8 +8011,7 @@ msgstr "Prepričajte se, da ima brskalnik omogočen %1$sdostop do lokacije%2$s."
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s."
-msgstr ""
-"Preverite, ali ima vaš brskalnik dovoljenje za %1$sdostop do lokacije%2$s."
+msgstr "Preverite, ali ima vaš brskalnik dovoljenje za %1$sdostop do lokacije%2$s."
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
@@ -8137,8 +8117,7 @@ msgstr "Ekvatorialna Gvineja"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"V trenutku izbrišite podatke o brskanju z našim gumbom %1$sFire Button%2$s"
+msgstr "V trenutku izbrišite podatke o brskanju z našim gumbom %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -8763,7 +8742,7 @@ msgstr "Nadaljnje vprašanje"
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
-msgstr ""
+msgstr "Nadaljnja vprašanja ostanejo zasebna."
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8869,8 +8848,7 @@ msgstr "Brezplačni in zasebni klepeti, ki jih anonimiziramo"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Brezplačni in zasebni klepeti, ki jih anonimiziramo. Račun ni potreben."
+msgstr "Brezplačni in zasebni klepeti, ki jih anonimiziramo. Račun ni potreben."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9286,7 +9264,7 @@ msgstr ""
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
 msgctxt "Tooltip on the header logo for sunglasses searches"
 msgid "Get DuckDuckGo sunglasses and other gear."
-msgstr ""
+msgstr "Kupite sončna očala DuckDuckGo in drugo opremo."
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9593,8 +9571,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"V drugem brskalniku ali aplikaciji DuckDuckGo pojdite v %1$snastavitve Duck."
-"ai%2$s in nato v %3$sKlepeti › Sync & Backup › Sinhroniziraj z drugo "
+"V drugem brskalniku ali aplikaciji DuckDuckGo pojdite v %1$snastavitve "
+"Duck.ai%2$s in nato v %3$sKlepeti › Sync & Backup › Sinhroniziraj z drugo "
 "napravo%4$s ter optično preberite to kodo:"
 
 # smartling.placeholder_format=C
@@ -10528,7 +10506,7 @@ msgstr "Kako deluje"
 #. Headline in chat history about modals for the temporary encrypted server storage explanation.
 msgctxt "Chat history about modal list item headline"
 msgid "How it works"
-msgstr ""
+msgstr "Kako deluje"
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -10554,8 +10532,7 @@ msgstr ""
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr ""
-"Delež vaših dnevnih in tedenskih omejitev, ki ste jih doslej uporabili."
+msgstr "Delež vaših dnevnih in tedenskih omejitev, ki ste jih doslej uporabili."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -11002,8 +10979,7 @@ msgstr "V zgornjem meniju izberite %1$sOrodja%2$s > %3$sNastavitve%4$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
-msgstr ""
-"V pojavnem oknu potrdite %1$sTo naj bo moj privzeti ponudnik iskanja%2$s"
+msgstr "V pojavnem oknu potrdite %1$sTo naj bo moj privzeti ponudnik iskanja%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -11329,8 +11305,7 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr ""
-"Je ta kraj vreden obiska? Povzemi njegov ugled na podlagi ocen in mnenj."
+msgstr "Je ta kraj vreden obiska? Povzemi njegov ugled na podlagi ocen in mnenj."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -11380,8 +11355,7 @@ msgstr "Je hiter, brezplačen in zagotavlja še večjo spletno zaščito."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Dovolim, da me (zelo redko) vprašate o mojih izkušnjah z uporabo DuckDuckGo"
+msgstr "Dovolim, da me (zelo redko) vprašate o mojih izkušnjah z uporabo DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11899,8 +11873,7 @@ msgstr "Omogoča anonimno iskanje z DuckDuckGo"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr ""
-"Omogoča preklapljanje med pošiljanjem iskalnih poizvedb in pozivov v Duck.ai"
+msgstr "Omogoča preklapljanje med pošiljanjem iskalnih poizvedb in pozivov v Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11982,7 +11955,7 @@ msgstr "Povezava poteče čez 7 dni."
 #. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days. People can save a chat copy."
-msgstr ""
+msgstr "Povezava poteče čez 7 dni. Ljudje lahko shranijo kopijo klepeta."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -12891,8 +12864,7 @@ msgstr "Dosežena je mesečna omejitev"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Dosežena je mesečna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
+msgstr "Dosežena je mesečna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -13066,8 +13038,7 @@ msgstr "Več statističnih podatkov o medaljah je na voljo na %1$s"
 msgctxt ""
 "Note on the Olympics module as to where they can find more information"
 msgid "More medal stats on %solympics.com%s"
-msgstr ""
-"Več statističnih podatkov o medaljah je na voljo na %1$solympics.com%2$s"
+msgstr "Več statističnih podatkov o medaljah je na voljo na %1$solympics.com%2$s"
 
 # smartling.placeholder_format=C
 #. A link to more information on a topic. The placeholder is the name of a website. For example 'More on Wikipedia'.
@@ -14109,7 +14080,7 @@ msgstr "V redu, razumem!"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "OPTIONAL"
-msgstr ""
+msgstr "IZBIRNO"
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -14435,8 +14406,7 @@ msgstr "Odpri spletno mesto %1$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr ""
-"Odprite %1$sLokacija%2$s in se prepričajte, da je lokacija %3$somogočena%4$s."
+msgstr "Odprite %1$sLokacija%2$s in se prepričajte, da je lokacija %3$somogočena%4$s."
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -15411,8 +15381,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr ""
-"Rešite naslednji izziv in s tem potrdite, da je ta poziv ustvaril človek."
+msgstr "Rešite naslednji izziv in s tem potrdite, da je ta poziv ustvaril človek."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -15420,8 +15389,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr ""
-"Rešite naslednji izziv in s tem potrdite, da je to iskanje opravil človek."
+msgstr "Rešite naslednji izziv in s tem potrdite, da je to iskanje opravil človek."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -16241,7 +16209,7 @@ msgstr "Zaščiteno"
 #. Headline in sync-enabled chat history about modals explaining encrypted server storage.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Protected with end-to-end encryption"
-msgstr ""
+msgstr "Zaščiteno s celovitim šifriranjem"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -16380,7 +16348,7 @@ msgstr "Uvrstitve"
 #. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
 msgctxt "star rating on a product"
 msgid "Rated %s out of %s"
-msgstr ""
+msgstr "Ocenjeno s/z %1$s od %2$s"
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -16487,8 +16455,7 @@ msgstr ""
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr ""
-"Razmišljanje je temeljitejše, vendar porabi omejitve 2–5-krat hitreje. %1$s"
+msgstr "Razmišljanje je temeljitejše, vendar porabi omejitve 2–5-krat hitreje. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -16523,8 +16490,7 @@ msgstr "Nedavni zavihki"
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
-msgstr ""
-"Nastavitve shranjevanja nedavnih klepetov je mogoče prilagoditi v %1$s."
+msgstr "Nastavitve shranjevanja nedavnih klepetov je mogoče prilagoditi v %1$s."
 
 # smartling.placeholder_format=C
 #. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
@@ -16857,8 +16823,7 @@ msgstr "Zapomni si mojo izbiro"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Zapomni si mojo odločitev (to lahko spremenite v %1$s%2$s%3$sNastavitvah%4$s)"
+msgstr "Zapomni si mojo odločitev (to lahko spremenite v %1$s%2$s%3$sNastavitvah%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -17245,8 +17210,7 @@ msgstr "Rezultati ne vključujejo informacij z blokiranih spletnih mest."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr ""
-"Rezultati ne vključujejo blokiranih strani, ki jih lahko upravljate v: %1$s."
+msgstr "Rezultati ne vključujejo blokiranih strani, ki jih lahko upravljate v: %1$s."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -17609,8 +17573,7 @@ msgstr "Shrani do 30 vaših najnovejših klepetov lokalno v vaši napravi."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Shranite svoje klepete Duck.ai med napravami z uporabo celovitega šifriranja."
+msgstr "Shranite svoje klepete Duck.ai med napravami z uporabo celovitega šifriranja."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17622,7 +17585,7 @@ msgstr "Shrani vaše klepete v vseh vaših napravah."
 #. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
 msgctxt "Chat history about modal list item headline"
 msgid "Save your chats on this device"
-msgstr ""
+msgstr "Shrani klepete v tej napravi"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
@@ -17652,8 +17615,7 @@ msgstr "Spoznajte Duck.ai"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr ""
-"Spoznajte Duck.ai, brezplačen in zaseben klepet z UI ponudnika DuckDuckGo."
+msgstr "Spoznajte Duck.ai, brezplačen in zaseben klepet z UI ponudnika DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17763,8 +17725,7 @@ msgstr "Pomaknite navzdol in kliknite %1$sPrikaži napredne nastavitve%2$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr ""
-"Pomaknite stran navzdol in kliknite %1$sPrikaži napredne nastavitve%2$s."
+msgstr "Pomaknite stran navzdol in kliknite %1$sPrikaži napredne nastavitve%2$s."
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -17836,7 +17797,7 @@ msgctxt ""
 "Placeholder and accessibility label for the search input in the tab picker "
 "dialog"
 msgid "Search"
-msgstr ""
+msgstr "Iskanje"
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18369,8 +18330,8 @@ msgstr "V meniju Safari izberite %1$s»Nastavitev za to spletno mesto ...«%2$s.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Izberite %1$sPo meri%2$s in v vnosno polje vnesite %3$shttps://duckduckgo."
-"com%4$s"
+"Izberite %1$sPo meri%2$s in v vnosno polje vnesite "
+"%3$shttps://duckduckgo.com%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -19017,7 +18978,7 @@ msgstr "Nakup"
 #. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
 msgctxt "Button in the merchandise logo modal (mobile)"
 msgid "Shop Now"
-msgstr ""
+msgstr "Nakupuj zdaj"
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -19125,8 +19086,7 @@ msgstr "Pokaži DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"Pogosteje prikažite DuckAssist. (Lahko ga tudi popolnoma %1$sizklopite%2$s.)"
+msgstr "Pogosteje prikažite DuckAssist. (Lahko ga tudi popolnoma %1$sizklopite%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -19309,8 +19269,7 @@ msgstr "Prikaži stransko vrstico"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
-"Prikažite nasvete po korakih, da lahko kar najbolje izkoristite Duck.ai."
+msgstr "Prikažite nasvete po korakih, da lahko kar najbolje izkoristite Duck.ai."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -19412,8 +19371,7 @@ msgstr "Prikaže občasne opomnike, da dodate DuckDuckGo v svoje naprave"
 msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
-msgstr ""
-"Prikaže občasne opomnike, da se prijavite na glasila o zasebnosti DuckDuckGo"
+msgstr "Prikaže občasne opomnike, da se prijavite na glasila o zasebnosti DuckDuckGo"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19449,8 +19407,7 @@ msgstr "Prikaže pozdravno sporočilo na vrhu strani z rezultati iskanja"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Prikaže pozdravno sporočilo uporabnikom v meniju z nastavitvami za EU Android"
+msgstr "Prikaže pozdravno sporočilo uporabnikom v meniju z nastavitvami za EU Android"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -19790,8 +19747,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Žal nismo mogli poslati vaših povratnih informacij. Poskusite znova pozneje."
+msgstr "Žal nismo mogli poslati vaših povratnih informacij. Poskusite znova pozneje."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -20102,8 +20058,7 @@ msgstr "Ustavi ustvarjanje"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr ""
-"Onemogočite skrite sledilnike, ki se skrivajo v drugih spletnih mestih."
+msgstr "Onemogočite skrite sledilnike, ki se skrivajo v drugih spletnih mestih."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -20607,8 +20562,7 @@ msgstr "Preklopljeno na model %1$s"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr ""
-"S preklopom bo vaš klepet poslan modelu, ki nima nobene vidnosti ponudnika."
+msgstr "S preklopom bo vaš klepet poslan modelu, ki nima nobene vidnosti ponudnika."
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -20673,6 +20627,8 @@ msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
 msgstr ""
+"Sync & Backup shrani več vaših klepetov in jih sinhronizira v vseh vaših "
+"napravah."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20792,7 +20748,7 @@ msgstr "Sinhronizira vaše klepete v vseh vaših napravah."
 #. Headline in sync-enabled chat history about modals explaining cross-device sync.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Sync your chats across all your devices"
-msgstr ""
+msgstr "Sinhronizirajte klepete v vseh svojih napravah"
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -20912,8 +20868,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
-"Sodelujte v tej anonimni anketi in nam sporočite, kako lahko izboljšamo Duck."
-"ai."
+"Sodelujte v tej anonimni anketi in nam sporočite, kako lahko izboljšamo "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -21184,8 +21140,7 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr ""
-"Ponudnik modela izbriše vse podatke, povezane s tem klepetom, v 30 dneh."
+msgstr "Ponudnik modela izbriše vse podatke, povezane s tem klepetom, v 30 dneh."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -21383,12 +21338,14 @@ msgid ""
 "This chat and its generated images become public when you create and copy "
 "the link."
 msgstr ""
+"Ta klepet in slike, ustvarjene v njem, postanejo javni, ko ustvarite in "
+"kopirate povezavo."
 
 # smartling.placeholder_format=C
 #. Explains that creating and copying a share link makes the selected chat content public.
 msgctxt "Share modal info bullet about public access"
 msgid "This chat becomes public when you create and copy the link."
-msgstr ""
+msgstr "Ta klepet postane javen, ko ustvarite in kopirate povezavo."
 
 # smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
@@ -21669,8 +21626,7 @@ msgstr ""
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr ""
-"Tega deljenega klepeta ni bilo mogoče odpreti. Povezava je morda nepopolna."
+msgstr "Tega deljenega klepeta ni bilo mogoče odpreti. Povezava je morda nepopolna."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
@@ -21824,8 +21780,7 @@ msgstr "Nasveti"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr ""
-"Utrujeni od tega, da vam sledijo na spletu? %1$sMi vam lahko pomagamo.%2$s"
+msgstr "Utrujeni od tega, da vam sledijo na spletu? %1$sMi vam lahko pomagamo.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -21933,6 +21888,8 @@ msgstr "Danes"
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
+"Preklopite na zasebni klepet z umetno inteligenco ali %1$sonemogočite v "
+"nastavitvah%2$s."
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -22162,8 +22119,7 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"Prevedi ta angleški stavek v francoščino: »Kako pridem do najbližjega kina?«"
+msgstr "Prevedi ta angleški stavek v francoščino: »Kako pridem do najbližjega kina?«"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -22171,8 +22127,7 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"Prevedi ta slovenski stavek v angleščino: »Kako pridem do najbližjega kina?«"
+msgstr "Prevedi ta slovenski stavek v angleščino: »Kako pridem do najbližjega kina?«"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -22404,8 +22359,7 @@ msgstr "Poskusi dodati mesto, državo ali poštno številko"
 #. Message to display during errors for users who have AI enabled to encourage them to use that feature while the site is having issues. Example: 'Try asking Duck.ai, our private AI chat service:'
 msgctxt "noresults"
 msgid "Try asking %s, our private AI chat service:"
-msgstr ""
-"Poskusite vprašati %1$s, našo zasebno storitev klepeta z umetno inteligenco:"
+msgstr "Poskusite vprašati %1$s, našo zasebno storitev klepeta z umetno inteligenco:"
 
 # smartling.placeholder_format=C
 #. A message suggesting that the user clears their filters and tries their search again when they get no results
@@ -22437,8 +22391,7 @@ msgstr "Preizkusite omogočiti anonimno lokacijo za natančnejše rezultate."
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Poskusite eksperimentirati z vsakim modelom – dobili boste različne odzive."
+msgstr "Poskusite eksperimentirati z vsakim modelom – dobili boste različne odzive."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -22624,8 +22577,7 @@ msgstr "Preizkusite nedavno dodana odprtokodna modela Llama 3.1 in Mixtral"
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
-msgstr ""
-"Če želite začeti, poskusite uporabiti te pozive ali spodaj vnesite svoj poziv"
+msgstr "Če želite začeti, poskusite uporabiti te pozive ali spodaj vnesite svoj poziv"
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -22730,8 +22682,7 @@ msgstr "Izklopi Sync & Backup"
 #. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
 msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Turn Off Sync & Backup and Delete Server Data?"
-msgstr ""
-"Želite izklopiti funkcijo Sync & Backup in izbrisati podatke iz strežnika?"
+msgstr "Želite izklopiti funkcijo Sync & Backup in izbrisati podatke iz strežnika?"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22802,8 +22753,7 @@ msgstr "Za natančnejše rezultate vklopite %1$sNatančno lokacijo%2$s."
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr ""
-"Vklopite predvajalnik Duck Player za gledanje YouTuba brez ciljanih oglasov"
+msgstr "Vklopite predvajalnik Duck Player za gledanje YouTuba brez ciljanih oglasov"
 
 # smartling.placeholder_format=C
 #. Button that enables the Search/Duck.ai toggle.
@@ -22972,8 +22922,7 @@ msgstr "Povratnih informacij ni mogoče poslati"
 #. Message shown to the user when the voice chat failed to establish a connection, and they should try again later.
 msgctxt "voice chat"
 msgid "Unable to connect to voice chat, please try again later."
-msgstr ""
-"Povezave z glasovnim klepetom ni mogoče vzpostaviti. Poskusi znova pozneje."
+msgstr "Povezave z glasovnim klepetom ni mogoče vzpostaviti. Poskusi znova pozneje."
 
 # smartling.placeholder_format=C
 #. Message shown to the user when there was an issue connecting to their microphone.
@@ -23020,14 +22969,12 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"Za nastavitev %1$sOdpri z%2$s izberite %3$sDoločena stran ali strani%4$s"
+msgstr "Za nastavitev %1$sOdpri z%2$s izberite %3$sDoločena stran ali strani%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"Za nastavitev %1$sZAGON > Domača stran%2$s vnesite: https://duckduckgo.com"
+msgstr "Za nastavitev %1$sZAGON > Domača stran%2$s vnesite: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23174,8 +23121,7 @@ msgstr "Odklenite napredne modele umetne inteligence z naročnino %1$s"
 #. Tooltip text shown when the user hovers over the free badge telling the user that they can unlock advanced AI (Artificial Intelligence) models with a DuckDuckGo subscription.
 msgctxt "Tooltip for the free badge"
 msgid "Unlock advanced AI models with a DuckDuckGo subscription"
-msgstr ""
-"Odklenite napredne modele umetne inteligence z naročnino na DuckDuckGo."
+msgstr "Odklenite napredne modele umetne inteligence z naročnino na DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
@@ -23546,8 +23492,7 @@ msgstr "Uporabite DuckDuckGo Private Search"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"Uporabite zasebno iskanje DuckDuckGo na svojem iPadu, iPhonu ali Androidu!"
+msgstr "Uporabite zasebno iskanje DuckDuckGo na svojem iPadu, iPhonu ali Androidu!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -23770,6 +23715,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Yelp's ad network."
 msgstr ""
+"DuckDuckGo ščiti vašo zasebnost pri ogledu oglasov. S kliki oglasov upravlja "
+"oglaševalsko omrežje družbe Yelp."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -24136,8 +24083,7 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"Priloženih datotek ne moremo prebrati, ker je vsaj ena od njih šifrirana."
+msgstr "Priloženih datotek ne moremo prebrati, ker je vsaj ena od njih šifrirana."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24338,8 +24284,7 @@ msgstr ""
 #. Message that appears after submitting a feedback form.
 msgctxt "feedback form"
 msgid "We use feedback like this to improve DuckDuckGo."
-msgstr ""
-"Uporabljamo takšne povratne informacije kot so te, za izboljšanje DuckDuckGo."
+msgstr "Uporabljamo takšne povratne informacije kot so te, za izboljšanje DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Placeholder can be Apple Maps, TripAdvisor, and/or Foursquare
@@ -24403,8 +24348,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr ""
-"Žal nam je za to nevšečnost. Prizadevamo si, da bi bila vaša izkušnja boljša."
+msgstr "Žal nam je za to nevšečnost. Prizadevamo si, da bi bila vaša izkušnja boljša."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -24514,8 +24458,7 @@ msgstr "Dosežena je tedenska omejitev uporabe"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Dosežena je tedenska omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
+msgstr "Dosežena je tedenska omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -24660,8 +24603,7 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr ""
-"Katere dejavnike je treba upoštevati pri nakupu računalniškega zaslona?"
+msgstr "Katere dejavnike je treba upoštevati pri nakupu računalniškega zaslona?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
@@ -25070,8 +25012,7 @@ msgstr "Kje gledati: <strong>%1$s</strong>"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr ""
-"Pri nastavitvi Domača Stran kliknite %1$sNastavi na trenutno stran%2$s."
+msgstr "Pri nastavitvi Domača Stran kliknite %1$sNastavi na trenutno stran%2$s."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -25259,6 +25200,8 @@ msgid ""
 "With chat history on, up to %s of your most recent chats will be saved on "
 "this device."
 msgstr ""
+"Če je zgodovina klepetov vklopljena, bo v tej napravi shranjenih do toliko "
+"vaših najnovejših klepetov: %1$s."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline in the About Chat History modal.
@@ -25266,6 +25209,8 @@ msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, your most recent chats will be saved on this device."
 msgstr ""
+"Če je zgodovina klepetov vklopljena, bodo vaši najnovejši klepeti shranjeni "
+"v tej napravi."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -25846,8 +25791,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr ""
-"Tega sporočila ne boste več videli, razen če počistite podatke brskalnika."
+msgstr "Tega sporočila ne boste več videli, razen če počistite podatke brskalnika."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -25951,8 +25895,7 @@ msgstr "Dosegli ste najdaljše trajanje glasovnega klepeta za eno sejo."
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"Dosegli ste omejitev glasovnega klepeta za danes. Poskusite znova jutri."
+msgstr "Dosegli ste omejitev glasovnega klepeta za danes. Poskusite znova jutri."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -26432,15 +26375,13 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr ""
-"Dosegli ste največje število sporočil za en dan. Nadaljujte ta klepet jutri."
+msgstr "Dosegli ste največje število sporočil za en dan. Nadaljujte ta klepet jutri."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr ""
-"Dosegli ste trenutno omejitev glasovnega klepeta. Poskusite znova pozneje."
+msgstr "Dosegli ste trenutno omejitev glasovnega klepeta. Poskusite znova pozneje."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -26523,8 +26464,7 @@ msgstr "od %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"omogoča DuckDuckGo – spletna zaščita, ki ji vsak dan zaupajo milijoni ljudi."
+msgstr "omogoča DuckDuckGo – spletna zaščita, ki ji vsak dan zaupajo milijoni ljudi."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"
@@ -26669,7 +26609,7 @@ msgstr "min"
 #. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the chat options menu button"
 msgid "menu"
-msgstr ""
+msgstr "meni"
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.
@@ -26743,8 +26683,7 @@ msgstr "uradno spletno stran"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr ""
-"ali pa vpišite kodo želene barve, npr. %1$s (%2$s je kodiran znak %3$s)."
+msgstr "ali pa vpišite kodo želene barve, npr. %1$s (%2$s je kodiran znak %3$s)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/sq_AL/LC_MESSAGES/duckduckgo.po
+++ b/locales/sq_AL/LC_MESSAGES/duckduckgo.po
@@ -981,6 +981,11 @@ msgstr "Rreth Nesh"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1084,6 +1089,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "Reklama është e dyshimtë"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Shtoni DuckDuckGo-në"
@@ -1106,6 +1123,24 @@ msgstr "Shtojeni DuckDuckGo-në si motor kërkimesh"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Shtojeni DuckDuckGo-në te %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1144,6 +1179,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1215,6 +1264,11 @@ msgstr "Shtesa"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1461,6 +1515,11 @@ msgstr "Krejt ngjyrat"
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2831,6 +2890,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3233,9 +3299,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3251,6 +3327,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4551,6 +4634,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4835,6 +4923,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5173,6 +5266,11 @@ msgstr "Hidhe tej përgjithmonë"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6088,6 +6186,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6269,6 +6372,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6950,6 +7058,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7369,6 +7482,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8361,6 +8479,11 @@ msgid "How is it anonymous?"
 msgstr "Si është anonim?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9550,6 +9673,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11290,6 +11418,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "OK, e mora vesh!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -13016,6 +13149,11 @@ msgstr "Mbroni të dhënat tuaja në çdo pajisje."
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -13123,6 +13261,11 @@ msgstr "Shi"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Renditje"
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
 msgid "Rated %s/5"
@@ -14117,6 +14260,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14281,6 +14429,13 @@ msgstr "Kërko"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15231,6 +15386,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16580,6 +16740,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16660,6 +16827,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -17132,6 +17304,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17539,6 +17725,11 @@ msgstr "Sot"
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -19023,6 +19214,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -20203,6 +20401,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21310,6 +21521,11 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "m"
 msgstr "m"
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.
 msgctxt "Aria label for the menu button"

--- a/locales/sr_RS/LC_MESSAGES/duckduckgo.po
+++ b/locales/sr_RS/LC_MESSAGES/duckduckgo.po
@@ -982,6 +982,11 @@ msgstr "О нама"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1085,6 +1090,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "Оглас је сумњив"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Додај DuckDuckGo"
@@ -1106,6 +1123,24 @@ msgstr "Додај DuckDuckGo као Ваш интернет претражив�
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Додај DuckDuckGo за %s "
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1144,6 +1179,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1215,6 +1264,11 @@ msgstr "Додаци"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1461,6 +1515,11 @@ msgstr "Све боје"
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2826,6 +2885,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3227,9 +3293,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3245,6 +3321,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4516,6 +4599,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4800,6 +4888,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5138,6 +5231,11 @@ msgstr "Одбаци заувек"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6045,6 +6143,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6226,6 +6329,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6897,6 +7005,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7315,6 +7428,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8306,6 +8424,11 @@ msgid "How is it anonymous?"
 msgstr "Како је то анонимно?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9482,6 +9605,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11223,6 +11351,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "ОК, разумео сам!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12938,6 +13071,11 @@ msgstr "Заштитите ваше податке на сваком уређа�
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -13044,6 +13182,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -14032,6 +14175,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14191,6 +14339,13 @@ msgstr "Претрага"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15119,6 +15274,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16463,6 +16623,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16543,6 +16710,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -17011,6 +17183,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17419,6 +17605,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18886,6 +19077,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -20052,6 +20250,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21153,6 +21364,11 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "m"
 msgstr "мин"
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.
 msgctxt "Aria label for the menu button"

--- a/locales/sv_SE/LC_MESSAGES/duckduckgo.po
+++ b/locales/sv_SE/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: sv_SE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -22,8 +22,7 @@ msgstr "!Bang-sökgenvägar"
 msgctxt ""
 "Body copy for the Remove Device confirmation modal; %s is the device name"
 msgid "\"%s\" will no longer be able to access your synced data."
-msgstr ""
-"”%1$s” kommer inte längre att få tillgång till dina synkroniserade data."
+msgstr "”%1$s” kommer inte längre att få tillgång till dina synkroniserade data."
 
 # smartling.placeholder_format=C
 #. Used to specify the rank of a team/player in a specific ranking in short form. This should be interpreted as 'Ranked number <rankNumber> in the <rankingName> ranking. Here you only need to translate the # symbol for ranked number. If your language doesn't provide a single-letter convention, please leave #.
@@ -379,8 +378,7 @@ msgstr "%1$s använt"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
-"%1$s förbrukar gränserna upp till 2–5 gånger snabbare än basmodellerna %2$s"
+msgstr "%1$s förbrukar gränserna upp till 2–5 gånger snabbare än basmodellerna %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -444,8 +442,7 @@ msgstr "%1$s ord"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr ""
-"%1$sKlicka på %2$sLägg till%3$sMarkera %4$sTillåt%5$s och sedan på %6$sOK%7$s"
+msgstr "%1$sKlicka på %2$sLägg till%3$sMarkera %4$sTillåt%5$s och sedan på %6$sOK%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -1215,7 +1212,7 @@ msgstr "Om våra annonser"
 #. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
 msgctxt "Modal header for chat history with sync information"
 msgid "About Chat History with Sync & Backup"
-msgstr ""
+msgstr "Om chatthistorik med Sync & Backup"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
@@ -1350,7 +1347,7 @@ msgstr "Annonsen är misstänkt"
 #. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
 msgctxt "Button to open menu for attaching images or page context to AI chat"
 msgid "Add"
-msgstr ""
+msgstr "Lägg till"
 
 # smartling.placeholder_format=C
 #. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
@@ -1358,7 +1355,7 @@ msgctxt ""
 "Primary button that attaches the tabs the user checked in the tab picker "
 "dialog"
 msgid "Add"
-msgstr ""
+msgstr "Lägg till"
 
 # smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
@@ -1373,8 +1370,7 @@ msgstr "Installera tillägget DuckDuckGo"
 # smartling.placeholder_format=C
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
-msgstr ""
-"Ladda ner DuckDuckGo Privacy Essentials utan kostnad för din webbläsare:"
+msgstr "Ladda ner DuckDuckGo Privacy Essentials utan kostnad för din webbläsare:"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1392,13 +1388,13 @@ msgstr "Lägg till DuckDuckGo i %1$s"
 msgctxt ""
 "Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
 msgid "Add File"
-msgstr ""
+msgstr "Lägg till fil"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
 msgid "Add Image"
-msgstr ""
+msgstr "Lägg till bild"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
@@ -1406,7 +1402,7 @@ msgctxt ""
 "Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
 "item)"
 msgid "Add Image or File"
-msgstr ""
+msgstr "Lägg till bild eller fil"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1459,7 +1455,7 @@ msgctxt ""
 "Open the tab picker to attach browser tab content to the AI chat message "
 "(attach dropdown menu item)"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Lägg till flikar"
 
 # smartling.placeholder_format=C
 #. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
@@ -1467,7 +1463,7 @@ msgctxt ""
 "Title and accessible name of the tab-picker dialog opened from the attach "
 "dropdown menu"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Lägg till flikar"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1558,7 +1554,7 @@ msgstr "Lägger till de sista detaljerna"
 #. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
 msgctxt "Aria label for the additional instructions textarea"
 msgid "Additional instructions"
-msgstr ""
+msgstr "Ytterligare instruktioner"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1698,8 +1694,7 @@ msgstr "Afrikaans"
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid "After it downloads and opens, click %sInstall%s"
-msgstr ""
-"Efter att ha laddat ner och öppnat den klickar du på %1$sInstallera%2$s"
+msgstr "Efter att ha laddat ner och öppnat den klickar du på %1$sInstallera%2$s"
 
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
@@ -1868,7 +1863,7 @@ msgstr "Allt klart!"
 #. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the read-only textarea listing all AI instructions"
 msgid "All instructions"
-msgstr ""
+msgstr "Alla instruktioner"
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -1962,8 +1957,7 @@ msgstr "Vill du tillåta anonym filgranskning för den här chatten?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Tillåt annonser som respekterar integritet på DuckDuckGo Private Search"
+msgstr "Tillåt annonser som respekterar integritet på DuckDuckGo Private Search"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2296,22 +2290,19 @@ msgstr "Är du fortfarande där?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"Är du säker på att du vill rensa alla dina chattar? Detta kan inte ångras."
+msgstr "Är du säker på att du vill rensa alla dina chattar? Detta kan inte ångras."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr ""
-"Är du säker på att du vill rensa den här konversationen och starta en ny?"
+msgstr "Är du säker på att du vill rensa den här konversationen och starta en ny?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
 msgctxt "Body text for delete chat confirmation modal"
 msgid "Are you sure you want to delete this chat? This cannot be undone."
-msgstr ""
-"Är du säker på att du vill ta bort den här chatten? Detta kan inte ångras."
+msgstr "Är du säker på att du vill ta bort den här chatten? Detta kan inte ångras."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable chat history, with a warning that it will also delete currently saved chats including pinned chats.
@@ -2530,11 +2521,11 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist är en valbar funktion i våra sökresultat som anonymt kan generera AI-"
-"assisterade svar på sökfrågor. För att göra detta skannar den webben efter "
-"relevant innehåll och använder sedan AI-driven naturlig språkteknologi för "
-"att generera ett kort svar baserat på relevant information som hittats. Det "
-"är viktigt att komma ihåg att svaren genereras automatiskt från citerade "
+"Assist är en valbar funktion i våra sökresultat som anonymt kan generera "
+"AI-assisterade svar på sökfrågor. För att göra detta skannar den webben "
+"efter relevant innehåll och använder sedan AI-driven naturlig språkteknologi "
+"för att generera ett kort svar baserat på relevant information som hittats. "
+"Det är viktigt att komma ihåg att svaren genereras automatiskt från citerade "
 "källor och baseras på %1$sgenomsökning av webben%2$s."
 
 # smartling.placeholder_format=C
@@ -2636,8 +2627,7 @@ msgstr "Ljud lagras inte av oss eller av OpenAI efter att chatten avslutats."
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"Ljud lagras inte av oss eller av OpenAI efter att chatten har transkriberats."
+msgstr "Ljud lagras inte av oss eller av OpenAI efter att chatten har transkriberats."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2678,8 +2668,7 @@ msgstr "Autosvar"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr ""
-"Automatiskt genererad baserat på angivna källor. Kan innehålla felaktigheter."
+msgstr "Automatiskt genererad baserat på angivna källor. Kan innehålla felaktigheter."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -3327,8 +3316,8 @@ msgid ""
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
 "Surfa som vanligt medan vi ger dig integritetsskydd. Vi har förenat vår "
-"sökmotor, spårningsblockerare och tvingande kryptering i ett %1$s%2$s-"
-"tillägg%3$s."
+"sökmotor, spårningsblockerare och tvingande kryptering i ett "
+"%1$s%2$s-tillägg%3$s."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3583,7 +3572,7 @@ msgctxt ""
 "Secondary button that dismisses the tab picker dialog without attaching "
 "anything"
 msgid "Cancel"
-msgstr ""
+msgstr "Avbryt"
 
 # smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
@@ -3970,12 +3959,12 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"Med chatten (via vår tjänst Duck.ai) kan du ha anonyma konversationer med AI-"
-"chattmodeller från tredje part med stöd för modeller från OpenAI, Anthropic "
-"och fler. Om du stänger av den här inställningen döljs chattknappar och "
-"länkar på DuckDuckGo Search. Du kan dock fortfarande komma åt chatten när "
-"den här inställningen är avstängd genom att gå till %1$shttps://duck.ai%2$s "
-"direkt."
+"Med chatten (via vår tjänst Duck.ai) kan du ha anonyma konversationer med "
+"AI-chattmodeller från tredje part med stöd för modeller från OpenAI, "
+"Anthropic och fler. Om du stänger av den här inställningen döljs "
+"chattknappar och länkar på DuckDuckGo Search. Du kan dock fortfarande komma "
+"åt chatten när den här inställningen är avstängd genom att gå till "
+"%1$shttps://duck.ai%2$s direkt."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4083,7 +4072,7 @@ msgstr "Chattsvaret är stötande"
 #. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
 msgctxt "Chat history about modal list item headline"
 msgid "Chat storage varies by browser"
-msgstr ""
+msgstr "Chattlagring varierar beroende på webbläsare"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4095,7 +4084,7 @@ msgstr "Chatta med %1$s"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Chat with popular AI models, anonymized by us."
-msgstr ""
+msgstr "Chatta med populära AI-modeller, anonymiserat av oss."
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4122,6 +4111,8 @@ msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
 msgstr ""
+"Chattar lagras säkert på DuckDuckGos server med heltäckande kryptering. "
+"Ingen annan än du kan se dina uppgifter, inte ens vi."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4235,8 +4226,7 @@ msgstr "Kontrollera stavningen"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr ""
-"Kolla DuckDuckGos subreddit för att se uppdateringar om det här avbrottet."
+msgstr "Kolla DuckDuckGos subreddit för att se uppdateringar om det här avbrottet."
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4669,8 +4659,7 @@ msgstr "Klicka på %1$sInställningar%2$s i rullgardinsmenyn."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Klicka på %1$sAnvänd aktuella sidor%2$s och sedan på %3$sKlicka på OK%4$s."
+msgstr "Klicka på %1$sAnvänd aktuella sidor%2$s och sedan på %3$sKlicka på OK%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -5725,7 +5714,7 @@ msgstr "Nuvarande streak"
 #. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
 msgctxt "Suffix label indicating a tab is the currently active browser tab"
 msgid "Current Tab"
-msgstr ""
+msgstr "Nuvarande flik"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
@@ -6081,7 +6070,7 @@ msgstr "Radera chattar som är äldre än 30 dagar"
 #. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
 msgctxt "Button text in the modal for deleting all recent chats"
 msgid "Delete Chats and Shared Links"
-msgstr ""
+msgstr "Radera chattar och delade länkar"
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6307,8 +6296,7 @@ msgstr "Diktering i Duck.ai"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr ""
-"Diktering anonymiseras av oss och används aldrig för att träna AI-modeller."
+msgstr "Diktering anonymiseras av oss och används aldrig för att träna AI-modeller."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6501,7 +6489,7 @@ msgstr "Stäng kampanj"
 #. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the close button on the survey banner"
 msgid "Dismiss survey"
-msgstr ""
+msgstr "Avvisa undersökning"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6614,8 +6602,7 @@ msgstr "Ser du inte DuckDuckGo i listan?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr ""
-"Hittar du inte filen? %1$s%2$s%3$sKlicka här för att ladda ner den igen%4$s"
+msgstr "Hittar du inte filen? %1$s%2$s%3$sKlicka här för att ladda ner den igen%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6663,8 +6650,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"Vill du inte ha AI? Besök %1$snoai.duckduckgo.com%2$s för att söka utan AI-"
-"funktioner och med AI-bilder bortfiltrerade. %3$sLäs mer%4$s"
+"Vill du inte ha AI? Besök %1$snoai.duckduckgo.com%2$s för att söka utan "
+"AI-funktioner och med AI-bilder bortfiltrerade. %3$sLäs mer%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -7051,8 +7038,8 @@ msgid ""
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 "Duck.ai låter dig chatta privat med populära AI-modeller. Att inaktivera det "
-"döljer Duck.ai-knappar och länkar, men du kan fortfarande besöka %1$sduck."
-"ai%2$s direkt."
+"döljer Duck.ai-knappar och länkar, men du kan fortfarande besöka "
+"%1$sduck.ai%2$s direkt."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7132,9 +7119,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, privat AI-chattbot, gratis AI-chatt, anonym AI-"
-"chatt, AI-chatt utan registrering, OpenAI, Anthropic, Llama, Mistral, AI-"
-"modeller med öppen källkod, integritetsfokuserad AI, AI-chatt utan konto"
+"Duck.ai, DuckDuckGo AI, privat AI-chattbot, gratis AI-chatt, anonym "
+"AI-chatt, AI-chatt utan registrering, OpenAI, Anthropic, Llama, Mistral, "
+"AI-modeller med öppen källkod, integritetsfokuserad AI, AI-chatt utan konto"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7303,8 +7290,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chat är inte tillgänglig för tillfället. Försök igen senare."
+msgstr "DuckDuckGo AI Chat är inte tillgänglig för tillfället. Försök igen senare."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7675,7 +7661,7 @@ msgstr "Redigera prompt"
 #. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the message-editing text area"
 msgid "Edit message"
-msgstr ""
+msgstr "Redigera meddelande"
 
 # smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
@@ -7903,7 +7889,7 @@ msgstr "Krypterad modell"
 #. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
 msgctxt "Share modal info bullet about encryption"
 msgid "Encrypted so DuckDuckGo can't read your chat."
-msgstr ""
+msgstr "Krypterad så att DuckDuckGo inte kan läsa din chatt."
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8221,8 +8207,7 @@ msgstr "Förklara det accepterade svaret med enkla ord."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr ""
-"Förklara de grundläggande begreppen för svarta hål för mig på gymnasienivå."
+msgstr "Förklara de grundläggande begreppen för svarta hål för mig på gymnasienivå."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -8459,8 +8444,7 @@ msgstr "Feedback har skickats"
 msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
-msgstr ""
-"Din feedback påverkar direkt våra produktuppdateringar och förbättringar."
+msgstr "Din feedback påverkar direkt våra produktuppdateringar och förbättringar."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8614,8 +8598,7 @@ msgstr "Hitta <b>%1$s</b> i din nedladdningsmapp"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr ""
-"Hitta DuckDuckGo i listan som visas och klicka på %1$sAnvänd som standard%2$s"
+msgstr "Hitta DuckDuckGo i listan som visas och klicka på %1$sAnvänd som standard%2$s"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8652,8 +8635,7 @@ msgstr "Hitta sökresultat närmare dig."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr ""
-"Hitta resultat nära dig. %1$sDin plats förblir privat, säker och anonym."
+msgstr "Hitta resultat nära dig. %1$sDin plats förblir privat, säker och anonym."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8735,7 +8717,7 @@ msgstr "Följdfråga"
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
-msgstr ""
+msgstr "Följdfrågor förblir privata."
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8841,8 +8823,7 @@ msgstr "Kostnadsfria och privata chattar, anonymiserade av oss"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Kostnadsfria och privata chattar, anonymiserade av oss. Inget konto behövs."
+msgstr "Kostnadsfria och privata chattar, anonymiserade av oss. Inget konto behövs."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9250,14 +9231,13 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr ""
-"Skaffa DuckDuckGo VPN, avancerade Duck.ai och Identity Theft Restoration."
+msgstr "Skaffa DuckDuckGo VPN, avancerade Duck.ai och Identity Theft Restoration."
 
 # smartling.placeholder_format=C
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
 msgctxt "Tooltip on the header logo for sunglasses searches"
 msgid "Get DuckDuckGo sunglasses and other gear."
-msgstr ""
+msgstr "Skaffa DuckDuckGo-solglasögon och andra produkter."
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9370,9 +9350,9 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Få tillgång till avancerade AI-modeller i Duck.ai med ett DuckDuckGo-"
-"abonnemang, som även inkluderar vårt VPN och andra premiumskydd för "
-"integritet."
+"Få tillgång till avancerade AI-modeller i Duck.ai med ett "
+"DuckDuckGo-abonnemang, som även inkluderar vårt VPN och andra premiumskydd "
+"för integritet."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9870,8 +9850,7 @@ msgstr "Guatemala"
 #. Text for a prompt suggestion for guiding through the basic steps of replacing a window wiper.
 msgctxt "Full sentence for learning a new skill"
 msgid "Guide me through the basic steps of replacing a window wiper."
-msgstr ""
-"Guida mig genom de grundläggande stegen för att byta ut en fönstertorkare."
+msgstr "Guida mig genom de grundläggande stegen för att byta ut en fönstertorkare."
 
 # smartling.placeholder_format=C
 msgid "Guinea"
@@ -10496,7 +10475,7 @@ msgstr "Så funkar det"
 #. Headline in chat history about modals for the temporary encrypted server storage explanation.
 msgctxt "Chat history about modal list item headline"
 msgid "How it works"
-msgstr ""
+msgstr "Hur det fungerar"
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -10764,8 +10743,7 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"Om du fortfarande vill stödja oss, %1$shjälp till sprida DuckDuckGo%2$s"
+msgstr "Om du fortfarande vill stödja oss, %1$shjälp till sprida DuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -11345,8 +11323,7 @@ msgstr "Det är snabbt, gratis och ger dig ännu mer skydd online."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Det är okej att fråga mig om min upplevelse med DuckDuckGo (inte så ofta)"
+msgstr "Det är okej att fråga mig om min upplevelse med DuckDuckGo (inte så ofta)"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11946,7 +11923,7 @@ msgstr "Länken går ut om 7 dagar."
 #. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days. People can save a chat copy."
-msgstr ""
+msgstr "Länken går ut om 7 dagar. Personer kan spara en kopia av chatten."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11962,8 +11939,7 @@ msgstr "Länkar:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
-"Lista verktygen, materialen eller förutsättningarna jag behöver för detta."
+msgstr "Lista verktygen, materialen eller förutsättningarna jag behöver för detta."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12074,8 +12050,7 @@ msgstr "Läser in fler sökresultat med bilder när du skrollar"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr ""
-"Läser in fler sökresultat med bilder, videor och shopping när du skrollar"
+msgstr "Läser in fler sökresultat med bilder, videor och shopping när du skrollar"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -13406,10 +13381,11 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"Nya promptar och svar krypteras och lagras tillfälligt på en DuckDuckGo-"
-"server efter att de har skickats, så att du kan återställa chatten om din "
-"internetanslutning bryts. Om du inaktiverar chatthistoriken raderas fästa "
-"chattar och tillfällig lagring av nya promptar och svar inaktiveras."
+"Nya promptar och svar krypteras och lagras tillfälligt på en "
+"DuckDuckGo-server efter att de har skickats, så att du kan återställa "
+"chatten om din internetanslutning bryts. Om du inaktiverar chatthistoriken "
+"raderas fästa chattar och tillfällig lagring av nya promptar och svar "
+"inaktiveras."
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -14069,7 +14045,7 @@ msgstr "Okej, uppfattat!"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "OPTIONAL"
-msgstr ""
+msgstr "VALFRITT"
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -15324,8 +15300,7 @@ msgstr "Fäst"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
-"Fastnålade chattar kommer att visas högst upp bland dina senaste chattar."
+msgstr "Fastnålade chattar kommer att visas högst upp bland dina senaste chattar."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -15366,8 +15341,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr ""
-"Lös följande utmaning för att bekräfta att prompten görs av en människa."
+msgstr "Lös följande utmaning för att bekräfta att prompten görs av en människa."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -15375,8 +15349,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr ""
-"Lös följande utmaning för att bekräfta att sökningen görs av en människa."
+msgstr "Lös följande utmaning för att bekräfta att sökningen görs av en människa."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -16159,8 +16132,7 @@ msgstr "Fråga mig"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"Be mig använda min ungefärliga plats för att få sökresultat i närheten."
+msgstr "Be mig använda min ungefärliga plats för att få sökresultat i närheten."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -16195,7 +16167,7 @@ msgstr "Skyddad"
 #. Headline in sync-enabled chat history about modals explaining encrypted server storage.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Protected with end-to-end encryption"
-msgstr ""
+msgstr "Skyddat med heltäckande kryptering"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -16334,7 +16306,7 @@ msgstr "Rankning"
 #. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
 msgctxt "star rating on a product"
 msgid "Rated %s out of %s"
-msgstr ""
+msgstr "Betyg: %1$s av %2$s"
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -16493,8 +16465,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"De senaste chattarna lagras lokalt på din enhet istället för på DuckDuckGo-"
-"servrar eller andra fjärrservrar."
+"De senaste chattarna lagras lokalt på din enhet istället för på "
+"DuckDuckGo-servrar eller andra fjärrservrar."
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -16503,8 +16475,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"De senaste chattarna lagras lokalt på din enhet istället för på DuckDuckGo-"
-"servrar eller andra fjärrservrar."
+"De senaste chattarna lagras lokalt på din enhet istället för på "
+"DuckDuckGo-servrar eller andra fjärrservrar."
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -17561,8 +17533,7 @@ msgstr "Spara upp till 30 av dina senaste chattar lokalt på din enhet."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Spara dina Duck.ai-chattar mellan dina enheter med end-to-end-kryptering."
+msgstr "Spara dina Duck.ai-chattar mellan dina enheter med end-to-end-kryptering."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17574,7 +17545,7 @@ msgstr "Spara dina chattar på alla dina enheter."
 #. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
 msgctxt "Chat history about modal list item headline"
 msgid "Save your chats on this device"
-msgstr ""
+msgstr "Spara dina chattar på den här enheten"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
@@ -17751,15 +17722,13 @@ msgstr "Skrolla nedåt och leta reda på %1$sdin webbläsare%2$s i listan."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr ""
-"Skrolla ner till %1$sDuckDuckGo%2$s och ge tillåtelse att använda din plats."
+msgstr "Skrolla ner till %1$sDuckDuckGo%2$s och ge tillåtelse att använda din plats."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr ""
-"Skrolla ner till avsnittet %1$sTjänster%2$s och klicka på %3$sAdressfält%4$s."
+msgstr "Skrolla ner till avsnittet %1$sTjänster%2$s och klicka på %3$sAdressfält%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -17784,7 +17753,7 @@ msgctxt ""
 "Placeholder and accessibility label for the search input in the tab picker "
 "dialog"
 msgid "Search"
-msgstr ""
+msgstr "Sök"
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18109,8 +18078,7 @@ msgstr "En andra åsikt"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr ""
-"Spara och synkronisera dina chattar på ett säkert sätt på alla dina enheter."
+msgstr "Spara och synkronisera dina chattar på ett säkert sätt på alla dina enheter."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18119,8 +18087,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Lagra säkert nästan obegränsat antal chattar på vår server med end-to-end-"
-"kryptering och få åtkomst till dem från alla dina enheter."
+"Lagra säkert nästan obegränsat antal chattar på vår server med "
+"end-to-end-kryptering och få åtkomst till dem från alla dina enheter."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -18129,8 +18097,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Lagra säkert nästan obegränsat antal chattar på vår server med end-to-end-"
-"kryptering och få åtkomst till dem från alla dina enheter."
+"Lagra säkert nästan obegränsat antal chattar på vår server med "
+"end-to-end-kryptering och få åtkomst till dem från alla dina enheter."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18149,8 +18117,8 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"Lagra dina chattar på ett säkert sätt på vår server med end-to-end-"
-"kryptering och få åtkomst till dem från alla dina enheter."
+"Lagra dina chattar på ett säkert sätt på vår server med "
+"end-to-end-kryptering och få åtkomst till dem från alla dina enheter."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -18713,8 +18681,7 @@ msgstr ""
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr ""
-"Ställ in din plats manuellt eller se till att platstjänster är aktiverade."
+msgstr "Ställ in din plats manuellt eller se till att platstjänster är aktiverade."
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -18959,7 +18926,7 @@ msgstr "Butik"
 #. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
 msgctxt "Button in the merchandise logo modal (mobile)"
 msgid "Shop Now"
-msgstr ""
+msgstr "Handla nu"
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -19343,14 +19310,12 @@ msgstr "Visar mest besökta länkar i ny flik"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Visar påminnelser då och då om att lägga till DuckDuckGo i din webbläsare"
+msgstr "Visar påminnelser då och då om att lägga till DuckDuckGo i din webbläsare"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Visar påminnelser då och då om att lägga till DuckDuckGo i dina enheter"
+msgstr "Visar påminnelser då och då om att lägga till DuckDuckGo i dina enheter"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19368,8 +19333,7 @@ msgstr "Visar sidnummer där sidan med sökresultat bryts"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows sign-up form for the DuckDuckGo privacy newsletters"
-msgstr ""
-"Visar registreringsformuläret för nyhetsbrevet om integritet från DuckDuckGo"
+msgstr "Visar registreringsformuläret för nyhetsbrevet om integritet från DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/94erFcS.png
@@ -19395,8 +19359,7 @@ msgstr "Visar välkomstmeddelande högst upp på sidan med sökresultat"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Visar välkomstmeddelande till användare av inställningsmeny för Android i EU"
+msgstr "Visar välkomstmeddelande till användare av inställningsmeny för Android i EU"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -20225,8 +20188,7 @@ msgstr "Förslag på rubrik för ett blogginlägg"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
-"Föreslå relaterade artiklar eller ämnen som är värda att utforska härnäst."
+msgstr "Föreslå relaterade artiklar eller ämnen som är värda att utforska härnäst."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -20613,6 +20575,8 @@ msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
 msgstr ""
+"Sync & Backup sparar mer av dina chattar och synkroniserar dem mellan dina "
+"enheter."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20731,7 +20695,7 @@ msgstr "Synkronisera dina chattar mellan alla dina enheter."
 #. Headline in sync-enabled chat history about modals explaining cross-device sync.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Sync your chats across all your devices"
-msgstr ""
+msgstr "Synkronisera dina chattar mellan alla dina enheter"
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21222,8 +21186,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
 msgid "There's been an issue loading this answer. Please try again."
-msgstr ""
-"Det uppstod ett problem när det här svaret skulle läsas in. Försök igen."
+msgstr "Det uppstod ett problem när det här svaret skulle läsas in. Försök igen."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -21323,12 +21286,14 @@ msgid ""
 "This chat and its generated images become public when you create and copy "
 "the link."
 msgstr ""
+"Den här chatten och dess genererade bilder blir offentliga när du skapar och "
+"kopierar länken."
 
 # smartling.placeholder_format=C
 #. Explains that creating and copying a share link makes the selected chat content public.
 msgctxt "Share modal info bullet about public access"
 msgid "This chat becomes public when you create and copy the link."
-msgstr ""
+msgstr "Den här chatten blir offentlig när du skapar och kopierar länken."
 
 # smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
@@ -21556,8 +21521,8 @@ msgstr "Denna sida kräver javascript för att fungera."
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
 msgstr ""
-"Innehållet på den här sidan kommer att skickas med ditt meddelande till Duck."
-"ai"
+"Innehållet på den här sidan kommer att skickas med ditt meddelande till "
+"Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21607,8 +21572,7 @@ msgstr ""
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr ""
-"Den här delade chatten kunde inte öppnas. Länken kan vara ofullständig."
+msgstr "Den här delade chatten kunde inte öppnas. Länken kan vara ofullständig."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
@@ -21643,8 +21607,7 @@ msgstr "Denna video kan ännu inte visas här. Du kan titta på den på %1$s."
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Den här webbplats använder inte en säker, krypterad anslutning (HTTPS)."
+msgstr "Den här webbplats använder inte en säker, krypterad anslutning (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21829,8 +21792,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"För att överföra din chatthistorik till Duck.ai, uppdatera DuckDuckGo-"
-"webbläsaren till den senaste versionen och försök igen."
+"För att överföra din chatthistorik till Duck.ai, uppdatera "
+"DuckDuckGo-webbläsaren till den senaste versionen och försök igen."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -21861,15 +21824,15 @@ msgstr "Idag"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
-msgstr ""
+msgstr "Växla till privat AI-chatt eller %1$sinaktivera i inställningarna%2$s."
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
-"Växla för att prova privat AI-chatt eller %1$sinaktivera den i menyn %2$s."
-"%3$s"
+"Växla för att prova privat AI-chatt eller %1$sinaktivera den i menyn "
+"%2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -22940,14 +22903,13 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Under %1$sVid uppstart%2$s, välj %3$sStartsida%4$s och skriv: https://"
-"duckduckgo.com"
+"Under %1$sVid uppstart%2$s, välj %3$sStartsida%4$s och skriv: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"Under %1$sÖppna med%2$s, välj %3$sEn särskild sida eller grupp av sidor%4$s"
+msgstr "Under %1$sÖppna med%2$s, välj %3$sEn särskild sida eller grupp av sidor%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -22974,8 +22936,7 @@ msgstr "Under sektionen %1$sSök%2$s, klicka på %3$sHantera sökmotorer...%4$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr ""
-"Under Vid start, välj %1$sÖppna en särskild sida eller grupp av sidor%2$s"
+msgstr "Under Vid start, välj %1$sÖppna en särskild sida eller grupp av sidor%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -23082,8 +23043,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Lås upp avancerade AI-modeller och högre gränser med en DuckDuckGo-"
-"prenumeration"
+"Lås upp avancerade AI-modeller och högre gränser med en "
+"DuckDuckGo-prenumeration"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -23465,8 +23426,7 @@ msgstr "Använd DuckDuckGo Private Search"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"Använd privat sökning från DuckDuckGo på din iPad, iPhone eller Android!"
+msgstr "Använd privat sökning från DuckDuckGo på din iPad, iPhone eller Android!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -23689,6 +23649,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Yelp's ad network."
 msgstr ""
+"Visning av annonser är sekretesskyddat av DuckDuckGo. Annonsklick hanteras "
+"av Yelps annonsnätverk."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -23772,9 +23734,10 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"Gå till Duck.ai i din andra webbläsare eller DuckDuckGo-appen och öppna Duck."
-"ai-inställningarna. Välj Aktivera under Sync & Backup och välj Synkronisera "
-"med en annan enhet. Eller skanna QR-koden på din återställnings-PDF."
+"Gå till Duck.ai i din andra webbläsare eller DuckDuckGo-appen och öppna "
+"Duck.ai-inställningarna. Välj Aktivera under Sync & Backup och välj "
+"Synkronisera med en annan enhet. Eller skanna QR-koden på din "
+"återställnings-PDF."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23827,8 +23790,8 @@ msgstr "Röstchatt avslutad"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"Röstchatt är anonymiserad av oss och används aldrig för att träna AI-"
-"modeller."
+"Röstchatt är anonymiserad av oss och används aldrig för att träna "
+"AI-modeller."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -24008,8 +23971,7 @@ msgstr "Vi anonymiserar"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr ""
-"Vi kan anonymisera %1$sdin plats%2$s för att visa dig mer exakta resultat."
+msgstr "Vi kan anonymisera %1$sdin plats%2$s för att visa dig mer exakta resultat."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -24043,16 +24005,14 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can use your anonymous%s location%s to show you nearby results."
-msgstr ""
-"Vi kan använda din %1$splats%2$s anonymt för att visa resultat i närheten."
+msgstr "Vi kan använda din %1$splats%2$s anonymt för att visa resultat i närheten."
 
 # smartling.placeholder_format=C
 #. Error message displayed when one or more attached files are encrypted and cannot be read.
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"Vi kan inte läsa de bifogade filerna eftersom minst en av dem är krypterad."
+msgstr "Vi kan inte läsa de bifogade filerna eftersom minst en av dem är krypterad."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24063,8 +24023,7 @@ msgstr "Vi förföljer dig inte med annonser."
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr ""
-"Vi lagrar inte användarnamn eller annan personligt identifierbar information."
+msgstr "Vi lagrar inte användarnamn eller annan personligt identifierbar information."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -24095,8 +24054,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr ""
-"Vi spårar dig inte, och vi vill gärna veta varför du kom tillbaka idag:"
+msgstr "Vi spårar dig inte, och vi vill gärna veta varför du kom tillbaka idag:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -24268,8 +24226,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr ""
-"Vi blockerar spårare som försöker samla in dina uppgifter medan du surfar."
+msgstr "Vi blockerar spårare som försöker samla in dina uppgifter medan du surfar."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
@@ -24480,8 +24437,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"Välkommen till nya Duck.ai! Du kan nu importera dina nedladdade chattar."
+msgstr "Välkommen till nya Duck.ai! Du kan nu importera dina nedladdade chattar."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24576,8 +24532,7 @@ msgstr "Kan du ge några faktorer man ska tänka på när man köper en datorsk�
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr ""
-"Vilka är några sevärdheter man måste se första gången man besöker i Paris?"
+msgstr "Vilka är några sevärdheter man måste se första gången man besöker i Paris?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -24677,8 +24632,7 @@ msgstr "Vilka är de viktigaste lärdomarna?"
 #. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key things I will learn from this course?"
-msgstr ""
-"Vilka är de viktigaste sakerna jag kommer att lära mig av den här kursen?"
+msgstr "Vilka är de viktigaste sakerna jag kommer att lära mig av den här kursen?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
@@ -24703,8 +24657,7 @@ msgstr "Vilka är de mest rekommenderade rätterna här?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
-"Vilka är öppettiderna, platsen och kontaktuppgifterna för det här stället?"
+msgstr "Vilka är öppettiderna, platsen och kontaktuppgifterna för det här stället?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -24931,8 +24884,7 @@ msgstr "Vad vill du ge feedback om?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"Det du tittar på i DuckDuckGo påverkar inte dina rekommendationer på YouTube."
+msgstr "Det du tittar på i DuckDuckGo påverkar inte dina rekommendationer på YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -24964,8 +24916,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"När det är aktiverat kommer Duck.ai att visa omedelbara svar i chatten."
+msgstr "När det är aktiverat kommer Duck.ai att visa omedelbara svar i chatten."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -25023,8 +24974,7 @@ msgstr "Vilka är vi"
 #. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
-msgstr ""
-"Vilka ingår i rollistan och filmteamet, och vad är de annars kända för?"
+msgstr "Vilka ingår i rollistan och filmteamet, och vad är de annars kända för?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -25172,13 +25122,15 @@ msgid ""
 "With chat history on, up to %s of your most recent chats will be saved on "
 "this device."
 msgstr ""
+"När chatthistoriken är på sparas upp till %1$s av dina senaste chattar på "
+"den här enheten."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline in the About Chat History modal.
 msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, your most recent chats will be saved on this device."
-msgstr ""
+msgstr "När chatthistoriken är på sparas dina senaste chattar på den här enheten."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -25442,8 +25394,7 @@ msgstr "Ja, ny användare!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr ""
-"Ja, vi slänger data när du är klar med dem och de kan inte återställas."
+msgstr "Ja, vi slänger data när du är klar med dem och de kan inte återställas."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -25462,8 +25413,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"Du chattar med %1$s. AI-chattar kan visa felaktig eller stötande information."
+msgstr "Du chattar med %1$s. AI-chattar kan visa felaktig eller stötande information."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -25649,8 +25599,7 @@ msgstr ""
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can restore your settings after deleting cookies."
-msgstr ""
-"Du kan återställa dina inställningar efter att du har tagit bort kakor."
+msgstr "Du kan återställa dina inställningar efter att du har tagit bort kakor."
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -25910,8 +25859,8 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"YouTube (som ägs av Google) låter dig inte titta på videor anonymt. YouTube-"
-"videor som visas här spåras därför av YouTube/Google."
+"YouTube (som ägs av Google) låter dig inte titta på videor anonymt. "
+"YouTube-videor som visas här spåras därför av YouTube/Google."
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -26056,8 +26005,8 @@ msgstr "Dina chattar sparas nu."
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"Dina chattar är privata, sparas aldrig och används inte för att träna AI-"
-"modeller"
+"Dina chattar är privata, sparas aldrig och används inte för att träna "
+"AI-modeller"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
@@ -26200,10 +26149,10 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"Ditt lösenord genererar en 512-bitars nyckel med hjälp av Secure Hash-"
-"algoritmen %1$sSHA-2%2$s. Endast nyckeln och tillhörande inställningsfil "
-"lämnar din webbläsare. Vi sparar inställningsfilen med nyckeln som namn. "
-"DuckDuckGo känner aldrig till ditt lösenord."
+"Ditt lösenord genererar en 512-bitars nyckel med hjälp av Secure "
+"Hash-algoritmen %1$sSHA-2%2$s. Endast nyckeln och tillhörande "
+"inställningsfil lämnar din webbläsare. Vi sparar inställningsfilen med "
+"nyckeln som namn. DuckDuckGo känner aldrig till ditt lösenord."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -26436,8 +26385,7 @@ msgstr "av %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"av DuckDuckGo — onlineskydd som miljontals människor litar på varje dag."
+msgstr "av DuckDuckGo — onlineskydd som miljontals människor litar på varje dag."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"
@@ -26582,7 +26530,7 @@ msgstr "min"
 #. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the chat options menu button"
 msgid "menu"
-msgstr ""
+msgstr "meny"
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.
@@ -26657,8 +26605,8 @@ msgstr "den officiella webbplatsen"
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
 msgstr ""
-"eller skriv koden för färgen du vill ha, t.ex. %1$s (%2$s är ett kodat %3$s-"
-"tecken)"
+"eller skriv koden för färgen du vill ha, t.ex. %1$s (%2$s är ett kodat "
+"%3$s-tecken)"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/sv_SE/LC_MESSAGES/duckduckgo.po
+++ b/locales/sv_SE/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: sv_SE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1212,6 +1212,12 @@ msgid "About our ads"
 msgstr "Om våra annonser"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1341,6 +1347,20 @@ msgid "Ad is suspicious"
 msgstr "Annonsen är misstänkt"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Lägg till DuckDuckGo"
@@ -1366,6 +1386,27 @@ msgstr "Lägg till DuckDuckGo som sökmotor"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Lägg till DuckDuckGo i %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1411,6 +1452,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Lägg till sidans innehåll"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1496,6 +1553,12 @@ msgstr "Tillägg"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Lägger till de sista detaljerna"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1800,6 +1863,12 @@ msgstr "Alla färger"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Allt klart!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3509,6 +3578,14 @@ msgid "Cancel"
 msgstr "Avbryt"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4003,10 +4080,22 @@ msgid "Chat response is offensive"
 msgstr "Chattsvaret är stötande"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Chatta med %1$s"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4025,6 +4114,14 @@ msgstr "Chattar"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Chattar"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5625,6 +5722,12 @@ msgid "Current Streak"
 msgstr "Nuvarande streak"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5973,6 +6076,12 @@ msgstr "Radera chatt"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Radera chattar som är äldre än 30 dagar"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6387,6 +6496,12 @@ msgstr "Visa inte igen"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Stäng kampanj"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7557,6 +7672,12 @@ msgid "Edit Prompt"
 msgstr "Redigera prompt"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7777,6 +7898,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Krypterad modell"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8605,6 +8732,12 @@ msgid "Follow-up question"
 msgstr "Följdfråga"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9119,6 +9252,12 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
 "Skaffa DuckDuckGo VPN, avancerade Duck.ai och Identity Theft Restoration."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10352,6 +10491,12 @@ msgstr "På vilket sätt är det anonymt?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Så funkar det"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11796,6 +11941,12 @@ msgstr "Vunna lineouts"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "Länken går ut om 7 dagar."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13913,6 +14064,12 @@ msgstr "OK"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "Okej, uppfattat!"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16035,6 +16192,12 @@ msgid "Protected"
 msgstr "Skyddad"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Skydd. Integritet. Sinnesro."
@@ -16166,6 +16329,12 @@ msgstr "Regn"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Rankning"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17402,6 +17571,12 @@ msgid "Save your chats across all your devices."
 msgstr "Spara dina chattar på alla dina enheter."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17602,6 +17777,14 @@ msgstr "Sök"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Sök"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18771,6 +18954,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Butik"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20418,6 +20607,14 @@ msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr "Sync & Backup-data kan inte återställas efter 18 månaders inaktivitet."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20529,6 +20726,12 @@ msgstr "Synkronisera med en enhet i närheten."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Synkronisera dina chattar mellan alla dina enheter."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21112,6 +21315,22 @@ msgid "This Week"
 msgstr "Denna vecka"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21637,6 +21856,12 @@ msgstr "Idag"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Idag"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23458,6 +23683,14 @@ msgstr ""
 "av TripAdvisors annonsnätverk."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Jungfruöarna"
 
@@ -24933,6 +25166,21 @@ msgstr ""
 "Slå på eller stäng av det när som helst i menyn ”%1$s”."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26329,6 +26577,12 @@ msgstr "min"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "min"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/ta_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/ta_IN/LC_MESSAGES/duckduckgo.po
@@ -980,6 +980,11 @@ msgstr "எங்களைப் பற்றி"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1083,6 +1088,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "சந்தேகத்திற்குரிய விளம்பரம்"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #  Marked fuzzy because of translated trademark
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
@@ -1105,6 +1122,24 @@ msgstr "DuckDuckGoவை தேடுபொரியாக சேற்கவு
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "%s இல் DuckDuckGo வை சேர்க்க"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1143,6 +1178,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #  Marked fuzzy because of translated trademark
@@ -1215,6 +1264,11 @@ msgstr "துணை நிரல்கள்"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1461,6 +1515,11 @@ msgstr "அனைத்து வண்ணங்கள்"
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2824,6 +2883,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3227,9 +3293,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3245,6 +3321,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4513,6 +4596,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4797,6 +4885,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5135,6 +5228,11 @@ msgstr "நிரந்தரமாக நிராகரி"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6053,6 +6151,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6232,6 +6335,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6902,6 +7010,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7320,6 +7433,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8307,6 +8425,11 @@ msgid "How is it anonymous?"
 msgstr "இது எப்படி அநாமதேயமாக?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9482,6 +9605,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11226,6 +11354,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "சரி, கிடைத்தது!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12941,6 +13074,11 @@ msgstr "ஒவ்வொரு சாதனத்திலும் உங்க�
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -13047,6 +13185,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -14038,6 +14181,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14197,6 +14345,13 @@ msgstr "தேடு"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15132,6 +15287,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16476,6 +16636,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16556,6 +16723,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -17025,6 +17197,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17431,6 +17617,11 @@ msgstr "இன்று"
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18900,6 +19091,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -20069,6 +20267,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21170,6 +21381,11 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "m"
 msgstr "ம"
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.
 msgctxt "Aria label for the menu button"

--- a/locales/te_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/te_IN/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr "మా గురుంచి"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "ప్రకటన అనుమాస్పదమైనది"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "DuckDuckGoని చేర్చుకోండి"
@@ -1100,6 +1117,24 @@ msgstr "DuckDuckGoని సెర్చ్ ఇంజిన్‌గా చే�
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "DuckDuckGoని %sకు చేర్చుకోండి"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr "పొడగింతలు"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1454,6 +1508,11 @@ msgstr "అన్ని రంగులు"
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2803,6 +2862,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3203,9 +3269,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3221,6 +3297,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4479,6 +4562,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4763,6 +4851,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5101,6 +5194,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -5997,6 +6095,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6174,6 +6277,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6839,6 +6947,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7257,6 +7370,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8239,6 +8357,11 @@ msgid "How is it anonymous?"
 msgstr "ఇది ఏవిధంగా అజ్ఞాతంగా ఉంచుతుంది?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9395,6 +9518,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11134,6 +11262,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "సరే, అర్థమయ్యింది!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12834,6 +12967,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12940,6 +13078,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13928,6 +14071,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14083,6 +14231,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -14998,6 +15153,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16337,6 +16497,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16417,6 +16584,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16877,6 +17049,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17279,6 +17465,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18741,6 +18932,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19896,6 +20094,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20982,6 +21193,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/th_TH/LC_MESSAGES/duckduckgo.po
+++ b/locales/th_TH/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: th_TH\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -191,7 +191,8 @@ msgid ""
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
 "%1$s ใช้ได้กับ Pro เท่านั้น อัปเกรดการสมัครสมาชิก DuckDuckGo "
-"ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดล Plus หรือฟรี"
+"ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดล "
+"Plus หรือฟรี"
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -202,7 +203,8 @@ msgid ""
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
 "%1$s ใช้ได้กับ Pro เท่านั้น อัปเกรดการสมัครสมาชิก DuckDuckGo "
-"ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดล Plus หรือฟรี"
+"ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดล "
+"Plus หรือฟรี"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -219,7 +221,8 @@ msgid ""
 "model."
 msgstr ""
 "%1$s สามารถใช้ได้เฉพาะกับการสมัครใช้งาน DuckDuckGo เท่านั้น "
-"เปิดใช้งานการสมัครของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดลฟรี"
+"เปิดใช้งานการสมัครของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ "
+"หรือเปลี่ยนไปใช้โมเดลฟรี"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -227,7 +230,9 @@ msgctxt "Error message for model unavailability"
 msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
-msgstr "%1$s ไม่สามารถใช้งานได้ชั่วคราว โปรดเปลี่ยนไปใช้รุ่นอื่นหรือลองอีกครั้งในภายหลัง"
+msgstr ""
+"%1$s ไม่สามารถใช้งานได้ชั่วคราว "
+"โปรดเปลี่ยนไปใช้รุ่นอื่นหรือลองอีกครั้งในภายหลัง"
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -325,6 +330,7 @@ msgid ""
 "their servers."
 msgstr ""
 "%1$s ทํางานในสภาพแวดล้อมการดําเนินการที่เชื่อถือได้ "
+""
 "นี่หมายความว่าแม้แต่ผู้ให้บริการโมเดลก็ไม่สามารถดูคำแนะนำของคุณหรือการตอบสนองของโมเดล "
 "หรือบันทึกการแชทนี้บนเซิร์ฟเวอร์ของพวกเขา"
 
@@ -412,7 +418,8 @@ msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
 msgstr ""
-"%1$s จะออกจาก Duck.ai ใน %2$s วัน (%3$s) หลังจากนั้น คุณสามารถเปลี่ยนรุ่นเพื่อแชทต่อ"
+"%1$s จะออกจาก Duck.ai ใน %2$s วัน (%3$s) หลังจากนั้น "
+"คุณสามารถเปลี่ยนรุ่นเพื่อแชทต่อ"
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -422,7 +429,9 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
-msgstr "%1$s จะออกจาก Duck.ai ใน 1 วัน (%2$s) หลังจากนั้น คุณสามารถเปลี่ยนรุ่นเพื่อแชทต่อ"
+msgstr ""
+"%1$s จะออกจาก Duck.ai ใน 1 วัน (%2$s) หลังจากนั้น "
+"คุณสามารถเปลี่ยนรุ่นเพื่อแชทต่อ"
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -442,7 +451,8 @@ msgstr "%1$sคลิก%2$sเพิ่ม%3$sเลือก%4$sอนุญ�
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$sคลิก%2$sอนุญาต%3$sคลิก%4$sเพิ่ม%5$sเลือก%6$sอนุญาต%7$s จากนั้นคลิก%8$sตกลง%9$s"
+"%1$sคลิก%2$sอนุญาต%3$sคลิก%4$sเพิ่ม%5$sเลือก%6$sอนุญาต%7$s "
+"จากนั้นคลิก%8$sตกลง%9$s"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -494,13 +504,16 @@ msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
 msgstr ""
-"%1$sเรียนรู้เพิ่มเติม%2$s เกี่ยวกับวิธีการจัดเก็บแชทอย่างเป็นส่วนตัวบนเซิร์ฟเวอร์ของ DuckDuckGo"
+"%1$sเรียนรู้เพิ่มเติม%2$s "
+"เกี่ยวกับวิธีการจัดเก็บแชทอย่างเป็นส่วนตัวบนเซิร์ฟเวอร์ของ DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr "%1$sเรียนรู้เพิ่มเติม%2$s เกี่ยวกับวิธีการจัดเก็บแชทอย่างเป็นส่วนตัวบนอุปกรณ์ของคุณ"
+msgstr ""
+"%1$sเรียนรู้เพิ่มเติม%2$s "
+"เกี่ยวกับวิธีการจัดเก็บแชทอย่างเป็นส่วนตัวบนอุปกรณ์ของคุณ"
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -984,8 +997,9 @@ msgid ""
 "aichat%s."
 msgstr ""
 "AI Chat ช่วยให้คุณสนทนาแบบไม่ต้องระบุชื่อด้วยโมเดลแชท AI ของบริษัทอื่น "
-"การปิดฟีเจอร์นี้จะซ่อนฟีเจอร์ AI Chat ใน DuckDuckGo Search คุณยังคงสามารถเข้าถึง AI Chat "
-"ได้เมื่อปิดการตั้งค่านี้โดยไปที่ %1$sduckduckgo.com/aichat%2$s"
+"การปิดฟีเจอร์นี้จะซ่อนฟีเจอร์ AI Chat ใน DuckDuckGo Search "
+"คุณยังคงสามารถเข้าถึง AI Chat ได้เมื่อปิดการตั้งค่านี้โดยไปที่ "
+"%1$sduckduckgo.com/aichat%2$s"
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1048,7 +1062,8 @@ msgid ""
 msgstr ""
 "คำตอบที่ได้รับความช่วยเหลือจาก AI ขณะนี้ยังไม่รองรับคำถามที่ถามต่อโดยตรง "
 "แต่เรามีและมักจะเชื่อมโยงไปยัง %1$sDuck.ai%2$s สำหรับคำถามที่ถามต่อ "
-"ซึ่งเป็นบริการแชทส่วนตัวที่ใช้ AI และรองรับโมเดลแชทจาก OpenAI, Anthropic และอีกมากมาย"
+"ซึ่งเป็นบริการแชทส่วนตัวที่ใช้ AI และรองรับโมเดลแชทจาก OpenAI, Anthropic "
+"และอีกมากมาย"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1192,7 +1207,7 @@ msgstr "เกี่ยวกับโฆษณาของเรา"
 #. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
 msgctxt "Modal header for chat history with sync information"
 msgid "About Chat History with Sync & Backup"
-msgstr ""
+msgstr "เกี่ยวกับประวัติการแชทด้วย Sync & Backup"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
@@ -1239,7 +1254,8 @@ msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
 msgstr ""
-"เปิดใช้งาน %1$s ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดลฟรี"
+"เปิดใช้งาน %1$s ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ "
+"หรือเปลี่ยนไปใช้โมเดลฟรี"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1274,7 +1290,9 @@ msgstr "โฆษณา"
 #. An item in the ads tooltip that explains that ad clicks are managed by the ad network and are not used to profile you. The placeholder is the name of the ad network. For example: Microsoft
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
-msgstr "การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ %1$s และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
+msgstr ""
+"การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ %1$s "
+"และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
@@ -1282,7 +1300,8 @@ msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
 msgstr ""
-"การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ Microsoft และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
+"การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ Microsoft "
+"และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1323,7 +1342,7 @@ msgstr "โฆษณาน่าสงสัย"
 #. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
 msgctxt "Button to open menu for attaching images or page context to AI chat"
 msgid "Add"
-msgstr ""
+msgstr "เพิ่ม"
 
 # smartling.placeholder_format=C
 #. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
@@ -1331,7 +1350,7 @@ msgctxt ""
 "Primary button that attaches the tabs the user checked in the tab picker "
 "dialog"
 msgid "Add"
-msgstr ""
+msgstr "เพิ่ม"
 
 # smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
@@ -1366,13 +1385,13 @@ msgstr "เพิ่ม DuckDuckGo ลงใน %1$s"
 msgctxt ""
 "Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
 msgid "Add File"
-msgstr ""
+msgstr "เพิ่มไฟล์"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
 msgid "Add Image"
-msgstr ""
+msgstr "เพิ่มภาพ"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
@@ -1380,7 +1399,7 @@ msgctxt ""
 "Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
 "item)"
 msgid "Add Image or File"
-msgstr ""
+msgstr "เพิ่มภาพหรือไฟล์"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1433,7 +1452,7 @@ msgctxt ""
 "Open the tab picker to attach browser tab content to the AI chat message "
 "(attach dropdown menu item)"
 msgid "Add Tabs"
-msgstr ""
+msgstr "เพิ่มแท็บ"
 
 # smartling.placeholder_format=C
 #. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
@@ -1441,7 +1460,7 @@ msgctxt ""
 "Title and accessible name of the tab-picker dialog opened from the attach "
 "dropdown menu"
 msgid "Add Tabs"
-msgstr ""
+msgstr "เพิ่มแท็บ"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1532,7 +1551,7 @@ msgstr "การเก็บรายละเอียดขั้นสุด
 #. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
 msgctxt "Aria label for the additional instructions textarea"
 msgid "Additional instructions"
-msgstr ""
+msgstr "คำแนะนำเพิ่มเติม"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1674,7 +1693,9 @@ msgstr "หลังจากดาวน์โหลดและเปิด �
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr "หลังจากที่ดาวน์โหลดเสร็จเรียบร้อย ให้ค้นหาไฟล์ส่วนขยายแล้วดับเบิลคลิกเพื่อติดตั้ง"
+msgstr ""
+"หลังจากที่ดาวน์โหลดเสร็จเรียบร้อย "
+"ให้ค้นหาไฟล์ส่วนขยายแล้วดับเบิลคลิกเพื่อติดตั้ง"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1811,7 +1832,8 @@ msgid ""
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 "การแชททั้งหมดจะถูกทำให้ไม่ระบุชื่อโดย DuckDuckGo "
-"และการสนทนาของคุณจะไม่ถูกใช้ในการฝึกโมเดลการแชทโดย DuckDuckGo หรือผู้ให้บริการโมเดล"
+"และการสนทนาของคุณจะไม่ถูกใช้ในการฝึกโมเดลการแชทโดย DuckDuckGo "
+"หรือผู้ให้บริการโมเดล"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1835,7 +1857,7 @@ msgstr "เสร็จเรียบร้อย!"
 #. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the read-only textarea listing all AI instructions"
 msgid "All instructions"
-msgstr ""
+msgstr "คำแนะนำทั้งหมด"
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -1864,8 +1886,8 @@ msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
 msgstr ""
-"ข้อมูลเมตาส่วนบุคคลทั้งหมด (เช่น ที่อยู่ IP ของคุณ) จะถูกลบออกก่อนที่จะส่งการแชทไปยังผู้ให้บริการ "
-"AI"
+"ข้อมูลเมตาส่วนบุคคลทั้งหมด (เช่น ที่อยู่ IP ของคุณ) "
+"จะถูกลบออกก่อนที่จะส่งการแชทไปยังผู้ให้บริการ AI"
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1936,8 +1958,10 @@ msgid ""
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
 "อนุญาตให้ %1$s ค้นหาเว็บเพื่อปรับปรุงการตอบสนองต่อข้อความแจ้งที่เกี่ยวข้อง "
-"ส่งเฉพาะข้อความค้นหาที่สร้างโดย AI ไปยังเครื่องมือค้นหาที่มีการเก็บรักษาข้อมูลที่จํากัด "
-"คำแนะนำและการตอบสนองที่มี %2$s ยังคงมี %3$sการมองเห็นผู้ให้บริการเป็นศูนย์%4$s"
+"ส่งเฉพาะข้อความค้นหาที่สร้างโดย AI "
+"ไปยังเครื่องมือค้นหาที่มีการเก็บรักษาข้อมูลที่จํากัด "
+"คำแนะนำและการตอบสนองที่มี %2$s ยังคงมี "
+"%3$sการมองเห็นผู้ให้บริการเป็นศูนย์%4$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2082,7 +2106,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"การเข้าถึงโมเดล AI ยอดนิยมแบบไม่ระบุชื่อ รวมถึง %1$s, %2$sและ %3$s และ %4$sโอเพ่นซอร์ส"
+"การเข้าถึงโมเดล AI ยอดนิยมแบบไม่ระบุชื่อ รวมถึง %1$s, %2$sและ %3$s และ "
+"%4$sโอเพ่นซอร์ส"
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -2091,7 +2116,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"การเข้าถึงโมเดล AI ยอดนิยมแบบไม่ระบุชื่อ รวมถึง %1$s, %2$sและ %3$s และ %4$sโอเพ่นซอร์ส"
+"การเข้าถึงโมเดล AI ยอดนิยมแบบไม่ระบุชื่อ รวมถึง %1$s, %2$sและ %3$s และ "
+"%4$sโอเพ่นซอร์ส"
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -2105,8 +2131,8 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
-"สร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุตัวตนโดยอิงจากเนื้อหาบนเว็บ เลือกความถี่ที่คุณต้องการให้แสดง "
-"หรือปิดการใช้งานโดยสมบูรณ์"
+"สร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุตัวตนโดยอิงจากเนื้อหาบนเว็บ "
+"เลือกความถี่ที่คุณต้องการให้แสดง หรือปิดการใช้งานโดยสมบูรณ์"
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2153,7 +2179,8 @@ msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
 msgstr ""
-"คำแนะนำเพิ่มเติมที่เธอต้องการให้ Duck.ai ปฏิบัติตาม เช่น บอกข้อเท็จจริงเกี่ยวกับเป็ดให้ฉันรู้เสมอ"
+"คำแนะนำเพิ่มเติมที่เธอต้องการให้ Duck.ai ปฏิบัติตาม เช่น "
+"บอกข้อเท็จจริงเกี่ยวกับเป็ดให้ฉันรู้เสมอ"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2273,7 +2300,8 @@ msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
 msgstr ""
-"คุณแน่ใจหรือไม่ว่าต้องการปิดการใช้งานประวัติ การกระทำนี้จะลบแชททั้งหมด รวมถึงแชทที่ปักหมุดไว้ด้วย"
+"คุณแน่ใจหรือไม่ว่าต้องการปิดการใช้งานประวัติ การกระทำนี้จะลบแชททั้งหมด "
+"รวมถึงแชทที่ปักหมุดไว้ด้วย"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2282,7 +2310,8 @@ msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
 msgstr ""
-"คุณแน่ใจหรือไม่ว่าต้องการปิดการใช้งานแชทล่าสุด การดำเนินการนี้จะลบแชทล่าสุดที่มีการบันทึกไว้ด้วย"
+"คุณแน่ใจหรือไม่ว่าต้องการปิดการใช้งานแชทล่าสุด "
+"การดำเนินการนี้จะลบแชทล่าสุดที่มีการบันทึกไว้ด้วย"
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2320,8 +2349,8 @@ msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
 msgstr ""
-"ตามนโยบายความเป็นส่วนตัวของเรา เราจะไม่เก็บรวบรวมหรือแชร์ข้อมูลส่วนบุคคลใดๆ ด้วยตนเอง "
-"การปกป้องความเป็นส่วนตัวทั้งหมดนี้เกิดขึ้นบนอุปกรณ์ของคุณ"
+"ตามนโยบายความเป็นส่วนตัวของเรา เราจะไม่เก็บรวบรวมหรือแชร์ข้อมูลส่วนบุคคลใดๆ "
+"ด้วยตนเอง การปกป้องความเป็นส่วนตัวทั้งหมดนี้เกิดขึ้นบนอุปกรณ์ของคุณ"
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2464,12 +2493,16 @@ msgid ""
 "answers are only available in the U.S. (English) region."
 msgstr ""
 "Assist สามารถสร้างคำตอบที่ได้รับความช่วยเหลือจาก AI "
+""
 "โดยไม่ระบุตัวตนให้กับการค้นหาบางรายการโดยอิงจากการสรุปเนื้อหาเว็บที่เกี่ยวข้อง "
-"คุณสามารถเลือกได้ว่าต้องการให้ Assist ปรากฏบ่อยเพียงใด: ไม่แสดงเลย (ลบ Assist UI "
-"ออกจากผลการค้นหาทั้งหมด), ตามต้องการ (แสดงเฉพาะคำตอบที่ได้รับความช่วยเหลือจาก AI "
-"เมื่อคุณคลิกปุ่ม Assist), บางครั้ง (แสดงเฉพาะคำตอบที่ได้รับความช่วยเหลือจาก AI "
-"เมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง (แสดงบ่อยขึ้นในการค้นหาที่มีช่วงกว้างกว่า) สำหรับตอนนี้ "
-"คำตอบที่ได้รับความช่วยเหลือจาก AI มีให้บริการเฉพาะในภูมิภาคสหรัฐอเมริกา (ภาษาอังกฤษ) เท่านั้น"
+"คุณสามารถเลือกได้ว่าต้องการให้ Assist ปรากฏบ่อยเพียงใด: ไม่แสดงเลย (ลบ "
+"Assist UI ออกจากผลการค้นหาทั้งหมด), ตามต้องการ "
+"(แสดงเฉพาะคำตอบที่ได้รับความช่วยเหลือจาก AI เมื่อคุณคลิกปุ่ม Assist), "
+"บางครั้ง (แสดงเฉพาะคำตอบที่ได้รับความช่วยเหลือจาก AI "
+"เมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง "
+"(แสดงบ่อยขึ้นในการค้นหาที่มีช่วงกว้างกว่า) สำหรับตอนนี้ "
+"คำตอบที่ได้รับความช่วยเหลือจาก AI มีให้บริการเฉพาะในภูมิภาคสหรัฐอเมริกา "
+"(ภาษาอังกฤษ) เท่านั้น"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2481,9 +2514,14 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist เป็นฟีเจอร์เสริมในผลการค้นหาของเราที่สามารถสร้างคำตอบที่ได้รับความช่วยเหลือจาก AI "
-"สำหรับคำค้นหาโดยไม่ระบุชื่อได้ ในการดำเนินการนี้ ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง "
-"จากนั้นใช้เทคโนโลยีภาษาธรรมชาติที่ใช้ AI เพื่อสร้างคำตอบสั้นๆ ตามข้อมูลที่เกี่ยวข้องที่พบ "
+"Assist "
+""
+"เป็นฟีเจอร์เสริมในผลการค้นหาของเราที่สามารถสร้างคำตอบที่ได้รับความช่วยเหลือจาก "
+"AI สำหรับคำค้นหาโดยไม่ระบุชื่อได้ ในการดำเนินการนี้ "
+"ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง "
+"จากนั้นใช้เทคโนโลยีภาษาธรรมชาติที่ใช้ AI เพื่อสร้างคำตอบสั้นๆ "
+"ตามข้อมูลที่เกี่ยวข้องที่พบ "
+""
 "สิ่งสำคัญคือต้องจำไว้ว่าคำตอบนั้นถูกสร้างขึ้นโดยอัตโนมัติจากแหล่งข้อมูลที่ใช้อ้างอิง "
 "และขึ้นอยู่กับ%1$sการรวบรวมข้อมูลเว็บ%2$s"
 
@@ -2511,8 +2549,8 @@ msgid ""
 "At the café, airport, or hotel, DuckDuckGo VPN encrypts your connection and "
 "hides your IP address on Wi-Fi."
 msgstr ""
-"ที่คาเฟ่ สนามบิน หรือโรงแรม DuckDuckGo VPN จะเข้ารหัสการเชื่อมต่อของคุณและซ่อนที่อยู่ IP "
-"ของคุณเมื่อใช้ Wi‑Fi"
+"ที่คาเฟ่ สนามบิน หรือโรงแรม DuckDuckGo VPN "
+"จะเข้ารหัสการเชื่อมต่อของคุณและซ่อนที่อยู่ IP ของคุณเมื่อใช้ Wi‑Fi"
 
 # smartling.placeholder_format=C
 #. In the context of the National Hockey League (NHL), label for teams belonging to the Atlantic division
@@ -2659,8 +2697,8 @@ msgid ""
 "Assist is only available in English regions."
 msgstr ""
 "แสดง Assist โดยอัตโนมัติสำหรับการค้นหาที่เกี่ยวข้อง Assist "
-"สามารถค้นหาและสรุปข้อมูลโดยไม่ระบุตัวตนตามการค้นหาบางอย่าง สำหรับตอนนี้ Assist "
-"มีให้บริการเฉพาะในภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
+"สามารถค้นหาและสรุปข้อมูลโดยไม่ระบุตัวตนตามการค้นหาบางอย่าง สำหรับตอนนี้ "
+"Assist มีให้บริการเฉพาะในภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2670,8 +2708,8 @@ msgid ""
 "For now, DuckAssist is only available in English regions."
 msgstr ""
 "แสดง DuckAssist โดยอัตโนมัติสำหรับการค้นหาที่เกี่ยวข้อง DuckAssist "
-"สามารถค้นหาและสรุปข้อมูลโดยไม่ระบุตัวตนตามการค้นหาบางอย่าง สำหรับตอนนี้ DuckAssist "
-"มีให้บริการเฉพาะในภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
+"สามารถค้นหาและสรุปข้อมูลโดยไม่ระบุตัวตนตามการค้นหาบางอย่าง สำหรับตอนนี้ "
+"DuckAssist มีให้บริการเฉพาะในภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2877,8 +2915,8 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
-"ก่อนจัดเก็บรายงานนี้ DuckDuckGo จะทำให้การสนทนาของคุณไม่ระบุตัวตนโดยการลบ PII เช่น ชื่อ "
-"ที่อยู่อีเมล และเมตาดาต้าที่ระบุตัวตน"
+"ก่อนจัดเก็บรายงานนี้ DuckDuckGo จะทำให้การสนทนาของคุณไม่ระบุตัวตนโดยการลบ "
+"PII เช่น ชื่อ ที่อยู่อีเมล และเมตาดาต้าที่ระบุตัวตน"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3269,15 +3307,17 @@ msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"เรียกดูตามปกติขณะที่เราเพิ่มการปกป้องความเป็นส่วนตัวให้คุณ เรารวมเครื่องมือค้นหา "
-"เครื่องมือบล็อกตัวติดตาม และเครื่องมือบังคับใช้การเข้ารหัสไว้ด้วยกันใน%1$s%2$sส่วนขยาย%3$sเดียว"
+"เรียกดูตามปกติขณะที่เราเพิ่มการปกป้องความเป็นส่วนตัวให้คุณ "
+"เรารวมเครื่องมือค้นหา เครื่องมือบล็อกตัวติดตาม "
+"และเครื่องมือบังคับใช้การเข้ารหัสไว้ด้วยกันใน%1$s%2$sส่วนขยาย%3$sเดียว"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"เรียกดูตามปกติ แล้วเราจะดูแลส่วนที่เหลือให้เอง เรารวมเครื่องมือค้นหา เครื่องมือบล็อกตัวติดตาม "
+"เรียกดูตามปกติ แล้วเราจะดูแลส่วนที่เหลือให้เอง เรารวมเครื่องมือค้นหา "
+"เครื่องมือบล็อกตัวติดตาม "
 "และเครื่องมือบังคับใช้การเข้ารหัสไว้ด้วยกันใน%1$s%2$sส่วนขยาย%3$sเดียว"
 
 # smartling.placeholder_format=C
@@ -3286,8 +3326,9 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"เรียกดูตามปกติ แล้วเราจะดูแลส่วนที่เหลือให้เอง ดาวน์โหลดเพียงครั้งเดียวแล้วใช้งานได้ทั้ง Private "
-"Search, การบล็อกตัวติดตาม และการเข้ารหัสเว็บไซต์สำหรับ%1$sเบราว์เซอร์หลักๆ%2$s"
+"เรียกดูตามปกติ แล้วเราจะดูแลส่วนที่เหลือให้เอง "
+"ดาวน์โหลดเพียงครั้งเดียวแล้วใช้งานได้ทั้ง Private Search, การบล็อกตัวติดตาม "
+"และการเข้ารหัสเว็บไซต์สำหรับ%1$sเบราว์เซอร์หลักๆ%2$s"
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3394,9 +3435,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"ตามค่าเริ่มต้น การตั้งค่าจะได้รับการจัดเก็บอยู่ในคุกกี้เบราว์เซอร์ที่ไม่ใช่ส่วนบุคคล "
+"ตามค่าเริ่มต้น "
+"การตั้งค่าจะได้รับการจัดเก็บอยู่ในคุกกี้เบราว์เซอร์ที่ไม่ใช่ส่วนบุคคล "
 "(ในเบราว์เซอร์ของคุณ) คุณสามารถใช้ Cloud Save "
-"แบบไม่ระบุตัวตนเพื่อจัดเก็บข้อมูลการตั้งค่าอย่างถาวรยิ่งขึ้นได้ (บนเซิร์ฟเวอร์ระยะไกลในระบบคลาวด์) "
+"แบบไม่ระบุตัวตนเพื่อจัดเก็บข้อมูลการตั้งค่าอย่างถาวรยิ่งขึ้นได้ "
+"(บนเซิร์ฟเวอร์ระยะไกลในระบบคลาวด์) "
 "จะไม่มีการจัดเก็บข้อมูลที่สามารถระบุถึงตัวตนได้บนระบบคลาวด์และรหัสผ่านของคุณจะอยู่บนเบราว์เซอร์ของคุณเท่านั้น"
 
 # smartling.placeholder_format=C
@@ -3405,8 +3448,9 @@ msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"โดยการเปิดใช้งานการป้อนข้อความด้วยเสียง คุณยินยอมให้ข้อมูลเสียงของคุณถูกส่งไปยัง OpenAI "
-"เพื่อใช้งานคุณลักษณะนี้ ดู %1$s ของเราก่อนเริ่มต้น"
+"โดยการเปิดใช้งานการป้อนข้อความด้วยเสียง "
+"คุณยินยอมให้ข้อมูลเสียงของคุณถูกส่งไปยัง OpenAI เพื่อใช้งานคุณลักษณะนี้ ดู "
+"%1$s ของเราก่อนเริ่มต้น"
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3415,8 +3459,8 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"โดยการเปิดใช้งานการแชทด้วยเสียง คุณยินยอมให้ข้อมูลเสียงของคุณถูกส่งไปยัง OpenAI "
-"เพื่อใช้งานคุณลักษณะนี้ ดู %1$s ของเราก่อนเริ่มต้น"
+"โดยการเปิดใช้งานการแชทด้วยเสียง คุณยินยอมให้ข้อมูลเสียงของคุณถูกส่งไปยัง "
+"OpenAI เพื่อใช้งานคุณลักษณะนี้ ดู %1$s ของเราก่อนเริ่มต้น"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3523,7 +3567,7 @@ msgctxt ""
 "Secondary button that dismisses the tab picker dialog without attaching "
 "anything"
 msgid "Cancel"
-msgstr ""
+msgstr "ยกเลิก"
 
 # smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
@@ -3911,7 +3955,8 @@ msgstr ""
 "Chat (ผ่านบริการ Duck.ai ของเรา) ให้คุณสนทนาแบบไม่ระบุตัวตนกับโมเดลแชท AI "
 "ของบุคคลที่สาม ซึ่งรองรับโมเดลจาก OpenAI, Anthropic และอีกมากมาย "
 "การปิดการตั้งค่านี้จะซ่อนปุ่ม Chat และลิงก์บน DuckDuckGo Search อย่างไรก็ตาม "
-"คุณยังสามารถเข้าถึง Chat ได้เมื่อปิดการตั้งค่านี้โดยไปที่ %1$shttps://duck.ai%2$s โดยตรง"
+"คุณยังสามารถเข้าถึง Chat ได้เมื่อปิดการตั้งค่านี้โดยไปที่ "
+"%1$shttps://duck.ai%2$s โดยตรง"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4015,7 +4060,7 @@ msgstr "คำตอบของแชทไม่เหมาะสม"
 #. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
 msgctxt "Chat history about modal list item headline"
 msgid "Chat storage varies by browser"
-msgstr ""
+msgstr "พื้นที่จัดเก็บแชทแตกต่างกันไปตามเบราว์เซอร์"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4027,7 +4072,7 @@ msgstr "แชทกับ %1$s"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Chat with popular AI models, anonymized by us."
-msgstr ""
+msgstr "แชทกับโมเดล AI ยอดนิยม ไม่ระบุชื่อโดยเรา"
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4054,6 +4099,9 @@ msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
 msgstr ""
+"การแชทจะถูกจัดเก็บอย่างปลอดภัยบนเซิร์ฟเวอร์ของ DuckDuckGo "
+"ด้วยการเข้ารหัสแบบครบวงจร ไม่มีใครนอกจากคุณที่สามารถเห็นข้อมูลของคุณ "
+"แม้แต่เรา"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4062,8 +4110,8 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"แชทจะถูกเก็บไว้ในอุปกรณ์ของคุณแทนที่จะอยู่บนเซิร์ฟเวอร์ของ DuckDuckGo หรือเซิร์ฟเวอร์ระยะไกล "
-"การปิดประวัติการแชทจะลบแชทที่ปักหมุด"
+"แชทจะถูกเก็บไว้ในอุปกรณ์ของคุณแทนที่จะอยู่บนเซิร์ฟเวอร์ของ DuckDuckGo "
+"หรือเซิร์ฟเวอร์ระยะไกล การปิดประวัติการแชทจะลบแชทที่ปักหมุด"
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -4076,9 +4124,11 @@ msgid ""
 "prompts and responses."
 msgstr ""
 "แชทจะถูกจัดเก็บไว้ในอุปกรณ์ของคุณ "
-"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ DuckDuckGo "
-"หลังจากที่ส่งไปแล้ว เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต "
-"การปิดประวัติการแชทจะลบแชทที่ปักหมุด และปิดใช้งานการเก็บคำแนะนำและการตอบสนองใหม่ชั่วคราว"
+"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ "
+"DuckDuckGo หลังจากที่ส่งไปแล้ว "
+"เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต "
+"การปิดประวัติการแชทจะลบแชทที่ปักหมุด "
+"และปิดใช้งานการเก็บคำแนะนำและการตอบสนองใหม่ชั่วคราว"
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -4101,7 +4151,8 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"การแชทกับ %1$s จะไม่มีการมองเห็นจากผู้ให้บริการ แต่ไฟล์ทั้งหมดที่อัปโหลดใน Duck.ai "
+"การแชทกับ %1$s จะไม่มีการมองเห็นจากผู้ให้บริการ แต่ไฟล์ทั้งหมดที่อัปโหลดใน "
+"Duck.ai "
 "จะได้รับการตรวจสอบโดยไม่ระบุชื่อโดยผู้ให้บริการกลั่นกรองเนื้อหาสำหรับ %2$s"
 
 # smartling.placeholder_format=C
@@ -4162,7 +4213,9 @@ msgstr "ตรวจสอบการสะกดคำ"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr "ตรวจสอบ subreddit ของ DuckDuckGo เพื่อรับข้อมูลอัปเดตเกี่ยวกับการหยุดให้บริการครั้งนี้"
+msgstr ""
+"ตรวจสอบ subreddit ของ DuckDuckGo "
+"เพื่อรับข้อมูลอัปเดตเกี่ยวกับการหยุดให้บริการครั้งนี้"
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4265,7 +4318,8 @@ msgid ""
 "Choose from 40+ server locations worldwide to help block harmful sites and "
 "scams."
 msgstr ""
-"เลือกจากตำแหน่งเซิร์ฟเวอร์กว่า 40 แห่งทั่วโลกเพื่อช่วยบล็อกเว็บไซต์ที่เป็นอันตรายและการหลอกลวง"
+"เลือกจากตำแหน่งเซิร์ฟเวอร์กว่า 40 "
+"แห่งทั่วโลกเพื่อช่วยบล็อกเว็บไซต์ที่เป็นอันตรายและการหลอกลวง"
 
 # smartling.placeholder_format=C
 #. The title of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -4464,8 +4518,9 @@ msgid ""
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
 "การล้างข้อมูลเบราว์เซอร์จะลบแชท "
-"เบราว์เซอร์บางตัวอาจเก็บแชทล่าสุดไว้อย่างไม่มีกำหนดหรืออาจลบอัตโนมัติหลังจากไม่ได้ใช้งาน AI "
-"Chat เป็นเวลา 7 วันขึ้นไป"
+""
+"เบราว์เซอร์บางตัวอาจเก็บแชทล่าสุดไว้อย่างไม่มีกำหนดหรืออาจลบอัตโนมัติหลังจากไม่ได้ใช้งาน "
+"AI Chat เป็นเวลา 7 วันขึ้นไป"
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4476,8 +4531,8 @@ msgid ""
 "on your browser."
 msgstr ""
 "การล้างข้อมูลเบราว์เซอร์จะลบแชทล่าสุด "
-"แชทล่าสุดอาจถูกบันทึกไว้อย่างไม่มีกำหนดหรือลบอัตโนมัติหลังจาก 7 วันหากไม่ได้ใช้ Duck.ai "
-"ขึ้นอยู่กับเบราว์เซอร์ของคุณ"
+"แชทล่าสุดอาจถูกบันทึกไว้อย่างไม่มีกำหนดหรือลบอัตโนมัติหลังจาก 7 "
+"วันหากไม่ได้ใช้ Duck.ai ขึ้นอยู่กับเบราว์เซอร์ของคุณ"
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4486,7 +4541,8 @@ msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
 msgstr ""
-"การล้างข้อมูลเบราว์เซอร์จะรีเซ็ตไซต์ที่ถูกบล็อกของคุณ บันทึกรายการที่บล็อกของคุณอย่างถาวรใน"
+"การล้างข้อมูลเบราว์เซอร์จะรีเซ็ตไซต์ที่ถูกบล็อกของคุณ "
+"บันทึกรายการที่บล็อกของคุณอย่างถาวรใน"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4495,8 +4551,8 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"คลิก \"เพิ่มเติม\" เพื่อเจาะลึกหัวข้อ และถามคำถามติดตามผ่าน %1$sDuck.ai%2$s บริการแชท AI "
-"ส่วนตัวของเราที่รองรับโมเดลแชทจาก OpenAI, Anthropic และอื่น ๆ"
+"คลิก \"เพิ่มเติม\" เพื่อเจาะลึกหัวข้อ และถามคำถามติดตามผ่าน %1$sDuck.ai%2$s "
+"บริการแชท AI ส่วนตัวของเราที่รองรับโมเดลแชทจาก OpenAI, Anthropic และอื่น ๆ"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4538,7 +4594,8 @@ msgid ""
 "Click %sEdit > Preferences%s (on Windows) %sSeaMonkey > Preferences%s (on "
 "Mac)"
 msgstr ""
-"คลิก%1$sแก้ไข > ค่ากำหนด%2$s (บน Windows) %3$sSeaMonkey > ค่ากำหนด%4$s (บน Mac)"
+"คลิก%1$sแก้ไข > ค่ากำหนด%2$s (บน Windows) %3$sSeaMonkey > ค่ากำหนด%4$s (บน "
+"Mac)"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4569,7 +4626,8 @@ msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
 msgstr ""
-"คลิก %1$sSafari%2$s ในเมนูด้านบน (บน Windows ให้คลิก%3$sไอคอนเฟือง%4$sที่ด้านขวาบน)"
+"คลิก %1$sSafari%2$s ในเมนูด้านบน (บน Windows "
+"ให้คลิก%3$sไอคอนเฟือง%4$sที่ด้านขวาบน)"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4661,7 +4719,8 @@ msgid ""
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
 msgstr ""
 "คลิกหรือแตะ %1$sลบข้อมูลของฉัน%2$s การดำเนินการนี้จะลบข้อมูลออกจากระบบคลาวด์ "
-"แต่จะยังคงอยู่ในเบราว์เซอร์จนกว่าคุณจะคลิก/แตะ %3$sรีเซ็ตการตั้งค่าการค้นหาทั้งหมด%4$s"
+"แต่จะยังคงอยู่ในเบราว์เซอร์จนกว่าคุณจะคลิก/แตะ "
+"%3$sรีเซ็ตการตั้งค่าการค้นหาทั้งหมด%4$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4742,7 +4801,8 @@ msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
 msgstr ""
-"คลิกเมนูดรอปดาวน์ข้าง%1$sเครื่องมือค้นหาที่ใช้ในแถบที่อยู่%2$s และเลือก %3$sDuckDuckGo%4$s"
+"คลิกเมนูดรอปดาวน์ข้าง%1$sเครื่องมือค้นหาที่ใช้ในแถบที่อยู่%2$s และเลือก "
+"%3$sDuckDuckGo%4$s"
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
@@ -4950,7 +5010,8 @@ msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
 msgstr ""
-"Cloud Save ช่วยให้คุณบันทึกการตั้งค่าของคุณอย่างถาวรยิ่งขึ้นได้โดยการป้อนรหัสผ่าน "
+"Cloud Save "
+"ช่วยให้คุณบันทึกการตั้งค่าของคุณอย่างถาวรยิ่งขึ้นได้โดยการป้อนรหัสผ่าน "
 "ซึ่งเป็นการดำเนินการที่ไม่บังคับ"
 
 # smartling.placeholder_format=C
@@ -5393,8 +5454,8 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
-"คัดลอกรหัสจากอุปกรณ์อื่น ไปที่ %1$sDuck.ai Settings › Chats › Sync & Backup › Sync "
-"With Another Device%2$s แล้วลองอีกครั้ง"
+"คัดลอกรหัสจากอุปกรณ์อื่น ไปที่ %1$sDuck.ai Settings › Chats › Sync & Backup "
+"› Sync With Another Device%2$s แล้วลองอีกครั้ง"
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5629,7 +5690,7 @@ msgstr "สตรีคปัจจุบัน"
 #. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
 msgctxt "Suffix label indicating a tab is the currently active browser tab"
 msgid "Current Tab"
-msgstr ""
+msgstr "แท็บปัจจุบัน"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
@@ -5981,7 +6042,7 @@ msgstr "ลบแชทที่เก่ากว่า 30 วัน"
 #. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
 msgctxt "Button text in the modal for deleting all recent chats"
 msgid "Delete Chats and Shared Links"
-msgstr ""
+msgstr "ลบแชทและลิงก์ที่แชร์"
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6400,7 +6461,7 @@ msgstr "ปิดการเลื่อนระดับ"
 #. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the close button on the survey banner"
 msgid "Dismiss survey"
-msgstr ""
+msgstr "ปิดแบบสำรวจ"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6551,8 +6612,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
-"ไม่ต้องการ AI ใช่ไหม %1$snoai.duckduckgo.com%2$s ไม่มีฟีเจอร์ AI และกรองภาพ AI "
-"ออกแล้ว %3$sศึกษาเพิ่มเติม%4$s"
+"ไม่ต้องการ AI ใช่ไหม %1$snoai.duckduckgo.com%2$s ไม่มีฟีเจอร์ AI และกรองภาพ "
+"AI ออกแล้ว %3$sศึกษาเพิ่มเติม%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6561,8 +6622,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"ไม่ต้องการ AI ใช่ไหม ไปที่ %1$snoai.duckduckgo.com%2$s เพื่อค้นหาโดยไม่มีฟีเจอร์ AI "
-"และกรองภาพ AI ออก %3$sศึกษาเพิ่มเติม%4$s"
+"ไม่ต้องการ AI ใช่ไหม ไปที่ %1$snoai.duckduckgo.com%2$s "
+"เพื่อค้นหาโดยไม่มีฟีเจอร์ AI และกรองภาพ AI ออก %3$sศึกษาเพิ่มเติม%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6846,7 +6907,8 @@ msgid ""
 "pages automatically in Settings."
 msgstr ""
 "ตอนนี้ Duck.ai สามารถช่วยตอบคําถามเกี่ยวกับหน้าเว็บที่คุณกำลังดูอยู่ได้แล้ว "
-"เนื้อหาในหน้าจะถูกรวมเข้าไปเมื่อคุณแนบมัน ยกเว้นว่าคุณเลือกที่จะแนบหน้าโดยอัตโนมัติในการตั้งค่า"
+"เนื้อหาในหน้าจะถูกรวมเข้าไปเมื่อคุณแนบมัน "
+"ยกเว้นว่าคุณเลือกที่จะแนบหน้าโดยอัตโนมัติในการตั้งค่า"
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6897,8 +6959,8 @@ msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
 msgstr ""
-"Duck.ai ยังคงเป็นผลิตภัณฑ์ของ DuckDuckGo แต่ตอนนี้จะมีที่อยู่บนเว็บที่จดจำง่ายขึ้น: https://"
-"duck.ai"
+"Duck.ai ยังคงเป็นผลิตภัณฑ์ของ DuckDuckGo "
+"แต่ตอนนี้จะมีที่อยู่บนเว็บที่จดจำง่ายขึ้น: https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6913,7 +6975,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai ไม่สามารถใช้งานได้ชั่วคราว หากยังคงอยู่ โปรดส่งอีเมลรหัสที่ไม่ระบุชื่อนี้ %1$s ไปที่ %2$s"
+"Duck.ai ไม่สามารถใช้งานได้ชั่วคราว หากยังคงอยู่ "
+"โปรดส่งอีเมลรหัสที่ไม่ระบุชื่อนี้ %1$s ไปที่ %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6934,8 +6997,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"Duck.ai ให้คุณแชทแบบส่วนตัวกับโมเดล AI ยอดนิยม การปิดใช้งานจะซ่อนปุ่มและลิงก์ของ Duck.ai "
-"แต่คุณยังสามารถไปที่ %1$sduck.ai%2$s โดยตรง"
+"Duck.ai ให้คุณแชทแบบส่วนตัวกับโมเดล AI ยอดนิยม "
+"การปิดใช้งานจะซ่อนปุ่มและลิงก์ของ Duck.ai แต่คุณยังสามารถไปที่ "
+"%1$sduck.ai%2$s โดยตรง"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6946,10 +7010,10 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai ช่วยให้คุณสนทนาแบบไม่ระบุตัวตนกับโมเดลแชท AI ของบุคคลที่สาม รวมถึงโมเดลจาก "
-"OpenAI, Anthropic และอื่นๆ การปิดการตั้งค่านี้จะซ่อนปุ่ม Chat และลิงก์บน DuckDuckGo "
-"Search อย่างไรก็ตาม คุณยังสามารถเข้าถึง Duck.ai ได้เมื่อปิดการตั้งค่านี้โดยไปที่ %1$shttps://"
-"duck.ai%2$s โดยตรง"
+"Duck.ai ช่วยให้คุณสนทนาแบบไม่ระบุตัวตนกับโมเดลแชท AI ของบุคคลที่สาม "
+"รวมถึงโมเดลจาก OpenAI, Anthropic และอื่นๆ การปิดการตั้งค่านี้จะซ่อนปุ่ม Chat "
+"และลิงก์บน DuckDuckGo Search อย่างไรก็ตาม คุณยังสามารถเข้าถึง Duck.ai "
+"ได้เมื่อปิดการตั้งค่านี้โดยไปที่ %1$shttps://duck.ai%2$s โดยตรง"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -7010,9 +7074,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, แชทบอท AI ส่วนตัว, แชท AI ฟรี, แชท AI แบบไม่ระบุตัวตน, แชท "
-"AI ไม่ต้องสมัคร, OpenAI, Anthropic, Llama, Mistral, โมเดล AI โอเพนซอร์ส, AI "
-"ที่เน้นความเป็นส่วนตัว, แชท AI ไม่ต้องมีบัญชี"
+"Duck.ai, DuckDuckGo AI, แชทบอท AI ส่วนตัว, แชท AI ฟรี, แชท AI "
+"แบบไม่ระบุตัวตน, แชท AI ไม่ต้องสมัคร, OpenAI, Anthropic, Llama, Mistral, "
+"โมเดล AI โอเพนซอร์ส, AI ที่เน้นความเป็นส่วนตัว, แชท AI ไม่ต้องมีบัญชี"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7041,10 +7105,12 @@ msgid ""
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
 "DuckAssist สามารถค้นหาและสรุปข้อมูลโดยไม่ระบุตัวตนตามการค้นหาบางอย่าง "
-"คุณสามารถเลือกได้ว่าต้องการให้ DuckAssist ปรากฏบ่อยเพียงใด: ไม่แสดงเลย (ลบ DuckAssist "
-"UI ออกจากผลการค้นหาทั้งหมด), ตามต้องการ (แสดงเฉพาะเมื่อคุณคลิกปุ่ม Assist), บางครั้ง "
-"(แสดงเฉพาะเมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง (แสดงบ่อยขึ้นในการค้นหาที่มีช่วงกว้าง) "
-"สำหรับตอนนี้ DuckAssist มีให้บริการเฉพาะในภูมิภาคสหรัฐอเมริกา (ภาษาอังกฤษ) เท่านั้น"
+"คุณสามารถเลือกได้ว่าต้องการให้ DuckAssist ปรากฏบ่อยเพียงใด: ไม่แสดงเลย (ลบ "
+"DuckAssist UI ออกจากผลการค้นหาทั้งหมด), ตามต้องการ "
+"(แสดงเฉพาะเมื่อคุณคลิกปุ่ม Assist), บางครั้ง "
+"(แสดงเฉพาะเมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง "
+"(แสดงบ่อยขึ้นในการค้นหาที่มีช่วงกว้าง) สำหรับตอนนี้ DuckAssist "
+"มีให้บริการเฉพาะในภูมิภาคสหรัฐอเมริกา (ภาษาอังกฤษ) เท่านั้น"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7053,9 +7119,9 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist ไม่สามารถตอบคำถามที่ตามมาได้ อย่างไรก็ตาม เรายังมี %1$sDuckDuckGo AI "
-"Chat%2$s ซึ่งเป็นบริการแชทส่วนตัวที่ใช้ AI และรองรับโมเดลการแชทจาก OpenAI, Anthropic "
-"และอื่นๆ อีกมากมาย"
+"DuckAssist ไม่สามารถตอบคำถามที่ตามมาได้ อย่างไรก็ตาม เรายังมี %1$sDuckDuckGo "
+"AI Chat%2$s ซึ่งเป็นบริการแชทส่วนตัวที่ใช้ AI และรองรับโมเดลการแชทจาก "
+"OpenAI, Anthropic และอื่นๆ อีกมากมาย"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7064,9 +7130,9 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist ไม่สามารถตอบคำถามที่ถามต่อได้ อย่างไรก็ตาม เรายังมี DuckDuckGo %1$sAI "
-"Chat%2$s ซึ่งเป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI ที่รองรับโมเดลการแชทจาก OpenAI และ "
-"Anthropic"
+"DuckAssist ไม่สามารถตอบคำถามที่ถามต่อได้ อย่างไรก็ตาม เรายังมี DuckDuckGo "
+"%1$sAI Chat%2$s ซึ่งเป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI "
+"ที่รองรับโมเดลการแชทจาก OpenAI และ Anthropic"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7079,8 +7145,10 @@ msgid ""
 "checked for accuracy."
 msgstr ""
 "DuckAssist "
+""
 "เป็นคุณลักษณะใหม่ในผลการค้นหาของเราที่สามารถสร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุชื่อได้ "
-"ในการดำเนินการนี้ ระบบจะสแกน Wikipedia และเว็บไซต์ที่เกี่ยวข้องเพื่อหาเนื้อหาที่เกี่ยวข้อง "
+"ในการดำเนินการนี้ ระบบจะสแกน Wikipedia "
+"และเว็บไซต์ที่เกี่ยวข้องเพื่อหาเนื้อหาที่เกี่ยวข้อง "
 "จากนั้นใช้เทคโนโลยีภาษาธรรมชาติที่ขับเคลื่อนด้วย AI เพื่อสร้างข้อมูลสรุป "
 "โปรดทราบว่าขณะนี้คำตอบนั้นอิงจาก Wikipedia และเนื้อหาที่เกี่ยวข้อง "
 "และไม่ได้มีการตรวจสอบความถูกต้อง"
@@ -7098,11 +7166,16 @@ msgid ""
 "sources and based on %scrawling the web%s."
 msgstr ""
 "DuckAssist "
+""
 "เป็นฟีเจอร์เสริมในผลการค้นหาของเราที่สามารถสร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุชื่อได้ "
-"ในการดำเนินการนี้ ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง จากนั้นใช้เทคโนโลยีภาษาธรรมชาติที่ใช้ "
-"AI เพื่อสร้างคำตอบสั้นๆ ตามข้อมูลที่เกี่ยวข้องที่พบ คำตอบของ DuckAssist "
-"จะเชื่อมโยงโดยตรงกับแหล่งข้อมูลหนึ่งหรือสองแหล่งเสมอ โดยอ้างอิงแหล่งที่มาของคำตอบ "
+"ในการดำเนินการนี้ ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง "
+"จากนั้นใช้เทคโนโลยีภาษาธรรมชาติที่ใช้ AI เพื่อสร้างคำตอบสั้นๆ "
+"ตามข้อมูลที่เกี่ยวข้องที่พบ คำตอบของ DuckAssist "
+"จะเชื่อมโยงโดยตรงกับแหล่งข้อมูลหนึ่งหรือสองแหล่งเสมอ "
+"โดยอ้างอิงแหล่งที่มาของคำตอบ "
+""
 "เพื่อให้คุณสามารถไปยังแหล่งข้อมูลเพื่อดูข้อมูลโดยละเอียดเพิ่มเติมได้อย่างง่ายดาย "
+""
 "สิ่งสำคัญคือต้องจำไว้ว่าคำตอบนั้นถูกสร้างขึ้นโดยอัตโนมัติจากแหล่งข้อมูลที่ใช้อ้างอิง "
 "และขึ้นอยู่กับ%1$sการรวบรวมข้อมูลเว็บ%2$s"
 
@@ -7112,7 +7185,8 @@ msgid ""
 "DuckAssist responses are auto-generated based on listed sources and not "
 "checked for accuracy."
 msgstr ""
-"คำตอบ DuckAssist สร้างขึ้นโดยอัตโนมัติตามแหล่งที่มาที่ระบุไว้และไม่ได้ตรวจสอบความถูกต้อง"
+"คำตอบ DuckAssist "
+"สร้างขึ้นโดยอัตโนมัติตามแหล่งที่มาที่ระบุไว้และไม่ได้ตรวจสอบความถูกต้อง"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -7120,7 +7194,9 @@ msgctxt "Error message for service limit"
 msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
-msgstr "DuckDuckGo AI Chat ถึงจำนวนข้อความสูงสุดในหนึ่งวันแล้ว โปรดแชทต่อในวันพรุ่งนี้"
+msgstr ""
+"DuckDuckGo AI Chat ถึงจำนวนข้อความสูงสุดในหนึ่งวันแล้ว "
+"โปรดแชทต่อในวันพรุ่งนี้"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7129,8 +7205,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat เป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI ซึ่งปัจจุบันรองรับโมเดลการแชท "
-"%2$s ของ %1$s และ %4$s ของ %3$s"
+"DuckDuckGo AI Chat เป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI "
+"ซึ่งปัจจุบันรองรับโมเดลการแชท %2$s ของ %1$s และ %4$s ของ %3$s"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7139,8 +7215,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat เป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI ซึ่งปัจจุบันรองรับโมเดลการแชท "
-"%2$s ของ %1$s และ %4$s ของ %3$s"
+"DuckDuckGo AI Chat เป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI "
+"ซึ่งปัจจุบันรองรับโมเดลการแชท %2$s ของ %1$s และ %4$s ของ %3$s"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -7157,8 +7233,8 @@ msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
 msgstr ""
-"DuckDuckGo AI Chat ไม่สามารถใช้งานได้ชั่วคราว หากยังคงอยู่ โปรดส่งอีเมลรหัสที่ไม่ระบุชื่อนี้ "
-"%1$s ไปที่ %2$s"
+"DuckDuckGo AI Chat ไม่สามารถใช้งานได้ชั่วคราว หากยังคงอยู่ "
+"โปรดส่งอีเมลรหัสที่ไม่ระบุชื่อนี้ %1$s ไปที่ %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7166,7 +7242,9 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr "DuckDuckGo AI Chat ไม่สามารถใช้งานได้ชั่วคราว โปรดรีเฟรชหน้านี้แล้วลองอีกครั้ง"
+msgstr ""
+"DuckDuckGo AI Chat ไม่สามารถใช้งานได้ชั่วคราว "
+"โปรดรีเฟรชหน้านี้แล้วลองอีกครั้ง"
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7322,8 +7400,8 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"DuckDuckGo ทำให้รายงานเหล่านี้ไม่ระบุตัวตนโดยการลบ PII โดยอัตโนมัติ เช่น ชื่อ ที่อยู่อีเมล "
-"หมายเลขโทรศัพท์ และเมตาดาต้าที่ระบุตัวตน"
+"DuckDuckGo ทำให้รายงานเหล่านี้ไม่ระบุตัวตนโดยการลบ PII โดยอัตโนมัติ เช่น "
+"ชื่อ ที่อยู่อีเมล หมายเลขโทรศัพท์ และเมตาดาต้าที่ระบุตัวตน"
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -7331,7 +7409,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo ทําให้แชทของคุณไม่เปิดเผยตัวตน เมื่อคลิก '%1$s' คุณยอมรับ %2$s ของ Duck.ai"
+"DuckDuckGo ทําให้แชทของคุณไม่เปิดเผยตัวตน เมื่อคลิก '%1$s' คุณยอมรับ %2$s "
+"ของ Duck.ai"
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7340,7 +7419,8 @@ msgctxt ""
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
 msgstr ""
-"DuckDuckGo ทําให้แชทของคุณไม่เปิดเผยตัวตน เมื่อคลิก '%1$s' แสดงว่าคุณยอมรับ %2$s ของเรา"
+"DuckDuckGo ทําให้แชทของคุณไม่เปิดเผยตัวตน เมื่อคลิก '%1$s' แสดงว่าคุณยอมรับ "
+"%2$s ของเรา"
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7349,8 +7429,9 @@ msgid ""
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
 msgstr ""
-"DuckDuckGo จะบล็อกตัวติดตามบนเว็บไซต์ที่คุณเยี่ยมชม รวมถึงตัวติดตามจากบริษัทต่างๆ เช่น Google "
-"และ Facebook ซึ่งมักจะพยายามติดตามคุณบนเว็บไซต์อื่นๆ"
+"DuckDuckGo จะบล็อกตัวติดตามบนเว็บไซต์ที่คุณเยี่ยมชม "
+"รวมถึงตัวติดตามจากบริษัทต่างๆ เช่น Google และ Facebook "
+"ซึ่งมักจะพยายามติดตามคุณบนเว็บไซต์อื่นๆ"
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7362,9 +7443,11 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo ให้ความสำคัญกับความเป็นส่วนตัวตั้งแต่ขั้นตอนการออกแบบ เมื่อคุณเปิดใช้งานตำแหน่งที่ตั้ง "
+"DuckDuckGo ให้ความสำคัญกับความเป็นส่วนตัวตั้งแต่ขั้นตอนการออกแบบ "
+"เมื่อคุณเปิดใช้งานตำแหน่งที่ตั้ง "
 "ข้อมูลดังกล่าวจะได้รับการจัดเก็บไว้บนอุปกรณ์ของคุณเท่านั้น เมื่อคุณค้นหา "
-"อุปกรณ์ของคุณจึงจะส่งข้อมูลตำแหน่งที่ตั้งมาให้เรา ซึ่งเราจะใช้เพื่อปรับปรุงผลการค้นหาดังกล่าว "
+"อุปกรณ์ของคุณจึงจะส่งข้อมูลตำแหน่งที่ตั้งมาให้เรา "
+"ซึ่งเราจะใช้เพื่อปรับปรุงผลการค้นหาดังกล่าว "
 "จากนั้นเราจะทิ้งข้อมูลดังกล่าวในทันทีเพื่อให้ไม่มีการระบุตัวตนของคุณได้ "
 "%1$sดูข้อมูลเพิ่มเติมเกี่ยวกับวิธีที่เราออกแบบเทคโนโลยีนี้เพื่อปกป้องความเป็นส่วนตัวของคุณ%2$s"
 
@@ -7386,8 +7469,9 @@ msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
 msgstr ""
-"DuckDuckGo ใช้เฉพาะตำแหน่งที่ตั้งโดยประมาณของคุณ ซึ่งเราต้องการเพียงเพื่อให้ได้ผลลัพธ์ที่ดีขึ้น "
-"และใกล้คุณมากขึ้น %1$sดูข้อมูลเพิ่มเติม%2$s"
+"DuckDuckGo ใช้เฉพาะตำแหน่งที่ตั้งโดยประมาณของคุณ "
+"ซึ่งเราต้องการเพียงเพื่อให้ได้ผลลัพธ์ที่ดีขึ้น และใกล้คุณมากขึ้น "
+"%1$sดูข้อมูลเพิ่มเติม%2$s"
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7479,8 +7563,9 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"ทุกครั้งที่คุณขอให้แนะนำรหัสผ่าน เราจะได้รับรายการคำสุ่มหลายคำจากเซิร์ฟเวอร์ของ DuckDuckGo "
-"จากนั้นเราจะสุ่มคำ 4 - 5 คำจากรายการดังกล่าวในเบราว์เซอร์ "
+"ทุกครั้งที่คุณขอให้แนะนำรหัสผ่าน "
+"เราจะได้รับรายการคำสุ่มหลายคำจากเซิร์ฟเวอร์ของ DuckDuckGo จากนั้นเราจะสุ่มคำ "
+"4 - 5 คำจากรายการดังกล่าวในเบราว์เซอร์ "
 "เพื่อให้มั่นใจว่ารหัสผ่านมีความยาวอักขระอย่างน้อย 18-20 ตัว"
 
 # smartling.placeholder_format=C
@@ -7538,7 +7623,7 @@ msgstr "แก้ไขคำสั่ง"
 #. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the message-editing text area"
 msgid "Edit message"
-msgstr ""
+msgstr "แก้ไขข้อความ"
 
 # smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
@@ -7694,7 +7779,9 @@ msgstr "เปิดใช้งานการค้นหาเว็บ"
 msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
-msgstr "เปิดใช้ตำแหน่งที่ตั้งแบบไม่ระบุตัวตนเพื่อผลลัพธ์ที่แม่นยำยิ่งขึ้น คุณสามารถเปลี่ยนใจได้ในภายหลัง"
+msgstr ""
+"เปิดใช้ตำแหน่งที่ตั้งแบบไม่ระบุตัวตนเพื่อผลลัพธ์ที่แม่นยำยิ่งขึ้น "
+"คุณสามารถเปลี่ยนใจได้ในภายหลัง"
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7762,7 +7849,7 @@ msgstr "โมเดลที่เข้ารหัส"
 #. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
 msgctxt "Share modal info bullet about encryption"
 msgid "Encrypted so DuckDuckGo can't read your chat."
-msgstr ""
+msgstr "เข้ารหัสไว้ DuckDuckGo จึงไม่สามารถอ่านข้อความในแชทของคุณ"
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -7906,7 +7993,8 @@ msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
 msgstr ""
-"ป้อนรหัสผ่านใหม่แล้วคลิก/แตะ%1$sบันทึกการตั้งค่า%2$s การดำเนินการนี้จะบันทึกข้อมูลในรหัสผ่านใหม่"
+"ป้อนรหัสผ่านใหม่แล้วคลิก/แตะ%1$sบันทึกการตั้งค่า%2$s "
+"การดำเนินการนี้จะบันทึกข้อมูลในรหัสผ่านใหม่"
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -7932,7 +8020,8 @@ msgstr "ป้อนข้อความ"
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
 msgstr ""
-"ป้อนรายละเอียดต่อไปนี้: %1$sชื่อ%2$s: DuckDuckGo%3$s URL%4$s: %5$s นามแฝง%6$s: d%7$s"
+"ป้อนรายละเอียดต่อไปนี้: %1$sชื่อ%2$s: DuckDuckGo%3$s URL%4$s: %5$s "
+"นามแฝง%6$s: d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -8332,7 +8421,9 @@ msgstr ""
 msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
-msgstr "โปรดปรับเปลี่ยนการตั้งค่าด้านล่าง จากนั้นเพียงแค่คัดลอกและวางโค้ดลงในเว็บไซต์ของคุณ"
+msgstr ""
+"โปรดปรับเปลี่ยนการตั้งค่าด้านล่าง "
+"จากนั้นเพียงแค่คัดลอกและวางโค้ดลงในเว็บไซต์ของคุณ"
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8421,7 +8512,9 @@ msgstr "กรองภาพที่สร้างโดย AI จากผ�
 msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
-msgstr "กรองเว็บไซต์สแปม AI ที่รู้จักออกจากผลลัพธ์การค้นหารูปภาพ %1$sดูข้อมูลเพิ่มเติม%2$s"
+msgstr ""
+"กรองเว็บไซต์สแปม AI ที่รู้จักออกจากผลลัพธ์การค้นหารูปภาพ "
+"%1$sดูข้อมูลเพิ่มเติม%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8581,7 +8674,7 @@ msgstr "คำถามเพิ่มเติม"
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
-msgstr ""
+msgstr "ข้อความเพิ่มเติมยังคงเป็นส่วนตัว"
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8699,7 +8792,7 @@ msgstr "แก้ไข แชร์ และใช้ได้อย่าง�
 #. a filter for images with the CC BY usage license
 msgctxt "image-licence"
 msgid "Free to Modify, Share, and Use Commercially"
-msgstr "แก้ไข แชร์ และใช้ในเชิงพาณิชย์"
+msgstr "แก้ไข แชร์ และใช้ในเชิงพาณิชย์ ได้อย่างอิสระ"
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC-ND usage license
@@ -8799,7 +8892,8 @@ msgid ""
 "strong>."
 msgstr ""
 "จากแถบเมนูแอปบน Mac ให้เลือก <strong>DuckDuckGo</strong> &gt; "
-"<strong>ตรวจสอบการอัปเดต...</strong> จากนั้นเลือก <strong>ติดตั้งการอัปเดต</strong>"
+"<strong>ตรวจสอบการอัปเดต...</strong> จากนั้นเลือก "
+"<strong>ติดตั้งการอัปเดต</strong>"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9085,8 +9179,8 @@ msgid ""
 "Get DuckDuckGo VPN, advanced Duck.ai, Personal Info Removal, and Identity "
 "Theft Restoration."
 msgstr ""
-"รับ DuckDuckGo VPN, Duck.ai ขั้นสูง, บริการลบข้อมูลส่วนบุคคล และ Identity Theft "
-"Restoration"
+"รับ DuckDuckGo VPN, Duck.ai ขั้นสูง, บริการลบข้อมูลส่วนบุคคล และ Identity "
+"Theft Restoration"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
@@ -9098,7 +9192,7 @@ msgstr "รับ DuckDuckGo VPN, Duck.ai ขั้นสูง และ Identi
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
 msgctxt "Tooltip on the header logo for sunglasses searches"
 msgid "Get DuckDuckGo sunglasses and other gear."
-msgstr ""
+msgstr "รับแว่นกันแดด DuckDuckGo และสินค้าอื่นๆ"
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9157,7 +9251,9 @@ msgstr "เริ่ม"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the Privacy Pro subscription.
 msgctxt "SERP footer content"
 msgid "Get a VPN + two more protections in one easy subscription."
-msgstr "รับ VPN + การป้องกันเพิ่มเติมอีกสองรายการในการสมัครสมาชิกง่ายๆ เพียงครั้งเดียว"
+msgstr ""
+"รับ VPN + การป้องกันเพิ่มเติมอีกสองรายการในการสมัครสมาชิกง่ายๆ "
+"เพียงครั้งเดียว"
 
 # smartling.placeholder_format=C
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
@@ -9178,8 +9274,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, Personal Info Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"รับ VPN ที่รวดเร็วและไม่บันทึกข้อมูลการใช้งาน, แชท AI ขั้นสูง (ทางเลือก), บริการ Personal "
-"Info Removal และ Identity Theft Restoration"
+"รับ VPN ที่รวดเร็วและไม่บันทึกข้อมูลการใช้งาน, แชท AI ขั้นสูง (ทางเลือก), "
+"บริการ Personal Info Removal และ Identity Theft Restoration"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; 'advanced AI chat' refers to Duck.ai; Identity Theft Restoration is a bundled feature.
@@ -9188,8 +9284,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, and Identity Theft "
 "Restoration."
 msgstr ""
-"รับ VPN ที่รวดเร็วและไม่บันทึกข้อมูลการใช้งาน (no-log), แชท AI ขั้นสูงที่เป็นตัวเลือกเสริม "
-"และบริการ Identity Theft Restoration"
+"รับ VPN ที่รวดเร็วและไม่บันทึกข้อมูลการใช้งาน (no-log), แชท AI "
+"ขั้นสูงที่เป็นตัวเลือกเสริม และบริการ Identity Theft Restoration"
 
 # smartling.placeholder_format=C
 #. Description for the subscription modal where users can update their subscription to DuckDuckGo.
@@ -9198,8 +9294,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"เข้าถึงโมเดล AI ขั้นสูงใน Duck.ai ได้โดยการสมัครสมาชิก DuckDuckGo ซึ่งยังรวมถึง VPN "
-"และการปกป้องความเป็นส่วนตัวระดับพรีเมียมอื่นๆ ของเรา"
+"เข้าถึงโมเดล AI ขั้นสูงใน Duck.ai ได้โดยการสมัครสมาชิก DuckDuckGo "
+"ซึ่งยังรวมถึง VPN และการปกป้องความเป็นส่วนตัวระดับพรีเมียมอื่นๆ ของเรา"
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -9210,8 +9306,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"เข้าถึงโมเดล AI ขั้นสูงใน Duck.ai ด้วยการสมัครสมาชิก DuckDuckGo ซึ่งยังรวมถึง VPN "
-"และการปกป้องความเป็นส่วนตัวระดับพรีเมียมอื่นๆ ของเรา"
+"เข้าถึงโมเดล AI ขั้นสูงใน Duck.ai ด้วยการสมัครสมาชิก DuckDuckGo "
+"ซึ่งยังรวมถึง VPN และการปกป้องความเป็นส่วนตัวระดับพรีเมียมอื่นๆ ของเรา"
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9255,8 +9351,9 @@ msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
 msgstr ""
-"รับ VPN ที่รวดเร็ว ไม่เก็บบันทึกการใช้งานของเรา, ตัวเลือกในการเข้าถึงโมเดล AI "
-"ขั้นสูงพร้อมขีดจำกัดการแชทที่สูงขึ้น และการป้องกันระดับพรีเมียมอื่นๆ อีกมากมาย"
+"รับ VPN ที่รวดเร็ว ไม่เก็บบันทึกการใช้งานของเรา, ตัวเลือกในการเข้าถึงโมเดล "
+"AI ขั้นสูงพร้อมขีดจำกัดการแชทที่สูงขึ้น และการป้องกันระดับพรีเมียมอื่นๆ "
+"อีกมากมาย"
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9265,8 +9362,8 @@ msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, Personal Information Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"รับ VPN ที่ปลอดภัยและไม่เก็บบันทึกของเรา, Duck.ai ขั้นสูง, Personal Information Removal "
-"และ Identity Theft Restoration"
+"รับ VPN ที่ปลอดภัยและไม่เก็บบันทึกของเรา, Duck.ai ขั้นสูง, Personal "
+"Information Removal และ Identity Theft Restoration"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
@@ -9274,8 +9371,8 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
-"รับ VPN แบบไม่บันทึกกิจกรรมที่ปลอดภัย, Duck.ai ขั้นสูง และ Identity Theft Restoration "
-"ของเรา"
+"รับ VPN แบบไม่บันทึกกิจกรรมที่ปลอดภัย, Duck.ai ขั้นสูง และ Identity Theft "
+"Restoration ของเรา"
 
 # smartling.placeholder_format=C
 msgid ""
@@ -9375,8 +9472,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo แล้วไปที่ "
-"%3$sChats › Sync & Backup › Sync With Another Device › Copy Text Code%4$s"
+"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo "
+"แล้วไปที่ %3$sChats › Sync & Backup › Sync With Another Device › Copy Text "
+"Code%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9385,8 +9483,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo แล้วไปที่ "
-"%3$sChats › Sync & Backup › Sync With Another Device%4$s"
+"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo "
+"แล้วไปที่ %3$sChats › Sync & Backup › Sync With Another Device%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9396,8 +9494,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo แล้วไปที่ "
-"%3$sChats › Sync & Backup › Sync With Another Device%4$s แล้วสแกนรหัสนี้:"
+"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo "
+"แล้วไปที่ %3$sChats › Sync & Backup › Sync With Another Device%4$s "
+"แล้วสแกนรหัสนี้:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9407,9 +9506,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo แล้วไปที่ "
-"%3$sChats › Sync & Backup › Sync With Another Device%4$s หรือสแกนคิวอาร์บน PDF "
-"การกู้คืนของคุณ"
+"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo "
+"แล้วไปที่ %3$sChats › Sync & Backup › Sync With Another Device%4$s "
+"หรือสแกนคิวอาร์บน PDF การกู้คืนของคุณ"
 
 # smartling.placeholder_format=C
 #. Path to the pairing code on the other device. Bold segments are UI path labels.
@@ -9418,8 +9517,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
 msgstr ""
-"ไปที่ %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup › Sync With Another "
-"Device%4$s."
+"ไปที่ %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup › Sync With "
+"Another Device%4$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9435,7 +9534,8 @@ msgid ""
 "“Location Services” is turned on."
 msgstr ""
 "ไปที่ %1$sการตั้งค่า > ความเป็นส่วนตัวและความปลอดภัย > "
-"บริการหาตําแหน่งที่ตั้ง%2$sและตรวจสอบให้แน่ใจว่า \"บริการหาตําแหน่งที่ตั้ง\" เปิดอยู่"
+"บริการหาตําแหน่งที่ตั้ง%2$sและตรวจสอบให้แน่ใจว่า \"บริการหาตําแหน่งที่ตั้ง\" "
+"เปิดอยู่"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -9444,8 +9544,8 @@ msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
 msgstr ""
-"ไปที่ %1$sการตั้งค่า > ความเป็นส่วนตัวและความปลอดภัย > บริการหาตําแหน่งที่ตั้ง%2$s "
-"แล้วเลื่อนลงไปที่ %3$sDuckDuckGo%4$s"
+"ไปที่ %1$sการตั้งค่า > ความเป็นส่วนตัวและความปลอดภัย > "
+"บริการหาตําแหน่งที่ตั้ง%2$s แล้วเลื่อนลงไปที่ %3$sDuckDuckGo%4$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -10133,7 +10233,9 @@ msgctxt "settings"
 msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
-msgstr "เน้นข้อเท็จจริงสำคัญในคำตอบของ Search Assist เพื่อช่วยให้คุณค้นหาข้อมูลสำคัญได้เร็วขึ้น"
+msgstr ""
+"เน้นข้อเท็จจริงสำคัญในคำตอบของ Search Assist "
+"เพื่อช่วยให้คุณค้นหาข้อมูลสำคัญได้เร็วขึ้น"
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -10226,7 +10328,8 @@ msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
 msgstr ""
-"การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ Tripadvisor และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
+"การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ Tripadvisor "
+"และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -10323,7 +10426,7 @@ msgstr "วิธีการทำงาน"
 #. Headline in chat history about modals for the temporary encrypted server storage explanation.
 msgctxt "Chat history about modal list item headline"
 msgid "How it works"
-msgstr ""
+msgstr "วิธีการทำงาน"
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -10374,6 +10477,7 @@ msgid ""
 "How should I tactfully approach a colleague about their constant pencil "
 "tapping and what should I say?"
 msgstr ""
+""
 "ฉันจะบอกเพื่อนร่วมงานอย่างมีไหวพริบเกี่ยวกับการเคาะดินสออย่างต่อเนื่องได้อย่างไร "
 "และฉันควรจะพูดว่าอะไร"
 
@@ -10496,7 +10600,9 @@ msgctxt "Full sentence for recommending a book"
 msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
-msgstr "ฉันชอบหนังสือชื่อ Name of the Wind มีหนังสือ/ซีรีส์ดีๆ ที่คล้ายกันหรือไม่และเพราะเหตุใด"
+msgstr ""
+"ฉันชอบหนังสือชื่อ Name of the Wind มีหนังสือ/ซีรีส์ดีๆ "
+"ที่คล้ายกันหรือไม่และเพราะเหตุใด"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -10531,8 +10637,8 @@ msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
 msgstr ""
-"หากตำแหน่งที่ตั้งของเบราว์เซอร์ยังไม่พร้อมใช้งาน ให้ไปที่%1$sการตั้งค่า > ทั่วไป > รีเซ็ต > "
-"\"รีเซ็ตตำแหน่งที่ตั้งและความเป็นส่วนตัว\"%2$s"
+"หากตำแหน่งที่ตั้งของเบราว์เซอร์ยังไม่พร้อมใช้งาน ให้ไปที่%1$sการตั้งค่า > "
+"ทั่วไป > รีเซ็ต > \"รีเซ็ตตำแหน่งที่ตั้งและความเป็นส่วนตัว\"%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10542,9 +10648,9 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"หากตำแหน่งที่ตั้งของเบราว์เซอร์ยังไม่พร้อมใช้งาน จากเบราว์เซอร์ของคุณ ให้ไปที่ %1$s⋮ > เมนู > "
-"การตั้งค่า > การตั้งค่าเว็บไซต์ > ตำแหน่งที่ตั้ง%2$s และตรวจสอบว่า DuckDuckGo "
-"ได้รับอนุญาตให้เข้าถึงตำแหน่งที่ตั้ง"
+"หากตำแหน่งที่ตั้งของเบราว์เซอร์ยังไม่พร้อมใช้งาน จากเบราว์เซอร์ของคุณ "
+"ให้ไปที่ %1$s⋮ > เมนู > การตั้งค่า > การตั้งค่าเว็บไซต์ > ตำแหน่งที่ตั้ง%2$s "
+"และตรวจสอบว่า DuckDuckGo ได้รับอนุญาตให้เข้าถึงตำแหน่งที่ตั้ง"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10579,7 +10685,8 @@ msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
 msgstr ""
-"หากคุณไม่สามารถเข้าถึงอุปกรณ์ของคุณได้ คุณจะต้องใช้รหัสนี้เพื่อกู้คืนแชทที่บันทึกไว้ "
+"หากคุณไม่สามารถเข้าถึงอุปกรณ์ของคุณได้ "
+"คุณจะต้องใช้รหัสนี้เพื่อกู้คืนแชทที่บันทึกไว้ "
 "คุณสามารถบันทึกโค้ดนี้ลงในอุปกรณ์ของคุณเป็นไฟล์ข้อความได้"
 
 # smartling.placeholder_format=C
@@ -10596,7 +10703,8 @@ msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
 msgstr ""
-"หากคุณต้องการใช้ DuckDuckGo แบบไม่มี JavaScript โปรดใช้เวอร์ชัน %1$s หรือ %2$s ของเรา"
+"หากคุณต้องการใช้ DuckDuckGo แบบไม่มี JavaScript โปรดใช้เวอร์ชัน %1$s หรือ "
+"%2$s ของเรา"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10604,7 +10712,8 @@ msgstr ""
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
 msgstr ""
-"หากคุณต้องการ ให้เลือก \"หน้าแรก\" ถัดจาก \"หน้าต่างใหม่\" และ \"แท็บใหม่\" (เปิดด้วย)"
+"หากคุณต้องการ ให้เลือก \"หน้าแรก\" ถัดจาก \"หน้าต่างใหม่\" และ \"แท็บใหม่\" "
+"(เปิดด้วย)"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -10746,6 +10855,7 @@ msgid ""
 "server to prevent search leakage. %sLearn more%s."
 msgstr ""
 "ในเบราว์เซอร์เก่ากว่าบางรายการ "
+""
 "เราจำเป็นต้องเปลี่ยนเส้นทางการคลิกของคุณผ่านเซิร์ฟเวอร์ของเราเพื่อป้องกันการรั่วไหลของข้อมูลการค้นหา "
 "%1$sดูข้อมูลเพิ่มเติม%2$s"
 
@@ -11181,9 +11291,11 @@ msgid ""
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
 "รายการต่างๆ "
+""
 "ได้รับการจัดลำดับตามความเกี่ยวข้องกับข้อความค้นหาของคุณและจัดส่งผ่านเครือข่ายโฆษณาของ "
-"Microsoft การคลิกนำไปสู่หน้า Landing Page ของผู้ค้าโดยตรงและไม่เหมือนกับโฆษณา "
-"DuckDuckGo ไม่ได้รับการชดเชยสำหรับผลลัพธ์เหล่านี้"
+"Microsoft การคลิกนำไปสู่หน้า Landing Page "
+"ของผู้ค้าโดยตรงและไม่เหมือนกับโฆษณา DuckDuckGo "
+"ไม่ได้รับการชดเชยสำหรับผลลัพธ์เหล่านี้"
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -11192,7 +11304,8 @@ msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
 msgstr ""
-"การจดจำคำ 4 - 5 คำจะง่ายกว่าการจำตัวอักษรและตัวเลขแบบสุ่ม 10 ตัว และมีความปลอดภัยมากกว่า"
+"การจดจำคำ 4 - 5 คำจะง่ายกว่าการจำตัวอักษรและตัวเลขแบบสุ่ม 10 ตัว "
+"และมีความปลอดภัยมากกว่า"
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -11265,7 +11378,8 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Keep all your apps and online activity private on up to 5 devices at once."
 msgstr ""
-"รักษาความเป็นส่วนตัวของแอปและกิจกรรมออนไลน์ทั้งหมดของคุณบนอุปกรณ์สูงสุด 5 เครื่องพร้อมกัน"
+"รักษาความเป็นส่วนตัวของแอปและกิจกรรมออนไลน์ทั้งหมดของคุณบนอุปกรณ์สูงสุด 5 "
+"เครื่องพร้อมกัน"
 
 # smartling.placeholder_format=C
 #. An instruction to state that a list of companies/trackers will be updated with continued use
@@ -11759,7 +11873,7 @@ msgstr "ลิงก์หมดอายุใน 7 วัน"
 #. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days. People can save a chat copy."
-msgstr ""
+msgstr "ลิงก์หมดอายุใน 7 วัน ผู้คนสามารถบันทึกสำเนาของแชท"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13215,9 +13329,11 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ DuckDuckGo "
-"หลังจากที่ส่งไปแล้ว เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต "
-"การปิดประวัติการแชทจะลบแชทที่ปักหมุด และปิดใช้งานการเก็บคำแนะนำและการตอบสนองใหม่ชั่วคราว"
+"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ "
+"DuckDuckGo หลังจากที่ส่งไปแล้ว "
+"เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต "
+"การปิดประวัติการแชทจะลบแชทที่ปักหมุด "
+"และปิดใช้งานการเก็บคำแนะนำและการตอบสนองใหม่ชั่วคราว"
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -13877,7 +13993,7 @@ msgstr "เข้าใจแล้ว!"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "OPTIONAL"
-msgstr ""
+msgstr "ไม่บังคับ"
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -14045,8 +14161,8 @@ msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
 msgstr ""
-"สำหรับ Mac %1$sให้คลิก Maxthon > ค่ากำหนด%2$s สำหรับ Windows %3$sให้คลิกไอคอน %4$s "
-"> การตั้งค่า%5$s"
+"สำหรับ Mac %1$sให้คลิก Maxthon > ค่ากำหนด%2$s สำหรับ Windows "
+"%3$sให้คลิกไอคอน %4$s > การตั้งค่า%5$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -14055,8 +14171,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
 msgstr ""
-"ในอุปกรณ์อื่น ให้ไปที่ %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup › Sync "
-"With Another Device%4$s"
+"ในอุปกรณ์อื่น ให้ไปที่ %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup "
+"› Sync With Another Device%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14065,8 +14181,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
 msgstr ""
-"ในอุปกรณ์อื่น ให้ไปที่ %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup › Sync "
-"With Another Device%4$s แล้วสแกนรหัสนี้:"
+"ในอุปกรณ์อื่น ให้ไปที่ %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup "
+"› Sync With Another Device%4$s แล้วสแกนรหัสนี้:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14075,8 +14191,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
-"ในอุปกรณ์อื่น ให้ไปที่ %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup › Sync "
-"With Another Device%4$s หรือสแกนคิวอาร์บน PDF การกู้คืนของคุณ"
+"ในอุปกรณ์อื่น ให้ไปที่ %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup "
+"› Sync With Another Device%4$s หรือสแกนคิวอาร์บน PDF การกู้คืนของคุณ"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14104,7 +14220,8 @@ msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
 msgstr ""
-"ไฟล์ที่แนบมาไฟล์ใดไฟล์หนึ่งมีหน้าเว็บมากกว่าที่เรารองรับ โปรดอัปโหลดไฟล์ที่มี %1$s หน้าหรือน้อยกว่า"
+"ไฟล์ที่แนบมาไฟล์ใดไฟล์หนึ่งมีหน้าเว็บมากกว่าที่เรารองรับ "
+"โปรดอัปโหลดไฟล์ที่มี %1$s หน้าหรือน้อยกว่า"
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -14130,7 +14247,9 @@ msgctxt "cloudsave"
 msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
-msgstr "เฉพาะการตั้งค่าที่คุณเปลี่ยนแปลงเท่านั้น มีรายละเอียดอยู่ในหน้า%1$sพารามิเตอร์ URL%2$s"
+msgstr ""
+"เฉพาะการตั้งค่าที่คุณเปลี่ยนแปลงเท่านั้น "
+"มีรายละเอียดอยู่ในหน้า%1$sพารามิเตอร์ URL%2$s"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -14467,7 +14586,8 @@ msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
 msgstr ""
-"เครื่องมือค้นหาอื่นๆ จะติดตามการค้นหาของคุณแม้ว่าคุณจะอยู่ในโหมดการท่องเว็บแบบส่วนตัว "
+"เครื่องมือค้นหาอื่นๆ "
+"จะติดตามการค้นหาของคุณแม้ว่าคุณจะอยู่ในโหมดการท่องเว็บแบบส่วนตัว "
 "แต่เราไม่ติดตามคุณอย่างแน่นอน"
 
 # smartling.placeholder_format=C
@@ -14483,8 +14603,8 @@ msgid ""
 "more premium protections. All in one subscription."
 msgstr ""
 "VPN แบบไม่บันทึกกิจกรรมที่รวดเร็วของเรามาพร้อมกับการแชท AI "
-"ที่ชาญฉลาดยิ่งขึ้นพร้อมขีดจำกัดที่สูงขึ้น รวมถึงการป้องกันระดับพรีเมียมอื่นๆ อีกมากมาย "
-"การสมัครสมาชิกแบบครบวงจรในที่เดียว"
+"ที่ชาญฉลาดยิ่งขึ้นพร้อมขีดจำกัดที่สูงขึ้น รวมถึงการป้องกันระดับพรีเมียมอื่นๆ "
+"อีกมากมาย การสมัครสมาชิกแบบครบวงจรในที่เดียว"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -14492,7 +14612,8 @@ msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
 msgstr ""
-"นโยบายความเป็นส่วนตัวของเราเป็นเรื่องง่าย: เราไม่ได้เก็บรวบรวมหรือแชร์ข้อมูลส่วนบุคคลของคุณ"
+"นโยบายความเป็นส่วนตัวของเราเป็นเรื่องง่าย: "
+"เราไม่ได้เก็บรวบรวมหรือแชร์ข้อมูลส่วนบุคคลของคุณ"
 
 # smartling.placeholder_format=C
 msgid ""
@@ -14500,8 +14621,9 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"เบราว์เซอร์ส่วนตัวสำหรับอุปกรณ์มือถือของเรานั้นมาพร้อมกับเครื่องมือค้นหา เครื่องมือบล็อกตัวติดตาม "
-"เครื่องมือบังคับใช้การเข้ารหัส และอื่นๆ อีกมากมาย พร้อมใช้งานบน %1$siOS และ Android%2$s"
+"เบราว์เซอร์ส่วนตัวสำหรับอุปกรณ์มือถือของเรานั้นมาพร้อมกับเครื่องมือค้นหา "
+"เครื่องมือบล็อกตัวติดตาม เครื่องมือบังคับใช้การเข้ารหัส และอื่นๆ อีกมากมาย "
+"พร้อมใช้งานบน %1$siOS และ Android%2$s"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14754,8 +14876,8 @@ msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
 msgstr ""
-"ไม่สามารถกู้คืนรหัสผ่านได้เนื่องจากเราไม่ได้เชื่อมโยงที่อยู่ IP, ลายนิ้วมือจากเบราว์เซอร์ "
-"หรือข้อมูลอื่นใดเกี่ยวกับไฟล์"
+"ไม่สามารถกู้คืนรหัสผ่านได้เนื่องจากเราไม่ได้เชื่อมโยงที่อยู่ IP, "
+"ลายนิ้วมือจากเบราว์เซอร์ หรือข้อมูลอื่นใดเกี่ยวกับไฟล์"
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -14911,7 +15033,8 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
-"Personal Information Removal ค้นหาข้อมูลของคุณบนเว็บไซต์นายหน้าข้อมูลที่ขายข้อมูลนั้น "
+"Personal Information Removal "
+"ค้นหาข้อมูลของคุณบนเว็บไซต์นายหน้าข้อมูลที่ขายข้อมูลนั้น "
 "จากนั้นเราดำเนินการเพื่อให้ข้อมูลนั้นถูกลบออกแทนคุณ"
 
 # smartling.placeholder_format=C
@@ -14983,9 +15106,10 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
+""
 "การเรียงถ้อยคำในการค้นหาให้เป็นคำถามและเป็นประโยคสมบูรณ์ทำให้คำตอบที่ได้รับความช่วยเหลือจาก "
-"AI มีแนวโน้มที่จะปรากฏขึ้นโดยอัตโนมัติและมักจะให้คำตอบได้ดีกว่า หากต้องการปิดและซ่อนปุ่ม Assist "
-"ให้ไปที่ %1$sการตั้งค่าการค้นหา%2$s"
+"AI มีแนวโน้มที่จะปรากฏขึ้นโดยอัตโนมัติและมักจะให้คำตอบได้ดีกว่า "
+"หากต้องการปิดและซ่อนปุ่ม Assist ให้ไปที่ %1$sการตั้งค่าการค้นหา%2$s"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14995,8 +15119,9 @@ msgid ""
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
 "การเรียงถ้อยคำในการค้นหาให้เป็นคำถามและเป็นประโยคสมบูรณ์ทำให้ DuckAssist "
-"มีแนวโน้มที่จะปรากฏขึ้นและมักจะให้คำตอบที่ดีกว่า หากต้องการปรับวิธีการทํางานของคุณลักษณะนี้หรือปิด "
-"ให้ไปที่%1$sการตั้งค่า DuckAssist%2$s"
+"มีแนวโน้มที่จะปรากฏขึ้นและมักจะให้คำตอบที่ดีกว่า "
+"หากต้องการปรับวิธีการทํางานของคุณลักษณะนี้หรือปิด ให้ไปที่%1$sการตั้งค่า "
+"DuckAssist%2$s"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15007,8 +15132,8 @@ msgid ""
 "Settings%s."
 msgstr ""
 "การเรียงถ้อยคำในการค้นหาให้เป็นคำถามและเป็นประโยคสมบูรณ์ทำให้ DuckAssist "
-"มีแนวโน้มที่จะปรากฏขึ้นโดยอัตโนมัติและมักจะให้คำตอบได้ดีกว่า หากต้องการปิดและซ่อนปุ่ม Assist "
-"โปรดไปที่%1$sการตั้งค่า DuckAssist%2$s"
+"มีแนวโน้มที่จะปรากฏขึ้นโดยอัตโนมัติและมักจะให้คำตอบได้ดีกว่า "
+"หากต้องการปิดและซ่อนปุ่ม Assist โปรดไปที่%1$sการตั้งค่า DuckAssist%2$s"
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -15056,7 +15181,9 @@ msgctxt "Third party map app picker"
 msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
-msgstr "เลือกบริการเพื่อนำทางไปยังจุดหมายของคุณ แอปภายนอกจะไม่มีการป้องกันของ DuckDuckGo"
+msgstr ""
+"เลือกบริการเพื่อนำทางไปยังจุดหมายของคุณ แอปภายนอกจะไม่มีการป้องกันของ "
+"DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -15974,7 +16101,7 @@ msgstr "ได้รับการปกป้อง"
 #. Headline in sync-enabled chat history about modals explaining encrypted server storage.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Protected with end-to-end encryption"
-msgstr ""
+msgstr "ปกป้องด้วยการเข้ารหัสแบบครบวงจร"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -15987,7 +16114,9 @@ msgctxt "Full sentence for critiquing writing"
 msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
-msgstr "ให้คำแนะนำสองสามข้อเพื่อให้ข้อความต่อไปนี้กระชับมากขึ้น [แทรกข้อความของคุณเองที่นี่]"
+msgstr ""
+"ให้คำแนะนำสองสามข้อเพื่อให้ข้อความต่อไปนี้กระชับมากขึ้น "
+"[แทรกข้อความของคุณเองที่นี่]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -16111,7 +16240,7 @@ msgstr "การจัดอันดับ"
 #. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
 msgctxt "star rating on a product"
 msgid "Rated %s out of %s"
-msgstr ""
+msgstr "ได้ %1$s คะแนนจาก %2$s"
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -16288,8 +16417,9 @@ msgid ""
 "sent, to help recover a chat if you lose your internet connection."
 msgstr ""
 "การแชทล่าสุดจะถูกจัดเก็บไว้ในอุปกรณ์ของคุณ "
-"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ของ DuckDuckGo "
-"หลังจากที่ส่งไปแล้ว เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต"
+"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ของ "
+"DuckDuckGo หลังจากที่ส่งไปแล้ว "
+"เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต"
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -16571,8 +16701,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"รีโหลด DuckDuckGo โดยทำตามคำแนะนำ หรือคลิกปุ่ม &quot;รีเฟรช&quot; หรือ &quot;"
-"รีโหลด&quot; ของเบราว์เซอร์ของคุณ"
+"รีโหลด DuckDuckGo โดยทำตามคำแนะนำ หรือคลิกปุ่ม &quot;รีเฟรช&quot; หรือ "
+"&quot;รีโหลด&quot; ของเบราว์เซอร์ของคุณ"
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16680,7 +16810,8 @@ msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
 msgstr ""
-"นำปุ่ม \"ถาม\" ออก เพื่อให้คำตอบปรากฏขึ้นโดยอัตโนมัติตามการค้นหาที่เกี่ยวข้อง "
+"นำปุ่ม \"ถาม\" ออก "
+"เพื่อให้คำตอบปรากฏขึ้นโดยอัตโนมัติตามการค้นหาที่เกี่ยวข้อง "
 "คำตอบที่เก็บไว้จะแสดงโดยอัตโนมัติเสมอ"
 
 # smartling.placeholder_format=C
@@ -16689,7 +16820,8 @@ msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
 msgstr ""
-"นำปุ่ม \"สร้าง\" ออก เพื่อให้คำตอบปรากฏขึ้นโดยอัตโนมัติตามการค้นหาที่เกี่ยวข้อง "
+"นำปุ่ม \"สร้าง\" ออก "
+"เพื่อให้คำตอบปรากฏขึ้นโดยอัตโนมัติตามการค้นหาที่เกี่ยวข้อง "
 "คำตอบที่เก็บไว้จะแสดงโดยอัตโนมัติเสมอ"
 
 # smartling.placeholder_format=C
@@ -16748,8 +16880,9 @@ msgid ""
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
 msgstr ""
-"การรายงานจะไม่ระบุชื่อและส่งไปยัง DuckDuckGo เพื่อช่วยปรับปรุงบริการค้นหาของเรา "
-"ข้อเสนอแนะที่ไม่ระบุตัวตนของคุณจะแชร์กับ %1$s เพื่อช่วยปรับปรุงบริการ"
+"การรายงานจะไม่ระบุชื่อและส่งไปยัง DuckDuckGo "
+"เพื่อช่วยปรับปรุงบริการค้นหาของเรา ข้อเสนอแนะที่ไม่ระบุตัวตนของคุณจะแชร์กับ "
+"%1$s เพื่อช่วยปรับปรุงบริการ"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16757,8 +16890,8 @@ msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
 msgstr ""
-"รายงานที่ส่งไปยัง DuckDuckGo จะไม่ระบุชื่อ โปรดอย่าใส่ข้อมูลส่วนตัวหรือข้อมูลระบุตัวตนใดๆ "
-"ลงในข้อเสนอแนะของคุณ"
+"รายงานที่ส่งไปยัง DuckDuckGo จะไม่ระบุชื่อ "
+"โปรดอย่าใส่ข้อมูลส่วนตัวหรือข้อมูลระบุตัวตนใดๆ ลงในข้อเสนอแนะของคุณ"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16767,8 +16900,9 @@ msgid ""
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
 msgstr ""
-"รายงานที่ส่งไปยัง DuckDuckGo รวมข้อความทั้งหมดที่คุณขอให้เราแปลในระหว่างการโหลดหน้านี้ "
-"และจะไม่ระบุตัวตน โปรดอย่าใส่ข้อมูลส่วนตัวหรือข้อมูลระบุตัวตนใด ๆ ลงในข้อเสนอแนะของคุณ"
+"รายงานที่ส่งไปยัง DuckDuckGo "
+"รวมข้อความทั้งหมดที่คุณขอให้เราแปลในระหว่างการโหลดหน้านี้ และจะไม่ระบุตัวตน "
+"โปรดอย่าใส่ข้อมูลส่วนตัวหรือข้อมูลระบุตัวตนใด ๆ ลงในข้อเสนอแนะของคุณ"
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -16860,8 +16994,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
-"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย "
-"การเงิน การลงทุน หรือคำแนะนำทางวิชาชีพอื่นๆ คำตอบที่ได้รับความช่วยเหลือจาก AI อยู่ภายใต้ "
+"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น "
+"และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย การเงิน การลงทุน "
+"หรือคำแนะนำทางวิชาชีพอื่นๆ คำตอบที่ได้รับความช่วยเหลือจาก AI อยู่ภายใต้ "
 "%1$sข้อกำหนดในการให้บริการ%2$sของเรา"
 
 # smartling.placeholder_format=C
@@ -16871,8 +17006,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
 msgstr ""
-"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย "
-"การเงิน การลงทุน หรือคำแนะนำทางวิชาชีพอื่นๆ DuckAssist "
+"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น "
+"และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย การเงิน การลงทุน "
+"หรือคำแนะนำทางวิชาชีพอื่นๆ DuckAssist "
 "อยู่ภายใต้%1$sข้อกำหนดในการให้บริการ%2$sของเรา"
 
 # smartling.placeholder_format=C
@@ -16883,10 +17019,11 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย "
-"การเงิน การลงทุน หรือคำแนะนำทางวิชาชีพอื่น ๆ "
-"ข้อมูลเหล่านี้ถูกสร้างขึ้นจากเนื้อหาบนเว็บและอาจมีความไม่ถูกต้อง Search Assist อยู่ภายใต้ "
-"%1$sข้อกำหนดการให้บริการ%2$sของเรา"
+"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น "
+"และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย การเงิน การลงทุน "
+"หรือคำแนะนำทางวิชาชีพอื่น ๆ "
+"ข้อมูลเหล่านี้ถูกสร้างขึ้นจากเนื้อหาบนเว็บและอาจมีความไม่ถูกต้อง Search "
+"Assist อยู่ภายใต้ %1$sข้อกำหนดการให้บริการ%2$sของเรา"
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -17337,7 +17474,7 @@ msgstr "บันทึกการแชทของคุณในอุปก
 #. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
 msgctxt "Chat history about modal list item headline"
 msgid "Save your chats on this device"
-msgstr ""
+msgstr "บันทึกการแชทของคุณบนอุปกรณ์นี้"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
@@ -17485,7 +17622,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
 msgstr ""
-"เลื่อนลงและมองหา%1$sค้นหาในแถบที่อยู่%2$s คลิกที่%3$sเปลี่ยนแปลง%4$s (หรือ%5$sเพิ่มใหม่%6$s)"
+"เลื่อนลงและมองหา%1$sค้นหาในแถบที่อยู่%2$s คลิกที่%3$sเปลี่ยนแปลง%4$s "
+"(หรือ%5$sเพิ่มใหม่%6$s)"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17494,7 +17632,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
 msgstr ""
-"เลื่อนลงและมองหา%1$sค้นหาในแถบที่อยู่%2$s คลิกที่%3$sเปลี่ยนแปลง%4$s (หรือ %5$sเพิ่มใหม่%6$s)"
+"เลื่อนลงและมองหา%1$sค้นหาในแถบที่อยู่%2$s คลิกที่%3$sเปลี่ยนแปลง%4$s (หรือ "
+"%5$sเพิ่มใหม่%6$s)"
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -17543,7 +17682,7 @@ msgctxt ""
 "Placeholder and accessibility label for the search input in the tab picker "
 "dialog"
 msgid "Search"
-msgstr ""
+msgstr "ค้นหา"
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -17581,10 +17720,11 @@ msgid ""
 "subset of English speaking regions."
 msgstr ""
 "Search Assist สร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุชื่อ ในการดำเนินการนี้ "
-"ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง จากนั้นใช้ AI เพื่อสร้างคำตอบสั้น ๆ "
-"คุณสามารถเลือกได้ว่าต้องการให้มันปรากฏบ่อยแค่ไหน: ไม่เคย, ตามต้องการ (เฉพาะเมื่อคลิก "
-"Assist), บางครั้ง (เมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง (ในการค้นหาที่หลากหลาย) สำหรับตอนนี้ "
-"Search Assist มีให้บริการเฉพาะในบางภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
+"ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง จากนั้นใช้ AI เพื่อสร้างคำตอบสั้น "
+"ๆ คุณสามารถเลือกได้ว่าต้องการให้มันปรากฏบ่อยแค่ไหน: ไม่เคย, ตามต้องการ "
+"(เฉพาะเมื่อคลิก Assist), บางครั้ง (เมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง "
+"(ในการค้นหาที่หลากหลาย) สำหรับตอนนี้ Search Assist "
+"มีให้บริการเฉพาะในบางภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -17592,7 +17732,8 @@ msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
 msgstr ""
-"Search Assist ไม่พบข้อมูลที่เชื่อถือได้เพียงพอเพื่อสร้างคำตอบสำหรับคำถามนี้ ลองค้นหาอีกครั้ง"
+"Search Assist ไม่พบข้อมูลที่เชื่อถือได้เพียงพอเพื่อสร้างคำตอบสำหรับคำถามนี้ "
+"ลองค้นหาอีกครั้ง"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -17601,9 +17742,9 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist เป็นฟีเจอร์เสริมที่สร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุชื่อ ในการทำเช่นนี้ "
-"ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง %1$s%2$s จากนั้นใช้ AI เพื่อสร้างคำตอบสั้น ๆ "
-"ตามข้อมูลที่พบ"
+"Search Assist เป็นฟีเจอร์เสริมที่สร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุชื่อ "
+"ในการทำเช่นนี้ ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง %1$s%2$s จากนั้นใช้ "
+"AI เพื่อสร้างคำตอบสั้น ๆ ตามข้อมูลที่พบ"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -17724,8 +17865,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"ค้นหาเว็บไซต์อื่นด้วยทางลัด %1$s: การค้นหา \"!w ducks\" จะค้นหา \"ducks\" โดยตรงบน "
-"Wikipedia"
+"ค้นหาเว็บไซต์อื่นด้วยทางลัด %1$s: การค้นหา \"!w ducks\" จะค้นหา \"ducks\" "
+"โดยตรงบน Wikipedia"
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -17745,8 +17886,8 @@ msgid ""
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
 "ค้นหาอย่างเป็นส่วนตัวด้วยแอปหรือส่วนขยายของเรา "
-"เพิ่มการค้นหาเว็บแบบส่วนตัวลงในเบราว์เซอร์โปรดของคุณ หรือค้นหาโดยตรงที่ %1$sduckduckgo."
-"com%2$s"
+"เพิ่มการค้นหาเว็บแบบส่วนตัวลงในเบราว์เซอร์โปรดของคุณ หรือค้นหาโดยตรงที่ "
+"%1$sduckduckgo.com%2$s"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -17765,8 +17906,10 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
+""
 "การตั้งค่าการค้นหาจะถูกเก็บไว้ในคุกกี้เบราว์เซอร์ที่ไม่ใช่ส่วนบุคคลและที่เก็บข้อมูลภายในในเบราว์เซอร์ของคุณ "
 "แต่คุณยังสามารถใช้ Cloud Save "
+""
 "เพื่อจัดเก็บการตั้งค่าของคุณโดยไม่ระบุตัวตนบนเซิร์ฟเวอร์ระยะไกลในคลาวด์ได้อีกด้วย "
 "จะไม่มีการจัดเก็บข้อมูลที่สามารถระบุถึงตัวบุคคลได้บนระบบคลาวด์ "
 "และวลีรหัสผ่านของคุณจะอยู่บนเบราว์เซอร์ของคุณเท่านั้น"
@@ -17888,6 +18031,7 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
+""
 "จัดเก็บแชทได้เกือบไม่จำกัดบนเซิร์ฟเวอร์ของเราอย่างปลอดภัยด้วยการเข้ารหัสแบบครบวงจร "
 "และเข้าถึงได้จากอุปกรณ์ที่ซิงค์ทั้งหมดของคุณ"
 
@@ -18066,7 +18210,8 @@ msgstr "เลือก %1$s\"การตั้งค่าสำหรับ�
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"เลือก%1$sกำหนดเอง%2$s และป้อน %3$shttps://duckduckgo.com%4$s ลงในช่องการป้อนข้อมูล"
+"เลือก%1$sกำหนดเอง%2$s และป้อน %3$shttps://duckduckgo.com%4$s "
+"ลงในช่องการป้อนข้อมูล"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -18131,7 +18276,8 @@ msgstr "เลือก%1$sจัดการส่วนเสริม%2$sจ�
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
 msgstr ""
-"เลือก %1$sOpera > ค่ากำหนด%2$s (บน Mac) หรือ%3$sเมนู > การตั้งค่า%4$s (บน Windows)"
+"เลือก %1$sOpera > ค่ากำหนด%2$s (บน Mac) หรือ%3$sเมนู > การตั้งค่า%4$s (บน "
+"Windows)"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -18139,7 +18285,8 @@ msgstr ""
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
 msgstr ""
-"เลือก %1$sOpera > ค่ากำหนด%2$s (บน Mac) หรือ %3$sOpera > ตัวเลือก%4$s (บน Windows)"
+"เลือก %1$sOpera > ค่ากำหนด%2$s (บน Mac) หรือ %3$sOpera > ตัวเลือก%4$s (บน "
+"Windows)"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -18203,7 +18350,9 @@ msgstr "เลือก%1$sการตั้งค่า%2$s จากนั้
 msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
-msgstr "เลือก%1$sใช้หน้าเว็บนี้เป็นหน้าหลักเดียวของคุณ%2$s (หรือหนึ่งในตัวเลือกอื่นๆ ตามต้องการ)"
+msgstr ""
+"เลือก%1$sใช้หน้าเว็บนี้เป็นหน้าหลักเดียวของคุณ%2$s (หรือหนึ่งในตัวเลือกอื่นๆ "
+"ตามต้องการ)"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
@@ -18325,7 +18474,8 @@ msgid ""
 "respond. These instructions will apply to all of your conversations going "
 "forward."
 msgstr ""
-"ส่งพรอมต์ไปยังโมเดล AI พร้อมกับข้อความของคุณและคำแนะนำเกี่ยวกับวิธีการตอบกลับ "
+"ส่งพรอมต์ไปยังโมเดล AI "
+"พร้อมกับข้อความของคุณและคำแนะนำเกี่ยวกับวิธีการตอบกลับ "
 "คำแนะนำเหล่านี้จะใช้กับการสนทนาทั้งหมดของคุณต่อไป"
 
 # smartling.placeholder_format=C
@@ -18449,13 +18599,16 @@ msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
 msgstr ""
-"ตั้งค่า Sync & Backup หลังจากเปิดประวัติการแชทเพื่อให้การแชทของคุณซิงค์กันระหว่างอุปกรณ์ต่างๆ"
+"ตั้งค่า Sync & Backup "
+"หลังจากเปิดประวัติการแชทเพื่อให้การแชทของคุณซิงค์กันระหว่างอุปกรณ์ต่างๆ"
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr "ตั้งค่าตำแหน่งที่ตั้งของคุณด้วยตนเอง หรือตรวจสอบให้แน่ใจว่าได้เปิดใช้งานบริการตำแหน่งที่ตั้ง"
+msgstr ""
+"ตั้งค่าตำแหน่งที่ตั้งของคุณด้วยตนเอง "
+"หรือตรวจสอบให้แน่ใจว่าได้เปิดใช้งานบริการตำแหน่งที่ตั้ง"
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -18700,7 +18853,7 @@ msgstr "ร้านค้า"
 #. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
 msgctxt "Button in the merchandise logo modal (mobile)"
 msgid "Shop Now"
-msgstr ""
+msgstr "ช้อปเลย"
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -19094,7 +19247,8 @@ msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
 msgstr ""
-"แสดงการแจ้งเตือนเป็นครั้งคราวให้สมัครรับจดหมายข่าวเกี่ยวกับความเป็นส่วนตัวของ DuckDuckGo"
+"แสดงการแจ้งเตือนเป็นครั้งคราวให้สมัครรับจดหมายข่าวเกี่ยวกับความเป็นส่วนตัวของ "
+"DuckDuckGo"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19456,7 +19610,9 @@ msgctxt "noresults"
 msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
-msgstr "ขออภัย เราพบข้อผิดพลาดในการแสดงผลลัพธ์เหล่านี้ %1$sคลิกที่นี่%2$s เพื่อลองอีกครั้ง"
+msgstr ""
+"ขออภัย เราพบข้อผิดพลาดในการแสดงผลลัพธ์เหล่านี้ %1$sคลิกที่นี่%2$s "
+"เพื่อลองอีกครั้ง"
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
@@ -19935,7 +20091,9 @@ msgctxt "Full sentence for composing a card"
 msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
-msgstr "เสนอแนะวลีที่จะเขียนลงในการ์ดอวยพรให้หายไว ๆ สำหรับผู้ที่ฟื้นตัวจากการผ่าตัดหรือไม่"
+msgstr ""
+"เสนอแนะวลีที่จะเขียนลงในการ์ดอวยพรให้หายไว ๆ "
+"สำหรับผู้ที่ฟื้นตัวจากการผ่าตัดหรือไม่"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
@@ -20334,6 +20492,8 @@ msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
 msgstr ""
+"Sync & Backup "
+"จะบันทึกการแชทของคุณมากขึ้นและซิงค์การแชทเหล่านั้นในทุกอุปกรณ์ของคุณ"
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20382,8 +20542,9 @@ msgid ""
 msgstr ""
 "รหัสกู้คืนการซิงค์\n"
 "\n"
-"รหัสกู้คืนช่วยให้คุณสามารถซิงค์รหัสผ่าน ข้อมูลการกรอกอัตโนมัติ และการแชท Duck.ai "
-"ของคุณระหว่างอุปกรณ์หลายเครื่อง และกู้คืนข้อมูลที่ซิงค์ไว้หากคุณสูญเสียการเข้าถึงอุปกรณ์\n"
+"รหัสกู้คืนช่วยให้คุณสามารถซิงค์รหัสผ่าน ข้อมูลการกรอกอัตโนมัติ และการแชท "
+"Duck.ai ของคุณระหว่างอุปกรณ์หลายเครื่อง "
+"และกู้คืนข้อมูลที่ซิงค์ไว้หากคุณสูญเสียการเข้าถึงอุปกรณ์\n"
 "\n"
 "เก็บรักษาข้อมูลนี้ให้ปลอดภัย\n"
 "ทุกคนที่มีสิทธิ์เข้าถึงรหัสนี้สามารถเข้าถึงข้อมูลที่ซิงค์ของคุณ\n"
@@ -20393,9 +20554,11 @@ msgstr ""
 "วิธีการทำงานของโค้ดนี้คืออะไร?\n"
 "1. ไปที่ Duck.ai ในเบราว์เซอร์ของคุณ แล้วเปิดการตั้งค่า Duck.ai\n"
 "2. เลือก \"เปิดใช้งาน Sync & Backup\" จากนั้นเลือก \"Recover Synced Data\"\n"
-"3. คัดลอกรหัสการกู้คืนด้านบนและวางลงในช่องที่ระบุว่า \"Paste your code here\"\n"
+"3. คัดลอกรหัสการกู้คืนด้านบนและวางลงในช่องที่ระบุว่า \"Paste your code "
+"here\"\n"
 "\n"
-"หากคุณไม่ได้ใช้เบราว์เซอร์ DuckDuckGo ที่มี Sync & Backup เปิดใช้งานเป็นเวลาเกิน 18 เดือน "
+"หากคุณไม่ได้ใช้เบราว์เซอร์ DuckDuckGo ที่มี Sync & Backup "
+"เปิดใช้งานเป็นเวลาเกิน 18 เดือน "
 "ข้อมูลของคุณจะถูกลบออกจากเซิร์ฟเวอร์และไม่สามารถกู้คืนได้"
 
 # smartling.placeholder_format=C
@@ -20450,7 +20613,7 @@ msgstr "ซิงค์แชทของคุณในอุปกรณ์ท
 #. Headline in sync-enabled chat history about modals explaining cross-device sync.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Sync your chats across all your devices"
-msgstr ""
+msgstr "ซิงค์แชทของคุณในอุปกรณ์ทั้งหมดของคุณ"
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -20535,7 +20698,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
-"พก Duck.ai ไปกับคุณได้ทุกที่ รับแบบรวมอยู่ในแอปฟรีของเราเพื่อการเข้าถึงที่รวดเร็วยิ่งขึ้น "
+"พก Duck.ai ไปกับคุณได้ทุกที่ "
+"รับแบบรวมอยู่ในแอปฟรีของเราเพื่อการเข้าถึงที่รวดเร็วยิ่งขึ้น "
 "ไม่ว่าคุณจะอยู่ที่ไหน"
 
 # smartling.placeholder_format=C
@@ -20545,7 +20709,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
-"พก Duck.ai ไปกับคุณทุกที่ รับแบบที่รวมอยู่ในเบราว์เซอร์ฟรีของเราเพื่อการเข้าถึงที่รวดเร็วยิ่งขึ้น "
+"พก Duck.ai ไปกับคุณทุกที่ "
+"รับแบบที่รวมอยู่ในเบราว์เซอร์ฟรีของเราเพื่อการเข้าถึงที่รวดเร็วยิ่งขึ้น "
 "ไม่ว่าคุณจะท่องเว็บอยู่ที่ไหน"
 
 # smartling.placeholder_format=C
@@ -20569,7 +20734,9 @@ msgstr "ควบคุมข้อมูลส่วนบุคคลของ
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr "ทำแบบสำรวจที่ไม่ระบุตัวตนนี้เพื่อบอกให้เรารู้ว่าเราจะทำให้ Duck.ai ดีขึ้นได้อย่างไรบ้าง"
+msgstr ""
+"ทำแบบสำรวจที่ไม่ระบุตัวตนนี้เพื่อบอกให้เรารู้ว่าเราจะทำให้ Duck.ai "
+"ดีขึ้นได้อย่างไรบ้าง"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -20790,6 +20957,7 @@ msgid ""
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
 msgstr ""
+""
 "นั่นหมายความว่าข้อมูลที่ส่งระหว่างอุปกรณ์ของคุณกับหน้าเว็บเบื้องหลังลิงก์นี้มีความเสี่ยงมากขึ้นต่อการถูกดักข้อมูลโดยบุคคลที่สาม "
 "ในบางกรณีซึ่งเกิดขึ้นไม่บ่อย ข้อมูลนี้รวมถึงรหัสผ่านหรือรายละเอียดการชำระเงิน"
 
@@ -20831,6 +20999,7 @@ msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
 msgstr ""
+""
 "คีย์การเข้ารหัสจะถูกบันทึกไว้เฉพาะในที่เก็บข้อมูลในเครื่องของเบราว์เซอร์ของคุณ "
 "และมีเพียงคุณเท่านั้นที่สามารถเข้าถึงได้"
 
@@ -20853,7 +21022,9 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider does not save this chat or any associated data on their "
 "servers."
-msgstr "ผู้ให้บริการโมเดลไม่บันทึกการแชทนี้หรือข้อมูลที่เกี่ยวข้องใดๆ บนเซิร์ฟเวอร์ของเขา"
+msgstr ""
+"ผู้ให้บริการโมเดลไม่บันทึกการแชทนี้หรือข้อมูลที่เกี่ยวข้องใดๆ "
+"บนเซิร์ฟเวอร์ของเขา"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20946,6 +21117,7 @@ msgid ""
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
 msgstr ""
+""
 "สิทธิ์ของเบราว์เซอร์เหล่านี้ใช้เพื่อเพิ่มการปกป้องความเป็นส่วนตัวบนเว็บไซต์ที่คุณเยี่ยมชมโดยการบล็อกตัวติดตามที่ซ่อนอยู่ "
 "การเข้ารหัสการเชื่อมต่อเมื่อสามารถทำได้ และการตั้งค่าให้ DuckDuckGo "
 "เป็นเครื่องมือค้นหาเริ่มต้นของคุณ"
@@ -20993,7 +21165,9 @@ msgctxt "AI Chat: Error message for when a model is deprecated"
 msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
-msgstr "เวอร์ชันของโมเดล AI นี้ไม่ได้รับการสนับสนุนอีกต่อไป ลองเริ่มแชทใหม่ด้วยโมเดลรุ่นล่าสุด"
+msgstr ""
+"เวอร์ชันของโมเดล AI นี้ไม่ได้รับการสนับสนุนอีกต่อไป "
+"ลองเริ่มแชทใหม่ด้วยโมเดลรุ่นล่าสุด"
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -21027,13 +21201,13 @@ msgctxt ""
 msgid ""
 "This chat and its generated images become public when you create and copy "
 "the link."
-msgstr ""
+msgstr "แชทนี้และรูปภาพที่สร้างขึ้นจะเป็นสาธารณะเมื่อสร้างและคัดลอกลิงก์"
 
 # smartling.placeholder_format=C
 #. Explains that creating and copying a share link makes the selected chat content public.
 msgctxt "Share modal info bullet about public access"
 msgid "This chat becomes public when you create and copy the link."
-msgstr ""
+msgstr "แชทนี้จะเป็นสาธารณะเมื่อสร้างและคัดลอกลิงก์"
 
 # smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
@@ -21080,8 +21254,9 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"การสนทนานี้สร้างขึ้นด้วย DuckDuckGo AI Chat (%1$s) โดยใช้โมเดล %3$s ของ %2$s แชท AI "
-"อาจแสดงข้อมูลที่ไม่ถูกต้องหรือไม่เหมาะสม (ดู %4$s สำหรับข้อมูลเพิ่มเติม)"
+"การสนทนานี้สร้างขึ้นด้วย DuckDuckGo AI Chat (%1$s) โดยใช้โมเดล %3$s ของ %2$s "
+"แชท AI อาจแสดงข้อมูลที่ไม่ถูกต้องหรือไม่เหมาะสม (ดู %4$s "
+"สำหรับข้อมูลเพิ่มเติม)"
 
 # smartling.placeholder_format=C
 #. Renders to the right of the device name for the row that matches this device's id.
@@ -21098,8 +21273,8 @@ msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
 msgstr ""
-"อุปกรณ์นี้จะไม่สามารถเข้าถึงข้อมูลที่ซิงค์ของคุณบนอุปกรณ์อื่นได้อีกต่อไป แชท %1$s "
-"ครั้งสุดท้ายจะยังคงมีอยู่ในที่เก็บข้อมูลท้องถิ่น"
+"อุปกรณ์นี้จะไม่สามารถเข้าถึงข้อมูลที่ซิงค์ของคุณบนอุปกรณ์อื่นได้อีกต่อไป แชท "
+"%1$s ครั้งสุดท้ายจะยังคงมีอยู่ในที่เก็บข้อมูลท้องถิ่น"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21197,8 +21372,8 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
-"นี่เป็นเพียงตัวอย่างแชทเท่านั้น เปิดเมนูของแชทนี้ (จุดสามจุด) จากนั้นเลือก ปักหมุด "
-"เพื่อให้อยู่ที่ด้านบนสุดของแชท!"
+"นี่เป็นเพียงตัวอย่างแชทเท่านั้น เปิดเมนูของแชทนี้ (จุดสามจุด) จากนั้นเลือก "
+"ปักหมุด เพื่อให้อยู่ที่ด้านบนสุดของแชท!"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -21227,8 +21402,8 @@ msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
 msgstr ""
-"ผู้ให้บริการโมเดลจะลบข้อมูลที่เกี่ยวข้องกับแชทนี้ภายใน 30 วัน ผู้ให้บริการโมเดลอื่นๆ "
-"เป็นไปตามโมเดลการเก็บรักษาข้อมูลเป็นศูนย์"
+"ผู้ให้บริการโมเดลจะลบข้อมูลที่เกี่ยวข้องกับแชทนี้ภายใน 30 วัน "
+"ผู้ให้บริการโมเดลอื่นๆ เป็นไปตามโมเดลการเก็บรักษาข้อมูลเป็นศูนย์"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -21237,8 +21412,8 @@ msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
 msgstr ""
-"ผู้ให้บริการโมเดลนี้ไม่ได้เก็บข้อมูลใดๆ ที่เกี่ยวข้องกับการแชทนี้ ผู้ให้บริการโมเดลอื่นๆ "
-"ใช้โมเดลการเก็บรักษาข้อมูลที่จํากัด"
+"ผู้ให้บริการโมเดลนี้ไม่ได้เก็บข้อมูลใดๆ ที่เกี่ยวข้องกับการแชทนี้ "
+"ผู้ให้บริการโมเดลอื่นๆ ใช้โมเดลการเก็บรักษาข้อมูลที่จํากัด"
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -21275,6 +21450,7 @@ msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
 msgstr ""
+""
 "การดำเนินการนี้จะบันทึกการแชทของคุณด้วยการเข้ารหัสแบบครบวงจรบนเซิร์ฟเวอร์ที่ปลอดภัยของ "
 "DuckDuckGo ซึ่งต่อมาสามารถเข้าถึงได้จากเบราว์เซอร์ใดก็ตาม"
 
@@ -21285,8 +21461,9 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"การตั้งค่านี้ถูกเก็บไว้ในเบราว์เซอร์ของคุณ ซึ่งหมายความว่าถ้าคุณล้างข้อมูลเบราว์เซอร์บน "
-"duckduckgo.com คุณอาจเห็นคำตอบที่ได้รับความช่วยเหลือจาก AI อีกครั้ง"
+"การตั้งค่านี้ถูกเก็บไว้ในเบราว์เซอร์ของคุณ "
+"ซึ่งหมายความว่าถ้าคุณล้างข้อมูลเบราว์เซอร์บน duckduckgo.com "
+"คุณอาจเห็นคำตอบที่ได้รับความช่วยเหลือจาก AI อีกครั้ง"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21296,8 +21473,9 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"การตั้งค่านี้ถูกเก็บไว้ในเบราว์เซอร์ของคุณ ซึ่งหมายความว่าถ้าคุณล้างข้อมูลเบราว์เซอร์บน "
-"duckduckgo.com คุณอาจเห็นคำตอบที่ได้รับความช่วยเหลือจาก AI อีกครั้ง อย่างไรก็ตาม "
+"การตั้งค่านี้ถูกเก็บไว้ในเบราว์เซอร์ของคุณ "
+"ซึ่งหมายความว่าถ้าคุณล้างข้อมูลเบราว์เซอร์บน duckduckgo.com "
+"คุณอาจเห็นคำตอบที่ได้รับความช่วยเหลือจาก AI อีกครั้ง อย่างไรก็ตาม "
 "เรามีหน้าเริ่มต้นที่ไม่แสดงคำตอบที่ได้รับความช่วยเหลือจาก AI ด้วยที่ %1$s"
 
 # smartling.placeholder_format=C
@@ -21349,8 +21527,9 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"การกระทำนี้จะลบการแชท Duck.ai ทั้งหมดจากเบราว์เซอร์นี้ และตัดการเชื่อมต่อ Sync & Backup "
-"คุณยังสามารถเข้าถึงการแชทของคุณในเบราว์เซอร์อื่นๆ ที่เชื่อมต่อกับ Sync & Backup"
+"การกระทำนี้จะลบการแชท Duck.ai ทั้งหมดจากเบราว์เซอร์นี้ และตัดการเชื่อมต่อ "
+"Sync & Backup คุณยังสามารถเข้าถึงการแชทของคุณในเบราว์เซอร์อื่นๆ "
+"ที่เชื่อมต่อกับ Sync & Backup"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -21359,8 +21538,8 @@ msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
 msgstr ""
-"การดำเนินการนี้จะลบการแชททั้งหมดของคุณเมื่อเร็วๆ นี้ เว้นแต่ว่าจะมีการปักหมุดไว้ "
-"การกระทำนี้ย้อนกลับไม่ได้"
+"การดำเนินการนี้จะลบการแชททั้งหมดของคุณเมื่อเร็วๆ นี้ "
+"เว้นแต่ว่าจะมีการปักหมุดไว้ การกระทำนี้ย้อนกลับไม่ได้"
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -21378,7 +21557,9 @@ msgstr "การตั้งค่าทั้งหมดของคุณจ
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
 msgctxt "settings"
 msgid "This will reset your saved settings to default values. Continue?"
-msgstr "การดำเนินการนี้จะรีเซ็ตการตั้งค่าที่บันทึกไว้เป็นค่าเริ่มต้น ดำเนินการต่อหรือไม่"
+msgstr ""
+"การดำเนินการนี้จะรีเซ็ตการตั้งค่าที่บันทึกไว้เป็นค่าเริ่มต้น "
+"ดำเนินการต่อหรือไม่"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard column: holes completed in current round
@@ -21497,9 +21678,7 @@ msgctxt "directions"
 msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
-msgstr ""
-"วิธีการพิมพ์เส้นทาง:"
-"%1$sกลับไปยังแผนที่%2$sเลือกเส้นทางที่ต้องการพิมพ์%3$sเลือกไอคอนเครื่องพิมพ์%4$s"
+msgstr "วิธีการพิมพ์เส้นทาง:%1$sกลับไปยังแผนที่%2$sเลือกเส้นทางที่ต้องการพิมพ์%3$sเลือกไอคอนเครื่องพิมพ์%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -21509,7 +21688,8 @@ msgid ""
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
 msgstr ""
-"เพื่อกู้คืนข้อมูลที่ซิงค์ของคุณ คุณจำเป็นต้องมีรหัสกู้คืนที่คุณบันทึกไว้เมื่อคุณตั้งค่า Sync เป็นครั้งแรก "
+"เพื่อกู้คืนข้อมูลที่ซิงค์ของคุณ "
+"คุณจำเป็นต้องมีรหัสกู้คืนที่คุณบันทึกไว้เมื่อคุณตั้งค่า Sync เป็นครั้งแรก "
 "รหัสนี้อาจถูกบันทึกเป็น PDF บนอุปกรณ์ที่คุณใช้ตั้งค่าการซิงค์ในตอนแรก"
 
 # smartling.placeholder_format=C
@@ -21549,7 +21729,7 @@ msgstr "วันนี้"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
-msgstr ""
+msgstr "เปิด/ปิดเพื่อใช้แชท AI ส่วนตัว หรือ %1$sปิดใช้งานในการตั้งค่า%2$s"
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -21777,7 +21957,9 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "แปลประโยคภาษาอังกฤษนี้เป็นภาษาฝรั่งเศส: “ฉันจะไปโรงภาพยนตร์ที่ใกล้ที่สุดได้อย่างไร?”"
+msgstr ""
+"แปลประโยคภาษาอังกฤษนี้เป็นภาษาฝรั่งเศส: "
+"“ฉันจะไปโรงภาพยนตร์ที่ใกล้ที่สุดได้อย่างไร?”"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -21785,7 +21967,9 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "แปลประโยคภาษาไทยนี้เป็นภาษาอังกฤษ: “ฉันจะไปโรงภาพยนตร์ที่ใกล้ที่สุดได้อย่างไร?”"
+msgstr ""
+"แปลประโยคภาษาไทยนี้เป็นภาษาอังกฤษ: "
+"“ฉันจะไปโรงภาพยนตร์ที่ใกล้ที่สุดได้อย่างไร?”"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -22263,8 +22447,8 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"กำลังพยายามปิดใช้งานฟีเจอร์ AI อยู่ใช่ไหม ติดตั้งส่วนขยายการค้นหา %1$sDuckDuckGo No "
-"AI%2$s เพื่อจดจำการตั้งค่าของคุณ %3$sศึกษาเพิ่มเติม%4$s"
+"กำลังพยายามปิดใช้งานฟีเจอร์ AI อยู่ใช่ไหม ติดตั้งส่วนขยายการค้นหา "
+"%1$sDuckDuckGo No AI%2$s เพื่อจดจำการตั้งค่าของคุณ %3$sศึกษาเพิ่มเติม%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -22273,8 +22457,8 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"กำลังพยายามปิดใช้งานฟีเจอร์ AI อยู่ใช่ไหม เปลี่ยนไปใช้ส่วนขยายการค้นหา %1$sDuckDuckGo No "
-"AI%2$s เพื่อจดจำการตั้งค่าของคุณ %3$sศึกษาเพิ่มเติม%4$s"
+"กำลังพยายามปิดใช้งานฟีเจอร์ AI อยู่ใช่ไหม เปลี่ยนไปใช้ส่วนขยายการค้นหา "
+"%1$sDuckDuckGo No AI%2$s เพื่อจดจำการตั้งค่าของคุณ %3$sศึกษาเพิ่มเติม%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -22606,7 +22790,8 @@ msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
 msgstr ""
-"ภายใต้%1$sเมื่อเริ่มต้น%2$s ให้คลิก%3$sเปิดหน้าที่เฉพาะเจาะจง%4$s จากนั้นคลิก%5$sตั้งค่าหน้า%6$s"
+"ภายใต้%1$sเมื่อเริ่มต้น%2$s ให้คลิก%3$sเปิดหน้าที่เฉพาะเจาะจง%4$s "
+"จากนั้นคลิก%5$sตั้งค่าหน้า%6$s"
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
@@ -22614,7 +22799,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"ภายใต้%1$sเมื่อเริ่มต้น%2$s ให้เลือก%3$sหน้าแรก%4$s และป้อน: https://duckduckgo.com"
+"ภายใต้%1$sเมื่อเริ่มต้น%2$s ให้เลือก%3$sหน้าแรก%4$s และป้อน: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -22730,8 +22916,8 @@ msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
 msgstr ""
-"ปลดล็อก %1$s, การให้เหตุผล AI ที่สูงขึ้น, และขีดจำกัดการใช้งานสูงกว่า Plus ถึง 2 เท่า "
-"โดยการอัปเกรดเป็น Pro"
+"ปลดล็อก %1$s, การให้เหตุผล AI ที่สูงขึ้น, และขีดจำกัดการใช้งานสูงกว่า Plus "
+"ถึง 2 เท่า โดยการอัปเกรดเป็น Pro"
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -22889,7 +23075,8 @@ msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
 msgstr ""
-"อัปเดตเบราว์เซอร์ DuckDuckGo เพื่อเปิดใช้งานการสมัครสมาชิกใน Duck.ai และเข้าถึงโมเดลขั้นสูง"
+"อัปเดตเบราว์เซอร์ DuckDuckGo เพื่อเปิดใช้งานการสมัครสมาชิกใน Duck.ai "
+"และเข้าถึงโมเดลขั้นสูง"
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -23117,8 +23304,9 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"ใช้ ChatGPT, Claude และ AI อื่นๆ อย่างเป็นส่วนตัว ปกป้องแชทจากแฮกเกอร์ นักต้มตุ๋น "
-"และบริษัทต่าง ๆ เก็บข้อมูลให้เป็นความลับ ไม่มีค่าใช้จ่าย ไม่จำเป็นต้องมีบัญชี"
+"ใช้ ChatGPT, Claude และ AI อื่นๆ อย่างเป็นส่วนตัว ปกป้องแชทจากแฮกเกอร์ "
+"นักต้มตุ๋น และบริษัทต่าง ๆ เก็บข้อมูลให้เป็นความลับ ไม่มีค่าใช้จ่าย "
+"ไม่จำเป็นต้องมีบัญชี"
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -23172,7 +23360,9 @@ msgctxt "Description for the joiner-device success screen"
 msgid ""
 "Use this code to restore your data if you lose access to your devices. Keep "
 "it safe."
-msgstr "ใช้รหัสนี้เพื่อกู้คืนข้อมูลของคุณหากคุณไม่สามารถเข้าถึงอุปกรณ์ของคุณได้ เก็บรักษาไว้ให้ปลอดภัย"
+msgstr ""
+"ใช้รหัสนี้เพื่อกู้คืนข้อมูลของคุณหากคุณไม่สามารถเข้าถึงอุปกรณ์ของคุณได้ "
+"เก็บรักษาไว้ให้ปลอดภัย"
 
 # smartling.placeholder_format=C
 #. First sentence of the recovery section. The 18-month inactivity notice is rendered by the component using DUCKCHAT_SYNC_RECOVERY_INACTIVITY_NOTICE so both surfaces stay consistent.
@@ -23349,6 +23539,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Yelp's ad network."
 msgstr ""
+"การดูโฆษณาได้รับการปกป้องความเป็นส่วนตัวโดย DuckDuckGo "
+"การคลิกโฆษณาได้รับการจัดการโดยเครือข่ายโฆษณาของ Yelp"
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -23359,7 +23551,9 @@ msgstr "หมู่เกาะเวอร์จิน"
 msgctxt "duckassist"
 msgid ""
 "Visit %sAssist Settings%s to adjust how this feature works or turn it off."
-msgstr "ไปที่ %1$sการตั้งค่า Assist%2$s เพื่อปรับวิธีการทำงานของคุณลักษณะนี้หรือปิดการใช้งาน"
+msgstr ""
+"ไปที่ %1$sการตั้งค่า Assist%2$s "
+"เพื่อปรับวิธีการทำงานของคุณลักษณะนี้หรือปิดการใช้งาน"
 
 # smartling.placeholder_format=C
 #. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
@@ -23367,7 +23561,9 @@ msgctxt "duckassist"
 msgid ""
 "Visit %sDuckAssist Settings%s to adjust how this feature works or turn it "
 "off."
-msgstr "ไปที่ %1$sการตั้งค่า DuckAssist%2$s เพื่อปรับวิธีการทำงานของฟีเจอร์นี้หรือปิดการใช้งาน"
+msgstr ""
+"ไปที่ %1$sการตั้งค่า DuckAssist%2$s "
+"เพื่อปรับวิธีการทำงานของฟีเจอร์นี้หรือปิดการใช้งาน"
 
 # smartling.placeholder_format=C
 #. Prompt to visit DuckDuckGo on another device.
@@ -23390,8 +23586,9 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"เข้าไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณ แล้วไปที่ %1$sDuck.ai Settings%2$s > %3$sSync "
-"& Backup%4$s > %5$sManage%6$s จากนั้นเลือก %7$sSync With Another Device%8$s"
+"เข้าไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณ แล้วไปที่ %1$sDuck.ai Settings%2$s "
+"> %3$sSync & Backup%4$s > %5$sManage%6$s จากนั้นเลือก %7$sSync With Another "
+"Device%8$s"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23401,8 +23598,9 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"ไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณ แล้วเปิดการตั้งค่า Duck.ai เลือก \"เปิด\" ภายใต้ Sync "
-"& Backup และเลือก \"ซิงค์กับอุปกรณ์อื่น\" หรือสแกนคิวอาร์บน PDF การกู้คืนของคุณ"
+"ไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณ แล้วเปิดการตั้งค่า Duck.ai เลือก "
+"\"เปิด\" ภายใต้ Sync & Backup และเลือก \"ซิงค์กับอุปกรณ์อื่น\" "
+"หรือสแกนคิวอาร์บน PDF การกู้คืนของคุณ"
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -23412,9 +23610,9 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"เข้าไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณหรือแอป DuckDuckGo แล้วไปที่ %1$sDuck.ai "
-"Settings%2$s > %3$sSync & Backup%4$s > %5$sManage%6$s จากนั้นเลือก %7$sSync "
-"With Another Device%8$s"
+"เข้าไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณหรือแอป DuckDuckGo แล้วไปที่ "
+"%1$sDuck.ai Settings%2$s > %3$sSync & Backup%4$s > %5$sManage%6$s "
+"จากนั้นเลือก %7$sSync With Another Device%8$s"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23424,9 +23622,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"ไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณหรือแอป DuckDuckGo แล้วเปิดการตั้งค่า Duck.ai เลือก "
-"\"เปิด\" ภายใต้ Sync & Backup และเลือก \"ซิงค์กับอุปกรณ์อื่น\" หรือสแกนคิวอาร์บน PDF "
-"การกู้คืนของคุณ"
+"ไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณหรือแอป DuckDuckGo แล้วเปิดการตั้งค่า "
+"Duck.ai เลือก \"เปิด\" ภายใต้ Sync & Backup และเลือก \"ซิงค์กับอุปกรณ์อื่น\" "
+"หรือสแกนคิวอาร์บน PDF การกู้คืนของคุณ"
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23478,7 +23676,10 @@ msgstr "แชทด้วยเสียงสิ้นสุดลง"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr "เราจะทำให้การแชทด้วยเสียงไม่ถูกระบุชื่อและจะไม่มีการใช้การแชทด้วยเสียงเพื่อฝึกโมเดล AI"
+msgstr ""
+""
+"เราจะทำให้การแชทด้วยเสียงไม่ถูกระบุชื่อและจะไม่มีการใช้การแชทด้วยเสียงเพื่อฝึกโมเดล "
+"AI"
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -23643,8 +23844,10 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"การดูวิดีโอที่นี่หมายความว่าเว็บไซต์ที่โฮสต์นั้นสามารถติดตามคุณได้ เพราะเราต้องสตรีมเนื้อหาจากที่นั่น "
-"DuckDuckGo เป็นบริษัทอิสระและไม่มีความสัมพันธ์กับ YouTube ซึ่งวิดีโอส่วนใหญ่โฮสต์อยู่ที่นั่น"
+"การดูวิดีโอที่นี่หมายความว่าเว็บไซต์ที่โฮสต์นั้นสามารถติดตามคุณได้ "
+"เพราะเราต้องสตรีมเนื้อหาจากที่นั่น DuckDuckGo "
+"เป็นบริษัทอิสระและไม่มีความสัมพันธ์กับ YouTube "
+"ซึ่งวิดีโอส่วนใหญ่โฮสต์อยู่ที่นั่น"
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -23656,7 +23859,9 @@ msgstr "เราทำให้ไม่ระบุตัวตน"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr "เราสามารถเปิดใช้%1$s ตำแหน่งของคุณ%2$s แบบไม่ระบุตัวตนเพื่อแสดงผลลัพธ์ที่แม่นยำยิ่งขึ้น"
+msgstr ""
+"เราสามารถเปิดใช้%1$s ตำแหน่งของคุณ%2$s "
+"แบบไม่ระบุตัวตนเพื่อแสดงผลลัพธ์ที่แม่นยำยิ่งขึ้น"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -23668,8 +23873,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
-"เราสามารถแก้ไขได้เฉพาะสิ่งที่เราเห็นเท่านั้น เพื่อรายงานการตอบสนองที่เป็นอันตรายหรือผิดกฎหมาย "
-"โปรดแชร์การสนทนานี้กับ DuckDuckGo เพื่อที่เราจะสามารถสอบสวนและแก้ไขปัญหานี้"
+"เราสามารถแก้ไขได้เฉพาะสิ่งที่เราเห็นเท่านั้น "
+"เพื่อรายงานการตอบสนองที่เป็นอันตรายหรือผิดกฎหมาย โปรดแชร์การสนทนานี้กับ "
+"DuckDuckGo เพื่อที่เราจะสามารถสอบสวนและแก้ไขปัญหานี้"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -23681,7 +23887,8 @@ msgid ""
 "please share your prompt and response so we can investigate and address the "
 "issue."
 msgstr ""
-"เราสามารถแก้ไขได้เฉพาะสิ่งที่เราเห็นเท่านั้น เพื่อรายงานการตอบสนองที่เป็นอันตรายหรือผิดกฎหมาย "
+"เราสามารถแก้ไขได้เฉพาะสิ่งที่เราเห็นเท่านั้น "
+"เพื่อรายงานการตอบสนองที่เป็นอันตรายหรือผิดกฎหมาย "
 "โปรดแชร์คำแนะนำและการตอบสนองของคุณเพื่อที่เราจะสามารถสอบสวนและแก้ไขปัญหานี้"
 
 # smartling.placeholder_format=C
@@ -23695,7 +23902,9 @@ msgstr "เราสามารถใช้%1$sตำแหน่งที่�
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "เราไม่สามารถอ่านไฟล์ที่แนบมาได้ เนื่องจากอย่างน้อยหนึ่งในนั้นได้รับการเข้ารหัส"
+msgstr ""
+"เราไม่สามารถอ่านไฟล์ที่แนบมาได้ "
+"เนื่องจากอย่างน้อยหนึ่งในนั้นได้รับการเข้ารหัส"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23723,7 +23932,8 @@ msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
 msgstr ""
-"เราไม่จัดเก็บข้อมูลส่วนบุคคลของคุณ เราจะไม่แสดงโฆษณาแก่คุณในทุกๆ ที่ เราไม่ติดตามคุณ อย่างแน่นอน"
+"เราไม่จัดเก็บข้อมูลส่วนบุคคลของคุณ เราจะไม่แสดงโฆษณาแก่คุณในทุกๆ ที่ "
+"เราไม่ติดตามคุณ อย่างแน่นอน"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23736,7 +23946,9 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr "เนื่องจากเราไม่ได้ติดตามคุณ เราจึงอยากให้คุณช่วยบอกว่าสิ่งใดทำให้คุณกลับมาในวันนี้:"
+msgstr ""
+"เนื่องจากเราไม่ได้ติดตามคุณ "
+"เราจึงอยากให้คุณช่วยบอกว่าสิ่งใดทำให้คุณกลับมาในวันนี้:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -23745,7 +23957,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
 msgstr ""
-"เนื่องจากเราไม่ได้ติดตามคุณ เราจึงอยากให้คุณช่วยบอกว่าสิ่งใดทำให้คุณสนใจลองใช้บริการเราในวันนี้:"
+"เนื่องจากเราไม่ได้ติดตามคุณ "
+"เราจึงอยากให้คุณช่วยบอกว่าสิ่งใดทำให้คุณสนใจลองใช้บริการเราในวันนี้:"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23812,7 +24025,8 @@ msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
 msgstr ""
-"เราค้นหาและลบข้อมูลส่วนตัวของคุณออกจากเว็บไซต์นายหน้าข้อมูล นอกจากนี้ยังรับ VPN และอื่นๆ"
+"เราค้นหาและลบข้อมูลส่วนตัวของคุณออกจากเว็บไซต์นายหน้าข้อมูล นอกจากนี้ยังรับ "
+"VPN และอื่นๆ"
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -23821,7 +24035,8 @@ msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
 msgstr ""
-"เรามีข้อตกลงกับผู้ให้บริการ AI ทุกรายเพื่อให้มั่นใจว่าการแชทของคุณจะไม่ถูกใช้ในการฝึกฝน AI"
+"เรามีข้อตกลงกับผู้ให้บริการ AI "
+"ทุกรายเพื่อให้มั่นใจว่าการแชทของคุณจะไม่ถูกใช้ในการฝึกฝน AI"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23856,6 +24071,7 @@ msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
 msgstr ""
+""
 "เราใช้ตำแหน่งที่ตั้งแบบไม่ระบุตัวตนของคุณเพียงเพื่อให้ได้ผลลัพธ์ที่แม่นยำยิ่งขึ้นและใกล้คุณมากขึ้นเท่านั้น "
 "คุณสามารถเปลี่ยนใจได้เสมอในภายหลัง"
 
@@ -23873,7 +24089,9 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr "เราพึ่งพาคำติชมที่ไม่ระบุชื่อของคุณเพื่อปรับปรุง DuckDuckGo ให้ดียิ่งขึ้นสำหรับทุกคน"
+msgstr ""
+"เราพึ่งพาคำติชมที่ไม่ระบุชื่อของคุณเพื่อปรับปรุง DuckDuckGo "
+"ให้ดียิ่งขึ้นสำหรับทุกคน"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23909,8 +24127,8 @@ msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
 msgstr ""
-"เราจะสแกนเว็บไซต์นายหน้าข้อมูลเพื่อค้นหาอีเมล ชื่อ ที่อยู่ และข้อมูลอื่นๆ ของคุณ "
-"และดำเนินการเพื่อให้ทุกสิ่งที่เราพบเกี่ยวกับคุณถูกลบออก"
+"เราจะสแกนเว็บไซต์นายหน้าข้อมูลเพื่อค้นหาอีเมล ชื่อ ที่อยู่ และข้อมูลอื่นๆ "
+"ของคุณ และดำเนินการเพื่อให้ทุกสิ่งที่เราพบเกี่ยวกับคุณถูกลบออก"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23919,7 +24137,8 @@ msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
 msgstr ""
-"เราทราบถึงปัญหานี้แล้วและกำลังดำเนินการแก้ไขอยู่ ถ้าคุณยังเห็นข้อผิดพลาดนี้อยู่ กรุณาติดต่อ %1$s"
+"เราทราบถึงปัญหานี้แล้วและกำลังดำเนินการแก้ไขอยู่ "
+"ถ้าคุณยังเห็นข้อผิดพลาดนี้อยู่ กรุณาติดต่อ %1$s"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -23952,7 +24171,8 @@ msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
 msgstr ""
-"เราได้อัปเดตบริการ Duck.ai แล้ว เพื่อให้การเปลี่ยนแปลงมีผล เราจำเป็นต้องโหลดหน้านี้อีกครั้ง"
+"เราได้อัปเดตบริการ Duck.ai แล้ว เพื่อให้การเปลี่ยนแปลงมีผล "
+"เราจำเป็นต้องโหลดหน้านี้อีกครั้ง"
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -24060,7 +24280,9 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Weekly usage limit reached. You can keep chatting by using your monthly "
 "limit."
-msgstr "ถึงขีดจำกัดการใช้งานรายสัปดาห์แล้ว คุณสามารถแชทต่อโดยใช้ขีดจำกัดรายเดือนของคุณ"
+msgstr ""
+"ถึงขีดจำกัดการใช้งานรายสัปดาห์แล้ว "
+"คุณสามารถแชทต่อโดยใช้ขีดจำกัดรายเดือนของคุณ"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -24074,7 +24296,8 @@ msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
 msgstr ""
-"ยินดีต้อนรับสู่ Duck.ai การแชททั้งหมดที่นี่เป็นแบบส่วนตัว เราไม่ระบุชื่อและจะไม่ถูกใช้เพื่อฝึกโมเดล AI"
+"ยินดีต้อนรับสู่ Duck.ai การแชททั้งหมดที่นี่เป็นแบบส่วนตัว "
+"เราไม่ระบุชื่อและจะไม่ถูกใช้เพื่อฝึกโมเดล AI"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -24095,7 +24318,8 @@ msgid ""
 "to train AI models."
 msgstr ""
 "ยินดีต้อนรับสู่ DuckDuckGo AI Chat! เซสชันแชทนี้ขับเคลื่อนโดย %2$s ของ %1$s "
-"การแชททั้งหมดของคุณที่นี่เป็นแบบส่วนตัว และจะไม่ถูกจัดเก็บโดย DuckDuckGo หรือใช้เพื่อฝึกโมเดล AI"
+"การแชททั้งหมดของคุณที่นี่เป็นแบบส่วนตัว และจะไม่ถูกจัดเก็บโดย DuckDuckGo "
+"หรือใช้เพื่อฝึกโมเดล AI"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24202,7 +24426,9 @@ msgctxt "Full sentence for finding a better word"
 msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
-msgstr "มีตัวเลือกใดบ้างสำหรับคำว่า 'ดีกว่านี้' ในบริบทของ \"เราต้องทำให้ได้ดีกว่านี้\""
+msgstr ""
+"มีตัวเลือกใดบ้างสำหรับคำว่า 'ดีกว่านี้' ในบริบทของ "
+"\"เราต้องทำให้ได้ดีกว่านี้\""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -24227,10 +24453,11 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"คุณจะได้ประโยชน์อะไรบ้างจากการดาวน์โหลดเบราว์เซอร์ DuckDuckGo สำหรับผู้ที่สนใจใช้ Duck.ai "
-"อ้างอิงเฉพาะแหล่งข้อมูลอย่างเป็นทางการของ DuckDuckGo เท่านั้น แบ่งคำตอบออกเป็นส่วนๆ "
-"ที่ชัดเจนพร้อมชื่อหัวข้อ โดยเน้นที่การบูรณาการ Duck.ai และการปกป้องความเป็นส่วนตัว ทำให้สั้น "
-"ง่าย และเข้าใจได้ง่ายสำหรับคนที่มีหรือไม่มีประสบการณ์ด้าน AI หรือเทคนิคมากนัก"
+"คุณจะได้ประโยชน์อะไรบ้างจากการดาวน์โหลดเบราว์เซอร์ DuckDuckGo "
+"สำหรับผู้ที่สนใจใช้ Duck.ai อ้างอิงเฉพาะแหล่งข้อมูลอย่างเป็นทางการของ "
+"DuckDuckGo เท่านั้น แบ่งคำตอบออกเป็นส่วนๆ ที่ชัดเจนพร้อมชื่อหัวข้อ "
+"โดยเน้นที่การบูรณาการ Duck.ai และการปกป้องความเป็นส่วนตัว ทำให้สั้น ง่าย "
+"และเข้าใจได้ง่ายสำหรับคนที่มีหรือไม่มีประสบการณ์ด้าน AI หรือเทคนิคมากนัก"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24778,13 +25005,15 @@ msgid ""
 "With chat history on, up to %s of your most recent chats will be saved on "
 "this device."
 msgstr ""
+"เมื่อเปิดใช้งานประวัติการแชท จะสามารถบันทึกแชทล่าสุดได้สูงสุด %1$s "
+"รายการบนอุปกรณ์นี้"
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline in the About Chat History modal.
 msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, your most recent chats will be saved on this device."
-msgstr ""
+msgstr "เมื่อเปิดประวัติแชท แชทล่าสุดของคุณจะถูกบันทึกไว้ในอุปกรณ์นี้"
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -25090,7 +25319,9 @@ msgstr "คุณสามารถเข้าถึง DuckDuckGo AI Chat ไ�
 msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
-msgstr "คุณสามารถปรับวิธีการทำงานของ %1$s หรือปิดได้ตลอดเวลาใน %2$sการตั้งค่าการค้นหา%3$s"
+msgstr ""
+"คุณสามารถปรับวิธีการทำงานของ %1$s หรือปิดได้ตลอดเวลาใน "
+"%2$sการตั้งค่าการค้นหา%3$s"
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -25099,7 +25330,8 @@ msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
 msgstr ""
-"คุณสามารถปรับวิธีการทำงานของ Assist หรือปิดได้ตลอดเวลาใน %1$sการตั้งค่าการค้นหา%2$s"
+"คุณสามารถปรับวิธีการทำงานของ Assist หรือปิดได้ตลอดเวลาใน "
+"%1$sการตั้งค่าการค้นหา%2$s"
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
@@ -25238,7 +25470,9 @@ msgctxt "Organic result context menu"
 msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
-msgstr "คุณสามารถบล็อกได้เพียง %1$s ไซต์เท่านั้น ในการบล็อก %2$s คุณต้องเลิกบล็อกไซต์อื่นก่อน"
+msgstr ""
+"คุณสามารถบล็อกได้เพียง %1$s ไซต์เท่านั้น ในการบล็อก %2$s "
+"คุณต้องเลิกบล็อกไซต์อื่นก่อน"
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -25302,8 +25536,8 @@ msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
 msgstr ""
-"ตอนนี้คุณมีการเข้าถึง %1$s, การให้เหตุผล AI ที่สูงขึ้น, และขีดจำกัดการใช้งานสูงกว่า Plus ถึง 2 "
-"เท่า"
+"ตอนนี้คุณมีการเข้าถึง %1$s, การให้เหตุผล AI ที่สูงขึ้น, "
+"และขีดจำกัดการใช้งานสูงกว่า Plus ถึง 2 เท่า"
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -25378,7 +25612,8 @@ msgid ""
 "browse privately too. It’s already installed and can:"
 msgstr ""
 "ตอนนี้คุณกำลังค้นหาแบบเป็นส่วนตัวใน Chrome ใช้แอปของเราแทน Chrome "
-"เพื่อเรียกดูแบบเป็นส่วนตัวได้เช่นกัน แอปได้รับการติดตั้งไว้เรียบร้อยแล้วและสามารถ:"
+"เพื่อเรียกดูแบบเป็นส่วนตัวได้เช่นกัน "
+"แอปได้รับการติดตั้งไว้เรียบร้อยแล้วและสามารถ:"
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -25391,7 +25626,8 @@ msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
 msgstr ""
-"ตอนนี้คุณทำการกำลังค้นหาแบบมีความเป็นส่วนตัว %1$sดูเคล็ดลับเพื่อลดร่องรอยทางออนไลน์ให้มากยิ่งขึ้น"
+"ตอนนี้คุณทำการกำลังค้นหาแบบมีความเป็นส่วนตัว "
+"%1$sดูเคล็ดลับเพื่อลดร่องรอยทางออนไลน์ให้มากยิ่งขึ้น"
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -25467,8 +25703,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"คุณใช้พื้นที่จัดเก็บ Sync & Backup สำหรับการแชท Duck.ai พร้อมไฟล์แนบเต็มแล้ว ลบแชทที่เก่าที่สุด "
-"%1$s แชทเพื่อซิงค์ต่อ แชทที่ปักหมุดไว้จะไม่ถูกลบ"
+"คุณใช้พื้นที่จัดเก็บ Sync & Backup สำหรับการแชท Duck.ai พร้อมไฟล์แนบเต็มแล้ว "
+"ลบแชทที่เก่าที่สุด %1$s แชทเพื่อซิงค์ต่อ แชทที่ปักหมุดไว้จะไม่ถูกลบ"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25478,8 +25714,9 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"คุณหมดพื้นที่จัดเก็บข้อมูลสำรอง Sync & Backup สำหรับแชท Duck.ai แล้ว ลบแชท %1$s "
-"รายการที่เก่าที่สุดที่มีไฟล์แนบเพื่อดำเนินการ Sync ต่อ แชทที่ปักหมุดไว้จะไม่ถูกลบ"
+"คุณหมดพื้นที่จัดเก็บข้อมูลสำรอง Sync & Backup สำหรับแชท Duck.ai แล้ว ลบแชท "
+"%1$s รายการที่เก่าที่สุดที่มีไฟล์แนบเพื่อดำเนินการ Sync ต่อ "
+"แชทที่ปักหมุดไว้จะไม่ถูกลบ"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -25493,8 +25730,8 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"YouTube (Google เป็นเจ้าของ) ไม่อนุญาตให้คุณดูวิดีโอแบบไม่ระบุตัวตน การดูวิดีโอ YouTube "
-"ที่นี่จะถูกติดตามโดย YouTube/Google"
+"YouTube (Google เป็นเจ้าของ) ไม่อนุญาตให้คุณดูวิดีโอแบบไม่ระบุตัวตน "
+"การดูวิดีโอ YouTube ที่นี่จะถูกติดตามโดย YouTube/Google"
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -25516,7 +25753,8 @@ msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
 msgstr ""
-"การแชทล่าสุด %1$s รายการของคุณจะพร้อมใช้งานในที่เก็บข้อมูลในเครื่องบนเบราว์เซอร์เหล่านี้:"
+"การแชทล่าสุด %1$s "
+"รายการของคุณจะพร้อมใช้งานในที่เก็บข้อมูลในเครื่องบนเบราว์เซอร์เหล่านี้:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
@@ -25605,14 +25843,17 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"เบราว์เซอร์ของคุณแสดงรายการไซต์ที่คุณเยี่ยมชมบ่อยที่สุดDuckDuckGo ไม่มีสิทธิ์เข้าถึงข้อมูลนี้เด็ดขาด"
+"เบราว์เซอร์ของคุณแสดงรายการไซต์ที่คุณเยี่ยมชมบ่อยที่สุดDuckDuckGo "
+"ไม่มีสิทธิ์เข้าถึงข้อมูลนี้เด็ดขาด"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
-msgstr "เบราว์เซอร์ของคุณแสดงรายชื่อเว็บไซต์ที่เยี่ยมชมบ่อยที่สุด DuckDuckGo ไม่เคยเข้าถึงข้อมูลนี้"
+msgstr ""
+"เบราว์เซอร์ของคุณแสดงรายชื่อเว็บไซต์ที่เยี่ยมชมบ่อยที่สุด DuckDuckGo "
+"ไม่เคยเข้าถึงข้อมูลนี้"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -25660,7 +25901,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"การแชทของคุณเป็นแบบส่วนตัว เราจะไมบันทึกและใช้การแชทของคุณในการฝึกโมเดล AI เด็ดขาด"
+"การแชทของคุณเป็นแบบส่วนตัว เราจะไมบันทึกและใช้การแชทของคุณในการฝึกโมเดล AI "
+"เด็ดขาด"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -25668,7 +25910,8 @@ msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"การแชทของคุณเป็นแบบส่วนตัว เราจะไม่บันทึกและใช้การแชทของคุณในการฝึกโมเดล AI เด็ดขาด"
+"การแชทของคุณเป็นแบบส่วนตัว เราจะไม่บันทึกและใช้การแชทของคุณในการฝึกโมเดล AI "
+"เด็ดขาด"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -25768,7 +26011,8 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"รหัสผ่านของคุณสร้างคีย์ 512 บิตโดยใช้อัลกอริทึมการแฮชที่ปลอดภัยที่เรียกว่า %1$sSHA-2%2$s "
+"รหัสผ่านของคุณสร้างคีย์ 512 บิตโดยใช้อัลกอริทึมการแฮชที่ปลอดภัยที่เรียกว่า "
+"%1$sSHA-2%2$s "
 "เฉพาะคีย์และไฟล์การตั้งค่าที่เกี่ยวข้องเท่านั้นที่ออกจากเบราว์เซอร์ของคุณ "
 "เราบันทึกไฟล์การตั้งค่าโดยใช้คีย์เป็นชื่อ DuckDuckGo จะไม่ทราบรหัสผ่านของคุณ"
 
@@ -25785,7 +26029,8 @@ msgid ""
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
 msgstr ""
-"คำสั่งของเธอถูกส่งต่อผ่านเซิร์ฟเวอร์ DuckDuckGo และข้อมูลเมตาที่ระบุตัวตนส่วนบุคคลจะถูกลบออก "
+"คำสั่งของเธอถูกส่งต่อผ่านเซิร์ฟเวอร์ DuckDuckGo "
+"และข้อมูลเมตาที่ระบุตัวตนส่วนบุคคลจะถูกลบออก "
 "เพื่อให้ผู้ให้บริการโมเดลไม่สามารถเชื่อมโยงการสนทนาของคุณกลับไปยังคุณ"
 
 # smartling.placeholder_format=C
@@ -25831,8 +26076,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
-"การตั้งค่าของคุณถูกบันทึกไว้แล้ว แต่การล้างคุกกี้จะรีเซ็ตการตั้งค่าเหล่านั้น เปิดใช้งานส่วนขยาย "
-"%1$sDuckDuckGo No AI%2$s เพื่อให้การตั้งค่านี้คงอยู่ถาวร"
+"การตั้งค่าของคุณถูกบันทึกไว้แล้ว แต่การล้างคุกกี้จะรีเซ็ตการตั้งค่าเหล่านั้น "
+"เปิดใช้งานส่วนขยาย %1$sDuckDuckGo No AI%2$s เพื่อให้การตั้งค่านี้คงอยู่ถาวร"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25841,8 +26086,10 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"การตั้งค่าของคุณถูกบันทึกไว้แล้ว แต่การล้างคุกกี้จะเป็นการรีเซ็ตการตั้งค่าเหล่านั้น ติดตั้งส่วนขยาย "
-"%1$sDuckDuckGo No AI%2$s เพื่อให้การตั้งค่านี้คงอยู่ถาวร %3$sศึกษาเพิ่มเติม%4$s"
+"การตั้งค่าของคุณถูกบันทึกไว้แล้ว "
+"แต่การล้างคุกกี้จะเป็นการรีเซ็ตการตั้งค่าเหล่านั้น ติดตั้งส่วนขยาย "
+"%1$sDuckDuckGo No AI%2$s เพื่อให้การตั้งค่านี้คงอยู่ถาวร "
+"%3$sศึกษาเพิ่มเติม%4$s"
 
 # smartling.placeholder_format=C
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
@@ -26137,7 +26384,7 @@ msgstr "นาที"
 #. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the chat options menu button"
 msgid "menu"
-msgstr ""
+msgstr "เมนู"
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.
@@ -26211,7 +26458,9 @@ msgstr "เว็บไซต์อย่างเป็นทางการ"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr "หรือพิมพ์รหัสสีที่คุณต้องการ เช่น %1$s (%2$s เป็นรหัสอักขระ %3$s ตัวที่เข้ารหัสแล้ว)"
+msgstr ""
+"หรือพิมพ์รหัสสีที่คุณต้องการ เช่น %1$s (%2$s เป็นรหัสอักขระ %3$s "
+"ตัวที่เข้ารหัสแล้ว)"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/th_TH/LC_MESSAGES/duckduckgo.po
+++ b/locales/th_TH/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: th_TH\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1189,6 +1189,12 @@ msgid "About our ads"
 msgstr "เกี่ยวกับโฆษณาของเรา"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1314,6 +1320,20 @@ msgid "Ad is suspicious"
 msgstr "โฆษณาน่าสงสัย"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "เพิ่ม DuckDuckGo"
@@ -1340,6 +1360,27 @@ msgstr "เพิ่ม DuckDuckGo เป็นเครื่องมือค
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "เพิ่ม DuckDuckGo ลงใน %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1385,6 +1426,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "เพิ่มเนื้อหาในหน้า"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1470,6 +1527,12 @@ msgstr "ส่วนเสริม"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "การเก็บรายละเอียดขั้นสุดท้าย"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1767,6 +1830,12 @@ msgstr "ทุกสี"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "เสร็จเรียบร้อย!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3449,6 +3518,14 @@ msgid "Cancel"
 msgstr "ยกเลิก"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3935,10 +4012,22 @@ msgid "Chat response is offensive"
 msgstr "คำตอบของแชทไม่เหมาะสม"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "แชทกับ %1$s"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3957,6 +4046,14 @@ msgstr "แชท"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "แชท"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5529,6 +5626,12 @@ msgid "Current Streak"
 msgstr "สตรีคปัจจุบัน"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5873,6 +5976,12 @@ msgstr "ลบแชท"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "ลบแชทที่เก่ากว่า 30 วัน"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6286,6 +6395,12 @@ msgstr "ปิดตลอดไป"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "ปิดการเลื่อนระดับ"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7420,6 +7535,12 @@ msgid "Edit Prompt"
 msgstr "แก้ไขคำสั่ง"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7636,6 +7757,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "โมเดลที่เข้ารหัส"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8451,6 +8578,12 @@ msgid "Follow-up question"
 msgstr "คำถามเพิ่มเติม"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -8960,6 +9093,12 @@ msgstr ""
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr "รับ DuckDuckGo VPN, Duck.ai ขั้นสูง และ Identity Theft Restoration"
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10179,6 +10318,12 @@ msgstr "ทำไมกระบวนการนี้ไม่ระบุต
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "วิธีการทำงาน"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11609,6 +11754,12 @@ msgstr "ไลน์เอาต์ที่ได้"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "ลิงก์หมดอายุใน 7 วัน"
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13723,6 +13874,12 @@ msgid "OK, got it!"
 msgstr "เข้าใจแล้ว!"
 
 # smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -15814,6 +15971,12 @@ msgid "Protected"
 msgstr "ได้รับการปกป้อง"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "การป้องกัน ความเป็นส่วนตัว ความสบายใจ"
@@ -15943,6 +16106,12 @@ msgstr "ฝน"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "การจัดอันดับ"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17165,6 +17334,12 @@ msgid "Save your chats across all your devices."
 msgstr "บันทึกการแชทของคุณในอุปกรณ์ทั้งหมดของคุณ"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17361,6 +17536,14 @@ msgstr "ค้นหา"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "ค้นหา"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18512,6 +18695,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "ร้านค้า"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20139,6 +20328,14 @@ msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr "ข้อมูล Sync & Backup จะไม่สามารถกู้คืนได้หลังจากไม่ได้ใช้งานเป็นเวลา 18 เดือน"
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20248,6 +20445,12 @@ msgstr "ซิงค์กับอุปกรณ์ที่อยู่ใก
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "ซิงค์แชทของคุณในอุปกรณ์ทั้งหมดของคุณ"
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -20817,6 +21020,22 @@ msgid "This Week"
 msgstr "สัปดาห์นี้"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21325,6 +21544,12 @@ msgstr "วันนี้"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "วันนี้"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23118,6 +23343,14 @@ msgstr ""
 "การคลิกโฆษณาได้รับการจัดการโดยเครือข่ายโฆษณาของ TripAdvisor"
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "หมู่เกาะเวอร์จิน"
 
@@ -24539,6 +24772,21 @@ msgstr ""
 "เปิดหรือปิดใช้งานได้ตลอดเวลาในเมนู '%1$s'"
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -25884,6 +26132,12 @@ msgstr "นาที"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "นาที"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/tl_PH/LC_MESSAGES/duckduckgo.po
+++ b/locales/tl_PH/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Idagdag ang DuckDuckGo"
@@ -1099,6 +1116,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr "Mga add-on"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1453,6 +1507,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2800,6 +2859,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3200,9 +3266,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3218,6 +3294,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4477,6 +4560,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4761,6 +4849,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5099,6 +5192,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -5995,6 +6093,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6172,6 +6275,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6839,6 +6947,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7257,6 +7370,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8239,6 +8357,11 @@ msgid "How is it anonymous?"
 msgstr "Paano ito naging anonymous?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9396,6 +9519,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11133,6 +11261,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12833,6 +12966,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12939,6 +13077,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13927,6 +14070,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14082,6 +14230,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -14999,6 +15154,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16338,6 +16498,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16418,6 +16585,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16878,6 +17050,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17280,6 +17466,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18742,6 +18933,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19891,6 +20089,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20979,6 +21190,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/tokipona_XX/LC_MESSAGES/duckduckgo.po
+++ b/locales/tokipona_XX/LC_MESSAGES/duckduckgo.po
@@ -982,6 +982,11 @@ msgstr "o sona e mi"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1085,6 +1090,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "lipu esun li nasa"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "kepeken e ilo DuckDuckGo"
@@ -1104,6 +1121,24 @@ msgstr "sina o pali e ilo DuckDuckGo tawa e ilo tawa lukin"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "sina o pali e ilo DuckDuckGo lon %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1142,6 +1177,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1213,6 +1262,11 @@ msgstr "namako"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1459,6 +1513,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2807,6 +2866,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3207,9 +3273,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3225,6 +3301,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4492,6 +4575,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4776,6 +4864,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5114,6 +5207,11 @@ msgstr "o lukin ala lon tempo ale"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6011,6 +6109,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6188,6 +6291,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6857,6 +6965,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7275,6 +7388,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8260,6 +8378,11 @@ msgid "How is it anonymous?"
 msgstr "sona mi li pimeja kepeken nasin seme?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9421,6 +9544,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11158,6 +11286,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "pona!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12865,6 +12998,11 @@ msgstr "o awen e sitelen walo sin lon ijo ale."
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12971,6 +13109,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13959,6 +14102,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14117,6 +14265,13 @@ msgstr "lukin"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15043,6 +15198,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16382,6 +16542,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16462,6 +16629,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16924,6 +17096,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17328,6 +17514,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18796,6 +18987,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19951,6 +20149,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21044,6 +21255,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/tpi_PG/LC_MESSAGES/duckduckgo.po
+++ b/locales/tpi_PG/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr ""
@@ -1099,6 +1116,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr "Kisim mo."
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1453,6 +1507,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2800,6 +2859,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3200,9 +3266,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3218,6 +3294,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4475,6 +4558,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4759,6 +4847,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5097,6 +5190,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -5993,6 +6091,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6170,6 +6273,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6835,6 +6943,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7253,6 +7366,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8235,6 +8353,11 @@ msgid "How is it anonymous?"
 msgstr ""
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9388,6 +9511,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11125,6 +11253,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12825,6 +12958,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12931,6 +13069,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13919,6 +14062,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14074,6 +14222,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -14989,6 +15144,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16328,6 +16488,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16408,6 +16575,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16868,6 +17040,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17270,6 +17456,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18732,6 +18923,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19881,6 +20079,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20963,6 +21174,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/tr_TR/LC_MESSAGES/duckduckgo.po
+++ b/locales/tr_TR/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: tr_TR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -380,8 +380,7 @@ msgstr "%1$s kullanıldı"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
-"%1$s, limitleri temel modellere göre 2-5 kata kadar daha hızlı tüketir %2$s"
+msgstr "%1$s, limitleri temel modellere göre 2-5 kata kadar daha hızlı tüketir %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -968,8 +967,7 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"Duck.ai'ın yeni sürümü yayında! Devam etmek için lütfen bu sayfayı yenileyin."
+msgstr "Duck.ai'ın yeni sürümü yayında! Devam etmek için lütfen bu sayfayı yenileyin."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1225,7 +1223,7 @@ msgstr "Reklamlarımız hakkında"
 #. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
 msgctxt "Modal header for chat history with sync information"
 msgid "About Chat History with Sync & Backup"
-msgstr ""
+msgstr "Sync & Backup Özellikli Sohbet Geçmişi Hakkında"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
@@ -1360,7 +1358,7 @@ msgstr "Reklam şüpheli"
 #. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
 msgctxt "Button to open menu for attaching images or page context to AI chat"
 msgid "Add"
-msgstr ""
+msgstr "Ekle"
 
 # smartling.placeholder_format=C
 #. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
@@ -1368,7 +1366,7 @@ msgctxt ""
 "Primary button that attaches the tabs the user checked in the tab picker "
 "dialog"
 msgid "Add"
-msgstr ""
+msgstr "Ekle"
 
 # smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
@@ -1403,13 +1401,13 @@ msgstr "DuckDuckGo'yu %1$s tarayıcısına ekleyin"
 msgctxt ""
 "Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
 msgid "Add File"
-msgstr ""
+msgstr "Dosya Ekle"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
 msgid "Add Image"
-msgstr ""
+msgstr "Görsel Ekle"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
@@ -1417,7 +1415,7 @@ msgctxt ""
 "Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
 "item)"
 msgid "Add Image or File"
-msgstr ""
+msgstr "Görsel veya Dosya Ekle"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1470,7 +1468,7 @@ msgctxt ""
 "Open the tab picker to attach browser tab content to the AI chat message "
 "(attach dropdown menu item)"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Sekme Ekle"
 
 # smartling.placeholder_format=C
 #. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
@@ -1478,7 +1476,7 @@ msgctxt ""
 "Title and accessible name of the tab-picker dialog opened from the attach "
 "dropdown menu"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Sekme Ekle"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1569,7 +1567,7 @@ msgstr "Son dokunuşlar ekleniyor"
 #. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
 msgctxt "Aria label for the additional instructions textarea"
 msgid "Additional instructions"
-msgstr ""
+msgstr "Ek talimatlar"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1715,8 +1713,7 @@ msgstr "İndirdikten ve açtıktan sonra %1$sYükle%2$s seçeneğine tıklayın"
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr ""
-"İndirdikten sonra uzantı dosyasını bulun ve yüklemek için çift tıklayın"
+msgstr "İndirdikten sonra uzantı dosyasını bulun ve yüklemek için çift tıklayın"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1878,7 +1875,7 @@ msgstr "Hepsi tamam!"
 #. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the read-only textarea listing all AI instructions"
 msgid "All instructions"
-msgstr ""
+msgstr "Tüm talimatlar"
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2025,8 +2022,7 @@ msgstr "Zaten senkronize edildi."
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Also search privately on your iPad, iPhone, or Android!"
-msgstr ""
-"Ayrıca iPad, iPhone veya Android cihazınızda gizli arama yapabilirsiniz!"
+msgstr "Ayrıca iPad, iPhone veya Android cihazınızda gizli arama yapabilirsiniz!"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -2316,8 +2312,7 @@ msgstr ""
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr ""
-"Bu konuşmayı silip yeni bir konuşma başlatmak istediğinizden emin misiniz?"
+msgstr "Bu konuşmayı silip yeni bir konuşma başlatmak istediğinizden emin misiniz?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2576,8 +2571,8 @@ msgid ""
 "At the café, airport, or hotel, DuckDuckGo VPN encrypts your connection and "
 "hides your IP address on Wi-Fi."
 msgstr ""
-"Kafede, havaalanında veya otelde DuckDuckGo VPN, bağlantınızı şifreler ve Wi-"
-"Fi üzerindeki IP adresinizi gizler."
+"Kafede, havaalanında veya otelde DuckDuckGo VPN, bağlantınızı şifreler ve "
+"Wi-Fi üzerindeki IP adresinizi gizler."
 
 # smartling.placeholder_format=C
 #. In the context of the National Hockey League (NHL), label for teams belonging to the Atlantic division
@@ -2640,15 +2635,13 @@ msgstr "Ses"
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"Sohbet sona erdikten sonra ses tarafımızdan veya OpenAI tarafından saklanmaz."
+msgstr "Sohbet sona erdikten sonra ses tarafımızdan veya OpenAI tarafından saklanmaz."
 
 # smartling.placeholder_format=C
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"Sohbet sona erdikten sonra ses tarafımızdan veya OpenAI tarafından saklanmaz."
+msgstr "Sohbet sona erdikten sonra ses tarafımızdan veya OpenAI tarafından saklanmaz."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
@@ -3106,8 +3099,7 @@ msgstr "Bu siteyi tüm sonuçlarda engelleyin"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr ""
-"Takip edicileri engelleyin ve kişisel verilerinizin kontrolünü elinize alın"
+msgstr "Takip edicileri engelleyin ve kişisel verilerinizin kontrolünü elinize alın"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3534,8 +3526,7 @@ msgstr "Kamerun"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr ""
-"Tavuk, brokoli ve pirinci kullanarak birkaç basit tarif hazırlayabilir misin?"
+msgstr "Tavuk, brokoli ve pirinci kullanarak birkaç basit tarif hazırlayabilir misin?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3607,7 +3598,7 @@ msgctxt ""
 "Secondary button that dismisses the tab picker dialog without attaching "
 "anything"
 msgid "Cancel"
-msgstr ""
+msgstr "İptal"
 
 # smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
@@ -4109,7 +4100,7 @@ msgstr "Sohbet yanıtı rahatsız edici"
 #. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
 msgctxt "Chat history about modal list item headline"
 msgid "Chat storage varies by browser"
-msgstr ""
+msgstr "Sohbet depolama alanı tarayıcıya göre değişir."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4122,6 +4113,8 @@ msgstr "%1$s ile sohbet edin"
 msgctxt "new tab page"
 msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
+"Bilgileriniz anonimleştirilmiş olarak popüler yapay zeka modelleriyle sohbet "
+"edin."
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4148,6 +4141,9 @@ msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
 msgstr ""
+"Sohbetler, DuckDuckGo'nun sunucusunda uçtan uca şifreleme ile güvenli bir "
+"şekilde saklanır. Verilerinize sizden başka hiç kimse, hatta biz bile "
+"erişemeyiz."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4631,8 +4627,7 @@ msgstr "%1$sEkle%2$s seçeneğine tıklayın"
 #. Instructions on which buttons the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "Click %sAllow%s, then %sAdd%s."
-msgstr ""
-"%1$sİzin Ver%2$s seçeneğine, ardından %3$sEkle%4$s seçeneğine tıklayın."
+msgstr "%1$sİzin Ver%2$s seçeneğine, ardından %3$sEkle%4$s seçeneğine tıklayın."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -4745,15 +4740,13 @@ msgstr "Açılır menüden %1$sArama Ayarlarını Değiştir%2$s seçeneğine t�
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on %sSet as Default%s towards the bottom"
-msgstr ""
-"Alta doğru yer alan %1$sVarsayılan Olarak Ayarla%2$s seçeneğine tıklayın"
+msgstr "Alta doğru yer alan %1$sVarsayılan Olarak Ayarla%2$s seçeneğine tıklayın"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sSearch Providers%s under Add-on Types"
-msgstr ""
-"Eklenti Türleri bölümündeki %1$sArama Sağlayıcıları%2$s seçeneğine tıklayın"
+msgstr "Eklenti Türleri bölümündeki %1$sArama Sağlayıcıları%2$s seçeneğine tıklayın"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -4834,8 +4827,7 @@ msgstr "Adres çubuğundaki %1$sizinler simgesine%2$s tıklayın"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr ""
-"Arama yapmak için tarayıcınızın üst kısmındaki ördek simgesine tıklayın!"
+msgstr "Arama yapmak için tarayıcınızın üst kısmındaki ördek simgesine tıklayın!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -4887,8 +4879,7 @@ msgstr "Arama çubuğundaki büyüteç simgesine tıklayın"
 #. Tells users what icon to click in order to make DuckDuckGo the default engine in their browser.
 msgid ""
 "Click the magnifying glass in the search box (at the top of the browser)"
-msgstr ""
-"Arama kutusundaki büyüteç simgesine tıklayın (tarayıcının üst tarafında)"
+msgstr "Arama kutusundaki büyüteç simgesine tıklayın (tarayıcının üst tarafında)"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -5760,7 +5751,7 @@ msgstr "Mevcut Seri"
 #. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
 msgctxt "Suffix label indicating a tab is the currently active browser tab"
 msgid "Current Tab"
-msgstr ""
+msgstr "Mevcut Sekme"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
@@ -5915,8 +5906,7 @@ msgstr "Günlük limit doldu"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Günlük kullanım limiti doldu. Bu sohbete %1$s sonrasında devam edebilirsiniz."
+msgstr "Günlük kullanım limiti doldu. Bu sohbete %1$s sonrasında devam edebilirsiniz."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -6115,7 +6105,7 @@ msgstr "30 Günden Eski Sohbetleri Sil"
 #. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
 msgctxt "Button text in the modal for deleting all recent chats"
 msgid "Delete Chats and Shared Links"
-msgstr ""
+msgstr "Sohbetleri ve Paylaşılan Bağlantıları Sil"
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6538,7 +6528,7 @@ msgstr "Promosyonu kapat"
 #. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the close button on the survey banner"
 msgid "Dismiss survey"
-msgstr ""
+msgstr "Anketi kapat"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6651,8 +6641,7 @@ msgstr "DuckDuckGo'yu listede göremiyor musunuz?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr ""
-"Göremiyor musunuz? %1$s%2$s%3$sTekrar indirmek için buraya tıklayın%4$s"
+msgstr "Göremiyor musunuz? %1$s%2$s%3$sTekrar indirmek için buraya tıklayın%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -7083,8 +7072,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
-msgstr ""
-"Duck.ai geçici olarak kullanılamıyor. Lütfen daha sonra tekrar deneyin."
+msgstr "Duck.ai geçici olarak kullanılamıyor. Lütfen daha sonra tekrar deneyin."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7140,8 +7128,7 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
-msgstr ""
-"Duck.ai yanıtları belirli kaynaklara dayanmaz ve doğruluğu kontrol edilmez."
+msgstr "Duck.ai yanıtları belirli kaynaklara dayanmaz ve doğruluğu kontrol edilmez."
 
 # smartling.placeholder_format=C
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
@@ -7165,8 +7152,7 @@ msgstr "Duck.ai aboneliği yükseltildi!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.ai, gizli ve ücretsiz DuckDuckGo uygulamasında en iyi şekilde çalışır!"
+msgstr "Duck.ai, gizli ve ücretsiz DuckDuckGo uygulamasında en iyi şekilde çalışır!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7725,7 +7711,7 @@ msgstr "İstemi Düzenle"
 #. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the message-editing text area"
 msgid "Edit message"
-msgstr ""
+msgstr "Mesajı düzenle"
 
 # smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
@@ -7896,8 +7882,7 @@ msgstr "Duck.ai'da sesli dikte özelliğini etkinleştir"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr ""
-"Anonim konumu kullanmak için cihazınızdan konum ayarlarını etkinleştirin"
+msgstr "Anonim konumu kullanmak için cihazınızdan konum ayarlarını etkinleştirin"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -7954,7 +7939,7 @@ msgstr "Şifrelenmiş model"
 #. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
 msgctxt "Share modal info bullet about encryption"
 msgid "Encrypted so DuckDuckGo can't read your chat."
-msgstr ""
+msgstr "Şifrelendiği için DuckDuckGo sohbetinizi okuyamaz."
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8012,8 +7997,7 @@ msgstr "Duck.ai'ı beğeniyor musunuz?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr ""
-"'Konum' ayarı için %1$s'İzin Ver'%2$s ögesinin seçili olduğundan emin olun."
+msgstr "'Konum' ayarı için %1$s'İzin Ver'%2$s ögesinin seçili olduğundan emin olun."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -8656,8 +8640,7 @@ msgstr "Finansal danışman"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr ""
-"%1$sDuckDuckGo%2$s'yu bulun ve %3$sVarsayılan yap%4$s seçeneğine tıklayın"
+msgstr "%1$sDuckDuckGo%2$s'yu bulun ve %3$sVarsayılan yap%4$s seçeneğine tıklayın"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8708,8 +8691,7 @@ msgstr "Size daha yakın sonuçlar bulun."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr ""
-"Yakınınızdan sonuçlar bulun. %1$sKonumunuz gizli, güvende ve anonim kalır."
+msgstr "Yakınınızdan sonuçlar bulun. %1$sKonumunuz gizli, güvende ve anonim kalır."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8791,7 +8773,7 @@ msgstr "Takip sorusu"
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
-msgstr ""
+msgstr "Takip soruları gizli kalır."
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8897,8 +8879,7 @@ msgstr "Tarafımızdan anonimleştirilmiş ücretsiz ve gizli sohbetler"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Tarafımızdan anonimleştirilmiş ücretsiz ve gizli sohbetler. Hesap gerekmez."
+msgstr "Tarafımızdan anonimleştirilmiş ücretsiz ve gizli sohbetler. Hesap gerekmez."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8910,8 +8891,7 @@ msgstr "Ücretsiz Değiştirilebilen, Paylaşılabilen ve Kullanılabilen"
 #. a filter for images with the CC BY usage license
 msgctxt "image-licence"
 msgid "Free to Modify, Share, and Use Commercially"
-msgstr ""
-"Ücretsiz Değiştirilebilen, Paylaşılabilen ve Ticari Olarak Kullanılabilen"
+msgstr "Ücretsiz Değiştirilebilen, Paylaşılabilen ve Ticari Olarak Kullanılabilen"
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC-ND usage license
@@ -9313,7 +9293,7 @@ msgstr ""
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
 msgctxt "Tooltip on the header logo for sunglasses searches"
 msgid "Get DuckDuckGo sunglasses and other gear."
-msgstr ""
+msgstr "DuckDuckGo güneş gözlüklerini ve diğer ürünleri edinin."
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10125,8 +10105,7 @@ msgstr "DuckDuckGo'yu geliştirmemize yardımcı olun"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr ""
-"Geri bildirimlerinizle DuckDuckGo aramalarını geliştirmemize yardımcı olun"
+msgstr "Geri bildirimlerinizle DuckDuckGo aramalarını geliştirmemize yardımcı olun"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -10184,8 +10163,7 @@ msgstr "Arkadaşlarınızın ve ailenizin Duck Side'a katılmalarına yardımcı
 #. Text description for the Spread card in the SERP footer
 msgctxt "footer_card"
 msgid "Help your friends and family take back their privacy!"
-msgstr ""
-"Arkadaşlarınızın ve ailenizin gizliliklerini geri almalarına yardımcı olun!"
+msgstr "Arkadaşlarınızın ve ailenizin gizliliklerini geri almalarına yardımcı olun!"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -10322,8 +10300,7 @@ msgstr "E-posta adresinizi gizleyin"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Hides search term from being shown in browser tab/history"
-msgstr ""
-"Arama ifadesinin tarayıcı sekmesinde/geçmişinde gösterilmesini engeller"
+msgstr "Arama ifadesinin tarayıcı sekmesinde/geçmişinde gösterilmesini engeller"
 
 # smartling.placeholder_format=C
 #. The highest stock price in a day
@@ -10553,7 +10530,7 @@ msgstr "İşleyiş şekli"
 #. Headline in chat history about modals for the temporary encrypted server storage explanation.
 msgctxt "Chat history about modal list item headline"
 msgid "How it works"
-msgstr ""
+msgstr "İşleyiş şekli"
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -10577,8 +10554,7 @@ msgstr "Yapay zeka destekli cevapların ne kadar görünmesini istiyorsun?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr ""
-"Şimdiye kadar günlük ve haftalık limitlerinizin ne kadarını kullandığınız."
+msgstr "Şimdiye kadar günlük ve haftalık limitlerinizin ne kadarını kullandığınız."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10728,15 +10704,14 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"Rüzgârın Adı kitabını severim. Buna en çok benzeyen diğer iyi kitaplar/"
-"diziler nelerdir ve neden?"
+"Rüzgârın Adı kitabını severim. Buna en çok benzeyen diğer iyi "
+"kitaplar/diziler nelerdir ve neden?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
 msgctxt "Feedback option for difficulty in using chat"
 msgid "I need more help/info on how to use Chat"
-msgstr ""
-"Sohbeti nasıl kullanacağıma dair daha fazla yardım/bilgiye ihtiyacım var"
+msgstr "Sohbeti nasıl kullanacağıma dair daha fazla yardım/bilgiye ihtiyacım var"
 
 # smartling.placeholder_format=C
 msgid "IR Iran"
@@ -12009,6 +11984,8 @@ msgstr "Bağlantının süresi 7 gün içinde doluyor."
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
+"Bağlantının süresi 7 gün sonra dolacak. Kullanıcılar sohbetin bir kopyasını "
+"kaydedebilir."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -12024,8 +12001,7 @@ msgstr "Bağlantılar:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
-"Bunun için ihtiyacım olan araçları, malzemeleri veya ön koşulları listele."
+msgstr "Bunun için ihtiyacım olan araçları, malzemeleri veya ön koşulları listele."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12918,8 +12894,7 @@ msgstr "Aylık limit doldu"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Aylık kullanım limiti doldu. Bu sohbete %1$s sonrasında devam edebilirsiniz."
+msgstr "Aylık kullanım limiti doldu. Bu sohbete %1$s sonrasında devam edebilirsiniz."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -13081,8 +13056,7 @@ msgstr "Daha fazla bilgiyi %1$s %2$s makalesinde bulabilirsiniz."
 # smartling.placeholder_format=C
 #. Source (section, article and site) of the answer generated by duckassist (an instant answer based on generative AI)
 msgid "More info in the %s section of the %s %s article."
-msgstr ""
-"Daha fazla bilgiyi %2$s %3$s makalesinin %1$s bölümünde bulabilirsiniz."
+msgstr "Daha fazla bilgiyi %2$s %3$s makalesinin %1$s bölümünde bulabilirsiniz."
 
 # smartling.placeholder_format=C
 msgctxt ""
@@ -14137,7 +14111,7 @@ msgstr "Tamam, anladım!"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "OPTIONAL"
-msgstr ""
+msgstr "İSTEĞE BAĞLI"
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -15652,16 +15626,14 @@ msgstr "Lütfen bekleyin..."
 #. Tagline for the subscription promo shown in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Plus more premium features with a DuckDuckGo subscription."
-msgstr ""
-"DuckDuckGo aboneliğiyle daha birçok premium özelliğe sahip olabilirsiniz."
+msgstr "DuckDuckGo aboneliğiyle daha birçok premium özelliğe sahip olabilirsiniz."
 
 # smartling.placeholder_format=C
 #. A description to provide more detail on what Duck Player does (Duck Player is DDG's feature to watch youtube videos more privately)
 msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
-msgstr ""
-"Ayrıca, Duck Player'da izledikleriniz YouTube'daki önerilerinizi etkilemez."
+msgstr "Ayrıca, Duck Player'da izledikleriniz YouTube'daki önerilerinizi etkilemez."
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -16234,8 +16206,7 @@ msgstr "Bana sor"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"Yakınımdaki sonuçları almak için yaklaşık konumumu kullanmamı hatırlat."
+msgstr "Yakınımdaki sonuçları almak için yaklaşık konumumu kullanmamı hatırlat."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -16272,7 +16243,7 @@ msgstr "Korumalı"
 #. Headline in sync-enabled chat history about modals explaining encrypted server storage.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Protected with end-to-end encryption"
-msgstr ""
+msgstr "Uçtan uca şifreleme ile korunur"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -16411,7 +16382,7 @@ msgstr "Sıralamalar"
 #. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
 msgctxt "star rating on a product"
 msgid "Rated %s out of %s"
-msgstr ""
+msgstr "%2$s üzerinden %1$s puan aldı"
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -16878,8 +16849,9 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"Talimatları izleyerek veya tarayıcınızın &quot;Yenile&quot; veya &quot;"
-"Yeniden Yükle&quot; düğmesine tıklayarak DuckDuckGo'yu yeniden yükleyin."
+"Talimatları izleyerek veya tarayıcınızın &quot;Yenile&quot; veya "
+"&quot;Yeniden Yükle&quot; düğmesine tıklayarak DuckDuckGo'yu yeniden "
+"yükleyin."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -17275,8 +17247,7 @@ msgstr "Sonuçlar, engellenmiş sitelerden gelen bilgileri içermez."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr ""
-"Sonuçlar, %1$s bölümünden yönetebileceğin engellenmiş sitelerini içermez."
+msgstr "Sonuçlar, %1$s bölümünden yönetebileceğin engellenmiş sitelerini içermez."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -17639,8 +17610,7 @@ msgstr "En son 30 sohbetinizi cihazınıza yerel olarak kaydedin."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Duck.ai sohbetlerinizi cihazlar arasında uçtan uca şifreleme ile kaydedin"
+msgstr "Duck.ai sohbetlerinizi cihazlar arasında uçtan uca şifreleme ile kaydedin"
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17652,7 +17622,7 @@ msgstr "Sohbetlerinizi tüm cihazlarınıza kaydedin."
 #. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
 msgctxt "Chat history about modal list item headline"
 msgid "Save your chats on this device"
-msgstr ""
+msgstr "Sohbetlerinizi bu cihaza kaydedin"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
@@ -17682,8 +17652,7 @@ msgstr "Duck.ai'a merhaba deyin!"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr ""
-"Duck.ai'a merhaba deyin – DuckDuckGo'dan ücretsiz, gizli yapay zeka sohbeti."
+msgstr "Duck.ai'a merhaba deyin – DuckDuckGo'dan ücretsiz, gizli yapay zeka sohbeti."
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17869,13 +17838,12 @@ msgctxt ""
 "Placeholder and accessibility label for the search input in the tab picker "
 "dialog"
 msgid "Search"
-msgstr ""
+msgstr "Ara"
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
 msgid "Search %s to find results closer to you?"
-msgstr ""
-"Size daha yakın sonuçları bulmak için %1$s ifadesiyle arama yapılsın mı?"
+msgstr "Size daha yakın sonuçları bulmak için %1$s ifadesiyle arama yapılsın mı?"
 
 # smartling.placeholder_format=C
 #. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
@@ -18147,8 +18115,7 @@ msgstr "DuckDuckGo ile Ara"
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid "Search, browse, and chat privately in our free browser"
-msgstr ""
-"Ücretsiz tarayıcımızda gizli şekilde arama yapın, gezinin ve sohbet edin"
+msgstr "Ücretsiz tarayıcımızda gizli şekilde arama yapın, gezinin ve sohbet edin"
 
 # smartling.placeholder_format=C
 #. Message displayed sometimes at top of results (for bang syntax), e.g. <a href="https://duckduckgo.com/?q=twitter+test">https://duckduckgo.com/?q=twitter+test</a>
@@ -18377,8 +18344,7 @@ msgstr "En son güncellemelerimizden bazılarını gör"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr ""
-"Daha fazla bilgi için %1$sURL Parametre Referansı sayfasına%2$s göz atın."
+msgstr "Daha fazla bilgi için %1$sURL Parametre Referansı sayfasına%2$s göz atın."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -18447,8 +18413,7 @@ msgstr "Varsayılan Arama Motoru açılır menüsünden %1$sDuckDuckGo%2$s'yu se
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"Listeden %1$sDuckDuckGo%2$s'yu seçin ve konum erişimine %3$sizin verin%4$s"
+msgstr "Listeden %1$sDuckDuckGo%2$s'yu seçin ve konum erişimine %3$sizin verin%4$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18514,8 +18479,7 @@ msgstr "%1$sArama Motoru%2$s bölümünü seçin"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"
-msgstr ""
-"%1$sArama motoru%2$s bölümünü, ardından %3$sDiğerleri..%4$s ögesini seçin"
+msgstr "%1$sArama motoru%2$s bölümünü, ardından %3$sDiğerleri..%4$s ögesini seçin"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -18540,8 +18504,7 @@ msgstr "Açılır menüden %1$sSeçenekler%2$s ögesini seçin."
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sAdvanced settings%s"
-msgstr ""
-"%1$sAyarlar%2$s bölümünü, ardından %3$sGelişmiş ayarlar%4$s bölümünü seçin"
+msgstr "%1$sAyarlar%2$s bölümünü, ardından %3$sGelişmiş ayarlar%4$s bölümünü seçin"
 
 # smartling.placeholder_format=C
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -18571,8 +18534,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"Listeden %1$starayıcınızı%2$s seçin ve konum erişimine %3$sizin verin%4$s"
+msgstr "Listeden %1$starayıcınızı%2$s seçin ve konum erişimine %3$sizin verin%4$s"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -19070,7 +19032,7 @@ msgstr "Alışveriş"
 #. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
 msgctxt "Button in the merchandise logo modal (mobile)"
 msgid "Shop Now"
-msgstr ""
+msgstr "Şimdi Alışveriş Yap"
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -19178,8 +19140,7 @@ msgstr "DuckAssist <sup>BETA'</sup>yı göster"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"DuckAssist'i daha sık göster. (Ayrıca tamamen %1$skapatabilirsiniz%2$s.)"
+msgstr "DuckAssist'i daha sık göster. (Ayrıca tamamen %1$skapatabilirsiniz%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -19296,8 +19257,7 @@ msgstr "Tüm sonuçları gösterin"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show answers more often. (You can also %sturn them off%s.)"
-msgstr ""
-"Yanıtları daha sık göster. (İsterseniz %1$sbunları kapatabilirsiniz%2$s.)"
+msgstr "Yanıtları daha sık göster. (İsterseniz %1$sbunları kapatabilirsiniz%2$s.)"
 
 # smartling.placeholder_format=C
 #. Accessible label for the button that reveals a popover listing multiple citation sources in Duck.ai chat responses.
@@ -19363,8 +19323,7 @@ msgstr "Kenar çubuğunu göster"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
-"Duck.ai'dan en iyi şekilde yararlanmak için adım adım ipuçlarını gösterin."
+msgstr "Duck.ai'dan en iyi şekilde yararlanmak için adım adım ipuçlarını gösterin."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -19458,14 +19417,12 @@ msgstr "En çok ziyaret edilen bağlantıları yeni sekme sayfasında gösterir"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Tarayıcınıza DuckDuckGo'yu eklemeniz için zaman zaman anımsatıcılar gösterir"
+msgstr "Tarayıcınıza DuckDuckGo'yu eklemeniz için zaman zaman anımsatıcılar gösterir"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Cihazlarınıza DuckDuckGo'yu eklemeniz için zaman zaman anımsatıcılar gösterir"
+msgstr "Cihazlarınıza DuckDuckGo'yu eklemeniz için zaman zaman anımsatıcılar gösterir"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19494,8 +19451,7 @@ msgstr "Siz yazarken arama kutusunun altında öneriler gösterir"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr ""
-"Giriş sayfasında DuckDuckGo'nun gizlilik açısından avantajlarını gösterir"
+msgstr "Giriş sayfasında DuckDuckGo'nun gizlilik açısından avantajlarını gösterir"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19582,8 +19538,7 @@ msgstr "Site İsimleri"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr ""
-"Site araması geçici olarak kullanılamıyor. Bir çözüm üzerinde çalışıyoruz."
+msgstr "Site araması geçici olarak kullanılamıyor. Bir çözüm üzerinde çalışıyoruz."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19819,8 +19774,7 @@ msgctxt "Error message when an uploaded image cannot be decoded or processed"
 msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
-msgstr ""
-"Üzgünüz, yüklenen görsel işlenemedi. Farklı bir görsel veya format deneyin."
+msgstr "Üzgünüz, yüklenen görsel işlenemedi. Farklı bir görsel veya format deneyin."
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -19854,8 +19808,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Üzgünüz, geri bildiriminizi gönderemedik. Lütfen daha sonra tekrar deneyin."
+msgstr "Üzgünüz, geri bildiriminizi gönderemedik. Lütfen daha sonra tekrar deneyin."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19909,8 +19862,7 @@ msgstr "Kaynak metin temizlendi"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr ""
-"Kaynak metin özetlenemeyecek kadar uzun. Daha kısa bir seçimle tekrar dene."
+msgstr "Kaynak metin özetlenemeyecek kadar uzun. Daha kısa bir seçimle tekrar dene."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -20170,8 +20122,7 @@ msgstr "Diğer web sitelerinde sizi bekleyen gizli takip edicileri engelleyin."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Diğer web sitelerinde sizi bekleyen gizli takip edicilerin çoğunu engelleyin."
+msgstr "Diğer web sitelerinde sizi bekleyen gizli takip edicilerin çoğunu engelleyin."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20595,8 +20546,7 @@ msgstr "Model değiştir"
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
-msgstr ""
-"Bu sohbeti ücretsiz bir modele geçirin veya %1$s tarihine kadar bekleyin."
+msgstr "Bu sohbeti ücretsiz bir modele geçirin veya %1$s tarihine kadar bekleyin."
 
 # smartling.placeholder_format=C
 #. Button that switches the conversation to the second-opinion model. %s is the model name.
@@ -20734,6 +20684,8 @@ msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
 msgstr ""
+"Sync & Backup sohbetlerinizin daha fazlasını kaydeder ve tüm cihazlarınız "
+"arasında senkronize eder."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20854,7 +20806,7 @@ msgstr "Sohbetlerinizi tüm cihazlarınızda senkronize edin."
 #. Headline in sync-enabled chat history about modals explaining cross-device sync.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Sync your chats across all your devices"
-msgstr ""
+msgstr "Sohbetlerinizi tüm cihazlarınızda senkronize edin"
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21249,8 +21201,7 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr ""
-"Model sağlayıcı, bu sohbetle ilişkili tüm verileri 30 gün içinde siler."
+msgstr "Model sağlayıcı, bu sohbetle ilişkili tüm verileri 30 gün içinde siler."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -21419,8 +21370,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Bu Anında Yanıt, %1$sDuckDuckHack%2$s Topluluğu tarafından hazırlanmıştır."
+msgstr "Bu Anında Yanıt, %1$sDuckDuckHack%2$s Topluluğu tarafından hazırlanmıştır."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -21449,12 +21399,14 @@ msgid ""
 "This chat and its generated images become public when you create and copy "
 "the link."
 msgstr ""
+"Bağlantıyı oluşturup kopyaladığınızda bu sohbet ve oluşturulan görselleri "
+"herkese açık hale gelir."
 
 # smartling.placeholder_format=C
 #. Explains that creating and copying a share link makes the selected chat content public.
 msgctxt "Share modal info bullet about public access"
 msgid "This chat becomes public when you create and copy the link."
-msgstr ""
+msgstr "Bağlantıyı oluşturup kopyaladığında bu sohbet herkese açık hale gelir."
 
 # smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
@@ -21634,8 +21586,7 @@ msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
-msgstr ""
-"Bu sadece bir örnek sohbet. Silmek için yan menüdeki Fire Button'ı kullanın!"
+msgstr "Bu sadece bir örnek sohbet. Silmek için yan menüdeki Fire Button'ı kullanın!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -21769,8 +21720,7 @@ msgstr "Bu video henüz burada izlenemiyor. %1$s üzerinden izleyebilirsiniz."
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Bu web sayfası, güvenli ve şifrelenmiş bir bağlantı (HTTPS) kullanmıyor."
+msgstr "Bu web sayfası, güvenli ve şifrelenmiş bir bağlantı (HTTPS) kullanmıyor."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21790,8 +21740,7 @@ msgctxt "Body text for clear all recent chats confirmation modal"
 msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
-msgstr ""
-"Bu işlem, sabitlenmemiş tüm son sohbetlerinizi siler. Bu işlem geri alınamaz."
+msgstr "Bu işlem, sabitlenmemiş tüm son sohbetlerinizi siler. Bu işlem geri alınamaz."
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -21809,8 +21758,7 @@ msgstr "Tüm ayarlarınız silinecek. Devam edilsin mi?"
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
 msgctxt "settings"
 msgid "This will reset your saved settings to default values. Continue?"
-msgstr ""
-"Kayıtlı tüm ayarlarınız varsayılan değerlere sıfırlanacak. Devam edilsin mi?"
+msgstr "Kayıtlı tüm ayarlarınız varsayılan değerlere sıfırlanacak. Devam edilsin mi?"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard column: holes completed in current round
@@ -21884,8 +21832,7 @@ msgstr "İpuçları"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr ""
-"İnternette takip edilmekten bıktınız mı? %1$sSize yardımcı olabiliriz.%2$s"
+msgstr "İnternette takip edilmekten bıktınız mı? %1$sSize yardımcı olabiliriz.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -21917,8 +21864,7 @@ msgstr ""
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to Duck.ai’s %s and %s"
-msgstr ""
-"Devam etmek için Duck.ai'ın %1$s ve %2$skoşullarını kabul etmeniz gerekiyor"
+msgstr "Devam etmek için Duck.ai'ın %1$s ve %2$skoşullarını kabul etmeniz gerekiyor"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to AI Chat Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to DuckDuckGo AI Chat’s Privacy Policy and Terms of Service'
@@ -21991,7 +21937,7 @@ msgstr "Bugün"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
-msgstr ""
+msgstr "Gizli yapay zeka sohbetine geçin veya ayarlardan %1$sdevre dışı bırakın%2$s."
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -22180,8 +22126,7 @@ msgstr ""
 #. Placeholder for when we cannot report any blocked trackers yet
 msgctxt "tracker_stats"
 msgid "Tracking attempts blocked by DuckDuckGo will appear here"
-msgstr ""
-"DuckDuckGo tarafından engellenen izleme girişimleri burada görünecektir"
+msgstr "DuckDuckGo tarafından engellenen izleme girişimleri burada görünecektir"
 
 # smartling.placeholder_format=C
 #. Tooltip and accessible label for the confirm (checkmark) button that stops recording and sends audio for transcription.
@@ -22348,8 +22293,7 @@ msgstr "Bu tür mesajları görmeyi durdurmak için %1$s'u deneyin."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Sıfır sağlayıcı görünürlüğüne sahip ilk modelimiz olan %1$s modelini deneyin."
+msgstr "Sıfır sağlayıcı görünürlüğüne sahip ilk modelimiz olan %1$s modelini deneyin."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -22861,8 +22805,7 @@ msgstr "Daha doğru sonuçlar için %1$sKesin Konum%2$s'u açın"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr ""
-"YouTube'u hedeflenmiş reklamlar olmadan izlemek için Duck Player'ı açın"
+msgstr "YouTube'u hedeflenmiş reklamlar olmadan izlemek için Duck Player'ı açın"
 
 # smartling.placeholder_format=C
 #. Button that enables the Search/Duck.ai toggle.
@@ -22880,8 +22823,7 @@ msgstr "Daha doğru sonuçlar için \"Kesin Konum\"u açın."
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr ""
-"Daha doğru sonuçlar için \"Kesin konumu kullan\" özelliğini etkinleştirin."
+msgstr "Daha doğru sonuçlar için \"Kesin konumu kullan\" özelliğini etkinleştirin."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -23087,8 +23029,8 @@ msgstr ""
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"%1$sBAŞLANGIÇ > Giriş sayfası%2$s bölümünde şunu girin: https://duckduckgo."
-"com"
+"%1$sBAŞLANGIÇ > Giriş sayfası%2$s bölümünde şunu girin: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23122,8 +23064,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr ""
-"Arama bölümündeki açılır menüye tıklayın ve %1$sDuckDuckGo%2$s'yu seçin"
+msgstr "Arama bölümündeki açılır menüye tıklayın ve %1$sDuckDuckGo%2$s'yu seçin"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -23609,8 +23550,7 @@ msgstr "DuckDuckGo Private Search'ü kullanın"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"iPad', iPhone ya da Android'inizde DuckDuckGo private search'ü kullanın!"
+msgstr "iPad', iPhone ya da Android'inizde DuckDuckGo private search'ü kullanın!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -23833,6 +23773,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Yelp's ad network."
 msgstr ""
+"Reklam görüntüleme, DuckDuckGo’nun gizlilik koruması altındadır. Reklam "
+"tıklamaları Yelp'in reklam ağı tarafından yönetilir."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -24198,8 +24140,7 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"En az birinin şifrelenmiş olması nedeniyle ekli dosyaları okuyamıyoruz."
+msgstr "En az birinin şifrelenmiş olması nedeniyle ekli dosyaları okuyamıyoruz."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24301,8 +24242,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr ""
-"Gizli gezinme modunu kullansanız da kullanmasınız da sizi takip etmiyoruz."
+msgstr "Gizli gezinme modunu kullansanız da kullanmasınız da sizi takip etmiyoruz."
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
@@ -24401,8 +24341,7 @@ msgstr "Biz dahil hiç kimse arama geçmişinize ulaşamaz."
 #. Message that appears after submitting a feedback form.
 msgctxt "feedback form"
 msgid "We use feedback like this to improve DuckDuckGo."
-msgstr ""
-"Bunun gibi geri bildirimleri DuckDuckGo'yu geliştirmek için kullanıyoruz."
+msgstr "Bunun gibi geri bildirimleri DuckDuckGo'yu geliştirmek için kullanıyoruz."
 
 # smartling.placeholder_format=C
 #. Placeholder can be Apple Maps, TripAdvisor, and/or Foursquare
@@ -25137,8 +25076,7 @@ msgstr "<strong>%1$s</strong>Nerede İzlenir?"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr ""
-"Giriş sayfası yazan yerde %1$sMevcut Sayfaya Ayarla%2$s seçeneğine tıklayın."
+msgstr "Giriş sayfası yazan yerde %1$sMevcut Sayfaya Ayarla%2$s seçeneğine tıklayın."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -25328,13 +25266,15 @@ msgid ""
 "With chat history on, up to %s of your most recent chats will be saved on "
 "this device."
 msgstr ""
+"Sohbet geçmişi açıkken, en son sohbetlerinizden en fazla %1$s tanesi bu "
+"cihaza kaydedilir."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline in the About Chat History modal.
 msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, your most recent chats will be saved on this device."
-msgstr ""
+msgstr "Sohbet geçmişi açıkken en son sohbetleriniz bu cihaza kaydedilir."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -25695,8 +25635,7 @@ msgstr "Bunu istediğin zaman %1$sArama Ayarları%2$s'ndan değiştirebilirsin"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr ""
-"Limitiniz %1$s tarihinde sıfırlandığında bu sohbete devam edebilirsiniz."
+msgstr "Limitiniz %1$s tarihinde sıfırlandığında bu sohbete devam edebilirsiniz."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -25735,8 +25674,7 @@ msgstr "Aylık limiti kullanarak sohbet etmeye devam edebilirsiniz."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Artık bu cihazda 100'e kadar sohbeti kaydedebilirsiniz. Sohbete başlayın!"
+msgstr "Artık bu cihazda 100'e kadar sohbeti kaydedebilirsiniz. Sohbete başlayın!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -26023,8 +25961,7 @@ msgstr "Tek bir oturum için maksimum sesli sohbet süresine ulaştınız."
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"Bugünlük sesli sohbet limitinize ulaştınız. Lütfen yarın tekrar deneyin."
+msgstr "Bugünlük sesli sohbet limitinize ulaştınız. Lütfen yarın tekrar deneyin."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -26089,8 +26026,7 @@ msgctxt ""
 msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
-msgstr ""
-"Son %1$s sohbetiniz şu tarayıcılarda yerel depolama alanında saklanacaktır:"
+msgstr "Son %1$s sohbetiniz şu tarayıcılarda yerel depolama alanında saklanacaktır:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
@@ -26282,8 +26218,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr ""
-"Sohbetleriniz içeri aktarıldı. Hadi, Duck.ai'da kaldığınız yerden devam edin."
+msgstr "Sohbetleriniz içeri aktarıldı. Hadi, Duck.ai'da kaldığınız yerden devam edin."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -26330,8 +26265,7 @@ msgctxt ""
 "Subtitle of the one-time popover shown above the thumbs up/down buttons on "
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
-msgstr ""
-"Geri bildiriminiz anonimleştirilmiş ve yapay zekayı eğitmek için kullanılmaz."
+msgstr "Geri bildiriminiz anonimleştirilmiş ve yapay zekayı eğitmek için kullanılmaz."
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -26468,8 +26402,7 @@ msgctxt "Error message for input limit"
 msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
-msgstr ""
-"Maksimum mesaj boyutunu aştınız. Lütfen mesajınızı kısaltıp tekrar deneyin."
+msgstr "Maksimum mesaj boyutunu aştınız. Lütfen mesajınızı kısaltıp tekrar deneyin."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -26511,8 +26444,7 @@ msgstr ""
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr ""
-"Şimdilik sesli sohbet limitinize ulaştınız. Lütfen daha sonra tekrar deneyin."
+msgstr "Şimdilik sesli sohbet limitinize ulaştınız. Lütfen daha sonra tekrar deneyin."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -26595,8 +26527,7 @@ msgstr "(bir %1$s ürünü)"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"DuckDuckGo'dan — her gün milyonlarca kişinin güvendiği çevrimiçi koruma."
+msgstr "DuckDuckGo'dan — her gün milyonlarca kişinin güvendiği çevrimiçi koruma."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"
@@ -26741,7 +26672,7 @@ msgstr "dk"
 #. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the chat options menu button"
 msgid "menu"
-msgstr ""
+msgstr "Menü"
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/tr_TR/LC_MESSAGES/duckduckgo.po
+++ b/locales/tr_TR/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: tr_TR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1222,6 +1222,12 @@ msgid "About our ads"
 msgstr "Reklamlarımız hakkında"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1351,6 +1357,20 @@ msgid "Ad is suspicious"
 msgstr "Reklam şüpheli"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "DuckDuckGo'yu ekleyin"
@@ -1377,6 +1397,27 @@ msgstr "DuckDuckGo'yu arama motoru olarak ekleyin"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "DuckDuckGo'yu %1$s tarayıcısına ekleyin"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1422,6 +1463,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Sayfa İçeriği Ekle"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1507,6 +1564,12 @@ msgstr "Eklentiler"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Son dokunuşlar ekleniyor"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1810,6 +1873,12 @@ msgstr "Tüm renkler"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Hepsi tamam!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3533,6 +3602,14 @@ msgid "Cancel"
 msgstr "İptal"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4029,10 +4106,22 @@ msgid "Chat response is offensive"
 msgstr "Sohbet yanıtı rahatsız edici"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "%1$s ile sohbet edin"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4051,6 +4140,14 @@ msgstr "Sohbetler"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Sohbetler"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5660,6 +5757,12 @@ msgid "Current Streak"
 msgstr "Mevcut Seri"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -6007,6 +6110,12 @@ msgstr "Sohbetleri Sil"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "30 Günden Eski Sohbetleri Sil"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6424,6 +6533,12 @@ msgstr "Sonsuza dek kapat"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Promosyonu kapat"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7607,6 +7722,12 @@ msgid "Edit Prompt"
 msgstr "İstemi Düzenle"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7828,6 +7949,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Şifrelenmiş model"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8661,6 +8788,12 @@ msgid "Follow-up question"
 msgstr "Takip sorusu"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9175,6 +9308,12 @@ msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
 "DuckDuckGo VPN, gelişmiş Duck.ai ve Identity Theft Restoration özelliklerine "
 "sahip olun."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10409,6 +10548,12 @@ msgstr "Nasıl anonim oluyor?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "İşleyiş şekli"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11858,6 +12003,12 @@ msgstr "Kazanılan Kenar Atışları"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "Bağlantının süresi 7 gün içinde doluyor."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13981,6 +14132,12 @@ msgstr "Tamam"
 msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "Tamam, anladım!"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -16112,6 +16269,12 @@ msgid "Protected"
 msgstr "Korumalı"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Koruma. Gizlilik. İçiniz rahat olsun."
@@ -16243,6 +16406,12 @@ msgstr "Yağmur"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Sıralamalar"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17480,6 +17649,12 @@ msgid "Save your chats across all your devices."
 msgstr "Sohbetlerinizi tüm cihazlarınıza kaydedin."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17687,6 +17862,14 @@ msgstr "Ara"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Ara"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18882,6 +19065,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Alışveriş"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20539,6 +20728,14 @@ msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr "Sync & Backup verileri 18 ay kullanılmadıktan sonra kurtarılamaz."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20652,6 +20849,12 @@ msgstr "Yakındaki bir cihazla senkronize et."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Sohbetlerinizi tüm cihazlarınızda senkronize edin."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21238,6 +21441,22 @@ msgid "This Week"
 msgstr "Bu Hafta"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21767,6 +21986,12 @@ msgstr "Bugün"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Bugün"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23602,6 +23827,14 @@ msgstr ""
 "tıklamaları TripAdvisor'ın reklam ağı tarafından yönetilir."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Virgin Adaları"
 
@@ -25089,6 +25322,21 @@ msgstr ""
 "kullanılmaz. '%1$s' menüsünden istediğiniz zaman açıp kapatabilirsiniz."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26488,6 +26736,12 @@ msgstr "dk"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "dk"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/tr_TR/LC_MESSAGES/duckduckgo.po
+++ b/locales/tr_TR/LC_MESSAGES/duckduckgo.po
@@ -5186,7 +5186,7 @@ msgstr "Yarışma"
 #. Positive feedback category a user can select on the Search Assist feedback form, meaning the answer was complete.
 msgctxt "feedback form"
 msgid "Complete"
-msgstr "Tamamlandı"
+msgstr "Kapsamlı"
 
 # smartling.placeholder_format=C
 #. An option that completely disables the Assist feature.
@@ -5544,7 +5544,7 @@ msgstr "Telif hakkı ihlali"
 #. Soccer match stats
 msgctxt "Sports module"
 msgid "Corners"
-msgstr "Köşeler"
+msgstr "Kornerler"
 
 # smartling.placeholder_format=C
 #. Title of the Covid 19 module

--- a/locales/uk_UA/LC_MESSAGES/duckduckgo.po
+++ b/locales/uk_UA/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: uk_UA\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1215,6 +1215,12 @@ msgid "About our ads"
 msgstr "Про нашу рекламу"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1344,6 +1350,20 @@ msgid "Ad is suspicious"
 msgstr "Ця реклама підозріла"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Додати DuckDuckGo"
@@ -1370,6 +1390,27 @@ msgstr "Додати DuckDuckGo як пошукову систему"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Додати DuckDuckGo до %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1415,6 +1456,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "Додати вміст сторінки"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1500,6 +1557,12 @@ msgstr "Додатки"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "Додаю останні штрихи"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1803,6 +1866,12 @@ msgstr "Усі кольори"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "Все готово!"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3516,6 +3585,14 @@ msgid "Cancel"
 msgstr "Скасувати"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -4007,10 +4084,22 @@ msgid "Chat response is offensive"
 msgstr "Відповідь у чаті образлива"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "Чат з %1$s"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4029,6 +4118,14 @@ msgstr "Чати"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "Чати"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5633,6 +5730,12 @@ msgid "Current Streak"
 msgstr "Поточна серія"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5981,6 +6084,12 @@ msgstr "Видалити чати"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "Видалити чати, старші за 30 днів"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6394,6 +6503,12 @@ msgstr "Не показувати знову"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Відхилити рекламу"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7567,6 +7682,12 @@ msgid "Edit Prompt"
 msgstr "Редагувати запит"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7790,6 +7911,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "Зашифрована модель"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8632,6 +8759,12 @@ msgid "Follow-up question"
 msgstr "Додаткове запитання"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9150,6 +9283,12 @@ msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
 "Отримайте DuckDuckGo VPN, розширений Duck.ai та послугу Identity Theft "
 "Restoration."
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10384,6 +10523,12 @@ msgstr "Наскільки це анонімно?"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "Принципи роботи"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11836,6 +11981,12 @@ msgstr "Виграні коридори"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "Термін дії посилання закінчується через 7 днів."
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13964,6 +14115,12 @@ msgid "OK, got it!"
 msgstr "Гаразд, зрозуміло!"
 
 # smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -16090,6 +16247,12 @@ msgid "Protected"
 msgstr "Захищено"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "Захист. Конфіденційність. Спокій."
@@ -16221,6 +16384,12 @@ msgstr "Дощ"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "Рейтинг"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17458,6 +17627,12 @@ msgid "Save your chats across all your devices."
 msgstr "Зберігайте чати на всіх своїх пристроях."
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17659,6 +17834,14 @@ msgstr "Пошук"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "Пошук"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18852,6 +19035,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "Придбати"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20511,6 +20700,14 @@ msgstr ""
 "діяльності."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20625,6 +20822,12 @@ msgstr "Синхронізуйте з пристроєм поруч."
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "Синхронізуйте чати на всіх своїх пристроях."
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21206,6 +21409,22 @@ msgid "This Week"
 msgstr "Цього тижня"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21735,6 +21954,12 @@ msgstr "Сьогодні"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Сьогодні"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23573,6 +23798,14 @@ msgstr ""
 "Клацаннями оголошень керує рекламна мережа TripAdvisor."
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "Віргінські острови"
 
@@ -25052,6 +25285,21 @@ msgstr ""
 "ШІ. Увімкніть або вимкніть його будь-коли в меню «%1$s»."
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -26447,6 +26695,12 @@ msgstr "хв"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "хв"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/uk_UA/LC_MESSAGES/duckduckgo.po
+++ b/locales/uk_UA/LC_MESSAGES/duckduckgo.po
@@ -2,16 +2,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: uk_UA\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -23,8 +22,7 @@ msgstr "Пошукові ярлики !Bang"
 msgctxt ""
 "Body copy for the Remove Device confirmation modal; %s is the device name"
 msgid "\"%s\" will no longer be able to access your synced data."
-msgstr ""
-"\"%1$s\" більше не зможе отримати доступ до ваших синхронізованих даних."
+msgstr "\"%1$s\" більше не зможе отримати доступ до ваших синхронізованих даних."
 
 # smartling.placeholder_format=C
 #. Used to specify the rank of a team/player in a specific ranking in short form. This should be interpreted as 'Ranked number <rankNumber> in the <rankingName> ranking. Here you only need to translate the # symbol for ranked number. If your language doesn't provide a single-letter convention, please leave #.
@@ -510,8 +508,7 @@ msgstr "%1$sДізнатися більше%2$s"
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr ""
-"%1$sДокладніше%2$s про захищене зберігання чатів на сервері DuckDuckGo."
+msgstr "%1$sДокладніше%2$s про захищене зберігання чатів на сервері DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -955,8 +952,7 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"Доступна нова версія чату AI Chat! Оновіть цю сторінку, щоб продовжити."
+msgstr "Доступна нова версія чату AI Chat! Оновіть цю сторінку, щоб продовжити."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
@@ -1072,9 +1068,10 @@ msgid ""
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
 "Наразі можливість ставити подальші запитання штучному інтелекту не "
-"підтримується. Однак ми також пропонуємо і часто посилаємось на %1$sDuck."
-"ai%2$s для отримання відповідей на уточнювальні запитання. Duck.ai — це наша "
-"служба приватних чатів із ШІ на базі моделей OpenAI, Anthropic тощо."
+"підтримується. Однак ми також пропонуємо і часто посилаємось на "
+"%1$sDuck.ai%2$s для отримання відповідей на уточнювальні запитання. Duck.ai "
+"— це наша служба приватних чатів із ШІ на базі моделей OpenAI, Anthropic "
+"тощо."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1218,7 +1215,7 @@ msgstr "Про нашу рекламу"
 #. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
 msgctxt "Modal header for chat history with sync information"
 msgid "About Chat History with Sync & Backup"
-msgstr ""
+msgstr "Про історію чату з Sync & Backup"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
@@ -1353,7 +1350,7 @@ msgstr "Ця реклама підозріла"
 #. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
 msgctxt "Button to open menu for attaching images or page context to AI chat"
 msgid "Add"
-msgstr ""
+msgstr "Додати"
 
 # smartling.placeholder_format=C
 #. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
@@ -1361,7 +1358,7 @@ msgctxt ""
 "Primary button that attaches the tabs the user checked in the tab picker "
 "dialog"
 msgid "Add"
-msgstr ""
+msgstr "Додати"
 
 # smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
@@ -1396,13 +1393,13 @@ msgstr "Додати DuckDuckGo до %1$s"
 msgctxt ""
 "Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
 msgid "Add File"
-msgstr ""
+msgstr "Додати файл"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
 msgid "Add Image"
-msgstr ""
+msgstr "Додати зображення"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
@@ -1410,7 +1407,7 @@ msgctxt ""
 "Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
 "item)"
 msgid "Add Image or File"
-msgstr ""
+msgstr "Додати зображення або файл"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1463,7 +1460,7 @@ msgctxt ""
 "Open the tab picker to attach browser tab content to the AI chat message "
 "(attach dropdown menu item)"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Додати вкладки"
 
 # smartling.placeholder_format=C
 #. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
@@ -1471,7 +1468,7 @@ msgctxt ""
 "Title and accessible name of the tab-picker dialog opened from the attach "
 "dropdown menu"
 msgid "Add Tabs"
-msgstr ""
+msgstr "Додати вкладки"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1562,7 +1559,7 @@ msgstr "Додаю останні штрихи"
 #. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
 msgctxt "Aria label for the additional instructions textarea"
 msgid "Additional instructions"
-msgstr ""
+msgstr "Додаткові інструкції"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1871,7 +1868,7 @@ msgstr "Все готово!"
 #. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the read-only textarea listing all AI instructions"
 msgid "All instructions"
-msgstr ""
+msgstr "Усі інструкції"
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -1963,8 +1960,7 @@ msgstr "Дозволити анонімний перегляд файлів у �
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Дозволити рекламу, що поважає конфіденційність, у DuckDuckGo Private Search"
+msgstr "Дозволити рекламу, що поважає конфіденційність, у DuckDuckGo Private Search"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2297,8 +2293,7 @@ msgstr "Ти ще тут?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"Ви впевнені, що бажаєте очистити всі ваші чати? Цю дію не можна скасувати."
+msgstr "Ви впевнені, що бажаєте очистити всі ваші чати? Цю дію не можна скасувати."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2515,11 +2510,10 @@ msgstr ""
 "Assist може анонімно генерувати відповіді ШІ на деякі пошукові запити, "
 "узагальнюючи релевантний веб-контент. Можна вибрати частоту відображення "
 "Assist: «Ніколи» (повністю приховує інтерфейс Assist із результатів пошуку), "
-"«На вимогу» (відображаються лише відповіді ШІ при натисканні кнопки "
-"«Assist» ), «Іноді» (відображаються лише відповіді ШІ в разі високої "
-"релевантності) або «Часто» (відображається частіше у різних пошукових "
-"запитах). Наразі відповіді штучного інтелекту доступні лише в США "
-"(англійською)."
+"«На вимогу» (відображаються лише відповіді ШІ при натисканні кнопки «Assist» "
+"), «Іноді» (відображаються лише відповіді ШІ в разі високої релевантності) "
+"або «Часто» (відображається частіше у різних пошукових запитах). Наразі "
+"відповіді штучного інтелекту доступні лише в США (англійською)."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -3590,7 +3584,7 @@ msgctxt ""
 "Secondary button that dismisses the tab picker dialog without attaching "
 "anything"
 msgid "Cancel"
-msgstr ""
+msgstr "Скасувати"
 
 # smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
@@ -4087,7 +4081,7 @@ msgstr "Відповідь у чаті образлива"
 #. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
 msgctxt "Chat history about modal list item headline"
 msgid "Chat storage varies by browser"
-msgstr ""
+msgstr "Зберігання чатів залежить від браузера"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4099,7 +4093,7 @@ msgstr "Чат з %1$s"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Chat with popular AI models, anonymized by us."
-msgstr ""
+msgstr "Спілкуйтеся з популярними моделями ШІ — з анонімізацією чатів."
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4126,6 +4120,8 @@ msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
 msgstr ""
+"Чати безпечно зберігаються на сервері DuckDuckGo із застосуванням "
+"наскрізного шифрування. Ніхто, крім вас, не може бачити ваші дані, навіть ми."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4244,8 +4240,7 @@ msgstr "Перевірте сабреддіт DuckDuckGo, щоб дізнати�
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr ""
-"Перевірте сторінку статусу на наявність оновлень щодо цього відключення."
+msgstr "Перевірте сторінку статусу на наявність оновлень щодо цього відключення."
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4671,8 +4666,7 @@ msgstr "Оберіть %1$sНалаштування%2$s з меню вибору
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Натисніть %1$sВикористати поточні сторінки%2$s, потім натисніть %3$sОК%4$s."
+msgstr "Натисніть %1$sВикористати поточні сторінки%2$s, потім натисніть %3$sОК%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4788,8 +4782,7 @@ msgstr "Натисніть на вкладку %1$sЗагальні%2$s."
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click the %sellipsis icon%s in the toolbar."
-msgstr ""
-"Клацніть на %1$sпіктограмі у вигляді трьох точок%2$s в панелі інструментів."
+msgstr "Клацніть на %1$sпіктограмі у вигляді трьох точок%2$s в панелі інструментів."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to enable location service. Part of a list of instructions on how to enable location service.
@@ -4806,8 +4799,7 @@ msgstr "Натисніть %1$sзначок дозволів%2$s в адресн
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr ""
-"Натисніть на зображення качки у верхній частині браузера, щоб почати пошук!"
+msgstr "Натисніть на зображення качки у верхній частині браузера, щоб почати пошук!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -5733,7 +5725,7 @@ msgstr "Поточна серія"
 #. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
 msgctxt "Suffix label indicating a tab is the currently active browser tab"
 msgid "Current Tab"
-msgstr ""
+msgstr "Поточна вкладка"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
@@ -6089,7 +6081,7 @@ msgstr "Видалити чати, старші за 30 днів"
 #. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
 msgctxt "Button text in the modal for deleting all recent chats"
 msgid "Delete Chats and Shared Links"
-msgstr ""
+msgstr "Видалити чати та спільні посилання"
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6508,7 +6500,7 @@ msgstr "Відхилити рекламу"
 #. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the close button on the survey banner"
 msgid "Dismiss survey"
-msgstr ""
+msgstr "Закрити опитування"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7130,8 +7122,7 @@ msgstr "Duck.ai оновлено!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.ai найкраще працює в конфіденційному й безкоштовному додатку DuckDuckGo!"
+msgstr "Duck.ai найкраще працює в конфіденційному й безкоштовному додатку DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7175,10 +7166,10 @@ msgstr ""
 "У відповідь на деякі пошукові запити DuckAssist іноді анонімно шукає та "
 "узагальнює інформацію. Можна вибрати частоту відображення DuckAssist: "
 "«Ніколи» (повністю приховує інтерфейс DuckAssist із результатів пошуку), «На "
-"вимогу» (відображається лише при натисканні кнопки «Допомога»), "
-"«Іноді» (показується лише в разі високої релевантності) або "
-"«Часто» (відображається частіше у різних пошукових запитах). Наразі "
-"DuckAssist доступний лише у США (англійською)."
+"вимогу» (відображається лише при натисканні кнопки «Допомога»), «Іноді» "
+"(показується лише в разі високої релевантності) або «Часто» (відображається "
+"частіше у різних пошукових запитах). Наразі DuckAssist доступний лише у США "
+"(англійською)."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7238,8 +7229,8 @@ msgstr ""
 "основі штучного інтелекту. Відповіді DuckAssist завжди містять пряме "
 "посилання на одне або два джерела відповіді, тому ви можете швидко знайти "
 "більш детальну інформацію. Важливо пам'ятати, що відповіді автоматично "
-"генеруються із зазначених джерел і ґрунтуються на %1$sвідсканованих веб-"
-"сторінках%2$s."
+"генеруються із зазначених джерел і ґрунтуються на %1$sвідсканованих "
+"веб-сторінках%2$s."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -7474,8 +7465,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo анонімізує чати. Натиснувши «%1$s», ви погоджуєтесь з %2$s Duck."
-"ai."
+"DuckDuckGo анонімізує чати. Натиснувши «%1$s», ви погоджуєтесь з %2$s "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7483,8 +7474,7 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr ""
-"DuckDuckGo анонімізує чати. Натиснувши «%1$s», ви погоджуєтесь з нашими %2$s."
+msgstr "DuckDuckGo анонімізує чати. Натиснувши «%1$s», ви погоджуєтесь з нашими %2$s."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7685,14 +7675,13 @@ msgstr "Редагувати запит"
 #. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the message-editing text area"
 msgid "Edit message"
-msgstr ""
+msgstr "Редагувати повідомлення"
 
 # smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
-msgstr ""
-"Відредаговане зображення. Вартість %1$s (лише для внутрішнього використання)"
+msgstr "Відредаговане зображення. Вартість %1$s (лише для внутрішнього використання)"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is editing an image.
@@ -7705,8 +7694,7 @@ msgstr "Редагування зображення..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr ""
-"Редагування вашого повідомлення видалить відповідь нижче та згенерує нову."
+msgstr "Редагування вашого повідомлення видалить відповідь нижче та згенерує нову."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7916,7 +7904,7 @@ msgstr "Зашифрована модель"
 #. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
 msgctxt "Share modal info bullet about encryption"
 msgid "Encrypted so DuckDuckGo can't read your chat."
-msgstr ""
+msgstr "Зашифровано, тож DuckDuckGo не може прочитати ваш чат."
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -7974,8 +7962,7 @@ msgstr "Користуєтеся Duck.ai?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr ""
-"Переконайтеся, що для параметра 'Розташування' вибрано %1$s'Дозволити'%2$s."
+msgstr "Переконайтеся, що для параметра 'Розташування' вибрано %1$s'Дозволити'%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -8023,15 +8010,13 @@ msgstr "Переконайтеся, що доступ до розташуван�
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s"
-msgstr ""
-"Переконайтеся, що вашому браузеру дозволено %1$sдоступ до розташування%2$s"
+msgstr "Переконайтеся, що вашому браузеру дозволено %1$sдоступ до розташування%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s."
-msgstr ""
-"Переконайтеся, що вашому браузеру дозволено %1$sдоступ до розташування%2$s."
+msgstr "Переконайтеся, що вашому браузеру дозволено %1$sдоступ до розташування%2$s."
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
@@ -8246,8 +8231,7 @@ msgstr "Поясніть прийняту відповідь простими с
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr ""
-"Поясніть мені фундаментальні концепції чорних дір на рівні середньої школи."
+msgstr "Поясніть мені фундаментальні концепції чорних дір на рівні середньої школи."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -8589,8 +8573,7 @@ msgstr "Відфільтровує створені ШІ зображення з
 msgctxt "settings"
 msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
-msgstr ""
-"Відфільтровує створені ШІ зображення з результатів пошуку. %1$sДокладніше%2$s"
+msgstr "Відфільтровує створені ШІ зображення з результатів пошуку. %1$sДокладніше%2$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8627,8 +8610,7 @@ msgstr "Фінансовий радник"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr ""
-"Знайдіть %1$sDuckDuckGo%2$s та натисніть%3$sВибрати за замовчуванням%4$s"
+msgstr "Знайдіть %1$sDuckDuckGo%2$s та натисніть%3$sВибрати за замовчуванням%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8640,8 +8622,7 @@ msgstr "Знайдіть <b>%1$s</b> у папці завантажень"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr ""
-"Знайдіть DuckDuckGo у списку і натисніть %1$sОбрати за замовчуванням%2$s"
+msgstr "Знайдіть DuckDuckGo у списку і натисніть %1$sОбрати за замовчуванням%2$s"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8762,7 +8743,7 @@ msgstr "Додаткове запитання"
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
-msgstr ""
+msgstr "Додаткові повідомлення залишаються приватними."
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -9114,22 +9095,19 @@ msgstr "Загальне призначення"
 #. Text with short description for an AI (Artificial Intelligence) Model that has a high moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with high built-in moderation"
-msgstr ""
-"Штучний інтелект загального призначення з вбудованою високою модерацією"
+msgstr "Штучний інтелект загального призначення з вбудованою високою модерацією"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a low moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with low built-in moderation"
-msgstr ""
-"Штучний інтелект загального призначення з вбудованою низькою модерацією"
+msgstr "Штучний інтелект загального призначення з вбудованою низькою модерацією"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a medium moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with medium built-in moderation"
-msgstr ""
-"Штучний інтелект загального призначення із вбудованою середньою модерацією"
+msgstr "Штучний інтелект загального призначення із вбудованою середньою модерацією"
 
 # smartling.placeholder_format=C
 #. Text indicating that the AI (Artificial Intelligence) model is a model for general purpose use. General-purpose AI refers to AI systems that can perform a wide range of tasks, rather than being specialized for a specific task.
@@ -9190,8 +9168,7 @@ msgstr "Згенероване зображення"
 #. Title text shown for an assistant response that contains a generated image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Generated image. Cost %s (internal only)"
-msgstr ""
-"Згенероване зображення. Вартість %1$s (лише для внутрішнього використання)"
+msgstr "Згенероване зображення. Вартість %1$s (лише для внутрішнього використання)"
 
 # smartling.placeholder_format=C
 #. Aria label for the carousel (list of generated images) in the image generation mode.
@@ -9288,7 +9265,7 @@ msgstr ""
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
 msgctxt "Tooltip on the header logo for sunglasses searches"
 msgid "Get DuckDuckGo sunglasses and other gear."
-msgstr ""
+msgstr "Придбайте сонцезахисні окуляри DuckDuckGo та інші товари."
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10528,7 +10505,7 @@ msgstr "Принципи роботи"
 #. Headline in chat history about modals for the temporary encrypted server storage explanation.
 msgctxt "Chat history about modal list item headline"
 msgid "How it works"
-msgstr ""
+msgstr "Принципи роботи"
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -10578,8 +10555,7 @@ msgctxt "Full sentence for preparing for a conversation"
 msgid ""
 "How should I tactfully approach a colleague about their constant pencil "
 "tapping and what should I say?"
-msgstr ""
-"Як тактовно попросити колегу перестати постійно стукати олівцем по столу?"
+msgstr "Як тактовно попросити колегу перестати постійно стукати олівцем по столу?"
 
 # smartling.placeholder_format=C
 #. The title for a feedback prompt that includes thumbs up and thumbs down buttons
@@ -11448,8 +11424,7 @@ msgstr "Приєднуйтесь до нашої команди!"
 # smartling.placeholder_format=C
 msgctxt "showcase_donate"
 msgid "Join our $500,000 Privacy Challenge"
-msgstr ""
-"Приєднуйтеся до нашого змагання з приватності із призовим фондом у $500 000"
+msgstr "Приєднуйтеся до нашого змагання з приватності із призовим фондом у $500 000"
 
 # smartling.placeholder_format=C
 msgid "Jordan"
@@ -11903,8 +11878,8 @@ msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
 msgstr ""
-"Дозволяє перемикатися між надсиланням пошукових запитів та промптів до Duck."
-"ai"
+"Дозволяє перемикатися між надсиланням пошукових запитів та промптів до "
+"Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11987,6 +11962,8 @@ msgstr "Термін дії посилання закінчується чере
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
+"Термін дії посилання закінчується через 7 днів. Користувачі можуть зберегти "
+"копію чату."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -12105,8 +12082,7 @@ msgstr "Завантаження..."
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more image and video results when scrolling"
-msgstr ""
-"Завантаження інших результатів для зображень та відео при прокручуванні"
+msgstr "Завантаження інших результатів для зображень та відео при прокручуванні"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -14118,7 +14094,7 @@ msgstr "Гаразд, зрозуміло!"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "OPTIONAL"
-msgstr ""
+msgstr "НЕОБОВ'ЯЗКОВО"
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -14317,8 +14293,8 @@ msgid ""
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
 "На іншому пристрої перейдіть у %1$s«Налаштування Duck.ai»%2$s › %3$s«Чати» › "
-"Sync & Backup › «Синхронізувати з іншим пристроєм»%4$s. Або відскануйте QR-"
-"код для відновлення у вашому PDF-файлі."
+"Sync & Backup › «Синхронізувати з іншим пристроєм»%4$s. Або відскануйте "
+"QR-код для відновлення у вашому PDF-файлі."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14444,8 +14420,7 @@ msgstr "Відкрити вебсайт %1$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr ""
-"Відкрийте %1$s«Розташування»%2$s і переконайтеся, що воно %3$sувімкнене%4$s"
+msgstr "Відкрийте %1$s«Розташування»%2$s і переконайтеся, що воно %3$sувімкнене%4$s"
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -14614,8 +14589,7 @@ msgstr "Відкрити панель «Як працює Duck.ai»"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Відкрийте меню Safari та виберіть %1$sНалаштування для DuckDuckGo...%2$s"
+msgstr "Відкрийте меню Safari та виберіть %1$sНалаштування для DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -15004,8 +14978,8 @@ msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
 msgstr ""
-"Неможливо відновити парольні фрази, оскільки ми не пов'язуємо вашу IP-"
-"адресу, відбиток браузера чи інші дані з файлом."
+"Неможливо відновити парольні фрази, оскільки ми не пов'язуємо вашу "
+"IP-адресу, відбиток браузера чи інші дані з файлом."
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -15418,8 +15392,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr ""
-"Виконайте наступне завдання, щоб підтвердити, що цей запит здійснено людиною."
+msgstr "Виконайте наступне завдання, щоб підтвердити, що цей запит здійснено людиною."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -15427,8 +15400,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr ""
-"Виконайте наступне завдання, щоб підтвердити, що цей пошук здійснено людиною."
+msgstr "Виконайте наступне завдання, щоб підтвердити, що цей пошук здійснено людиною."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -15442,8 +15414,7 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr ""
-"Поясніть, чому відповідь у чаті є незаконною або небезпечною. (Необов'язково)"
+msgstr "Поясніть, чому відповідь у чаті є незаконною або небезпечною. (Необов'язково)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -16250,7 +16221,7 @@ msgstr "Захищено"
 #. Headline in sync-enabled chat history about modals explaining encrypted server storage.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Protected with end-to-end encryption"
-msgstr ""
+msgstr "Захищено наскрізним шифруванням"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -16389,7 +16360,7 @@ msgstr "Рейтинг"
 #. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
 msgctxt "star rating on a product"
 msgid "Rated %s out of %s"
-msgstr ""
+msgstr "Оцінка %1$s з %2$s"
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -16488,8 +16459,7 @@ msgstr "Обґрунтування може надавати кращі відп
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
-msgstr ""
-"Поглиблена логіка, але досягає лімітів використання у 2–5 разів швидше. %1$s"
+msgstr "Поглиблена логіка, але досягає лімітів використання у 2–5 разів швидше. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
@@ -16865,8 +16835,7 @@ msgstr "Запам'ятати вибір"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Запам'ятати мій вибір (це можна змінити в %1$s%2$s%3$sНалаштуваннях%4$s)"
+msgstr "Запам'ятати мій вибір (це можна змінити в %1$s%2$s%3$sНалаштуваннях%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -17630,7 +17599,7 @@ msgstr "Зберігайте чати на всіх своїх пристроя�
 #. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
 msgctxt "Chat history about modal list item headline"
 msgid "Save your chats on this device"
-msgstr ""
+msgstr "Зберігайте свої чати на цьому пристрої"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
@@ -17815,8 +17784,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr ""
-"Прокрутіть вниз до розділу %1$sСервіси%2$s та клацніть %3$sПанель адреси%4$s."
+msgstr "Прокрутіть вниз до розділу %1$sСервіси%2$s та клацніть %3$sПанель адреси%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -17841,7 +17809,7 @@ msgctxt ""
 "Placeholder and accessibility label for the search input in the tab picker "
 "dialog"
 msgid "Search"
-msgstr ""
+msgstr "Пошук"
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18170,8 +18138,7 @@ msgstr "Друга думка"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr ""
-"Безпечно зберігайте та синхронізуйте твої чати на всіх своїх пристроях."
+msgstr "Безпечно зберігайте та синхронізуйте твої чати на всіх своїх пристроях."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18389,21 +18356,18 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Оберіть %1$sDuckDuckGo%2$s та клацніть %3$sВстановити за замовчуванням%4$s!"
+msgstr "Оберіть %1$sDuckDuckGo%2$s та клацніть %3$sВстановити за замовчуванням%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"Виберіть %1$sDuckDuckGo%2$s і натисніть %3$sВстановити за замовчуванням%4$s"
+msgstr "Виберіть %1$sDuckDuckGo%2$s і натисніть %3$sВстановити за замовчуванням%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"Виберіть %1$sDuckDuckGo%2$s і натисніть %3$sВстановити за замовчуванням%4$s."
+msgstr "Виберіть %1$sDuckDuckGo%2$s і натисніть %3$sВстановити за замовчуванням%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -18614,8 +18578,7 @@ msgstr "Вибраний текст із %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr ""
-"Вибраний текст занадто довгий. Спробуйте ще раз, вибравши коротший фрагмент."
+msgstr "Вибраний текст занадто довгий. Спробуйте ще раз, вибравши коротший фрагмент."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -18866,8 +18829,7 @@ msgstr "Поділитися"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Розкажіть про DuckDuckGo та допоможіть вашим друзям повернути приватність!"
+msgstr "Розкажіть про DuckDuckGo та допоможіть вашим друзям повернути приватність!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -19040,7 +19002,7 @@ msgstr "Придбати"
 #. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
 msgctxt "Button in the merchandise logo modal (mobile)"
 msgid "Shop Now"
-msgstr ""
+msgstr "Придбати зараз"
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -19426,14 +19388,12 @@ msgstr "Показує найпопулярніші посилання у нов
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Показує періодичні нагадування про додавання DuckDuckGo до вашого браузера"
+msgstr "Показує періодичні нагадування про додавання DuckDuckGo до вашого браузера"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Показує періодичні нагадування про додавання DuckDuckGo на ваших пристроях"
+msgstr "Показує періодичні нагадування про додавання DuckDuckGo на ваших пристроях"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19477,8 +19437,7 @@ msgstr "Показує привітальне повідомлення вгор�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Показує привітальне повідомлення користувачам з меню налаштувань Android в ЄС"
+msgstr "Показує привітальне повідомлення користувачам з меню налаштувань Android в ЄС"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -19714,8 +19673,7 @@ msgstr "Щось пішло не так при збереженні на сер�
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr ""
-"Сталася помилка під час увімкнення функції Sync & Backup. Повторіть спробу."
+msgstr "Сталася помилка під час увімкнення функції Sync & Backup. Повторіть спробу."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -19819,8 +19777,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"На жаль, нам не вдалося надіслати ваш відгук. Будь ласка, спробуйте пізніше."
+msgstr "На жаль, нам не вдалося надіслати ваш відгук. Будь ласка, спробуйте пізніше."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -20705,7 +20662,7 @@ msgctxt "Chat history with sync modal list item description"
 msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
-msgstr ""
+msgstr "Sync & Backup зберігає більше ваших чатів і синхронізує їх на всіх пристроях."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20827,7 +20784,7 @@ msgstr "Синхронізуйте чати на всіх своїх прист�
 #. Headline in sync-enabled chat history about modals explaining cross-device sync.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Sync your chats across all your devices"
-msgstr ""
+msgstr "Синхронізуйте свої чати на всіх пристроях"
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -21371,8 +21328,7 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr ""
-"Ця модель ШІ більше не доступна. Спробуйте почати новий чат з іншою моделлю."
+msgstr "Ця модель ШІ більше не доступна. Спробуйте почати новий чат з іншою моделлю."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -21417,12 +21373,14 @@ msgid ""
 "This chat and its generated images become public when you create and copy "
 "the link."
 msgstr ""
+"Цей чат і згенеровані в ньому зображення стануть публічними після створення "
+"та копіювання посилання."
 
 # smartling.placeholder_format=C
 #. Explains that creating and copying a share link makes the selected chat content public.
 msgctxt "Share modal info bullet about public access"
 msgid "This chat becomes public when you create and copy the link."
-msgstr ""
+msgstr "Цей чат стає публічним після створення та копіювання посилання."
 
 # smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
@@ -21564,16 +21522,14 @@ msgstr "Це зображення не вдалося створити."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr ""
-"Цей тип зображення не підтримується, прикріпіть файл JPG, PNG, WebP або GIF"
+msgstr "Цей тип зображення не підтримується, прикріпіть файл JPG, PNG, WebP або GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr ""
-"Цей тип зображення не підтримується. Додайте файл JPG, PNG, WebP або GIF."
+msgstr "Цей тип зображення не підтримується. Додайте файл JPG, PNG, WebP або GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -21652,8 +21608,7 @@ msgstr "Для роботи цієї сторінки необхідний Javas
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Вміст цієї сторінки буде надіслано до Duck.ai разом із вашим повідомленням"
+msgstr "Вміст цієї сторінки буде надіслано до Duck.ai разом із вашим повідомленням"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21740,8 +21695,7 @@ msgstr ""
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Ця вебсторінка не використовує захищене, зашифроване, з'єднання (HTTPS)."
+msgstr "Ця вебсторінка не використовує захищене, зашифроване, з'єднання (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21781,8 +21735,7 @@ msgstr "Це зітре усі налаштування. Продовжити?"
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
 msgctxt "settings"
 msgid "This will reset your saved settings to default values. Continue?"
-msgstr ""
-"Це призведе до скидання ваших налаштувань до стандартних значень. Продовжити?"
+msgstr "Це призведе до скидання ваших налаштувань до стандартних значень. Продовжити?"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard column: holes completed in current round
@@ -21959,7 +21912,7 @@ msgstr "Сьогодні"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
-msgstr ""
+msgstr "Перемкніть у приватний чат зі ШІ або %1$sвимкніть у налаштуваннях%2$s."
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -22465,8 +22418,7 @@ msgstr "Спробуйте увімкнути анонімне розташув�
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Спробуйте поекспериментувати з кожною моделлю — вони дадуть різні відповіді."
+msgstr "Спробуйте поекспериментувати з кожною моделлю — вони дадуть різні відповіді."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -22559,8 +22511,7 @@ msgstr "Спробуйте наш браузер,"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr ""
-"Спробуйте нашу домашню сторінку, яка ніколи не показує ці повідомлення:"
+msgstr "Спробуйте нашу домашню сторінку, яка ніколи не показує ці повідомлення:"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time; shown in the US. Invites the user to start a free trial of the paid subscription.
@@ -22595,8 +22546,7 @@ msgstr "Спробуйте налаштувати ваше розташуван�
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Try the %sDuckDuckGo Browser.%s Fast. Free. Private."
-msgstr ""
-"Спробуйте браузер %1$sDuckDuckGo.%2$s Швидко. Безплатно. Конфіденційно."
+msgstr "Спробуйте браузер %1$sDuckDuckGo.%2$s Швидко. Безплатно. Конфіденційно."
 
 # smartling.placeholder_format=C
 #. Link to a page where users can download the DuckDuckGo Browser for iOS or Android.
@@ -22829,8 +22779,7 @@ msgstr "Вимкнути:"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on %sPrecise Location%s for more accurate results"
-msgstr ""
-"Увімкніть «%1$sТочне розташування%2$s» для отримання точніших результатів"
+msgstr "Увімкніть «%1$sТочне розташування%2$s» для отримання точніших результатів"
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -23061,8 +23010,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"В меню %1$sЗАПУСК > Домашня сторінка%2$s введіть: https://duckduckgo.com"
+msgstr "В меню %1$sЗАПУСК > Домашня сторінка%2$s введіть: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23072,8 +23020,7 @@ msgstr "В %1$sНалаштуваннях пошуку%2$s оберіть %3$sDu
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr ""
-"В розділі %1$sПошук в адресному рядку%2$s виберіть %3$sДодати новий%4$s"
+msgstr "В розділі %1$sПошук в адресному рядку%2$s виберіть %3$sДодати новий%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -23093,8 +23040,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr ""
-"Під рядком пошуку натисніть на випадне меню та виберіть %1$sDuckDuckGo%2$s"
+msgstr "Під рядком пошуку натисніть на випадне меню та виберіть %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -23233,8 +23179,7 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr ""
-"Розблокуйте більше потужних моделей ШІ, підписавшись на DuckDuckGo. %1$s"
+msgstr "Розблокуйте більше потужних моделей ШІ, підписавшись на DuckDuckGo. %1$s"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -23465,8 +23410,7 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr ""
-"Переходьте на план Pro, щоб розблокувати вдвічі вищі ліміти, ніж у плані Plus"
+msgstr "Переходьте на план Pro, щоб розблокувати вдвічі вищі ліміти, ніж у плані Plus"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -23775,8 +23719,7 @@ msgstr "Переглянути ціни на проживання"
 # smartling.placeholder_format=C
 #. A description for the ads tooltip that explains that viewing ads is privacy protected by DuckDuckGo.
 msgid "Viewing ads is privacy protected by DuckDuckGo."
-msgstr ""
-"Перегляд оголошень виконується із захистом конфіденційності DuckDuckGo."
+msgstr "Перегляд оголошень виконується із захистом конфіденційності DuckDuckGo."
 
 # smartling.placeholder_format=C
 msgctxt "Ads GDPR, internal use only. Do not change"
@@ -23804,6 +23747,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Yelp's ad network."
 msgstr ""
+"Перегляд оголошень виконується із захистом конфіденційності DuckDuckGo. "
+"Клацаннями оголошень керує рекламна мережа Yelp."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -23891,8 +23836,8 @@ msgid ""
 msgstr ""
 "Відвідайте сайт Duck.ai в іншому браузері або в додатку DuckDuckGo та "
 "відкрийте налаштування Duck.ai. Виберіть «Увімкнути» у розділі «Sync & "
-"Backup» та виберіть «Синхронізувати з іншим пристроєм». Або відскануйте QR-"
-"код у PDF-файлі для відновлення."
+"Backup» та виберіть «Синхронізувати з іншим пристроєм». Або відскануйте "
+"QR-код у PDF-файлі для відновлення."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -24170,8 +24115,7 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"Не вдається зчитати додані файли, оскільки принаймні один із них зашифровано."
+msgstr "Не вдається зчитати додані файли, оскільки принаймні один із них зашифровано."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24236,8 +24180,7 @@ msgstr "Ми ніколи не стежимо за вами."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr ""
-"Ми не відстежуємо вас. Це наша Політика конфіденційності, якщо коротко."
+msgstr "Ми не відстежуємо вас. Це наша Політика конфіденційності, якщо коротко."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -24388,8 +24331,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr ""
-"Трекери, що намагаються збирати ваші дані під час перегляду, блокуватимуться."
+msgstr "Трекери, що намагаються збирати ваші дані під час перегляду, блокуватимуться."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
@@ -24822,8 +24764,7 @@ msgstr "Які страви тут варто скуштувати?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
-"Які години роботи, місцезнаходження та контактна інформація цього місця?"
+msgstr "Які години роботи, місцезнаходження та контактна інформація цього місця?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -24974,8 +24915,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Що таке збережена в хмарі закладка і чим вона відрізняється від URL-"
-"параметрів?"
+"Що таке збережена в хмарі закладка і чим вона відрізняється від "
+"URL-параметрів?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -25050,8 +24991,7 @@ msgstr "Про що б ви хотіли залишити відгук?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"Те, що ви дивитеся в DuckDuckGo, не вплине на ваші рекомендації на YouTube."
+msgstr "Те, що ви дивитеся в DuckDuckGo, не вплине на ваші рекомендації на YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -25291,6 +25231,8 @@ msgid ""
 "With chat history on, up to %s of your most recent chats will be saved on "
 "this device."
 msgstr ""
+"Якщо історію чатів увімкнено, на цьому пристрої буде збережено до %1$s ваших "
+"останніх чатів."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline in the About Chat History modal.
@@ -25298,6 +25240,8 @@ msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, your most recent chats will be saved on this device."
 msgstr ""
+"Коли історію чатів увімкнено, ваші останні чати зберігатимуться на цьому "
+"пристрої."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -25881,8 +25825,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr ""
-"Ви більше не побачите це повідомлення, якщо не очистите дані свого браузера."
+msgstr "Ви більше не побачите це повідомлення, якщо не очистите дані свого браузера."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -26050,8 +25993,7 @@ msgctxt ""
 msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
-msgstr ""
-"Ваші %1$s останні чати будуть доступні у локальному сховищі на цих браузерах:"
+msgstr "Ваші %1$s останні чати будуть доступні у локальному сховищі на цих браузерах:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
@@ -26180,8 +26122,7 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr ""
-"Ваші чати є приватними і ніколи не використовуються для навчання моделей ШІ"
+msgstr "Ваші чати є приватними і ніколи не використовуються для навчання моделей ШІ"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -26241,8 +26182,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr ""
-"Ваші чати імпортовано. Продовжуйте з того місця, де ви зупинилися у Duck.ai."
+msgstr "Ваші чати імпортовано. Продовжуйте з того місця, де ви зупинилися у Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -26700,7 +26640,7 @@ msgstr "хв"
 #. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the chat options menu button"
 msgid "menu"
-msgstr ""
+msgstr "меню"
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/ur_PK/LC_MESSAGES/duckduckgo.po
+++ b/locales/ur_PK/LC_MESSAGES/duckduckgo.po
@@ -978,6 +978,11 @@ msgstr ""
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1081,6 +1086,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr ""
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "DuckDuckGo شامل کریں"
@@ -1099,6 +1116,24 @@ msgstr ""
 
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
 msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1138,6 +1173,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1209,6 +1258,11 @@ msgstr "اضافی پلگ ان"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1455,6 +1509,11 @@ msgstr ""
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2802,6 +2861,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3202,9 +3268,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3220,6 +3296,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4479,6 +4562,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4763,6 +4851,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5101,6 +5194,11 @@ msgstr ""
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -5997,6 +6095,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6174,6 +6277,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6841,6 +6949,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7259,6 +7372,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8241,6 +8359,11 @@ msgid "How is it anonymous?"
 msgstr "یہ کس طرح گمنام ہے؟"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9402,6 +9525,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11141,6 +11269,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr ""
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12841,6 +12974,11 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -12947,6 +13085,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -13935,6 +14078,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14090,6 +14238,13 @@ msgstr ""
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15007,6 +15162,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16346,6 +16506,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16426,6 +16593,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16886,6 +17058,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17288,6 +17474,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18750,6 +18941,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -19899,6 +20097,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -20985,6 +21196,11 @@ msgstr ""
 #. An abbreviated form of "minute" that can be displayed in a small space e.g. "1m"
 msgctxt "published date for videos"
 msgid "m"
+msgstr ""
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
 msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/vi_VN/LC_MESSAGES/duckduckgo.po
+++ b/locales/vi_VN/LC_MESSAGES/duckduckgo.po
@@ -980,6 +980,11 @@ msgstr "Về chúng tôi"
 msgid "About our ads"
 msgstr ""
 
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1083,6 +1088,18 @@ msgctxt "feedback form"
 msgid "Ad is suspicious"
 msgstr "Quảng cáo rất khả nghi"
 
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "Thêm DuckDuckGo"
@@ -1104,6 +1121,24 @@ msgstr "Thêm DuckDuckGo làm công cụ tìm kiếm"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "Thêm DuckDuckGo vào %s"
+
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
@@ -1142,6 +1177,20 @@ msgctxt ""
 "Attach page context from the current tab to the AI chat message (standalone "
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
+msgstr ""
+
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
 msgstr ""
 
 #. https://duckduckgo.com/search_box near the top
@@ -1213,6 +1262,11 @@ msgstr "Các tiện ích"
 #. Loading message shown when the image generation is nearing completion.
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
+msgstr ""
+
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
 msgstr ""
 
 #. Label that's displayed next to an address below a web search result.
@@ -1457,6 +1511,11 @@ msgstr "Tất cả màu sắc"
 #. Title shown to the host device (the one that is logged in) after the pair completes.
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
+msgstr ""
+
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
 msgstr ""
 
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -2822,6 +2881,13 @@ msgctxt "Secondary action that dismisses the turn-off Sync & Backup dialog"
 msgid "Cancel"
 msgstr ""
 
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3222,9 +3288,19 @@ msgctxt "Feedback option for offensive chat response"
 msgid "Chat response is offensive"
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
+msgstr ""
+
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
 msgstr ""
 
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3240,6 +3316,13 @@ msgstr ""
 #. Title for the chats section on the sidebar.
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
+msgstr ""
+
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
 msgstr ""
 
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4511,6 +4594,11 @@ msgctxt "Sports module"
 msgid "Current Streak"
 msgstr ""
 
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -4795,6 +4883,11 @@ msgstr ""
 #. Button text to delete unpinned chats older than 30 days to free up sync storage.
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
+msgstr ""
+
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
 msgstr ""
 
 #. Button text to confirm deletion of an image.
@@ -5133,6 +5226,11 @@ msgstr "Hủy bỏ vĩnh viễn"
 #. ARIA label describing the action of the dismiss button on the sidemenu subscription promo.
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
+msgstr ""
+
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
 msgstr ""
 
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6040,6 +6138,11 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Edit Prompt"
 msgstr ""
 
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -6219,6 +6322,11 @@ msgctxt ""
 "Ephemeral badge next to the model name in a Duck.ai assistant message for "
 "encrypted inference models"
 msgid "Encrypted model"
+msgstr ""
+
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
 msgstr ""
 
 #. shown after the DuckDuckGo extension is installed
@@ -6888,6 +6996,11 @@ msgstr ""
 msgid "Follow-up question"
 msgstr ""
 
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -7306,6 +7419,11 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
+msgstr ""
+
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
 msgstr ""
 
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -8292,6 +8410,11 @@ msgid "How is it anonymous?"
 msgstr "Nó ẩn danh như thế nào?"
 
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
+msgid "How it works"
+msgstr ""
+
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
 msgid "How it works"
 msgstr ""
 
@@ -9461,6 +9584,11 @@ msgstr ""
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
+msgstr ""
+
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11198,6 +11326,11 @@ msgctxt "mobile promotion on desktop"
 msgid "OK, got it!"
 msgstr "OK, đã rõ!"
 
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -12913,6 +13046,11 @@ msgstr "Bảo vệ dữ liệu của bạn trên mọi thiết bị."
 msgid "Protected"
 msgstr ""
 
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr ""
@@ -13019,6 +13157,11 @@ msgstr ""
 #. Used to refer to rankings of a team or player in a sports league. For example, the AP 25 rankings for NCAA college football. Rankings are different than standings (win-loss-tie record) for some sports. Most rankings consider the rank number 1 to be the 'best' team/player in the league.
 msgctxt "Sports module"
 msgid "Rankings"
+msgstr ""
+
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
 msgstr ""
 
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -14007,6 +14150,11 @@ msgctxt "Description for Chat History when sync is enabled"
 msgid "Save your chats across all your devices."
 msgstr ""
 
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -14166,6 +14314,13 @@ msgstr "Tìm kiếm"
 
 #. Label for the button that forces the LLM in Duck.ai to use web search to answer the question for the user.
 msgctxt "Label for button to force web search in Duck.ai"
+msgid "Search"
+msgstr ""
+
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
 msgid "Search"
 msgstr ""
 
@@ -15093,6 +15248,11 @@ msgstr ""
 #. Call to action button that appears in a merchant ad extension dropdown and on clicking takes the user to an external product page
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
+msgstr ""
+
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
 msgstr ""
 
 #. Label above shopping search results.
@@ -16437,6 +16597,13 @@ msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
 
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -16517,6 +16684,11 @@ msgstr ""
 #. List item explaining that chats are synced across all user devices when Sync & Backup is enabled.
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
+msgstr ""
+
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
 msgstr ""
 
 #. Label preceding the list of devices currently registered to the account.
@@ -16985,6 +17157,20 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr ""
 
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -17389,6 +17575,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
 msgstr ""
 
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -18857,6 +19048,13 @@ msgid ""
 "TripAdvisor's ad network."
 msgstr ""
 
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
 msgid "Virgin Islands"
 msgstr ""
 
@@ -20024,6 +20222,19 @@ msgid ""
 "on or off anytime in the '%s' menu."
 msgstr ""
 
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -21124,6 +21335,11 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "m"
 msgstr "p"
+
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 #. Aria label for the button that opens the menu in the mobile variant.
 msgctxt "Aria label for the menu button"

--- a/locales/zh_CN/LC_MESSAGES/duckduckgo.po
+++ b/locales/zh_CN/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1185,6 +1185,12 @@ msgid "About our ads"
 msgstr "关于我们的广告"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1308,6 +1314,20 @@ msgid "Ad is suspicious"
 msgstr "广告信息可疑"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "添加 DuckDuckGo"
@@ -1332,6 +1352,27 @@ msgstr "添加 DuckDuckGo 搜索引擎"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "将 DuckDuckGo 添加至 %1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1377,6 +1418,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "添加页面内容"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1462,6 +1519,12 @@ msgstr "插件"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "添加最后的润色"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1759,6 +1822,12 @@ msgstr "不限颜色"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "全部完成！"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3425,6 +3494,14 @@ msgid "Cancel"
 msgstr "取消"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3911,10 +3988,22 @@ msgid "Chat response is offensive"
 msgstr "聊天回复令人反感"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "与 %1$s 聊天"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3933,6 +4022,14 @@ msgstr "聊天"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "聊天"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5501,6 +5598,12 @@ msgid "Current Streak"
 msgstr "当前连胜场数"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5845,6 +5948,12 @@ msgstr "删除聊天记录"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "删除超过 30 天的聊天记录"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6255,6 +6364,12 @@ msgstr "不再显示"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "关闭促销信息"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7379,6 +7494,12 @@ msgid "Edit Prompt"
 msgstr "编辑提示"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7595,6 +7716,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "加密模型"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8407,6 +8534,12 @@ msgid "Follow-up question"
 msgstr "后续问题"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -8917,6 +9050,12 @@ msgstr ""
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr "获取 DuckDuckGo VPN、高级 Duck.ai 和 Identity Theft Restoration 服务。"
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10130,6 +10269,12 @@ msgstr "这是匿名的吗？"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "如何使用"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11550,6 +11695,12 @@ msgstr "争边球获胜次数"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "链接将在 7 天后失效。"
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13664,6 +13815,12 @@ msgid "OK, got it!"
 msgstr "好的，知道了！"
 
 # smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -15750,6 +15907,12 @@ msgid "Protected"
 msgstr "受保护"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "保护。隐私。安心。"
@@ -15879,6 +16042,12 @@ msgstr "下雨"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "排名"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17094,6 +17263,12 @@ msgid "Save your chats across all your devices."
 msgstr "在所有设备上保留你的聊天记录。"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17292,6 +17467,14 @@ msgstr "搜索"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "搜索"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18437,6 +18620,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "购买"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20061,6 +20250,14 @@ msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr "Sync & Backup 数据在 18 个月未活动后将无法恢复。"
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20170,6 +20367,12 @@ msgstr "与附近设备同步。"
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "在所有设备上同步你的聊天记录。"
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -20733,6 +20936,22 @@ msgid "This Week"
 msgstr "本周"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21238,6 +21457,12 @@ msgstr "今天"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "今天"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23024,6 +23249,14 @@ msgstr ""
 "DuckDuckGo 会保护观看广告的隐私。广告点击量由 TripAdvisor 广告网络管理。"
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "维尔京群岛"
 
@@ -24437,6 +24670,21 @@ msgstr ""
 "在“%1$s”菜单中开启或关闭。"
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -25765,6 +26013,12 @@ msgstr "分钟"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "分钟"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/zh_CN/LC_MESSAGES/duckduckgo.po
+++ b/locales/zh_CN/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -189,9 +189,7 @@ msgctxt "Error message when a Plus subscriber tries to use a Pro-only model"
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr ""
-"%1$s 仅限 Pro 订户使用。请在此浏览器中再次升级 DuckDuckGo 订阅以继续聊天，或"
-"者切换到 Plus 或免费模型。"
+msgstr "%1$s 仅限 Pro 订户使用。请在此浏览器中再次升级 DuckDuckGo 订阅以继续聊天，或者切换到 Plus 或免费模型。"
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -200,9 +198,7 @@ msgctxt ""
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr ""
-"%1$s 仅限 Pro 订户使用。请在此浏览器中再次升级 DuckDuckGo 订阅以继续聊天，或"
-"者切换到 Plus 或免费模型。"
+msgstr "%1$s 仅限 Pro 订户使用。请在此浏览器中再次升级 DuckDuckGo 订阅以继续聊天，或者切换到 Plus 或免费模型。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -217,9 +213,7 @@ msgid ""
 "%s is only available with a DuckDuckGo subscription. Activate your "
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
-msgstr ""
-"%1$s 仅限 DuckDuckGo 订阅用户使用。在这个浏览器中重新激活你的订阅以继续聊天，"
-"或切换到免费模式。"
+msgstr "%1$s 仅限 DuckDuckGo 订阅用户使用。在这个浏览器中重新激活你的订阅以继续聊天，或切换到免费模式。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -323,9 +317,7 @@ msgid ""
 "%s runs in a Trusted Execution Environment. This means not even the model "
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
-msgstr ""
-"%1$s 在可信执行环境中运行。这意味着即使是模型提供商也无法查看您的提示或模型的"
-"响应，也不会在其服务器上保存此聊天记录。"
+msgstr "%1$s 在可信执行环境中运行。这意味着即使是模型提供商也无法查看您的提示或模型的响应，也不会在其服务器上保存此聊天记录。"
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -439,8 +431,7 @@ msgstr "%1$s点击%2$s添加%3$s勾选%4$s允许%5$s，然后点击%6$s确定%7$
 #. Instructions on what buttons the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr ""
-"%1$s点击%2$s允许%3$s点击%4$s添加%5$s勾选%6$s允许%7$s，然后点击%8$s确定%9$s"
+msgstr "%1$s点击%2$s允许%3$s点击%4$s添加%5$s勾选%6$s允许%7$s，然后点击%8$s确定%9$s"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -449,9 +440,7 @@ msgctxt "install-duckduckgo"
 msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
-msgstr ""
-"%1$s点击%2$s继续安装%3$s点击%4$s添加%5$s勾选%6$s允许%7$s，然后点击%8$s确"
-"定%9$s"
+msgstr "%1$s点击%2$s继续安装%3$s点击%4$s添加%5$s勾选%6$s允许%7$s，然后点击%8$s确定%9$s"
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -920,8 +909,7 @@ msgstr "客场"
 msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
-msgstr ""
-"网络问题导致 Search Assist 无法生成答案。请检查网络连接，然后再试一次。"
+msgstr "网络问题导致 Search Assist 无法生成答案。请检查网络连接，然后再试一次。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
@@ -979,9 +967,8 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"可以利用 AI Chat 与第三方人工智能聊天模型进行匿名对话。关闭此功能将隐藏 "
-"DuckDuckGo Search 中的 AI Chat 功能。关闭此设置后，仍可以通过访问 "
-"%1$sduckduckgo.com/aichat%2$s 来使用 AI Chat。"
+"可以利用 AI Chat 与第三方人工智能聊天模型进行匿名对话。关闭此功能将隐藏 DuckDuckGo Search 中的 AI Chat "
+"功能。关闭此设置后，仍可以通过访问 %1$sduckduckgo.com/aichat%2$s 来使用 AI Chat。"
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1042,9 +1029,8 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"人工智能辅助的答案目前不直接支持后续问题。不过，我们还提供 %1$sDuck.ai%2$s 并"
-"通常会与其链接来解答后续问题，这是我们基于人工智能的私人聊天服务，支持 "
-"OpenAI 和 Anthropic 等公司的聊天模型。"
+"人工智能辅助的答案目前不直接支持后续问题。不过，我们还提供 %1$sDuck.ai%2$s "
+"并通常会与其链接来解答后续问题，这是我们基于人工智能的私人聊天服务，支持 OpenAI 和 Anthropic 等公司的聊天模型。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1188,7 +1174,7 @@ msgstr "关于我们的广告"
 #. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
 msgctxt "Modal header for chat history with sync information"
 msgid "About Chat History with Sync & Backup"
-msgstr ""
+msgstr "关于已开启 Sync & Backup 的聊天记录"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
@@ -1317,7 +1303,7 @@ msgstr "广告信息可疑"
 #. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
 msgctxt "Button to open menu for attaching images or page context to AI chat"
 msgid "Add"
-msgstr ""
+msgstr "添加"
 
 # smartling.placeholder_format=C
 #. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
@@ -1325,7 +1311,7 @@ msgctxt ""
 "Primary button that attaches the tabs the user checked in the tab picker "
 "dialog"
 msgid "Add"
-msgstr ""
+msgstr "添加"
 
 # smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
@@ -1358,13 +1344,13 @@ msgstr "将 DuckDuckGo 添加至 %1$s"
 msgctxt ""
 "Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
 msgid "Add File"
-msgstr ""
+msgstr "添加文件"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
 msgid "Add Image"
-msgstr ""
+msgstr "添加图像"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
@@ -1372,7 +1358,7 @@ msgctxt ""
 "Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
 "item)"
 msgid "Add Image or File"
-msgstr ""
+msgstr "添加图像或文件"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1425,7 +1411,7 @@ msgctxt ""
 "Open the tab picker to attach browser tab content to the AI chat message "
 "(attach dropdown menu item)"
 msgid "Add Tabs"
-msgstr ""
+msgstr "添加标签页"
 
 # smartling.placeholder_format=C
 #. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
@@ -1433,7 +1419,7 @@ msgctxt ""
 "Title and accessible name of the tab-picker dialog opened from the attach "
 "dropdown menu"
 msgid "Add Tabs"
-msgstr ""
+msgstr "添加标签页"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1524,7 +1510,7 @@ msgstr "添加最后的润色"
 #. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
 msgctxt "Aria label for the additional instructions textarea"
 msgid "Additional instructions"
-msgstr ""
+msgstr "附加指令"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1801,9 +1787,7 @@ msgctxt "Privacy & Terms section description on the Duck.ai settings page"
 msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
-msgstr ""
-"DuckDuckGo 会对所有聊天内容进行匿名处理，并且 DuckDuckGo 或模型提供方不会使用"
-"你的对话来训练聊天模型"
+msgstr "DuckDuckGo 会对所有聊天内容进行匿名处理，并且 DuckDuckGo 或模型提供方不会使用你的对话来训练聊天模型"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1827,7 +1811,7 @@ msgstr "全部完成！"
 #. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the read-only textarea listing all AI instructions"
 msgid "All instructions"
-msgstr ""
+msgstr "所有指令"
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -1925,8 +1909,8 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"允许 %1$s 搜索网络，以改善对相关提示的回复质量。仅将人工智能生成的查询发送给"
-"数据留存期有限的搜索引擎。%2$s 的提示和回复仍然%3$s完全不会向提供商显示%4$s。"
+"允许 %1$s 搜索网络，以改善对相关提示的回复质量。仅将人工智能生成的查询发送给数据留存期有限的搜索引擎。%2$s "
+"的提示和回复仍然%3$s完全不会向提供商显示%4$s。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2091,8 +2075,7 @@ msgctxt "settings"
 msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
-msgstr ""
-"根据网页内容匿名生成搜索查询答案。你可以选择该功能的显示频率，或完全关闭它。"
+msgstr "根据网页内容匿名生成搜索查询答案。你可以选择该功能的显示频率，或完全关闭它。"
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2302,9 +2285,7 @@ msgstr "截至"
 msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
-msgstr ""
-"根据我们的隐私协议，我们本身不会收集或传播任何隐私信息，仅会立足于你的设备保"
-"护隐私。"
+msgstr "根据我们的隐私协议，我们本身不会收集或传播任何隐私信息，仅会立足于你的设备保护隐私。"
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2446,11 +2427,9 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assist 可以在总结相关网页内容的基础上，为某些搜索匿名生成人工智能辅助答案。可"
-"以选择显示 Assist 的频率：从不（从搜索结果中完全移除 Assist 用户界面)、按需"
-"（仅在点击“Assist”按钮时显示人工智能辅助的答案）、有时（仅在高度相关时显示人"
-"工智能辅助的答案）或经常（在更广泛的搜索中更频繁地显示）。人工智能辅助的答案"
-"目前仅供美国（英语）地区使用。"
+"Assist 可以在总结相关网页内容的基础上，为某些搜索匿名生成人工智能辅助答案。可以选择显示 Assist 的频率：从不（从搜索结果中完全移除 "
+"Assist "
+"用户界面)、按需（仅在点击“Assist”按钮时显示人工智能辅助的答案）、有时（仅在高度相关时显示人工智能辅助的答案）或经常（在更广泛的搜索中更频繁地显示）。人工智能辅助的答案目前仅供美国（英语）地区使用。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2462,10 +2441,8 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist 是我们搜索结果中的一项可选功能，可以匿名生成人工智能辅助的搜索查询答"
-"案。为此，该功能会扫描网络上的相关内容，然后使用人工智能驱动的自然语言技术，"
-"根据找到的相关信息生成简短的答案。请务必记住，这些回复来自引用的资料来源，并"
-"通过%1$s爬取网络内容%2$s自动生成。"
+"Assist "
+"是我们搜索结果中的一项可选功能，可以匿名生成人工智能辅助的搜索查询答案。为此，该功能会扫描网络上的相关内容，然后使用人工智能驱动的自然语言技术，根据找到的相关信息生成简短的答案。请务必记住，这些回复来自引用的资料来源，并通过%1$s爬取网络内容%2$s自动生成。"
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2490,9 +2467,7 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "At the café, airport, or hotel, DuckDuckGo VPN encrypts your connection and "
 "hides your IP address on Wi-Fi."
-msgstr ""
-"无论是在咖啡馆、机场还是酒店，DuckDuckGo VPN 都能加密你的网络连接，并在 Wi-"
-"Fi 环境下隐藏你的 IP 地址。"
+msgstr "无论是在咖啡馆、机场还是酒店，DuckDuckGo VPN 都能加密你的网络连接，并在 Wi-Fi 环境下隐藏你的 IP 地址。"
 
 # smartling.placeholder_format=C
 #. In the context of the National Hockey League (NHL), label for teams belonging to the Atlantic division
@@ -2637,9 +2612,7 @@ msgid ""
 "Automatically shows Assist for relevant searches. Assist can anonymously "
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
-msgstr ""
-"为相关搜索自动显示 Assist。Assist 可以匿名查找和汇总信息，以响应某些搜索。"
-"Assist 目前仅供英语地区使用。"
+msgstr "为相关搜索自动显示 Assist。Assist 可以匿名查找和汇总信息，以响应某些搜索。Assist 目前仅供英语地区使用。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2647,9 +2620,7 @@ msgid ""
 "Automatically shows DuckAssist for relevant searches. DuckAssist can "
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
-msgstr ""
-"为相关搜索自动显示 DuckAssist。DuckAssist 可以匿名查找和汇总信息，以响应某些"
-"搜索。DuckAssist 目前仅供英语地区使用。"
+msgstr "为相关搜索自动显示 DuckAssist。DuckAssist 可以匿名查找和汇总信息，以响应某些搜索。DuckAssist 目前仅供英语地区使用。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2854,9 +2825,7 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
-msgstr ""
-"在存储此报告之前，DuckDuckGo 会通过删除姓名、电子邮件地址和识别元数据等个人身"
-"份信息，对你的对话进行匿名化处理。"
+msgstr "在存储此报告之前，DuckDuckGo 会通过删除姓名、电子邮件地址和识别元数据等个人身份信息，对你的对话进行匿名化处理。"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2985,8 +2954,7 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Block harmful sites, hide your IP address, plus get more premium protections "
 "with our subscription."
-msgstr ""
-"订阅我们的服务即可屏蔽有害网站、隐藏你的 IP 地址，并解锁更多高级保护功能。"
+msgstr "订阅我们的服务即可屏蔽有害网站、隐藏你的 IP 地址，并解锁更多高级保护功能。"
 
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
@@ -3245,26 +3213,20 @@ msgstr "浏览文件"
 msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr ""
-"正常上网，让我们来保护你的隐私。我们的 %1$s%2$s 扩展 %3$s 中预置了搜索引擎，"
-"还能屏蔽跟踪程序、开启网站加密。"
+msgstr "正常上网，让我们来保护你的隐私。我们的 %1$s%2$s 扩展 %3$s 中预置了搜索引擎，还能屏蔽跟踪程序、开启网站加密。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr ""
-"正常上网，剩下的交给我们。我们的 %1$s%2$s 扩展 %3$s 中预置了搜索引擎，还能屏"
-"蔽跟踪程序、开启网站加密。"
+msgstr "正常上网，剩下的交给我们。我们的 %1$s%2$s 扩展 %3$s 中预置了搜索引擎，还能屏蔽跟踪程序、开启网站加密。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we’ll take care of the rest. Get bundled private "
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
-msgstr ""
-"正常上网，剩下的交给我们。我们为 %1$s 主流浏览器 %2$s 提供了扩展，一键下载即"
-"可匿名搜索、屏蔽跟踪程序、开启网站加密。"
+msgstr "正常上网，剩下的交给我们。我们为 %1$s 主流浏览器 %2$s 提供了扩展，一键下载即可匿名搜索、屏蔽跟踪程序、开启网站加密。"
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3371,18 +3333,15 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"默认情况下，设置存储在浏览器 Cookie 中，不含隐私信息。你也可以使用匿名的 "
-"Cloud Save 功能把设置长期存放在我们的云服务器上，同样不会泄露隐私，使用的口令"
-"也只有浏览器知道。"
+"默认情况下，设置存储在浏览器 Cookie 中，不含隐私信息。你也可以使用匿名的 Cloud Save "
+"功能把设置长期存放在我们的云服务器上，同样不会泄露隐私，使用的口令也只有浏览器知道。"
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
 msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
-msgstr ""
-"启用听写，即表示你同意将自己的语音数据发送给 OpenAI，以使用此功能。在开始使用"
-"之前，请参阅我们的%1$s。"
+msgstr "启用听写，即表示你同意将自己的语音数据发送给 OpenAI，以使用此功能。在开始使用之前，请参阅我们的%1$s。"
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3390,9 +3349,7 @@ msgctxt "voice chat"
 msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
-msgstr ""
-"启用语音聊天，即表示你同意将自己的语音数据发送给 OpenAI，以使用此功能。在开始"
-"使用之前，请参阅我们的%1$s。"
+msgstr "启用语音聊天，即表示你同意将自己的语音数据发送给 OpenAI，以使用此功能。在开始使用之前，请参阅我们的%1$s。"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3499,7 +3456,7 @@ msgctxt ""
 "Secondary button that dismisses the tab picker dialog without attaching "
 "anything"
 msgid "Cancel"
-msgstr ""
+msgstr "取消"
 
 # smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
@@ -3884,10 +3841,9 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"可以利用聊天功能（通过我们的 Duck.ai 服务提供）与第三方人工智能聊天模型进行匿"
-"名对话，该功能支持 OpenAI、Anthropic 等公司的模型。关闭此设置将隐藏 "
-"DuckDuckGo Search 上的聊天按钮和链接。不过，即使关闭该设置，仍然可以直接通过"
-"访问 %1$shttps://duck.ai%2$s 来使用聊天功能。 "
+"可以利用聊天功能（通过我们的 Duck.ai 服务提供）与第三方人工智能聊天模型进行匿名对话，该功能支持 OpenAI、Anthropic "
+"等公司的模型。关闭此设置将隐藏 DuckDuckGo Search 上的聊天按钮和链接。不过，即使关闭该设置，仍然可以直接通过访问 "
+"%1$shttps://duck.ai%2$s 来使用聊天功能。 "
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3991,7 +3947,7 @@ msgstr "聊天回复令人反感"
 #. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
 msgctxt "Chat history about modal list item headline"
 msgid "Chat storage varies by browser"
-msgstr ""
+msgstr "聊天记录存储因浏览器而异"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4003,7 +3959,7 @@ msgstr "与 %1$s 聊天"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Chat with popular AI models, anonymized by us."
-msgstr ""
+msgstr "与热门 AI 模型聊天，我们会对用户的身份信息进行匿名化处理。"
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4029,7 +3985,7 @@ msgctxt "Chat history with sync modal list item description"
 msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
-msgstr ""
+msgstr "聊天记录采用端到端加密技术，安全存储在 DuckDuckGo 服务器上。除了你之外，没有人可以看到你的数据，甚至我们也不行。"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4037,9 +3993,7 @@ msgctxt "Description for Chat History feature"
 msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
-msgstr ""
-"聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或远程服务器上。禁用聊天历"
-"史记录会删除已置顶的聊天记录。"
+msgstr "聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或远程服务器上。禁用聊天历史记录会删除已置顶的聊天记录。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -4051,9 +4005,8 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"聊天记录会存储在本地设备上。新的提示和回复在发送后会被加密并暂时存储在 "
-"DuckDuckGo 服务器上，以便在断开互联网连接时帮助恢复聊天记录。禁用聊天记录将删"
-"除置顶的聊天记录，并禁用新提示和回复的临时存储功能。"
+"聊天记录会存储在本地设备上。新的提示和回复在发送后会被加密并暂时存储在 DuckDuckGo "
+"服务器上，以便在断开互联网连接时帮助恢复聊天记录。禁用聊天记录将删除置顶的聊天记录，并禁用新提示和回复的临时存储功能。"
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -4075,9 +4028,7 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
-msgstr ""
-"与 %1$s 的聊天内容对提供商完全不可见，但上传到 Duck.ai 的所有文件均会由内容审"
-"核提供商以匿名方式进行审核，以检查是否包含 %2$s。"
+msgstr "与 %1$s 的聊天内容对提供商完全不可见，但上传到 Duck.ai 的所有文件均会由内容审核提供商以匿名方式进行审核，以检查是否包含 %2$s。"
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -4436,9 +4387,7 @@ msgctxt "Information about the effect of clearing browser data on recent chats"
 msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
-msgstr ""
-"清除浏览器数据会删除聊天记录。某些浏览器可能会无限期保留最近的聊天记录，或者"
-"在超过 7 天未使用 AI Chat 后自动将其删除。"
+msgstr "清除浏览器数据会删除聊天记录。某些浏览器可能会无限期保留最近的聊天记录，或者在超过 7 天未使用 AI Chat 后自动将其删除。"
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4447,9 +4396,7 @@ msgid ""
 "Clearing browser data deletes recent chats. Recent chats may be saved "
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
-msgstr ""
-"清除浏览器数据会删除近期聊天记录。在不使用 Duck.ai 的情况下，可以无限期保存近"
-"期聊天记录，或在 7 天后自动删除，具体取决于浏览器的设置。"
+msgstr "清除浏览器数据会删除近期聊天记录。在不使用 Duck.ai 的情况下，可以无限期保存近期聊天记录，或在 7 天后自动删除，具体取决于浏览器的设置。"
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4466,8 +4413,8 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"点击“更多”以深入了解某个主题，并通过 %1$sDuck.ai%2$s 提出后续问题，我们的私密"
-"人工智能聊天服务支持 OpenAI、Anthropic 等聊天模型。"
+"点击“更多”以深入了解某个主题，并通过 %1$sDuck.ai%2$s 提出后续问题，我们的私密人工智能聊天服务支持 OpenAI、Anthropic "
+"等聊天模型。"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4508,9 +4455,7 @@ msgstr "在弹出的菜单中点击 %1$s更改搜索设置%2$s"
 msgid ""
 "Click %sEdit > Preferences%s (on Windows) %sSeaMonkey > Preferences%s (on "
 "Mac)"
-msgstr ""
-"Windows 系统点击 %1$s编辑 > 首选项%2$s，Mac 系统点击 %3$sSeaMonkey > 首选"
-"项%4$s"
+msgstr "Windows 系统点击 %1$s编辑 > 首选项%2$s，Mac 系统点击 %3$sSeaMonkey > 首选项%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4540,9 +4485,7 @@ msgstr "在左侧的列表中点击 %1$s隐私和服务%2$s。"
 msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
-msgstr ""
-"在顶部菜单栏中点击 %1$sSafari 浏览器%2$s（Windows 系统点击右上角的 %3$s齿轮图"
-"标%4$s）"
+msgstr "在顶部菜单栏中点击 %1$sSafari 浏览器%2$s（Windows 系统点击右上角的 %3$s齿轮图标%4$s）"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4632,9 +4575,7 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
-msgstr ""
-"点击或轻触“%1$s删除我的数据%2$s”，即可删除来自云端的数据，但只要不点击／轻"
-"触“%3$s重置所有搜索设置%4$s”，相关数据就会一直保留在浏览器中。"
+msgstr "点击或轻触“%1$s删除我的数据%2$s”，即可删除来自云端的数据，但只要不点击／轻触“%3$s重置所有搜索设置%4$s”，相关数据就会一直保留在浏览器中。"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4644,9 +4585,7 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
-msgstr ""
-"点击“%1$s删除我的数据%2$s”即可将云端的数据删除，但只要不点击“%3$s恢复初始设"
-"置%4$s”，从云端同步的设置就会一直保留在浏览器中。"
+msgstr "点击“%1$s删除我的数据%2$s”即可将云端的数据删除，但只要不点击“%3$s恢复初始设置%4$s”，从云端同步的设置就会一直保留在浏览器中。"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4714,9 +4653,7 @@ msgstr "点击搜索栏中的下拉菜单"
 msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
-msgstr ""
-"点击 %1$s在地址栏中使用的搜索引擎%2$s 旁边的下拉菜单，选择 "
-"%3$sDuckDuckGo%4$s。"
+msgstr "点击 %1$s在地址栏中使用的搜索引擎%2$s 旁边的下拉菜单，选择 %3$sDuckDuckGo%4$s。"
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
@@ -5364,9 +5301,7 @@ msgctxt "Description for the wrong code error screen"
 msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
-msgstr ""
-"从其他设备复制代码。前往“%1$sDuck.ai 设置 › 聊天 › Sync & Backup › 与其他设备"
-"同步%2$s”并重试。"
+msgstr "从其他设备复制代码。前往“%1$sDuck.ai 设置 › 聊天 › Sync & Backup › 与其他设备同步%2$s”并重试。"
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5601,7 +5536,7 @@ msgstr "当前连胜场数"
 #. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
 msgctxt "Suffix label indicating a tab is the currently active browser tab"
 msgid "Current Tab"
-msgstr ""
+msgstr "当前标签页"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
@@ -5953,7 +5888,7 @@ msgstr "删除超过 30 天的聊天记录"
 #. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
 msgctxt "Button text in the modal for deleting all recent chats"
 msgid "Delete Chats and Shared Links"
-msgstr ""
+msgstr "删除聊天记录和共享链接"
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6079,9 +6014,7 @@ msgctxt "Description at the top of the Duck.ai shared links modal"
 msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
-msgstr ""
-"删除链接会导致该链接失效。已打开对话并将其添加到自己聊天中的人，将保留各自的"
-"副本。"
+msgstr "删除链接会导致该链接失效。已打开对话并将其添加到自己聊天中的人，将保留各自的副本。"
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6194,8 +6127,7 @@ msgstr "暂时无法使用听写功能"
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
-msgstr ""
-"听写功能使用 OpenAI 模型将语音转为文本，因此无需输入便可以在 Duck.ai 中聊天。"
+msgstr "听写功能使用 OpenAI 模型将语音转为文本，因此无需输入便可以在 Duck.ai 中聊天。"
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6369,7 +6301,7 @@ msgstr "关闭促销信息"
 #. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the close button on the survey banner"
 msgid "Dismiss survey"
-msgstr ""
+msgstr "关闭调查问卷"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6519,9 +6451,7 @@ msgctxt "settings"
 msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
-msgstr ""
-"不想使用人工智能？%1$snoai.duckduckgo.com%2$s 不提供任何 AI 功能，并会筛选掉 "
-"AI 生成的图像。 %3$s了解详情%4$s"
+msgstr "不想使用人工智能？%1$snoai.duckduckgo.com%2$s 不提供任何 AI 功能，并会筛选掉 AI 生成的图像。 %3$s了解详情%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6530,8 +6460,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"不想使用 AI？请访问 %1$snoai.duckduckgo.com%2$s 以在搜索时禁用 AI 功能并过滤"
-"掉 AI 生成的图像。%3$s了解详情%4$s"
+"不想使用 AI？请访问 %1$snoai.duckduckgo.com%2$s 以在搜索时禁用 AI 功能并过滤掉 AI "
+"生成的图像。%3$s了解详情%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6813,9 +6743,7 @@ msgid ""
 "Duck.ai can now help answer questions about the page you're viewing. Page "
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
-msgstr ""
-"Duck.ai 现在可以帮助回答你正在浏览的页面问题。页面内容仅在你附加时纳入，除非"
-"你选择在设置中自动附加页面。"
+msgstr "Duck.ai 现在可以帮助回答你正在浏览的页面问题。页面内容仅在你附加时纳入，除非你选择在设置中自动附加页面。"
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6824,9 +6752,7 @@ msgctxt ""
 msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
-msgstr ""
-"Duck.ai 无法访问本地存储来保存您的聊天记录。请检查浏览器设置或禁用任何扩展程"
-"序再试一次。"
+msgstr "Duck.ai 无法访问本地存储来保存您的聊天记录。请检查浏览器设置或禁用任何扩展程序再试一次。"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6849,9 +6775,7 @@ msgid ""
 "Duck.ai is created by DuckDuckGo. We're an independent online protection "
 "company for anyone who wants to take back control of their personal "
 "information."
-msgstr ""
-"Duck.ai 由 DuckDuckGo 创建。我们是一家独立的在线安全保护公司，致力于帮助任何"
-"希望重新掌控自己个人信息的人。"
+msgstr "Duck.ai 由 DuckDuckGo 创建。我们是一家独立的在线安全保护公司，致力于帮助任何希望重新掌控自己个人信息的人。"
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6865,9 +6789,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
-msgstr ""
-"Duck.ai 仍然是 DuckDuckGo 的产品，但现在将拥有一个更容易记住的网站主页："
-"https://duck.ai"
+msgstr "Duck.ai 仍然是 DuckDuckGo 的产品，但现在将拥有一个更容易记住的网站主页：https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6881,9 +6803,7 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
-msgstr ""
-"暂时无法使用 Duck.ai。如果仍有问题，请通过电子邮件将此匿名代码 %1$s 发送到 "
-"%2$s"
+msgstr "暂时无法使用 Duck.ai。如果仍有问题，请通过电子邮件将此匿名代码 %1$s 发送到 %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6903,9 +6823,7 @@ msgctxt "settings"
 msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
-msgstr ""
-"Duck.ai 让你能够私密地与热门 AI 模型进行对话。禁用后将隐藏 Duck.ai 按钮和链"
-"接，但你仍然可以直接访问 %1$sduck.ai%2$s。"
+msgstr "Duck.ai 让你能够私密地与热门 AI 模型进行对话。禁用后将隐藏 Duck.ai 按钮和链接，但你仍然可以直接访问 %1$sduck.ai%2$s。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6916,10 +6834,9 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"可以利用 Duck.ai 与第三方人工智能聊天模型进行匿名对话，包括来自 OpenAI、"
-"Anthropic 等公司的模型。关闭此设置将隐藏 DuckDuckGo Search 中的 Duck.ai 按钮"
-"和链接。不过，即使关闭该设置，仍然可以直接通过访问 %1$shttps://duck.ai%2$s 来"
-"使用 Duck.ai。"
+"可以利用 Duck.ai 与第三方人工智能聊天模型进行匿名对话，包括来自 OpenAI、Anthropic 等公司的模型。关闭此设置将隐藏 "
+"DuckDuckGo Search 中的 Duck.ai 按钮和链接。不过，即使关闭该设置，仍然可以直接通过访问 "
+"%1$shttps://duck.ai%2$s 来使用 Duck.ai。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6980,9 +6897,8 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai、DuckDuckGo AI、私人 AI 聊天机器人、免费 AI 聊天、匿名 AI 聊天、无需"
-"注册的 AI 聊天、OpenAI、Anthropic、Llama、Mistral、开源 AI 模型、注重隐私的 "
-"AI、无需账户的 AI 聊天"
+"Duck.ai、DuckDuckGo AI、私人 AI 聊天机器人、免费 AI 聊天、匿名 AI 聊天、无需注册的 AI "
+"聊天、OpenAI、Anthropic、Llama、Mistral、开源 AI 模型、注重隐私的 AI、无需账户的 AI 聊天"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7010,10 +6926,10 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"DuckAssist 可以匿名查找和汇总信息，以响应某些搜索。可以选择 DuckAssist 的显示"
-"频率：从不（从搜索结果中完全移除 DuckAssist 用户界面)、按需（仅在点击“协助”按"
-"钮时显示）、有时（仅在高度相关时显示）或经常（在更广泛的搜索中更频繁地显"
-"示）。DuckAssist 目前仅供美国（英语）地区使用。"
+"DuckAssist 可以匿名查找和汇总信息，以响应某些搜索。可以选择 DuckAssist 的显示频率：从不（从搜索结果中完全移除 "
+"DuckAssist "
+"用户界面)、按需（仅在点击“协助”按钮时显示）、有时（仅在高度相关时显示）或经常（在更广泛的搜索中更频繁地显示）。DuckAssist "
+"目前仅供美国（英语）地区使用。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7022,9 +6938,8 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist 无法回答后续问题，但是，我们还提供 %1$sDuckDuckGo AI Chat%2$s，这"
-"是一种人工智能驱动的私密聊天服务，支持包括 OpenAI 和 Anthropic 在内的多种聊天"
-"模型。"
+"DuckAssist 无法回答后续问题，但是，我们还提供 %1$sDuckDuckGo AI "
+"Chat%2$s，这是一种人工智能驱动的私密聊天服务，支持包括 OpenAI 和 Anthropic 在内的多种聊天模型。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7033,8 +6948,8 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist 无法回答后续问题，但是，我们还提供 DuckDuckGo %1$sAI Chat%2$s，这"
-"是一种人工智能驱动的私密聊天服务，支持 OpenAI 和 Anthropic 的聊天模型。"
+"DuckAssist 无法回答后续问题，但是，我们还提供 DuckDuckGo %1$sAI Chat%2$s，这是一种人工智能驱动的私密聊天服务，支持 "
+"OpenAI 和 Anthropic 的聊天模型。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7046,10 +6961,10 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist 是我们搜索结果中的一项新功能，可以匿名生成搜索查询的答案。为此，该"
-"功能会扫描维基百科和相关网站的相关内容，然后使用人工智能驱动的自然语言技术生"
-"成这些信息的摘要。 请注意，其回复目前基于维基百科和相关内容，其准确性未经核"
-"实。"
+"DuckAssist "
+""
+"是我们搜索结果中的一项新功能，可以匿名生成搜索查询的答案。为此，该功能会扫描维基百科和相关网站的相关内容，然后使用人工智能驱动的自然语言技术生成这些信息的摘要。 "
+"请注意，其回复目前基于维基百科和相关内容，其准确性未经核实。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7063,11 +6978,10 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssist 是我们搜索结果中的一项可选功能，可以匿名生成搜索查询的答案。为此，"
-"该功能会扫描网络上的相关内容，然后使用人工智能驱动的自然语言技术，根据找到的"
-"相关信息生成简短的答案。DuckAssist 的回复始终直接链接到一个或两个资料来源，并"
-"注明答案的出处，以便你轻松获取更详细的信息。请务必记住，这些回复来自引用的资"
-"料来源，并通过%1$s爬取网络内容%2$s自动生成。"
+"DuckAssist "
+""
+"是我们搜索结果中的一项可选功能，可以匿名生成搜索查询的答案。为此，该功能会扫描网络上的相关内容，然后使用人工智能驱动的自然语言技术，根据找到的相关信息生成简短的答案。DuckAssist "
+"的回复始终直接链接到一个或两个资料来源，并注明答案的出处，以便你轻松获取更详细的信息。请务必记住，这些回复来自引用的资料来源，并通过%1$s爬取网络内容%2$s自动生成。"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -7090,9 +7004,7 @@ msgctxt "Modal body for information"
 msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
-msgstr ""
-"DuckDuckGo AI Chat 是一种私密人工智能驱动型聊天服务，目前支持 %1$s 的 %2$s "
-"和 %3$s 的 %4$s 聊天模型。"
+msgstr "DuckDuckGo AI Chat 是一种私密人工智能驱动型聊天服务，目前支持 %1$s 的 %2$s 和 %3$s 的 %4$s 聊天模型。"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7100,9 +7012,7 @@ msgctxt "Onboarding welcome screen subtitle"
 msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
-msgstr ""
-"DuckDuckGo AI Chat 是一种私密人工智能驱动型聊天服务，目前支持 %1$s 的 %2$s "
-"和 %3$s 的 %4$s 聊天模型。"
+msgstr "DuckDuckGo AI Chat 是一种私密人工智能驱动型聊天服务，目前支持 %1$s 的 %2$s 和 %3$s 的 %4$s 聊天模型。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -7118,9 +7028,7 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
-msgstr ""
-"暂时无法使用 DuckDuckGo AI Chat。如果仍有问题，请通过电子邮件将此匿名代码 "
-"%1$s 发送到 %2$s"
+msgstr "暂时无法使用 DuckDuckGo AI Chat。如果仍有问题，请通过电子邮件将此匿名代码 %1$s 发送到 %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7283,18 +7191,14 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
-msgstr ""
-"DuckDuckGo 通过自动删除姓名、电子邮件地址、电话号码和识别元数据等个人身份信息"
-"来对这些报告进行匿名化。"
+msgstr "DuckDuckGo 通过自动删除姓名、电子邮件地址、电话号码和识别元数据等个人身份信息来对这些报告进行匿名化。"
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
 msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
-msgstr ""
-"DuckDuckGo 会对你的聊天内容进行匿名处理。点击“%1$s”即表示你同意 Duck.ai 的 "
-"%2$s。"
+msgstr "DuckDuckGo 会对你的聊天内容进行匿名处理。点击“%1$s”即表示你同意 Duck.ai 的 %2$s。"
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7302,8 +7206,7 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr ""
-"DuckDuckGo 会对你的聊天内容进行匿名处理。点击“%1$s”即表示你同意我们的 %2$s。"
+msgstr "DuckDuckGo 会对你的聊天内容进行匿名处理。点击“%1$s”即表示你同意我们的 %2$s。"
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7311,9 +7214,7 @@ msgid ""
 "DuckDuckGo blocks trackers on websites you visit, including trackers from "
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
-msgstr ""
-"DuckDuckGo 会屏蔽所访问网站的跟踪程序，包括来自 Google 和 Facebook 等公司的跟"
-"踪程序，这些公司经常试图在其他网站上跟踪你。"
+msgstr "DuckDuckGo 会屏蔽所访问网站的跟踪程序，包括来自 Google 和 Facebook 等公司的跟踪程序，这些公司经常试图在其他网站上跟踪你。"
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7325,9 +7226,8 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo 的设计力图保护用户隐私，定位信息仅存储于你的设备中，只有发起搜索时"
-"会上传给我们用以优化搜索结果，搜索完成后我们也不会保留，以保证搜索匿名"
-"性。%1$s详细了解我们是如何设计这一功能来保护隐私的%2$s。"
+"DuckDuckGo "
+"的设计力图保护用户隐私，定位信息仅存储于你的设备中，只有发起搜索时会上传给我们用以优化搜索结果，搜索完成后我们也不会保留，以保证搜索匿名性。%1$s详细了解我们是如何设计这一功能来保护隐私的%2$s。"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -7346,8 +7246,7 @@ msgctxt "settings"
 msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
-msgstr ""
-"DuckDuckGo 只需了解你的大致位置即可优化你附近的搜索结果。%1$s了解详情%2$s。"
+msgstr "DuckDuckGo 只需了解你的大致位置即可优化你附近的搜索结果。%1$s了解详情%2$s。"
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7439,8 +7338,8 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"当你选择自动生成口令时，我们会从 DuckDuckGo 服务器获取一系列随机的英文词汇，"
-"并在浏览器端从中选取四五个，保证总长度至少有 18 到 20 个字符。"
+"当你选择自动生成口令时，我们会从 DuckDuckGo 服务器获取一系列随机的英文词汇，并在浏览器端从中选取四五个，保证总长度至少有 18 到 20 "
+"个字符。"
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7497,7 +7396,7 @@ msgstr "编辑提示"
 #. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the message-editing text area"
 msgid "Edit message"
-msgstr ""
+msgstr "编辑消息"
 
 # smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
@@ -7695,9 +7594,7 @@ msgctxt "precise_user_location"
 msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
-msgstr ""
-"启用匿名定位功能可获得更精确的结果，但 DuckDuckGo 仍会保密你的搜索和确切位置"
-"信息。"
+msgstr "启用匿名定位功能可获得更精确的结果，但 DuckDuckGo 仍会保密你的搜索和确切位置信息。"
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7721,7 +7618,7 @@ msgstr "加密模型"
 #. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
 msgctxt "Share modal info bullet about encryption"
 msgid "Encrypted so DuckDuckGo can't read your chat."
-msgstr ""
+msgstr "已加密，因此 DuckDuckGo 无法读取你的聊天内容。"
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -7889,8 +7786,7 @@ msgstr "输入文本"
 #. Instructions for how to change the default search engine.
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
-msgstr ""
-"输入下列信息：%1$s名称%2$s：DuckDuckGo%3$s搜索串%4$s：%5$s快捷字%6$s：d%7$s"
+msgstr "输入下列信息：%1$s名称%2$s：DuckDuckGo%3$s搜索串%4$s：%5$s快捷字%6$s：d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -8281,9 +8177,7 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
-msgstr ""
-"类似你这样的反馈会直接影响我们的产品更新和改进。希望我们也能解决你提出的问"
-"题。"
+msgstr "类似你这样的反馈会直接影响我们的产品更新和改进。希望我们也能解决你提出的问题。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -8537,7 +8431,7 @@ msgstr "后续问题"
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
-msgstr ""
+msgstr "后续问题会保密。"
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8754,9 +8648,8 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"在 Mac 的应用程序菜单栏中选择“<strong>DuckDuckGo</strong>” &gt; "
-"“<strong>Check for Updates...</strong>”（查看更新……），然后选"
-"择“<strong>Install Update</strong>”（安装更新）。"
+"在 Mac 的应用程序菜单栏中选择“<strong>DuckDuckGo</strong>” &gt; “<strong>Check for "
+"Updates...</strong>”（查看更新……），然后选择“<strong>Install Update</strong>”（安装更新）。"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9042,8 +8935,8 @@ msgid ""
 "Get DuckDuckGo VPN, advanced Duck.ai, Personal Info Removal, and Identity "
 "Theft Restoration."
 msgstr ""
-"获取 DuckDuckGo VPN、高级 Duck.ai、Personal Information Removal 以及 "
-"Identity Theft Restoration 服务。"
+"获取 DuckDuckGo VPN、高级 Duck.ai、Personal Information Removal 以及 Identity Theft "
+"Restoration 服务。"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
@@ -9055,7 +8948,7 @@ msgstr "获取 DuckDuckGo VPN、高级 Duck.ai 和 Identity Theft Restoration �
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
 msgctxt "Tooltip on the header logo for sunglasses searches"
 msgid "Get DuckDuckGo sunglasses and other gear."
-msgstr ""
+msgstr "购买 DuckDuckGo 太阳镜和其他周边商品。"
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9135,8 +9028,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, Personal Info Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"获取快速的无日志 VPN、可选高级人工智能聊天、Personal Information Removal 以"
-"及 Identity Theft Restoration 服务。"
+"获取快速的无日志 VPN、可选高级人工智能聊天、Personal Information Removal 以及 Identity Theft "
+"Restoration 服务。"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; 'advanced AI chat' refers to Duck.ai; Identity Theft Restoration is a bundled feature.
@@ -9144,9 +9037,7 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, and Identity Theft "
 "Restoration."
-msgstr ""
-"获取快速的无日志 VPN、可选高级人工智能聊天以及 Identity Theft Restoration 服"
-"务。"
+msgstr "获取快速的无日志 VPN、可选高级人工智能聊天以及 Identity Theft Restoration 服务。"
 
 # smartling.placeholder_format=C
 #. Description for the subscription modal where users can update their subscription to DuckDuckGo.
@@ -9154,9 +9045,7 @@ msgctxt "Description of the modal to upgrade the DuckDuckGo subscription"
 msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
-msgstr ""
-"订阅 DuckDuckGo 即可使用 Duck.ai 的高级人工智能模型，同时还包括我们的 VPN 和"
-"其他高级隐私保护功能。"
+msgstr "订阅 DuckDuckGo 即可使用 Duck.ai 的高级人工智能模型，同时还包括我们的 VPN 和其他高级隐私保护功能。"
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -9166,9 +9055,7 @@ msgctxt ""
 msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
-msgstr ""
-"通过 DuckDuckGo 订阅使用 Duck.ai 的高级人工智能模型，其中还包括我们的 VPN 和"
-"其他高级隐私保护功能。"
+msgstr "通过 DuckDuckGo 订阅使用 Duck.ai 的高级人工智能模型，其中还包括我们的 VPN 和其他高级隐私保护功能。"
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9211,9 +9098,7 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
-msgstr ""
-"获取我们快速的无日志 VPN、可选高级人工智能模型（具备更高的聊天限额）以及更多"
-"高级保护功能。"
+msgstr "获取我们快速的无日志 VPN、可选高级人工智能模型（具备更高的聊天限额）以及更多高级保护功能。"
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9222,16 +9107,15 @@ msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, Personal Information Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"获取我们安全的无日志 VPN、高级 Duck.ai、Personal Information Removal 以及 "
-"Identity Theft Restoration 服务。"
+"获取我们安全的无日志 VPN、高级 Duck.ai、Personal Information Removal 以及 Identity Theft "
+"Restoration 服务。"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr ""
-"获取我们安全的无日志 VPN，高级 Duck.ai 以及 Identity Theft Restoration 服务。"
+msgstr "获取我们安全的无日志 VPN，高级 Duck.ai 以及 Identity Theft Restoration 服务。"
 
 # smartling.placeholder_format=C
 msgid ""
@@ -9331,8 +9215,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"在其他浏览器中前往 %1$sDuck.ai 设置%2$s，或在 DuckDuckGo 应用程序中前往%3$s聊"
-"天 › Sync & Backup › 与其他设备同步 › 复制文本二维码%4$s"
+"在其他浏览器中前往 %1$sDuck.ai 设置%2$s，或在 DuckDuckGo 应用程序中前往%3$s聊天 › Sync & Backup › "
+"与其他设备同步 › 复制文本二维码%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9341,8 +9225,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"在其他浏览器或 DuckDuckGo 应用程序中前往 %1$sDuck.ai 设置%2$s，然后进入%3$s聊"
-"天 › Sync & Backup › 与其他设备同步%4$s"
+"在其他浏览器或 DuckDuckGo 应用程序中前往 %1$sDuck.ai 设置%2$s，然后进入%3$s聊天 › Sync & Backup › "
+"与其他设备同步%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9352,8 +9236,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"在其他浏览器或 DuckDuckGo 应用程序中前往 %1$sDuck.ai 设置%2$s，然后加入%3$s聊"
-"天 › Sync & Backup › 与其他设备同步%4$s并扫描此二维码："
+"在其他浏览器或 DuckDuckGo 应用程序中前往 %1$sDuck.ai 设置%2$s，然后加入%3$s聊天 › Sync & Backup › "
+"与其他设备同步%4$s并扫描此二维码："
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9363,8 +9247,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"在其他浏览器或 DuckDuckGo 应用程序中前往 %1$sDuck.ai 设置%2$s，然后进入%3$s聊"
-"天 › Sync & Backup › 与其他设备同步%4$s。或者扫描恢复 PDF 中的二维码。"
+"在其他浏览器或 DuckDuckGo 应用程序中前往 %1$sDuck.ai 设置%2$s，然后进入%3$s聊天 › Sync & Backup › "
+"与其他设备同步%4$s。或者扫描恢复 PDF 中的二维码。"
 
 # smartling.placeholder_format=C
 #. Path to the pairing code on the other device. Bold segments are UI path labels.
@@ -9372,8 +9256,7 @@ msgctxt "Detail under the first numbered step on the Enter Code tab"
 msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
-msgstr ""
-"前往“%1$sDuck.ai 设置%2$s › %3$s聊天 › Sync & Backup › 与其他设备同步%4$s”。"
+msgstr "前往“%1$sDuck.ai 设置%2$s › %3$s聊天 › Sync & Backup › 与其他设备同步%4$s”。"
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9395,9 +9278,7 @@ msgctxt "precise_user_location"
 msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
-msgstr ""
-"转到%1$s“设置” > “隐私” > “权限管理器” > “定位”%2$s，然后向下滚动至 "
-"%3$sDuckDuckGo%4$s。"
+msgstr "转到%1$s“设置” > “隐私” > “权限管理器” > “定位”%2$s，然后向下滚动至 %3$sDuckDuckGo%4$s。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -10111,9 +9992,7 @@ msgstr "历史"
 msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
-msgstr ""
-"按下键盘上的 %1$s回车键%2$s%3$s将 DuckDuckGo 添加到列表中，%4$s然后点击 %5$s"
-"设为默认搜索引擎%6$s"
+msgstr "按下键盘上的 %1$s回车键%2$s%3$s将 DuckDuckGo 添加到列表中，%4$s然后点击 %5$s设为默认搜索引擎%6$s"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -10126,9 +10005,7 @@ msgstr "白苗语"
 msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
-msgstr ""
-"稍等！将其改回默认搜索引擎将禁用 DuckDuckGo 扩展程序，并将失去我们的隐私保"
-"护。"
+msgstr "稍等！将其改回默认搜索引擎将禁用 DuckDuckGo 扩展程序，并将失去我们的隐私保护。"
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -10274,7 +10151,7 @@ msgstr "如何使用"
 #. Headline in chat history about modals for the temporary encrypted server storage explanation.
 msgctxt "Chat history about modal list item headline"
 msgid "How it works"
-msgstr ""
+msgstr "如何使用"
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -10479,9 +10356,7 @@ msgctxt "precise_user_location"
 msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
-msgstr ""
-"如果仍然无法使用浏览器定位，请前往%1$s“设置” > “通用” > “还原” > “还原位置与"
-"隐私”%2$s。"
+msgstr "如果仍然无法使用浏览器定位，请前往%1$s“设置” > “通用” > “还原” > “还原位置与隐私”%2$s。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10491,8 +10366,8 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"如果仍然无法使用浏览器定位，请在浏览器中转到%1$s“⋮” > “菜单” > “设置” > “网站"
-"设置” > “位置”%2$s，并确认已允许 DuckDuckGo 使用定位信息。"
+"如果仍然无法使用浏览器定位，请在浏览器中转到%1$s“⋮” > “菜单” > “设置” > “网站设置” > “位置”%2$s，并确认已允许 "
+"DuckDuckGo 使用定位信息。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10506,8 +10381,7 @@ msgstr "如果你继续看到此错误，请联系 %1$s。"
 msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
-msgstr ""
-"如果找不到 %1$sDuckDuckGo%2$s，你需要手动将其添加到 %3$s其他搜索引擎%4$s 中"
+msgstr "如果找不到 %1$sDuckDuckGo%2$s，你需要手动将其添加到 %3$s其他搜索引擎%4$s 中"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -10515,9 +10389,7 @@ msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
-msgstr ""
-"如果你对我们的聊天提供商或任何特定的聊天回复有疑虑，也可以直接联系 %1$s 和 "
-"%2$s 支持页面。"
+msgstr "如果你对我们的聊天提供商或任何特定的聊天回复有疑虑，也可以直接联系 %1$s 和 %2$s 支持页面。"
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10525,9 +10397,7 @@ msgctxt "Body for the Sync & Backup recovery code screen"
 msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
-msgstr ""
-"如果您无法访问自己的设备，则将需要此代码来恢复保存的聊天记录。您可以将此代码"
-"以文本文件的形式保存到设备中。"
+msgstr "如果您无法访问自己的设备，则将需要此代码来恢复保存的聊天记录。您可以将此代码以文本文件的形式保存到设备中。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
@@ -10542,9 +10412,7 @@ msgstr "如果你仍愿支持我们，可%1$s协助推广 DuckDuckGo%2$s"
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr ""
-"如需在关闭 JavaScript 的情况下使用 DuckDuckGo，请使用我们的 %1$s 或者 %2$s 版"
-"本。"
+msgstr "如需在关闭 JavaScript 的情况下使用 DuckDuckGo，请使用我们的 %1$s 或者 %2$s 版本。"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10691,9 +10559,7 @@ msgctxt "settings"
 msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
-msgstr ""
-"如果使用某些过时的浏览器，点击搜索结果后需要经过我们的服务器重定向才能避免泄"
-"露搜索内容。%1$s了解详情%2$s。"
+msgstr "如果使用某些过时的浏览器，点击搜索结果后需要经过我们的服务器重定向才能避免泄露搜索内容。%1$s了解详情%2$s。"
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -10703,8 +10569,7 @@ msgctxt ""
 msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
-msgstr ""
-"在 DuckDuckGo 浏览器中，前往设置 › Sync & Backup，然后选择“与其他设备同步”。"
+msgstr "在 DuckDuckGo 浏览器中，前往设置 › Sync & Backup，然后选择“与其他设备同步”。"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -10718,9 +10583,7 @@ msgctxt "cloudsave"
 msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
-msgstr ""
-"本着透明公开的原则，上传的信息也没有加密处理，如果你感兴趣的话可以看到我们具"
-"体都存了什么。"
+msgstr "本着透明公开的原则，上传的信息也没有加密处理，如果你感兴趣的话可以看到我们具体都存了什么。"
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -11125,8 +10988,8 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"结果根据与搜索词的相关程度排序，并通过 Microsoft 的广告网络提供。链接直接指向"
-"商户页面，与广告不同，DuckDuckGo 不会通过这些搜索结果获得收益。"
+"结果根据与搜索词的相关程度排序，并通过 Microsoft 的广告网络提供。链接直接指向商户页面，与广告不同，DuckDuckGo "
+"不会通过这些搜索结果获得收益。"
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -11700,7 +11563,7 @@ msgstr "链接将在 7 天后失效。"
 #. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days. People can save a chat copy."
-msgstr ""
+msgstr "链接将在 7 天后失效。用户可以保存聊天记录副本。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13156,9 +13019,8 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"新的提示和回复在发送后会被加密并暂时存储在 DuckDuckGo 服务器上，以便在断开互"
-"联网连接时帮助恢复聊天记录。禁用聊天记录将删除置顶的聊天记录，并禁用新提示和"
-"回复的临时存储功能。"
+"新的提示和回复在发送后会被加密并暂时存储在 DuckDuckGo "
+"服务器上，以便在断开互联网连接时帮助恢复聊天记录。禁用聊天记录将删除置顶的聊天记录，并禁用新提示和回复的临时存储功能。"
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -13818,7 +13680,7 @@ msgstr "好的，知道了！"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "OPTIONAL"
-msgstr ""
+msgstr "可选"
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -13985,9 +13847,7 @@ msgstr "按需"
 msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
-msgstr ""
-"Mac 系统 %1$s点击 Maxthon > 设置%2$s，Windows 系统 %3$s点击 %4$s 图标 > 设"
-"置%5$s"
+msgstr "Mac 系统 %1$s点击 Maxthon > 设置%2$s，Windows 系统 %3$s点击 %4$s 图标 > 设置%5$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -13995,9 +13855,7 @@ msgctxt "Instruction under the Scan QR tab sub-heading"
 msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
-msgstr ""
-"在另一台设备上，前往“%1$sDuck.ai 设置%2$s › %3$s聊天 › Sync & Backup › 与其他"
-"设备同步%4$s”"
+msgstr "在另一台设备上，前往“%1$sDuck.ai 设置%2$s › %3$s聊天 › Sync & Backup › 与其他设备同步%4$s”"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14005,9 +13863,7 @@ msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
 msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
-msgstr ""
-"在另一台设备上，前往“%1$sDuck.ai 设置%2$s › %3$s聊天 › Sync & Backup › 与其他"
-"设备同步%4$s”并扫描此代码："
+msgstr "在另一台设备上，前往“%1$sDuck.ai 设置%2$s › %3$s聊天 › Sync & Backup › 与其他设备同步%4$s”并扫描此代码："
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14016,8 +13872,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
-"在另一台设备上，前往“%1$sDuck.ai 设置%2$s › %3$s聊天 › Sync & Backup › 与其他"
-"设备同步%4$s”。或者扫描恢复 PDF 中的二维码。"
+"在另一台设备上，前往“%1$sDuck.ai 设置%2$s › %3$s聊天 › Sync & Backup › 与其他设备同步%4$s”。或者扫描恢复 "
+"PDF 中的二维码。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14406,9 +14262,7 @@ msgctxt "homepage onboarding"
 msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
-msgstr ""
-"即使在隐私浏览模式中，某些搜索引擎照样会跟踪你。而我们不会跟踪你，就这么简"
-"单。"
+msgstr "即使在隐私浏览模式中，某些搜索引擎照样会跟踪你。而我们不会跟踪你，就这么简单。"
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -14421,9 +14275,7 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Our fast, no-log VPN comes with smarter AI chats with higher limits, plus "
 "more premium protections. All in one subscription."
-msgstr ""
-"我们快速的无日志 VPN 附带更智能、限额更高的人工智能聊天功能，以及更多高级保护"
-"功能。一站式订阅服务。"
+msgstr "我们快速的无日志 VPN 附带更智能、限额更高的人工智能聊天功能，以及更多高级保护功能。一站式订阅服务。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -14437,9 +14289,7 @@ msgid ""
 "Our private browser for mobile comes equipped with our search engine, "
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
-msgstr ""
-"我们的移动端隐私浏览器预置了搜索引擎，还可以屏蔽跟踪程序、开启网站加密等等。"
-"现已支持 %1$siOS 和 Android%2$s。"
+msgstr "我们的移动端隐私浏览器预置了搜索引擎，还可以屏蔽跟踪程序、开启网站加密等等。现已支持 %1$siOS 和 Android%2$s。"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14691,9 +14541,7 @@ msgctxt "cloudsave"
 msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
-msgstr ""
-"我们存储设置时并未记录你的 IP 地址、浏览器指纹或任何其他信息，因此无法找回口"
-"令。"
+msgstr "我们存储设置时并未记录你的 IP 地址、浏览器指纹或任何其他信息，因此无法找回口令。"
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -14848,9 +14696,7 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
-msgstr ""
-"Personal Information Removal 会在出售个人信息的数据中介网站上查找你的信息。然"
-"后，我们会努力为你将其删除。"
+msgstr "Personal Information Removal 会在出售个人信息的数据中介网站上查找你的信息。然后，我们会努力为你将其删除。"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -14920,9 +14766,7 @@ msgid ""
 "assisted answers more likely to appear automatically and often yields better "
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
-msgstr ""
-"以问题和完整的句子进行搜索，会更有可能自动显示人工智能辅助的答案，通常也能获"
-"得更佳答案。若要将其关闭并隐藏“Assist”按钮，请访问“%1$s搜索设置%2$s”。"
+msgstr "以问题和完整的句子进行搜索，会更有可能自动显示人工智能辅助的答案，通常也能获得更佳答案。若要将其关闭并隐藏“Assist”按钮，请访问“%1$s搜索设置%2$s”。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14931,8 +14775,8 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"以问题和完整的句子进行搜索，会更有可能显示 DuckAssist，通常也能获得更佳答"
-"案。 如需调整此功能的工作方式或将其关闭，请访问 %1$sDuckAssist 设置%2$s。"
+"以问题和完整的句子进行搜索，会更有可能显示 DuckAssist，通常也能获得更佳答案。 如需调整此功能的工作方式或将其关闭，请访问 "
+"%1$sDuckAssist 设置%2$s。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14942,8 +14786,8 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"以问题和完整的句子进行搜索，会更有可能自动显示 DuckAssist，通常也能获得更佳答"
-"案。若要将其关闭并隐藏“协助”按钮，请访问 %1$sDuckAssist 设置%2$s。"
+"以问题和完整的句子进行搜索，会更有可能自动显示 DuckAssist，通常也能获得更佳答案。若要将其关闭并隐藏“协助”按钮，请访问 "
+"%1$sDuckAssist 设置%2$s。"
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14983,8 +14827,7 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, "
 "Mistral, etc."
-msgstr ""
-"选择热门 AI 并与之对话，比如 GPT-5 mini、Claude Haiku 4.5、Mistral 等。"
+msgstr "选择热门 AI 并与之对话，比如 GPT-5 mini、Claude Haiku 4.5、Mistral 等。"
 
 # smartling.placeholder_format=C
 #. The description of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -15140,9 +14983,7 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
-msgstr ""
-"请粘贴你的提示和有问题的输出内容（删除所有个人信息），并说明相关内容为何有害"
-"或非法。"
+msgstr "请粘贴你的提示和有问题的输出内容（删除所有个人信息），并说明相关内容为何有害或非法。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15150,9 +14991,7 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
-msgstr ""
-"请粘贴你的提示和有问题的输出内容（删除任何个人信息），并说明相关内容为何违法"
-"或有害。"
+msgstr "请粘贴你的提示和有问题的输出内容（删除任何个人信息），并说明相关内容为何违法或有害。"
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -15910,7 +15749,7 @@ msgstr "受保护"
 #. Headline in sync-enabled chat history about modals explaining encrypted server storage.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Protected with end-to-end encryption"
-msgstr ""
+msgstr "采用端到端加密技术"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -16047,7 +15886,7 @@ msgstr "排名"
 #. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
 msgctxt "star rating on a product"
 msgid "Rated %s out of %s"
-msgstr ""
+msgstr "评分：%1$s/%2$s"
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -16201,8 +16040,7 @@ msgctxt "Description for recent chats feature"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr ""
-"近期聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或其他远程服务器上。"
+msgstr "近期聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或其他远程服务器上。"
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -16210,8 +16048,7 @@ msgctxt "Description of where recent chats are stored"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr ""
-"近期聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或其他远程服务器上。"
+msgstr "近期聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或其他远程服务器上。"
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -16220,9 +16057,7 @@ msgid ""
 "Recent chats are stored locally on your device. New prompts and responses "
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
-msgstr ""
-"最近的聊天记录会存储在本地设备上。新的提示和回复在发送后会被加密并暂时存储在 "
-"DuckDuckGo 服务器上，以便在断开互联网连接时帮助恢复聊天记录。"
+msgstr "最近的聊天记录会存储在本地设备上。新的提示和回复在发送后会被加密并暂时存储在 DuckDuckGo 服务器上，以便在断开互联网连接时帮助恢复聊天记录。"
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -16503,9 +16338,7 @@ msgstr "重新加载 Duck.ai"
 msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
-msgstr ""
-"请按照说明重新加载 DuckDuckGo，或点击浏览器的“Refresh”（刷新）或“Reload”（重"
-"新加载）按钮。"
+msgstr "请按照说明重新加载 DuckDuckGo，或点击浏览器的“Refresh”（刷新）或“Reload”（重新加载）按钮。"
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16612,18 +16445,14 @@ msgctxt "settings"
 msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
-msgstr ""
-"移除“Ask”（询问）按钮，以便在相关搜索的响应中自动显示答案。一律自动显示缓存的"
-"答案。"
+msgstr "移除“Ask”（询问）按钮，以便在相关搜索的响应中自动显示答案。一律自动显示缓存的答案。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
-msgstr ""
-"移除“Generate”（生成）按钮，以便在相关搜索的响应中自动显示答案。一律自动显示"
-"缓存的答案。"
+msgstr "移除“Generate”（生成）按钮，以便在相关搜索的响应中自动显示答案。一律自动显示缓存的答案。"
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -16680,18 +16509,14 @@ msgid ""
 "Reports are anonymous and sent to DuckDuckGo to help improve our search "
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
-msgstr ""
-"你的反馈将以匿名方式发送至 DuckDuckGo，以帮助我们改进搜索服务，同时也将匿名提"
-"供给 %1$s，以便共同提高服务质量。"
+msgstr "你的反馈将以匿名方式发送至 DuckDuckGo，以帮助我们改进搜索服务，同时也将匿名提供给 %1$s，以便共同提高服务质量。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
-msgstr ""
-"发给 DuckDuckGo 的报告均为匿名。请不要在反馈中包含任何个人或可识别身份的信"
-"息。"
+msgstr "发给 DuckDuckGo 的报告均为匿名。请不要在反馈中包含任何个人或可识别身份的信息。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16699,9 +16524,7 @@ msgid ""
 "Reports sent to DuckDuckGo include all of the text you've asked us to "
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
-msgstr ""
-"发送给 DuckDuckGo 的报告包括你在此页面加载过程中要求我们翻译的所有文本，且是"
-"匿名形式。请不要在反馈中包含任何个人或可识别身份的信息。"
+msgstr "发送给 DuckDuckGo 的报告包括你在此页面加载过程中要求我们翻译的所有文本，且是匿名形式。请不要在反馈中包含任何个人或可识别身份的信息。"
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -16792,9 +16615,7 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
-msgstr ""
-"回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议。人工智能辅助"
-"的答案受我们的%1$s服务条款%2$s约束。"
+msgstr "回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议。人工智能辅助的答案受我们的%1$s服务条款%2$s约束。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16802,9 +16623,7 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
-msgstr ""
-"回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议。DuckAssist 受"
-"我们的%1$s服务条款%2$s约束。"
+msgstr "回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议。DuckAssist 受我们的%1$s服务条款%2$s约束。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16814,8 +16633,8 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议，且根据网络内"
-"容生成，可能包含不准确的信息。Search Assist 受我们的%1$s服务条款%2$s约束。"
+"回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议，且根据网络内容生成，可能包含不准确的信息。Search Assist "
+"受我们的%1$s服务条款%2$s约束。"
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -17239,9 +17058,7 @@ msgctxt "Description for Chat History feature with Encrypted Storage option"
 msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
-msgstr ""
-"在本地设备上保存多达 30 条最新聊天记录，还可使用加密存储功能保存更多聊天记"
-"录。"
+msgstr "在本地设备上保存多达 30 条最新聊天记录，还可使用加密存储功能保存更多聊天记录。"
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -17266,7 +17083,7 @@ msgstr "在所有设备上保留你的聊天记录。"
 #. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
 msgctxt "Chat history about modal list item headline"
 msgid "Save your chats on this device"
-msgstr ""
+msgstr "在此设备上保存你的聊天记录"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
@@ -17413,9 +17230,7 @@ msgstr "向下滚动并点击 %1$s查看高级设置%2$s。"
 msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
-msgstr ""
-"向下滚动并找到%1$s地址栏使用的搜索引擎%2$s，点击%3$s更改搜索引擎%4$s（或%5$s"
-"添加搜索引擎%6$s）"
+msgstr "向下滚动并找到%1$s地址栏使用的搜索引擎%2$s，点击%3$s更改搜索引擎%4$s（或%5$s添加搜索引擎%6$s）"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17423,9 +17238,7 @@ msgstr ""
 msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
-msgstr ""
-"向下滚动并找到 %1$s地址栏使用的搜索引擎%2$s，点击 %3$s更改搜索引擎%4$s（或 "
-"%5$s添加搜索引擎%6$s）。"
+msgstr "向下滚动并找到 %1$s地址栏使用的搜索引擎%2$s，点击 %3$s更改搜索引擎%4$s（或 %5$s添加搜索引擎%6$s）。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -17474,7 +17287,7 @@ msgctxt ""
 "Placeholder and accessibility label for the search input in the tab picker "
 "dialog"
 msgid "Search"
-msgstr ""
+msgstr "搜索"
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -17511,10 +17324,10 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist 匿名生成搜索查询的答案。为此，该功能会扫描网络以查找相关内容，"
-"然后使用人工智能生成简短的答案。可以选择其出现的频率：从不、按需（仅在点"
-"击“Assist”时显示）、有时（仅在高度相关时显示）或经常（在更广泛的搜索中显"
-"示）。Search Assist 目前仅供部分英语地区使用。"
+"Search Assist "
+""
+"匿名生成搜索查询的答案。为此，该功能会扫描网络以查找相关内容，然后使用人工智能生成简短的答案。可以选择其出现的频率：从不、按需（仅在点击“Assist”时显示）、有时（仅在高度相关时显示）或经常（在更广泛的搜索中显示）。Search "
+"Assist 目前仅供部分英语地区使用。"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -17530,8 +17343,8 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist 是一项可选功能，可以匿名生成搜索查询的答案。为此，该功能会%1$s"
-"扫描网络%2$s以查找相关内容，然后使用人工智能根据找到的信息生成简短的答案。"
+"Search Assist "
+"是一项可选功能，可以匿名生成搜索查询的答案。为此，该功能会%1$s扫描网络%2$s以查找相关内容，然后使用人工智能根据找到的信息生成简短的答案。"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -17651,8 +17464,7 @@ msgctxt "noresults"
 msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
-msgstr ""
-"使用 %1$s 快捷键搜索其他网站：搜索“!w ducks”将直接在维基百科上搜索“ducks”。"
+msgstr "使用 %1$s 快捷键搜索其他网站：搜索“!w ducks”将直接在维基百科上搜索“ducks”。"
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -17670,9 +17482,7 @@ msgstr "匿名搜索并屏蔽跟踪程序"
 msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
-msgstr ""
-"通过我们的移动应用或扩展程序匿名搜索，或将搜索引擎加入浏览器，抑或直接打开 "
-"%1$sduckduckgo.com%2$s 发起搜索。"
+msgstr "通过我们的移动应用或扩展程序匿名搜索，或将搜索引擎加入浏览器，抑或直接打开 %1$sduckduckgo.com%2$s 发起搜索。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -17691,9 +17501,8 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"搜索设置会存储在非个人浏览器 Cookie 和浏览器的本地存储中，但也可以使用 Cloud "
-"Save 将设置匿名存储在云端的远程服务器上。系统不会在云端存储任何个人身份信息，"
-"且你的口令仅限在你的浏览器中使用。"
+"搜索设置会存储在非个人浏览器 Cookie 和浏览器的本地存储中，但也可以使用 Cloud Save "
+"将设置匿名存储在云端的远程服务器上。系统不会在云端存储任何个人身份信息，且你的口令仅限在你的浏览器中使用。"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -17795,9 +17604,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr ""
-"使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有设备"
-"访问。"
+msgstr "使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有设备访问。"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -17805,9 +17612,7 @@ msgctxt "Description for encrypted storage feature"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr ""
-"使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有设备"
-"访问。"
+msgstr "使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有设备访问。"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17815,9 +17620,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
-msgstr ""
-"使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有已同"
-"步的设备访问。"
+msgstr "使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有已同步的设备访问。"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17825,9 +17628,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
-msgstr ""
-"利用端到端加密功能将聊天记录安全地存储在我们的服务器上，并可从所有设备访问相"
-"关内容。"
+msgstr "利用端到端加密功能将聊天记录安全地存储在我们的服务器上，并可从所有设备访问相关内容。"
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -17841,9 +17642,7 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
-msgstr ""
-"采用端到端加密技术，安全存储在 DuckDuckGo 服务器上。除了你之外，没有人可以看"
-"到你的数据，甚至我们也不行。"
+msgstr "采用端到端加密技术，安全存储在 DuckDuckGo 服务器上。除了你之外，没有人可以看到你的数据，甚至我们也不行。"
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
@@ -18057,16 +17856,14 @@ msgstr "在弹出的菜单中点击 %1$s管理加载项%2$s"
 #. Tells users where in the settings menu they can change their default search engine.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
-msgstr ""
-"Mac 系统点击 %1$sOpera > 设置%2$s，Windows 系统点击 %3$s菜单 > 设置%4$s"
+msgstr "Mac 系统点击 %1$sOpera > 设置%2$s，Windows 系统点击 %3$s菜单 > 设置%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
-msgstr ""
-"Mac 系统点击 %1$sOpera > 设置%2$s，Windows 系统点击 %3$sOpera > 选项%4$s"
+msgstr "Mac 系统点击 %1$sOpera > 设置%2$s，Windows 系统点击 %3$sOpera > 选项%4$s"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -18251,9 +18048,7 @@ msgid ""
 "Sends a prompt to AI models with your messages with instructions on how to "
 "respond. These instructions will apply to all of your conversations going "
 "forward."
-msgstr ""
-"向人工智能模型发送包含你的消息的提示，并附带回复说明。这些说明将适用于你今后"
-"的所有对话。"
+msgstr "向人工智能模型发送包含你的消息的提示，并附带回复说明。这些说明将适用于你今后的所有对话。"
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -18481,9 +18276,7 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
-msgstr ""
-"与人工智能模型共享城市级位置信息，以提升相关性。Duck.ai 绝不会向我们或人工智"
-"能模型透露你的精确位置。"
+msgstr "与人工智能模型共享城市级位置信息，以提升相关性。Duck.ai 绝不会向我们或人工智能模型透露你的精确位置。"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -18578,8 +18371,7 @@ msgctxt ""
 msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
-msgstr ""
-"将您的提示和聊天回复分享给 DuckDuckGo（举报非法和有害内容时需要执行此步骤）"
+msgstr "将您的提示和聊天回复分享给 DuckDuckGo（举报非法和有害内容时需要执行此步骤）"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -18605,9 +18397,7 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Shield your online activity with our no-log, fast VPN. Simple to set up and "
 "easy to turn on and off anytime."
-msgstr ""
-"使用我们快速的无日志 VPN 来保护你的在线活动。易于设置，并且可以随时轻松开启或"
-"关闭。"
+msgstr "使用我们快速的无日志 VPN 来保护你的在线活动。易于设置，并且可以随时轻松开启或关闭。"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -18625,7 +18415,7 @@ msgstr "购买"
 #. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
 msgctxt "Button in the merchandise logo modal (mobile)"
 msgid "Shop Now"
-msgstr ""
+msgstr "立即购买"
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -18970,18 +18760,14 @@ msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
-msgstr ""
-"提醒：在 DuckDuckGo 上进行的所有搜索均为匿名搜索。关闭此功能可隐藏提醒，且不"
-"会影响搜索隐私。"
+msgstr "提醒：在 DuckDuckGo 上进行的所有搜索均为匿名搜索。关闭此功能可隐藏提醒，且不会影响搜索隐私。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
-msgstr ""
-"提醒：在 DuckDuckGo 上进行的所有搜索始终受到保护。关闭此功能可隐藏提醒，且不"
-"会影响搜索保护。"
+msgstr "提醒：在 DuckDuckGo 上进行的所有搜索始终受到保护。关闭此功能可隐藏提醒，且不会影响搜索保护。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20255,7 +20041,7 @@ msgctxt "Chat history with sync modal list item description"
 msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
-msgstr ""
+msgstr "Sync & Backup 可保存更多聊天记录，并在所有设备上同步相关记录。"
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20304,8 +20090,7 @@ msgid ""
 msgstr ""
 "同步恢复代码\n"
 "\n"
-"恢复代码允许你在多个设备之间同步密码、自动填充数据和 Duck.ai 聊天记录，并在无"
-"法访问某个设备时恢复已同步的数据。\n"
+"恢复代码允许你在多个设备之间同步密码、自动填充数据和 Duck.ai 聊天记录，并在无法访问某个设备时恢复已同步的数据。\n"
 "\n"
 "请妥善保管此信息。\n"
 "任何可访问此代码的人都可以访问你的同步数据。\n"
@@ -20317,8 +20102,7 @@ msgstr ""
 "2. 选择“开启 Sync & Backup”，然后选择“恢复同步数据”\n"
 " 3. 复制上方的恢复代码，并将其粘贴到“在此处粘贴代码”处\n"
 "\n"
-"如果你超过 18 个月未使用启用 Sync & Backup 功能的 DuckDuckGo 浏览器，你的数据"
-"将从服务器中删除且无法恢复。"
+"如果你超过 18 个月未使用启用 Sync & Backup 功能的 DuckDuckGo 浏览器，你的数据将从服务器中删除且无法恢复。"
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -20372,7 +20156,7 @@ msgstr "在所有设备上同步你的聊天记录。"
 #. Headline in sync-enabled chat history about modals explaining cross-device sync.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Sync your chats across all your devices"
-msgstr ""
+msgstr "在所有设备上同步你的聊天记录"
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -20456,9 +20240,7 @@ msgctxt "Product-tour success modal body - mobile variant"
 msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
-msgstr ""
-"随时随地使用 Duck.ai。下载内置此功能的免费应用——无论你身在何处，都能快速调"
-"用。"
+msgstr "随时随地使用 Duck.ai。下载内置此功能的免费应用——无论你身在何处，都能快速调用。"
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20466,9 +20248,7 @@ msgctxt "Product-tour success modal body"
 msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
-msgstr ""
-"随时随地使用 Duck.ai。将其内置于我们的免费浏览器中——无论你何时浏览网页，都能"
-"快速调用。"
+msgstr "随时随地使用 Duck.ai。将其内置于我们的免费浏览器中——无论你何时浏览网页，都能快速调用。"
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20711,9 +20491,7 @@ msgid ""
 "That means information sent between your device and the webpage behind this "
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
-msgstr ""
-"这意味着你与网站之间传输的信息更有可能被第三方截获，其中甚至包括你的密码和银"
-"行账号。"
+msgstr "这意味着你与网站之间传输的信息更有可能被第三方截获，其中甚至包括你的密码和银行账号。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -20829,8 +20607,7 @@ msgctxt "Error message when there was an issue saving a chat to the browser"
 msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
-msgstr ""
-"在本地保存此聊天时出现了错误。请检查你的浏览器设置以确保已启用本地数据存储。"
+msgstr "在本地保存此聊天时出现了错误。请检查你的浏览器设置以确保已启用本地数据存储。"
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -20862,9 +20639,7 @@ msgid ""
 "These browser permissions are used to add privacy protection on websites you "
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
-msgstr ""
-"所需的浏览器权限用于屏蔽网页跟踪程序、尽可能建立加密连接，并将 DuckDuckGo 设"
-"为默认搜索引擎，从而保护你的隐私。"
+msgstr "所需的浏览器权限用于屏蔽网页跟踪程序、尽可能建立加密连接，并将 DuckDuckGo 设为默认搜索引擎，从而保护你的隐私。"
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -20943,13 +20718,13 @@ msgctxt ""
 msgid ""
 "This chat and its generated images become public when you create and copy "
 "the link."
-msgstr ""
+msgstr "当您创建并复制该链接后，此聊天记录及其生成的图像将会公开。"
 
 # smartling.placeholder_format=C
 #. Explains that creating and copying a share link makes the selected chat content public.
 msgctxt "Share modal info bullet about public access"
 msgid "This chat becomes public when you create and copy the link."
-msgstr ""
+msgstr "创建并复制该链接后，此聊天记录将会公开。"
 
 # smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
@@ -20963,9 +20738,7 @@ msgctxt "Export chat feature in AI Chat"
 msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
-msgstr ""
-"此对话由 Duck.ai (%1$s) 使用 %2$s 的 %3$s 模型生成。人工智能聊天可能会显示不"
-"准确或令人反感的信息（详情请参阅%4$s）。"
+msgstr "此对话由 Duck.ai (%1$s) 使用 %2$s 的 %3$s 模型生成。人工智能聊天可能会显示不准确或令人反感的信息（详情请参阅%4$s）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20974,9 +20747,7 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using multiple chat "
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
-msgstr ""
-"此对话由 Duck.ai (%1$s) 使用多个聊天模型生成。人工智能聊天可能会显示不准确或"
-"令人反感的信息（详情请参阅%2$s）。"
+msgstr "此对话由 Duck.ai (%1$s) 使用多个聊天模型生成。人工智能聊天可能会显示不准确或令人反感的信息（详情请参阅%2$s）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20984,9 +20755,7 @@ msgctxt "Export chat feature in AI Chat"
 msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
-msgstr ""
-"这段对话通过 Duck.ai 语音聊天生成 (%1$s)。人工智能可能会提供不准确或令人反感"
-"的信息。（详情请参见 %2$s）。"
+msgstr "这段对话通过 Duck.ai 语音聊天生成 (%1$s)。人工智能可能会提供不准确或令人反感的信息。（详情请参见 %2$s）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -20996,8 +20765,8 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"此对话由 DuckDuckGo AI Chat (%1$s) 使用 %2$s 的 %3$s 模型生成。人工智能聊天可"
-"能会显示不准确或令人反感的信息（详情请参阅%4$s）。"
+"此对话由 DuckDuckGo AI Chat (%1$s) 使用 %2$s 的 %3$s "
+"模型生成。人工智能聊天可能会显示不准确或令人反感的信息（详情请参阅%4$s）。"
 
 # smartling.placeholder_format=C
 #. Renders to the right of the device name for the row that matches this device's id.
@@ -21013,9 +20782,7 @@ msgctxt ""
 msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
-msgstr ""
-"此设备将无法再访问你在其他设备上已同步的数据。最近的 %1$s 条聊天记录仍将保留"
-"在本地存储中。"
+msgstr "此设备将无法再访问你在其他设备上已同步的数据。最近的 %1$s 条聊天记录仍将保留在本地存储中。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21112,9 +20879,7 @@ msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
-msgstr ""
-"这只是一个示例聊天记录。打开其菜单（三个点），然后选择“置顶”，将其置于聊天记"
-"录顶部！"
+msgstr "这只是一个示例聊天记录。打开其菜单（三个点），然后选择“置顶”，将其置于聊天记录顶部！"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -21142,9 +20907,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
-msgstr ""
-"该模型提供商会在 30 天内删除与此聊天记录相关的数据。其他模型提供商遵循零数据"
-"保留模式。"
+msgstr "该模型提供商会在 30 天内删除与此聊天记录相关的数据。其他模型提供商遵循零数据保留模式。"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -21152,9 +20915,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
-msgstr ""
-"该模型提供商不会存储与此聊天记录相关的任何数据。其他模型提供商遵循有限的数据"
-"保留模式。"
+msgstr "该模型提供商不会存储与此聊天记录相关的任何数据。其他模型提供商遵循有限的数据保留模式。"
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -21190,9 +20951,7 @@ msgctxt "First paragraph for the Sync & Backup intro screen"
 msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
-msgstr ""
-"这将使用端到端加密技术将您的聊天记录安全地存储在 DuckDuckGo 的安全服务器上，"
-"之后可以通过任何浏览器访问这些记录。"
+msgstr "这将使用端到端加密技术将您的聊天记录安全地存储在 DuckDuckGo 的安全服务器上，之后可以通过任何浏览器访问这些记录。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21200,9 +20959,7 @@ msgctxt "duckassist"
 msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
-msgstr ""
-"此设置存储在你的浏览器中，这意味着如果清除了 duckduckgo.com 的浏览器数据，那"
-"么你可能会再次看到 AI 辅助的答案。"
+msgstr "此设置存储在你的浏览器中，这意味着如果清除了 duckduckgo.com 的浏览器数据，那么你可能会再次看到 AI 辅助的答案。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21212,9 +20969,8 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"此设置存储在你的浏览器中，这意味着如果清除了 duckduckgo.com 的浏览器数据，那"
-"么你可能会再次看到 AI 辅助的答案。不过，我们还有一个起始页，它从不在 %1$s 显"
-"示 AI 辅助答案。"
+"此设置存储在你的浏览器中，这意味着如果清除了 duckduckgo.com 的浏览器数据，那么你可能会再次看到 AI "
+"辅助的答案。不过，我们还有一个起始页，它从不在 %1$s 显示 AI 辅助答案。"
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
@@ -21265,8 +21021,8 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"这将删除你在此浏览器中的所有 Duck.ai 聊天记录，并断开 Sync & Backup 连接。你"
-"仍然可以在连接到 Sync & Backup 的其他浏览器中浏览你的聊天记录。"
+"这将删除你在此浏览器中的所有 Duck.ai 聊天记录，并断开 Sync & Backup 连接。你仍然可以在连接到 Sync & Backup "
+"的其他浏览器中浏览你的聊天记录。"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -21411,8 +21167,7 @@ msgctxt "directions"
 msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
-msgstr ""
-"打印路线具体操作：%1$s返回地图。%2$s选择要打印的路线。%3$s点击打印图标。%4$s"
+msgstr "打印路线具体操作：%1$s返回地图。%2$s选择要打印的路线。%3$s点击打印图标。%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -21421,9 +21176,7 @@ msgid ""
 "To restore your synced data, you'll need the Recovery Code you saved when "
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
-msgstr ""
-"需要使用首次设置同步时保存的恢复代码来还原已同步的数据。此代码可能已以 PDF 格"
-"式保存到最初用于设置同步的设备上。"
+msgstr "需要使用首次设置同步时保存的恢复代码来还原已同步的数据。此代码可能已以 PDF 格式保存到最初用于设置同步的设备上。"
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -21431,9 +21184,7 @@ msgctxt "duckai_migration"
 msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
-msgstr ""
-"如需将聊天记录转移到 Duck.ai，请先将 DuckDuckGo 浏览器升级至最新版本，然后再"
-"试一次。"
+msgstr "如需将聊天记录转移到 Duck.ai，请先将 DuckDuckGo 浏览器升级至最新版本，然后再试一次。"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -21462,7 +21213,7 @@ msgstr "今天"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
-msgstr ""
+msgstr "切换至私密 AI 聊天，或%1$s在设置中禁用%2$s。"
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -21641,8 +21392,7 @@ msgctxt "tracker_stats"
 msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
-msgstr ""
-"此处将显示被 DuckDuckGo 阻止的跟踪企图。继续浏览以查看我们阻止了多少次。"
+msgstr "此处将显示被 DuckDuckGo 阻止的跟踪企图。继续浏览以查看我们阻止了多少次。"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -22174,9 +21924,7 @@ msgctxt "settings"
 msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
-msgstr ""
-"想要禁用 AI 功能？安装 %1$sDuckDuckGo No AI%2$s 搜索扩展程序，以便记住你的设"
-"置。%3$s了解详情%4$s"
+msgstr "想要禁用 AI 功能？安装 %1$sDuckDuckGo No AI%2$s 搜索扩展程序，以便记住你的设置。%3$s了解详情%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -22184,9 +21932,7 @@ msgctxt "settings"
 msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
-msgstr ""
-"想要禁用 AI 功能？切换到 %1$sDuckDuckGo No AI%2$s 搜索扩展程序，以便记住你的"
-"设置。%3$s了解详情%4$s"
+msgstr "想要禁用 AI 功能？切换到 %1$sDuckDuckGo No AI%2$s 搜索扩展程序，以便记住你的设置。%3$s了解详情%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -22386,9 +22132,7 @@ msgctxt "settings"
 msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
-msgstr ""
-"在生成 DuckAssist 答案时键入相关内容。关闭此功能可能会导致搜索与显示答案之间"
-"出现短暂的延迟。"
+msgstr "在生成 DuckAssist 答案时键入相关内容。关闭此功能可能会导致搜索与显示答案之间出现短暂的延迟。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -22517,16 +22261,14 @@ msgstr "了解优点和缺点"
 msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
-msgstr ""
-"在%1$s启动时%2$s下，点击%3$s打开特定页面%4$s，然后点击 %5$s设置页面%6$s。"
+msgstr "在%1$s启动时%2$s下，点击%3$s打开特定页面%4$s，然后点击 %5$s设置页面%6$s。"
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
-msgstr ""
-"在%1$s启动时%2$s下，选择%3$s主页%4$s并将主页设为 https://duckduckgo.com"
+msgstr "在%1$s启动时%2$s下，选择%3$s主页%4$s并将主页设为 https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -22641,9 +22383,7 @@ msgctxt "Description of the modal to upgrade to Pro"
 msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
-msgstr ""
-"升级至 Pro 计划，即可解锁 %1$s、更强大的 AI 推理能力，以及比 Plus 计划高 2 倍"
-"的使用限额。"
+msgstr "升级至 Pro 计划，即可解锁 %1$s、更强大的 AI 推理能力，以及比 Plus 计划高 2 倍的使用限额。"
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -23025,9 +22765,7 @@ msgctxt "duckai_seo"
 msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
-msgstr ""
-"私密地使用 ChatGPT、Claude 和其他人工智能工具。保护聊天内容免受黑客、骗子和公"
-"司的侵害。确保信息保密。免费。无需账户。"
+msgstr "私密地使用 ChatGPT、Claude 和其他人工智能工具。保护聊天内容免受黑客、骗子和公司的侵害。确保信息保密。免费。无需账户。"
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -23245,8 +22983,7 @@ msgctxt "Single Place Hotel Offers Module"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
-msgstr ""
-"DuckDuckGo 会保护观看广告的隐私。广告点击量由 TripAdvisor 广告网络管理。"
+msgstr "DuckDuckGo 会保护观看广告的隐私。广告点击量由 TripAdvisor 广告网络管理。"
 
 # smartling.placeholder_format=C
 #. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
@@ -23254,7 +22991,7 @@ msgctxt "Ads GDPR"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Yelp's ad network."
-msgstr ""
+msgstr "DuckDuckGo 会保护观看广告的隐私。广告点击量由 Yelp 广告网络管理。"
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -23296,8 +23033,8 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"在您的另一个浏览器中访问 Duck.ai，然后前往 %1$sDuck.ai 设置%2$s > %3$sSync & "
-"Backup%4$s > %5$s管理%6$s，然后选择%7$s与另一台设备同步%8$s。"
+"在您的另一个浏览器中访问 Duck.ai，然后前往 %1$sDuck.ai 设置%2$s > %3$sSync & Backup%4$s > "
+"%5$s管理%6$s，然后选择%7$s与另一台设备同步%8$s。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23307,8 +23044,8 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"在其他浏览器中访问 Duck.ai 并打开 Duck.ai 设置。在 Sync & Backup 栏下选择“开"
-"启”，然后选择“与其他设备同步”。或者扫描恢复 PDF 中的二维码。"
+"在其他浏览器中访问 Duck.ai 并打开 Duck.ai 设置。在 Sync & Backup "
+"栏下选择“开启”，然后选择“与其他设备同步”。或者扫描恢复 PDF 中的二维码。"
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -23318,9 +23055,8 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"在另一个浏览器或 DuckDuckGo 应用程序中访问 Duck.ai，然后前往“%1$sDuck.ai 设"
-"置%2$s > %3$sSync & Backup%4$s > %5$s管理%6$s”，然后选择“%7$s与其他设备同"
-"步%8$s”。"
+"在另一个浏览器或 DuckDuckGo 应用程序中访问 Duck.ai，然后前往“%1$sDuck.ai 设置%2$s > %3$sSync & "
+"Backup%4$s > %5$s管理%6$s”，然后选择“%7$s与其他设备同步%8$s”。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23330,9 +23066,8 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"在另一个浏览器或 DuckDuckGo 应用程序中访问 Duck.ai，然后打开 Duck.ai 设置。"
-"在 Sync & Backup 栏下选择“开启”，然后选择“与其他设备同步”。或者扫描恢复 PDF "
-"中的二维码。"
+"在另一个浏览器或 DuckDuckGo 应用程序中访问 Duck.ai，然后打开 Duck.ai 设置。在 Sync & Backup "
+"栏下选择“开启”，然后选择“与其他设备同步”。或者扫描恢复 PDF 中的二维码。"
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23527,9 +23262,7 @@ msgstr "在 Duck Player 中观看"
 msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
-msgstr ""
-"在 Duck Player 中观看，以屏蔽 YouTube 上的个性化广告，并防止你的观看活动影响 "
-"YouTube 推荐。"
+msgstr "在 Duck Player 中观看，以屏蔽 YouTube 上的个性化广告，并防止你的观看活动影响 YouTube 推荐。"
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -23549,8 +23282,8 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"在此处观看视频意味着其托管网站可以跟踪你，因为我们必须从该网站流式传输内容。"
-"DuckDuckGo 是一家独立公司，与托管大多数视频的 YouTube 没有任何关系。"
+"在此处观看视频意味着其托管网站可以跟踪你，因为我们必须从该网站流式传输内容。DuckDuckGo 是一家独立公司，与托管大多数视频的 YouTube "
+"没有任何关系。"
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -23573,9 +23306,7 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
-msgstr ""
-"我们只能处理我们看得到的问题。要举报有害或非法的回复，请分享此对话给 "
-"DuckDuckGo，这样我们才能调查并处理这个问题。"
+msgstr "我们只能处理我们看得到的问题。要举报有害或非法的回复，请分享此对话给 DuckDuckGo，这样我们才能调查并处理这个问题。"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -23586,9 +23317,7 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share your prompt and response so we can investigate and address the "
 "issue."
-msgstr ""
-"我们只能处理我们看得到的问题。要举报有害或非法的回复，请先分享您的提示词和回"
-"复，这样我们才能调查并处理这个问题。"
+msgstr "我们只能处理我们看得到的问题。要举报有害或非法的回复，请先分享您的提示词和回复，这样我们才能调查并处理这个问题。"
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
@@ -23641,9 +23370,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr ""
-"我们想请你聊聊是什么让你继续使用 DuckDuckGo，你所写和浏览的一切将不会被我们跟"
-"踪："
+msgstr "我们想请你聊聊是什么让你继续使用 DuckDuckGo，你所写和浏览的一切将不会被我们跟踪："
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -23651,9 +23378,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
-msgstr ""
-"我们想请你聊聊是什么让你信任并使用 DuckDuckGo，你所写和浏览的一切将不会被我们"
-"跟踪："
+msgstr "我们想请你聊聊是什么让你信任并使用 DuckDuckGo，你所写和浏览的一切将不会被我们跟踪："
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23717,8 +23442,7 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
-msgstr ""
-"我们会从数据中介网站查找并删除你的个人信息。此外，还可以获取 VPN 及更多功能。"
+msgstr "我们会从数据中介网站查找并删除你的个人信息。此外，还可以获取 VPN 及更多功能。"
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -23758,8 +23482,7 @@ msgctxt "precise_user_location"
 msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
-msgstr ""
-"匿名定位仅用于为你提供更近、更优质的搜索结果，将来你也可以随时选择关闭。"
+msgstr "匿名定位仅用于为你提供更近、更优质的搜索结果，将来你也可以随时选择关闭。"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
@@ -23767,9 +23490,7 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
-msgstr ""
-"我们会定期在数据中介网站上扫描你的个人信息，并通过易于使用的仪表板与你共享我"
-"们的进度。"
+msgstr "我们会定期在数据中介网站上扫描你的个人信息，并通过易于使用的仪表板与你共享我们的进度。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -23795,9 +23516,7 @@ msgid ""
 "We use feedback like this to improve DuckDuckGo. Suggestions will be "
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
-msgstr ""
-"你的反馈意见能帮助我们改进 DuckDuckGo。%1$s 将酌情采纳你的建议，但搜索结果更"
-"正可能需要一段时间。"
+msgstr "你的反馈意见能帮助我们改进 DuckDuckGo。%1$s 将酌情采纳你的建议，但搜索结果更正可能需要一段时间。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23810,9 +23529,7 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
-msgstr ""
-"我们会在数据中介网站上扫描你的电子邮件、姓名、地址等信息，并努力删除找到的有"
-"关你的任何信息。"
+msgstr "我们会在数据中介网站上扫描你的电子邮件、姓名、地址等信息，并努力删除找到的有关你的任何信息。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23820,8 +23537,7 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
-msgstr ""
-"我们了解这个问题，目前正在努力解决。如果你继续看到此错误，请联系 %1$s。"
+msgstr "我们了解这个问题，目前正在努力解决。如果你继续看到此错误，请联系 %1$s。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -23829,8 +23545,7 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. Sometimes "
 "clearing your browser's cache can help."
-msgstr ""
-"我们了解这个问题，目前正在努力解决。有时候，清除浏览器的缓存可能会有帮助。"
+msgstr "我们了解这个问题，目前正在努力解决。有时候，清除浏览器的缓存可能会有帮助。"
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -23973,9 +23688,7 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
-msgstr ""
-"欢迎使用 Duck.ai！此处所有聊天内容均为私密，我们已对其进行匿名化处理，不会用"
-"于训练人工智能模型。"
+msgstr "欢迎使用 Duck.ai！此处所有聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -23983,9 +23696,7 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
-msgstr ""
-"欢迎使用 DuckDuckGo AI Chat！此处所有聊天内容均为私密，我们已对其进行匿名化处"
-"理，不会用于训练人工智能模型。"
+msgstr "欢迎使用 DuckDuckGo AI Chat！此处所有聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -23995,8 +23706,8 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"欢迎使用 DuckDuckGo AI Chat！此聊天会话由 %1$s 的 %2$s 提供支持。此处所有聊天"
-"内容均为私密，DuckDuckGo 绝不会存储或用于训练 AI 模型。"
+"欢迎使用 DuckDuckGo AI Chat！此聊天会话由 %1$s 的 %2$s 提供支持。此处所有聊天内容均为私密，DuckDuckGo "
+"绝不会存储或用于训练 AI 模型。"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24128,9 +23839,8 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"对于有兴趣使用 Duck.ai 的人来说，下载 DuckDuckGo 浏览器有哪些好处？仅参考官"
-"方 DuckDuckGo 来源。将响应分为清晰的部分，标题聚焦于 Duck.ai 集成和隐私保护。"
-"保持内容简短、简单，易于理解，适合有或没有太多人工智能或技术经验的人。"
+"对于有兴趣使用 Duck.ai 的人来说，下载 DuckDuckGo 浏览器有哪些好处？仅参考官方 DuckDuckGo "
+"来源。将响应分为清晰的部分，标题聚焦于 Duck.ai 集成和隐私保护。保持内容简短、简单，易于理解，适合有或没有太多人工智能或技术经验的人。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24665,9 +24375,7 @@ msgctxt "new tab page"
 msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
-msgstr ""
-"使用 Duck.ai，你的聊天内容均已匿名处理，且绝不会用于训练 AI。 可以随时"
-"在“%1$s”菜单中开启或关闭。"
+msgstr "使用 Duck.ai，你的聊天内容均已匿名处理，且绝不会用于训练 AI。 可以随时在“%1$s”菜单中开启或关闭。"
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
@@ -24675,14 +24383,14 @@ msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, up to %s of your most recent chats will be saved on "
 "this device."
-msgstr ""
+msgstr "启用聊天记录后，此设备最多可以保存 %1$s 条最新聊天记录。"
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline in the About Chat History modal.
 msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, your most recent chats will be saved on this device."
-msgstr ""
+msgstr "启用聊天记录后，最新聊天记录将保存在此设备上。"
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24971,8 +24679,7 @@ msgctxt "noresults"
 msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
-msgstr ""
-"可以%1$s或使用 %2$s 搜索快捷键从 DuckDuckGo 在其他搜索引擎上直接进行搜索。"
+msgstr "可以%1$s或使用 %2$s 搜索快捷键从 DuckDuckGo 在其他搜索引擎上直接进行搜索。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -25016,8 +24723,7 @@ msgstr "您最多可以附加 %1$s 个文本选中内容。"
 msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
-msgstr ""
-"可以在%1$s搜索设置%2$s中更改显示 Search Assist 的频率，或者将其完全关闭。"
+msgstr "可以在%1$s搜索设置%2$s中更改显示 Search Assist 的频率，或者将其完全关闭。"
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -25192,9 +24898,7 @@ msgctxt "Description of the post-upgrade success modal"
 msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
-msgstr ""
-"你现在可以享用 %1$s、更强大的人工智能推理能力以及比 Plus 计划高 2 倍的使用限"
-"额。"
+msgstr "你现在可以享用 %1$s、更强大的人工智能推理能力以及比 Plus 计划高 2 倍的使用限额。"
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -25202,9 +24906,7 @@ msgctxt "Description text for the subscription welcome modal"
 msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
-msgstr ""
-"现在可以使用高级人工智能模型。可以在 DuckDuckGo 浏览器中使用 VPN 和其他 "
-"DuckDuckGo 订阅保护功能。"
+msgstr "现在可以使用高级人工智能模型。可以在 DuckDuckGo 浏览器中使用 VPN 和其他 DuckDuckGo 订阅保护功能。"
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -25225,9 +24927,7 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr ""
-"你将无法再通过此浏览器访问已保存的聊天记录。最近 30 条聊天记录仍将保留在本地"
-"存储中。这不会从加密服务器中删除你的聊天记录。"
+msgstr "你将无法再通过此浏览器访问已保存的聊天记录。最近 30 条聊天记录仍将保留在本地存储中。这不会从加密服务器中删除你的聊天记录。"
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -25236,9 +24936,7 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr ""
-"你将无法再通过此浏览器访问已保存的聊天记录。最近 30 条聊天记录仍将保留在本地"
-"存储中。这不会从加密服务器中删除你的聊天记录。"
+msgstr "你将无法再通过此浏览器访问已保存的聊天记录。最近 30 条聊天记录仍将保留在本地存储中。这不会从加密服务器中删除你的聊天记录。"
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -25265,9 +24963,7 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
-msgstr ""
-"现在使用 Chrome 搜索再也不用担心泄露隐私了。与 Chrome 相比，使用我们已经安装"
-"的 App 上网还能进一步保护隐私，它可以："
+msgstr "现在使用 Chrome 搜索再也不用担心泄露隐私了。与 Chrome 相比，使用我们已经安装的 App 上网还能进一步保护隐私，它可以："
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -25355,8 +25051,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"包含附件的 Duck.ai 聊天记录的 Sync & Backup 存储空间已经用完。删除最早的 "
-"%1$s 条聊天记录以恢复同步。置顶的聊天记录不会被删除。"
+"包含附件的 Duck.ai 聊天记录的 Sync & Backup 存储空间已经用完。删除最早的 %1$s "
+"条聊天记录以恢复同步。置顶的聊天记录不会被删除。"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25366,8 +25062,8 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"您已经用完 Duck.ai 聊天记录的 Sync & Backup 存储空间。删除最早的 %1$s 条包含"
-"附件的聊天记录，以恢复同步功能。置顶的聊天记录不会被删除。"
+"您已经用完 Duck.ai 聊天记录的 Sync & Backup 存储空间。删除最早的 %1$s "
+"条包含附件的聊天记录，以恢复同步功能。置顶的聊天记录不会被删除。"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -25380,9 +25076,7 @@ msgstr "你已用尽存储空间"
 msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
-msgstr ""
-"Google 旗下的 YouTube 不允许匿名观看视频，因此在这里观看 YouTube 视频仍会被 "
-"Google 与 YouTube 跟踪。"
+msgstr "Google 旗下的 YouTube 不允许匿名观看视频，因此在这里观看 YouTube 视频仍会被 Google 与 YouTube 跟踪。"
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -25450,9 +25144,7 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
-msgstr ""
-"系统将从 DuckDuckGo 服务器中删除你的备份。所有设备都会断开同步连接。在以下浏"
-"览器中，你最近的 %1$s 条聊天记录将保存在本地存储中："
+msgstr "系统将从 DuckDuckGo 服务器中删除你的备份。所有设备都会断开同步连接。在以下浏览器中，你最近的 %1$s 条聊天记录将保存在本地存储中："
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -25461,9 +25153,7 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
-msgstr ""
-"系统将从 DuckDuckGo 服务器中删除你的备份。所有设备都会断开同步连接。在以下浏"
-"览器中，你最近的 100 条聊天记录将保存在本地存储中："
+msgstr "系统将从 DuckDuckGo 服务器中删除你的备份。所有设备都会断开同步连接。在以下浏览器中，你最近的 100 条聊天记录将保存在本地存储中："
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -25502,8 +25192,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"你与 %1$s 的聊天内容将保密。人工智能聊天可能会显示不准确或令人反感的信息。"
+msgstr "你与 %1$s 的聊天内容将保密。人工智能聊天可能会显示不准确或令人反感的信息。"
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -25528,16 +25217,14 @@ msgstr "你的聊天内容均为私密，绝不会用于训练人工智能模型
 msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"你的聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
+msgstr "你的聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
 msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"你的聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
+msgstr "你的聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -25565,9 +25252,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
-msgstr ""
-"聊天记录仍会保持私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。请"
-"按照以下步骤保留聊天记录。"
+msgstr "聊天记录仍会保持私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。请按照以下步骤保留聊天记录。"
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -25606,9 +25291,7 @@ msgctxt "newsletter email collection"
 msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
-msgstr ""
-"我们绝不会透露你的电子邮件地址，%1$s或把它与匿名搜索关联。[%2$sExample "
-"message%3$s]"
+msgstr "我们绝不会透露你的电子邮件地址，%1$s或把它与匿名搜索关联。[%2$sExample message%3$s]"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -25651,9 +25334,8 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"我们采用一种名为 %1$sSHA-2%2$s 的安全散列算法将你的口令不可逆地映射到一个 "
-"512 位的密钥，浏览器仅发送这一密钥和你要保存的设置，以便我们将收到的设置与密"
-"钥相关联。因此，DuckDuckGo 不可能得知你使用的口令。"
+"我们采用一种名为 %1$sSHA-2%2$s 的安全散列算法将你的口令不可逆地映射到一个 512 "
+"位的密钥，浏览器仅发送这一密钥和你要保存的设置，以便我们将收到的设置与密钥相关联。因此，DuckDuckGo 不可能得知你使用的口令。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25667,9 +25349,7 @@ msgid ""
 "Your prompts are relayed through DuckDuckGo servers and stripped of "
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
-msgstr ""
-"你的提示词会经由 DuckDuckGo 服务器中转，并剥离个人身份元数据，因此模型提供商"
-"无法将对话内容与你本人关联起来。"
+msgstr "你的提示词会经由 DuckDuckGo 服务器中转，并剥离个人身份元数据，因此模型提供商无法将对话内容与你本人关联起来。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25713,9 +25393,7 @@ msgctxt "settings"
 msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
-msgstr ""
-"已保存你的设置，但清理浏览器 Cookie 会将其重置。启用 %1$sDuckDuckGo No "
-"AI%2$s 扩展插件，以便永久保存你的设置。"
+msgstr "已保存你的设置，但清理浏览器 Cookie 会将其重置。启用 %1$sDuckDuckGo No AI%2$s 扩展插件，以便永久保存你的设置。"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25724,8 +25402,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"已保存你的设置，但清理浏览器 Cookie 会将其重置。安装 %1$sDuckDuckGo No "
-"AI%2$s 扩展插件，以便永久保存你的设置。%3$s了解详情%4$s"
+"已保存你的设置，但清理浏览器 Cookie 会将其重置。安装 %1$sDuckDuckGo No AI%2$s "
+"扩展插件，以便永久保存你的设置。%3$s了解详情%4$s"
 
 # smartling.placeholder_format=C
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
@@ -25744,9 +25422,7 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
-msgstr ""
-"你现在正在使用 Chrome 进行私密搜索。不妨使用我们的浏览器代替 Chrome，以获得更"
-"多保护。已安装该浏览器并可以："
+msgstr "你现在正在使用 Chrome 进行私密搜索。不妨使用我们的浏览器代替 Chrome，以获得更多保护。已安装该浏览器并可以："
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -26018,7 +25694,7 @@ msgstr "分钟"
 #. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the chat options menu button"
 msgid "menu"
-msgstr ""
+msgstr "菜单"
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/zh_TW/LC_MESSAGES/duckduckgo.po
+++ b/locales/zh_TW/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: zh_TW\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1185,6 +1185,12 @@ msgid "About our ads"
 msgstr "關於我們的廣告"
 
 # smartling.placeholder_format=C
+#. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
+msgctxt "Modal header for chat history with sync information"
+msgid "About Chat History with Sync & Backup"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
 msgctxt "settingsvalue"
 msgid "Above Title"
@@ -1308,6 +1314,20 @@ msgid "Ad is suspicious"
 msgstr "此廣告有可疑"
 
 # smartling.placeholder_format=C
+#. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
+msgctxt "Button to open menu for attaching images or page context to AI chat"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
+msgctxt ""
+"Primary button that attaches the tabs the user checked in the tab picker "
+"dialog"
+msgid "Add"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
 msgid "Add DuckDuckGo"
 msgstr "新增DuckDuckGo"
@@ -1332,6 +1352,27 @@ msgstr "新增DuckDuckGo作為搜尋引擎"
 #. Link to add the DuckDuckGo extension to the user's web browser. The placeholder is the name of the browser the user is currently using. For example: 'Add DuckDuckGo to Chrome'
 msgid "Add DuckDuckGo to %s"
 msgstr "將DuckDuckGo新增至%1$s"
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only PDF file upload is supported in the Duck.ai chat.
+msgctxt ""
+"Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
+msgid "Add File"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
+msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
+msgid "Add Image"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
+msgctxt ""
+"Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
+"item)"
+msgid "Add Image or File"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1377,6 +1418,22 @@ msgctxt ""
 "CTA button and icon toggle tooltip)"
 msgid "Add Page Content"
 msgstr "新增頁面內容"
+
+# smartling.placeholder_format=C
+#. Title-case label for the tab-picker option in the attach dropdown menu.
+msgctxt ""
+"Open the tab picker to attach browser tab content to the AI chat message "
+"(attach dropdown menu item)"
+msgid "Add Tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
+msgctxt ""
+"Title and accessible name of the tab-picker dialog opened from the attach "
+"dropdown menu"
+msgid "Add Tabs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1462,6 +1519,12 @@ msgstr "附加元件"
 msgctxt "Loading state message"
 msgid "Adding finishing touches"
 msgstr "進行最後的潤飾"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
+msgctxt "Aria label for the additional instructions textarea"
+msgid "Additional instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1759,6 +1822,12 @@ msgstr "所有顏色"
 msgctxt "Title for the host-device success screen"
 msgid "All done!"
 msgstr "全部完成！"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the read-only textarea listing all AI instructions"
+msgid "All instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -3428,6 +3497,14 @@ msgid "Cancel"
 msgstr "取消"
 
 # smartling.placeholder_format=C
+#. Discards any tabs the user checked in the tab picker dialog and closes it, leaving existing attachments untouched.
+msgctxt ""
+"Secondary button that dismisses the tab picker dialog without attaching "
+"anything"
+msgid "Cancel"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
 msgctxt "Site filter message"
 msgid "Cancel"
@@ -3914,10 +3991,22 @@ msgid "Chat response is offensive"
 msgstr "聊天回覆令人反感"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
+msgctxt "Chat history about modal list item headline"
+msgid "Chat storage varies by browser"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
 msgctxt "Placeholder text user’s chat input"
 msgid "Chat with %s"
 msgstr "與 %1$s 聊天"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Chat with popular AI models, anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -3936,6 +4025,14 @@ msgstr "聊天"
 msgctxt "Title for the chats section on the sidebar"
 msgid "Chats"
 msgstr "聊天"
+
+# smartling.placeholder_format=C
+#. Supporting copy under the end-to-end encryption headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
+"Nobody but you can see your data, not even us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5499,6 +5596,12 @@ msgid "Current Streak"
 msgstr "目前連勝 / 連敗"
 
 # smartling.placeholder_format=C
+#. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
+msgctxt "Suffix label indicating a tab is the currently active browser tab"
+msgid "Current Tab"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
 msgctxt "Menu item to attach current tab page context to AI chat"
 msgid "Current Tab Content"
@@ -5843,6 +5946,12 @@ msgstr "刪除聊天記錄"
 msgctxt "Sync limit modal button"
 msgid "Delete Chats Older Than 30 Days"
 msgstr "刪除超過 30 天的聊天記錄"
+
+# smartling.placeholder_format=C
+#. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
+msgctxt "Button text in the modal for deleting all recent chats"
+msgid "Delete Chats and Shared Links"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6253,6 +6362,12 @@ msgstr "知道了，不用再提醒"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "關閉促銷廣告"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the close button on the survey banner"
+msgid "Dismiss survey"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -7375,6 +7490,12 @@ msgid "Edit Prompt"
 msgstr "編輯提示"
 
 # smartling.placeholder_format=C
+#. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the message-editing text area"
+msgid "Edit message"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
@@ -7591,6 +7712,12 @@ msgctxt ""
 "encrypted inference models"
 msgid "Encrypted model"
 msgstr "加密模型"
+
+# smartling.placeholder_format=C
+#. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
+msgctxt "Share modal info bullet about encryption"
+msgid "Encrypted so DuckDuckGo can't read your chat."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8406,6 +8533,12 @@ msgid "Follow-up question"
 msgstr "後續問題"
 
 # smartling.placeholder_format=C
+#. Explains that messages added after the shared copy remain private to the person continuing the chat.
+msgctxt "Share modal info bullet about private original chat"
+msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -8915,6 +9048,12 @@ msgstr ""
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr "取得 DuckDuckGo VPN、先進的 Duck.ai 以及 Identity Theft Restoration。"
+
+# smartling.placeholder_format=C
+#. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
+msgctxt "Tooltip on the header logo for sunglasses searches"
+msgid "Get DuckDuckGo sunglasses and other gear."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -10125,6 +10264,12 @@ msgstr "如何保持匿名？"
 #. Link text in the dictation settings section that opens the dictation privacy info modal.
 msgid "How it works"
 msgstr "如何運作"
+
+# smartling.placeholder_format=C
+#. Headline in chat history about modals for the temporary encrypted server storage explanation.
+msgctxt "Chat history about modal list item headline"
+msgid "How it works"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -11545,6 +11690,12 @@ msgstr "邊線爭球成功次數"
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
 msgstr "連結會在 7 天後到期。"
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days. People can save a chat copy."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13659,6 +13810,12 @@ msgid "OK, got it!"
 msgstr "好，瞭解！"
 
 # smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "OPTIONAL"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Separator label between actions.
 msgctxt "duckai_migration"
 msgid "OR"
@@ -15748,6 +15905,12 @@ msgid "Protected"
 msgstr "受到保護"
 
 # smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining encrypted server storage.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Protected with end-to-end encryption"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
 msgid "Protection. Privacy. Peace of mind."
 msgstr "防護。隱私。安心。"
@@ -15877,6 +16040,12 @@ msgstr "雨"
 msgctxt "Sports module"
 msgid "Rankings"
 msgstr "排名"
+
+# smartling.placeholder_format=C
+#. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
+msgctxt "star rating on a product"
+msgid "Rated %s out of %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -17089,6 +17258,12 @@ msgid "Save your chats across all your devices."
 msgstr "將你的聊天記錄儲存到所有裝置上。"
 
 # smartling.placeholder_format=C
+#. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
+msgctxt "Chat history about modal list item headline"
+msgid "Save your chats on this device"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
 msgctxt "Chat history about modal list item"
 msgid "Save your most recent chats."
@@ -17283,6 +17458,14 @@ msgstr "搜尋"
 msgctxt "Label for button to force web search in Duck.ai"
 msgid "Search"
 msgstr "搜尋"
+
+# smartling.placeholder_format=C
+#. Placeholder text and accessibility label for the search field that filters the list of open browser tabs in the tab picker dialog.
+msgctxt ""
+"Placeholder and accessibility label for the search input in the tab picker "
+"dialog"
+msgid "Search"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -18424,6 +18607,12 @@ msgstr "Shift+Enter"
 msgctxt "merchant promotion product ad extension"
 msgid "Shop"
 msgstr "購物"
+
+# smartling.placeholder_format=C
+#. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
+msgctxt "Button in the merchandise logo modal (mobile)"
+msgid "Shop Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -20048,6 +20237,14 @@ msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr "Sync & Backup 資料無活動 18 個月後將無法恢復。"
 
 # smartling.placeholder_format=C
+#. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
+msgctxt "Chat history with sync modal list item description"
+msgid ""
+"Sync & Backup saves more of your chats and syncs them across all of your "
+"devices."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
 msgctxt "Action that opens the pairing flow from inside Manage"
 msgid "Sync Another Device"
@@ -20155,6 +20352,12 @@ msgstr "與附近裝置同步。"
 msgctxt "Chat history with sync modal list item"
 msgid "Sync your chats across all of your devices."
 msgstr "將你的聊天記錄同步到所有裝置。"
+
+# smartling.placeholder_format=C
+#. Headline in sync-enabled chat history about modals explaining cross-device sync.
+msgctxt "Chat history with sync modal list item headline"
+msgid "Sync your chats across all your devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -20718,6 +20921,22 @@ msgid "This Week"
 msgstr "本週"
 
 # smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes both the selected chat content and its generated images public.
+msgctxt ""
+"Share modal info bullet about public access when generated images are "
+"included"
+msgid ""
+"This chat and its generated images become public when you create and copy "
+"the link."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that creating and copying a share link makes the selected chat content public.
+msgctxt "Share modal info bullet about public access"
+msgid "This chat becomes public when you create and copy the link."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
@@ -21224,6 +21443,12 @@ msgstr "今天"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "今天"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Toggle to private AI chat or %sdisable in settings%s."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -23011,6 +23236,14 @@ msgstr ""
 "理。"
 
 # smartling.placeholder_format=C
+#. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
+msgctxt "Ads GDPR"
+msgid ""
+"Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
+"Yelp's ad network."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Virgin Islands"
 msgstr "維京群島"
 
@@ -24424,6 +24657,21 @@ msgstr ""
 "在「%1$s」選單中將其開啟或關閉。"
 
 # smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, up to %s of your most recent chats will be saved on "
+"this device."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Supporting copy under the save-on-device headline in the About Chat History modal.
+msgctxt "Chat history about modal list item description"
+msgid ""
+"With chat history on, your most recent chats will be saved on this device."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -25752,6 +26000,12 @@ msgstr "分"
 msgctxt "published date for videos"
 msgid "m"
 msgstr "分"
+
+# smartling.placeholder_format=C
+#. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
+msgctxt "Aria label for the chat options menu button"
+msgid "menu"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.

--- a/locales/zh_TW/LC_MESSAGES/duckduckgo.po
+++ b/locales/zh_TW/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: zh_TW\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -189,9 +189,7 @@ msgctxt "Error message when a Plus subscriber tries to use a Pro-only model"
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr ""
-"%1$s 只適用於 Pro。在此瀏覽器中再次升級你的 DuckDuckGo 訂閱以繼續聊天，或切換"
-"至 Plus 或免費模式。"
+msgstr "%1$s 只適用於 Pro。在此瀏覽器中再次升級你的 DuckDuckGo 訂閱以繼續聊天，或切換至 Plus 或免費模式。"
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -200,9 +198,7 @@ msgctxt ""
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr ""
-"%1$s 只適用於 Pro。請在此瀏覽器中再次升級你的 DuckDuckGo 訂閱以繼續聊天，或切"
-"換至 Plus 或免費模式。"
+msgstr "%1$s 只適用於 Pro。請在此瀏覽器中再次升級你的 DuckDuckGo 訂閱以繼續聊天，或切換至 Plus 或免費模式。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -217,9 +213,7 @@ msgid ""
 "%s is only available with a DuckDuckGo subscription. Activate your "
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
-msgstr ""
-"%1$s 只有訂閱 DuckDuckGo 才能使用。在此瀏覽器中再次啟用你的訂閱以繼續聊天，或"
-"切換至免費模式。"
+msgstr "%1$s 只有訂閱 DuckDuckGo 才能使用。在此瀏覽器中再次啟用你的訂閱以繼續聊天，或切換至免費模式。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -324,8 +318,8 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$s 運行於受信任執行環境（Trusted Execution Environment）。這表示即使是模型"
-"提供商也無法看到您的提示或模型的回應，也不會在其伺服器上儲存此聊天。"
+"%1$s 運行於受信任執行環境（Trusted Execution "
+"Environment）。這表示即使是模型提供商也無法看到您的提示或模型的回應，也不會在其伺服器上儲存此聊天。"
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -410,8 +404,7 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
-msgstr ""
-"%1$s 將在 %2$s 天後離開 Duck.ai (%3$s)。之後，您可以切換模型以繼續此聊天。"
+msgstr "%1$s 將在 %2$s 天後離開 Duck.ai (%3$s)。之後，您可以切換模型以繼續此聊天。"
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -421,8 +414,7 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
-msgstr ""
-"%1$s 將在 1 天後 (%2$s) 離開 Duck.ai。之後，您可以切換模型以繼續此聊天。"
+msgstr "%1$s 將在 1 天後 (%2$s) 離開 Duck.ai。之後，您可以切換模型以繼續此聊天。"
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -450,8 +442,7 @@ msgctxt "install-duckduckgo"
 msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
-msgstr ""
-"%1$s按%2$s繼續安裝%3$s按%4$s新增%5$s勾選%6$s允許%7$s，然後按%8$s確定%9$s"
+msgstr "%1$s按%2$s繼續安裝%3$s按%4$s新增%5$s勾選%6$s允許%7$s，然後按%8$s確定%9$s"
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -920,8 +911,7 @@ msgstr "客場戰績"
 msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
-msgstr ""
-"網路問題導致 Search Assist 無法生成答案。請檢查你的連線，接著再試一次。"
+msgstr "網路問題導致 Search Assist 無法生成答案。請檢查你的連線，接著再試一次。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
@@ -979,9 +969,8 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"AI Chat 能讓您與第三方 AI Chat 模型匿名對話。關閉此功能將隱藏 DuckDuckGo "
-"Search 上的 AI Chat 功能。關閉此設定後，您仍可透過造訪 %1$sduckduckgo.com/"
-"aichat%2$s 使用 AI Chat 功能。"
+"AI Chat 能讓您與第三方 AI Chat 模型匿名對話。關閉此功能將隱藏 DuckDuckGo Search 上的 AI Chat "
+"功能。關閉此設定後，您仍可透過造訪 %1$sduckduckgo.com/aichat%2$s 使用 AI Chat 功能。"
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1042,9 +1031,8 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"AI 輔助的答案目前不直接支援後續問題。不過，我們也提供並經常連結到 %1$sDuck."
-"ai%2$s 以回答後續問題，這是我們的私密 AI 驅動的聊天服務，支援來自 OpenAI、"
-"Anthropic 等的聊天模型。"
+"AI 輔助的答案目前不直接支援後續問題。不過，我們也提供並經常連結到 %1$sDuck.ai%2$s 以回答後續問題，這是我們的私密 AI "
+"驅動的聊天服務，支援來自 OpenAI、Anthropic 等的聊天模型。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1188,7 +1176,7 @@ msgstr "關於我們的廣告"
 #. Title of the modal that provides information about Chat History when Sync & Backup is enabled. The first three spaces are non-breaking (\u00a0) so the title wraps after 'with' rather than leaving an orphan word; translators may reposition or drop them to suit the target language.
 msgctxt "Modal header for chat history with sync information"
 msgid "About Chat History with Sync & Backup"
-msgstr ""
+msgstr "關於聊天記錄與 Sync & Backup"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the URL for a result ABOVE the TITLE of the result -- Example image: https://i.imgur.com/bTm8PCc.png
@@ -1317,7 +1305,7 @@ msgstr "此廣告有可疑"
 #. Accessible text of a button that opens a dropdown menu with options to attach images or page context to the current AI chat message.
 msgctxt "Button to open menu for attaching images or page context to AI chat"
 msgid "Add"
-msgstr ""
+msgstr "新增"
 
 # smartling.placeholder_format=C
 #. Confirms the tab selection and attaches the checked tabs to the current Duck.ai chat message.
@@ -1325,7 +1313,7 @@ msgctxt ""
 "Primary button that attaches the tabs the user checked in the tab picker "
 "dialog"
 msgid "Add"
-msgstr ""
+msgstr "新增"
 
 # smartling.placeholder_format=C
 #. Link to add the DuckDuckGo extension to the user's web browser.
@@ -1358,13 +1346,13 @@ msgstr "將DuckDuckGo新增至%1$s"
 msgctxt ""
 "Add PDF files to the Duck.ai chat conversation (attach dropdown menu item)"
 msgid "Add File"
-msgstr ""
+msgstr "新增檔案"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
 msgctxt "Add an image to the AI chat conversation (attach dropdown menu item)"
 msgid "Add Image"
-msgstr ""
+msgstr "新增圖片"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when both image and PDF file upload are supported in the Duck.ai chat.
@@ -1372,7 +1360,7 @@ msgctxt ""
 "Add images or PDFs to the Duck.ai chat conversation (attach dropdown menu "
 "item)"
 msgid "Add Image or File"
-msgstr ""
+msgstr "新增圖片或檔案"
 
 # smartling.placeholder_format=C
 #. Title-case label used in the attach dropdown menu when only image upload is supported in the Duck.ai chat.
@@ -1425,7 +1413,7 @@ msgctxt ""
 "Open the tab picker to attach browser tab content to the AI chat message "
 "(attach dropdown menu item)"
 msgid "Add Tabs"
-msgstr ""
+msgstr "新增分頁"
 
 # smartling.placeholder_format=C
 #. Title shown at the top of the tab-picker dialog, and its accessible name. Distinct from the dropdown menu item that opens it (DUCKCHAT_ACTION_ATTACH_PAGE_CONTEXT_MENU_ITEM), which says "Add Tabs".
@@ -1433,7 +1421,7 @@ msgctxt ""
 "Title and accessible name of the tab-picker dialog opened from the attach "
 "dropdown menu"
 msgid "Add Tabs"
-msgstr ""
+msgstr "新增分頁"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box near the top
@@ -1524,7 +1512,7 @@ msgstr "進行最後的潤飾"
 #. Accessible label (aria-label) for the textarea in the Customize Responses dialog where users type extra instructions for the AI model. Announced by screen readers only; the visible placeholder text gives a longer example. Please keep the text short.
 msgctxt "Aria label for the additional instructions textarea"
 msgid "Additional instructions"
-msgstr ""
+msgstr "附加指示"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an address below a web search result.
@@ -1801,9 +1789,7 @@ msgctxt "Privacy & Terms section description on the Duck.ai settings page"
 msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
-msgstr ""
-"所有聊天內容均由 DuckDuckGo 進行匿名處理，且你的對話不會由 DuckDuckGo 或模型"
-"供應商用於訓練聊天模型"
+msgstr "所有聊天內容均由 DuckDuckGo 進行匿名處理，且你的對話不會由 DuckDuckGo 或模型供應商用於訓練聊天模型"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1827,7 +1813,7 @@ msgstr "全部完成！"
 #. Accessible label (aria-label) for the read-only textarea in the Customize Responses dialog that shows the combined instructions sent to the AI model. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the read-only textarea listing all AI instructions"
 msgid "All instructions"
-msgstr ""
+msgstr "所有指示"
 
 # smartling.placeholder_format=C
 #. This is shown in a layout selector for images, other options are: square, tall, wide  https://duckduckgo.com/?q=images+of+cats&iar=images&iax=images&ia=images.
@@ -1855,9 +1841,7 @@ msgctxt "Body copy for the anonymized card in the How Duck.ai Works panel"
 msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
-msgstr ""
-"在將聊天內容傳送給 AI 服務提供者之前，所有個人元資料（例如您的 IP 位址）都會"
-"被移除。"
+msgstr "在將聊天內容傳送給 AI 服務提供者之前，所有個人元資料（例如您的 IP 位址）都會被移除。"
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1927,8 +1911,8 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"允許 %1$s 搜尋網頁，以調整相關提示的回應。僅將 AI 生成的查詢傳送到資料保留期"
-"限有限的搜尋引擎。%2$s 的提示和回應仍具有%3$s零提供者可見度%4$s。"
+"允許 %1$s 搜尋網頁，以調整相關提示的回應。僅將 AI 生成的查詢傳送到資料保留期限有限的搜尋引擎。%2$s "
+"的提示和回應仍具有%3$s零提供者可見度%4$s。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2093,8 +2077,7 @@ msgctxt "settings"
 msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
-msgstr ""
-"根據網頁內容匿名生成搜尋查詢的答案。你可以選擇它出現的頻率，或完全停用它。"
+msgstr "根據網頁內容匿名生成搜尋查詢的答案。你可以選擇它出現的頻率，或完全停用它。"
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2267,9 +2250,7 @@ msgctxt "Body text for disable recent chats confirmation modal"
 msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
-msgstr ""
-"你是否確定要停用「最近的聊天記錄」？這麽做的話，也會將最近儲存下來的所有聊天"
-"記錄一併刪除。"
+msgstr "你是否確定要停用「最近的聊天記錄」？這麽做的話，也會將最近儲存下來的所有聊天記錄一併刪除。"
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2306,9 +2287,7 @@ msgstr "更新時間："
 msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
-msgstr ""
-"根據我們的隱私政策規範，我們不會主動收集或分享任何個人資訊。這些隱私保護作業"
-"皆於你的裝置上進行。"
+msgstr "根據我們的隱私政策規範，我們不會主動收集或分享任何個人資訊。這些隱私保護作業皆於你的裝置上進行。"
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2450,10 +2429,9 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assist 可匿名根據相關網頁內容的摘要，生成某些搜尋的 AI 輔助答案。您可以選擇想"
-"要 Assist 出現的頻率：從不 (從搜尋結果中完全移除 Assist 使用介面)、隨選 (僅在"
-"點按 Assist 按鈕後顯示)、有時 (僅在高度相關時顯示) 或經常 (在更廣泛的搜尋中更"
-"頻繁地顯示)。目前，AI 輔助答案僅在美國 (英文) 地區提供。"
+"Assist 可匿名根據相關網頁內容的摘要，生成某些搜尋的 AI 輔助答案。您可以選擇想要 Assist 出現的頻率：從不 (從搜尋結果中完全移除 "
+"Assist 使用介面)、隨選 (僅在點按 Assist 按鈕後顯示)、有時 (僅在高度相關時顯示) 或經常 "
+"(在更廣泛的搜尋中更頻繁地顯示)。目前，AI 輔助答案僅在美國 (英文) 地區提供。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2465,10 +2443,8 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist 是我們搜尋結果中的一項選用功能，能夠匿名產生由 AI 協助的搜尋查詢答案。"
-"為了完成此任務，它將掃描網路以便查詢相關內容，接著使用人工智慧支援的自然語言"
-"技術，根據找到的相關資訊產生簡短的答案。重要的是要記住，回應是從引用的來源並"
-"根據%1$s搜耙網路%2$s自動產生的。"
+"Assist 是我們搜尋結果中的一項選用功能，能夠匿名產生由 AI "
+"協助的搜尋查詢答案。為了完成此任務，它將掃描網路以便查詢相關內容，接著使用人工智慧支援的自然語言技術，根據找到的相關資訊產生簡短的答案。重要的是要記住，回應是從引用的來源並根據%1$s搜耙網路%2$s自動產生的。"
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2493,9 +2469,7 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "At the café, airport, or hotel, DuckDuckGo VPN encrypts your connection and "
 "hides your IP address on Wi-Fi."
-msgstr ""
-"無論是在咖啡廳、機場還是飯店，DuckDuckGo VPN 都能加密你的網路連線，並在 Wi-"
-"Fi 上隱藏你的 IP 位址。"
+msgstr "無論是在咖啡廳、機場還是飯店，DuckDuckGo VPN 都能加密你的網路連線，並在 Wi-Fi 上隱藏你的 IP 位址。"
 
 # smartling.placeholder_format=C
 #. In the context of the National Hockey League (NHL), label for teams belonging to the Atlantic division
@@ -2640,9 +2614,7 @@ msgid ""
 "Automatically shows Assist for relevant searches. Assist can anonymously "
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
-msgstr ""
-"自動顯示相關搜尋的 Assist 功能。Assist 能夠匿名搜尋與摘要資訊，以便回應某些搜"
-"尋結果。目前，Assist 僅供英語地區使用。"
+msgstr "自動顯示相關搜尋的 Assist 功能。Assist 能夠匿名搜尋與摘要資訊，以便回應某些搜尋結果。目前，Assist 僅供英語地區使用。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2651,8 +2623,8 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"對相關的搜尋自動顯示 DuckAssist。DuckAssist 能夠匿名搜尋與摘要資訊，以便回應"
-"某些搜尋結果。目前，DuckAssist 僅供說英文的地區使用。"
+"對相關的搜尋自動顯示 DuckAssist。DuckAssist 能夠匿名搜尋與摘要資訊，以便回應某些搜尋結果。目前，DuckAssist "
+"僅供說英文的地區使用。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2857,9 +2829,7 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
-msgstr ""
-"在儲存此報告前，DuckDuckGo 會透過移除姓名、電子郵件地址及識別中繼資料等個人身"
-"份資訊，將你的對話匿名化。"
+msgstr "在儲存此報告前，DuckDuckGo 會透過移除姓名、電子郵件地址及識別中繼資料等個人身份資訊，將你的對話匿名化。"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2988,8 +2958,7 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Block harmful sites, hide your IP address, plus get more premium protections "
 "with our subscription."
-msgstr ""
-"封鎖有害網站、隱藏你的 IP 地址，訂閱我們的服務還能獲得更多高階保護功能。"
+msgstr "封鎖有害網站、隱藏你的 IP 地址，訂閱我們的服務還能獲得更多高階保護功能。"
 
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
@@ -3248,26 +3217,20 @@ msgstr "瀏覽檔案"
 msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr ""
-"享受隱私保護，只管放心瀏覽。我們將搜尋引擎、追蹤器封鎖程式以及加密執行程式組"
-"合為一項%1$s%2$s延伸模組%3$s。"
+msgstr "享受隱私保護，只管放心瀏覽。我們將搜尋引擎、追蹤器封鎖程式以及加密執行程式組合為一項%1$s%2$s延伸模組%3$s。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr ""
-"你盡可放心瀏覽，其餘的交給我們處理。我們將搜尋引擎、追蹤器封鎖程式以及加密執"
-"行程式組合為一項%1$s%2$s延伸模組%3$s。"
+msgstr "你盡可放心瀏覽，其餘的交給我們處理。我們將搜尋引擎、追蹤器封鎖程式以及加密執行程式組合為一項%1$s%2$s延伸模組%3$s。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we’ll take care of the rest. Get bundled private "
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
-msgstr ""
-"你盡可放心瀏覽，其餘的交給我們處理。只需下載一次，即可取得為%1$s主要瀏覽"
-"器%2$s設計的私密搜尋、追蹤器封鎖、網站加密等多合一功能。"
+msgstr "你盡可放心瀏覽，其餘的交給我們處理。只需下載一次，即可取得為%1$s主要瀏覽器%2$s設計的私密搜尋、追蹤器封鎖、網站加密等多合一功能。"
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3374,18 +3337,15 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"預設情況下，所有的設定都使用非個人的 Cookie 儲存（在你的瀏覽器）。你也可以使"
-"用匿名的 Could Save 以更持久的方式來將設定儲存在雲端的遠端伺服器。所有可識別"
-"的個人資訊都不會儲存在雲端，你的通關密語也不會從瀏覽器洩漏。"
+"預設情況下，所有的設定都使用非個人的 Cookie 儲存（在你的瀏覽器）。你也可以使用匿名的 Could Save "
+"以更持久的方式來將設定儲存在雲端的遠端伺服器。所有可識別的個人資訊都不會儲存在雲端，你的通關密語也不會從瀏覽器洩漏。"
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
 msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
-msgstr ""
-"啟用語音輸入功能即表示您同意將您的語音資料傳送至 OpenAI 以使用此功能。在開始"
-"之前，請先查看我們的%1$s。"
+msgstr "啟用語音輸入功能即表示您同意將您的語音資料傳送至 OpenAI 以使用此功能。在開始之前，請先查看我們的%1$s。"
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3393,9 +3353,7 @@ msgctxt "voice chat"
 msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
-msgstr ""
-"啟用語音聊天功能，即表示您同意將您的語音資料傳送至 OpenAI 以使用此功能。在開"
-"始之前，請先查看我們的%1$s。"
+msgstr "啟用語音聊天功能，即表示您同意將您的語音資料傳送至 OpenAI 以使用此功能。在開始之前，請先查看我們的%1$s。"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3502,7 +3460,7 @@ msgctxt ""
 "Secondary button that dismisses the tab picker dialog without attaching "
 "anything"
 msgid "Cancel"
-msgstr ""
+msgstr "取消"
 
 # smartling.placeholder_format=C
 #. A label for the button that allows the user to dismiss a messsage that allows them to filter the results by domain.
@@ -3887,10 +3845,9 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"聊天 (透過我們的 Duck.ai 服務) 能讓你與第三方 AI 聊天模型進行匿名對話，支援 "
-"OpenAI、Anthropic 等模型。關閉此設定將隱藏 DuckDuckGo Search 上的聊天按鈕和連"
-"結。不過，關閉此設定後，您仍可透過造訪 %1$shttps://duck.ai%2$s 直接使用聊天功"
-"能。"
+"聊天 (透過我們的 Duck.ai 服務) 能讓你與第三方 AI 聊天模型進行匿名對話，支援 OpenAI、Anthropic 等模型。關閉此設定將隱藏 "
+"DuckDuckGo Search 上的聊天按鈕和連結。不過，關閉此設定後，您仍可透過造訪 %1$shttps://duck.ai%2$s "
+"直接使用聊天功能。"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3994,7 +3951,7 @@ msgstr "聊天回覆令人反感"
 #. Headline in the About Chat History modal explaining that browser behavior affects local chat storage.
 msgctxt "Chat history about modal list item headline"
 msgid "Chat storage varies by browser"
-msgstr ""
+msgstr "聊天記錄儲存方式因瀏覽器而異"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4006,7 +3963,7 @@ msgstr "與 %1$s 聊天"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Chat with popular AI models, anonymized by us."
-msgstr ""
+msgstr "與我們進行匿名化處理的熱門 AI 模型對話。"
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4032,7 +3989,7 @@ msgctxt "Chat history with sync modal list item description"
 msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
-msgstr ""
+msgstr "聊天記錄採用端對端加密，安全儲存在 DuckDuckGo 的伺服器上。除了你之外，沒有人可以看到你的資料，連我們也不行。"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4040,9 +3997,7 @@ msgctxt "Description for Chat History feature"
 msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
-msgstr ""
-"聊天記錄會儲存在你的裝置本機上，而非 DuckDuckGo 伺服器或其他遠端伺服器。停用"
-"聊天記錄將刪除置頂的聊天。"
+msgstr "聊天記錄會儲存在你的裝置本機上，而非 DuckDuckGo 伺服器或其他遠端伺服器。停用聊天記錄將刪除置頂的聊天。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -4054,9 +4009,8 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"聊天記錄將儲存在你的裝置本地。新的提示和回應在傳送後會被加密並暫時儲存在 "
-"DuckDuckGo 伺服器上，以便在你失去網路連線時協助恢復聊天。停用聊天紀錄會刪除置"
-"頂的聊天記錄，並停用新提示和回應的暫時儲存功能。"
+"聊天記錄將儲存在你的裝置本地。新的提示和回應在傳送後會被加密並暫時儲存在 DuckDuckGo "
+"伺服器上，以便在你失去網路連線時協助恢復聊天。停用聊天紀錄會刪除置頂的聊天記錄，並停用新提示和回應的暫時儲存功能。"
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -4078,9 +4032,7 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
-msgstr ""
-"與 %1$s 的聊天完全沒有供應商可見度，但在 Duck.ai 上傳的所有檔案都會由內容審柴"
-"供應商匿名審核，以用於 %2$s。"
+msgstr "與 %1$s 的聊天完全沒有供應商可見度，但在 Duck.ai 上傳的所有檔案都會由內容審柴供應商匿名審核，以用於 %2$s。"
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -4439,9 +4391,7 @@ msgctxt "Information about the effect of clearing browser data on recent chats"
 msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
-msgstr ""
-"清除瀏覽器資料的話，也會將聊天記錄一併刪除。特定的瀏覽器可能會無限期保留最近"
-"的聊天記錄，或是在你超過 7 天未使用 AI Chat 後自動將聊天記錄刪除。"
+msgstr "清除瀏覽器資料的話，也會將聊天記錄一併刪除。特定的瀏覽器可能會無限期保留最近的聊天記錄，或是在你超過 7 天未使用 AI Chat 後自動將聊天記錄刪除。"
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4451,8 +4401,8 @@ msgid ""
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
 msgstr ""
-"清除瀏覽器資料的話，也會將最近的聊天記錄一併刪除。最近的聊天記錄可能會無限期"
-"保存，或在不使用 Duck.ai 的情況下 7 天後自動刪除，視您的瀏覽器而定。"
+"清除瀏覽器資料的話，也會將最近的聊天記錄一併刪除。最近的聊天記錄可能會無限期保存，或在不使用 Duck.ai 的情況下 7 "
+"天後自動刪除，視您的瀏覽器而定。"
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4469,8 +4419,8 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"按一下「更多」深入瞭解主題，並透過 %1$sDuck.ai%2$s 提出後續問題，這是我們的私"
-"人 AI 聊天服務，支援來自 OpenAI、Anthropic 等的聊天模型。"
+"按一下「更多」深入瞭解主題，並透過 %1$sDuck.ai%2$s 提出後續問題，這是我們的私人 AI 聊天服務，支援來自 "
+"OpenAI、Anthropic 等的聊天模型。"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4631,9 +4581,7 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
-msgstr ""
-"按一下或點擊 %1$s刪除我的資料%2$s。這將從雲端移除資料，但資料仍將留存於您的瀏"
-"覽器中，等您按一下/點擊%3$s重設所有搜尋設定%4$s才會刪除。"
+msgstr "按一下或點擊 %1$s刪除我的資料%2$s。這將從雲端移除資料，但資料仍將留存於您的瀏覽器中，等您按一下/點擊%3$s重設所有搜尋設定%4$s才會刪除。"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4643,9 +4591,7 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
-msgstr ""
-"按一下或點按%1$s刪除我的資料%2$s。這即會從雲端移除資料，但資料仍會留存於你的"
-"瀏覽器中，等你按一下/點按%3$s重設所有設定%4$s才會刪除。"
+msgstr "按一下或點按%1$s刪除我的資料%2$s。這即會從雲端移除資料，但資料仍會留存於你的瀏覽器中，等你按一下/點按%3$s重設所有設定%4$s才會刪除。"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4920,8 +4866,7 @@ msgctxt "cloudsave"
 msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
-msgstr ""
-"Cloud Save將更長久地保留你的設定，只要輸入通關密語即可套用。此項純屬自願。"
+msgstr "Cloud Save將更長久地保留你的設定，只要輸入通關密語即可套用。此項純屬自願。"
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -5362,9 +5307,7 @@ msgctxt "Description for the wrong code error screen"
 msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
-msgstr ""
-"從其他裝置複製代碼。前往 %1$s Duck.ai 設定 › 聊天 › Sync & Backup › 與其他裝"
-"置同步%2$s，然後再試一次。"
+msgstr "從其他裝置複製代碼。前往 %1$s Duck.ai 設定 › 聊天 › Sync & Backup › 與其他裝置同步%2$s，然後再試一次。"
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5599,7 +5542,7 @@ msgstr "目前連勝 / 連敗"
 #. Label appended to a tab entry to indicate it is the user's currently active browser tab. Surrounding punctuation (a bullet separator or parentheses) is added by the UI, so this string must not include any.
 msgctxt "Suffix label indicating a tab is the currently active browser tab"
 msgid "Current Tab"
-msgstr ""
+msgstr "目前分頁"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that attaches the current tab's page content to the AI chat message.
@@ -5951,7 +5894,7 @@ msgstr "刪除超過 30 天的聊天記錄"
 #. Text for a button that clears all recent chats and revokes every shared chat link created on this device.
 msgctxt "Button text in the modal for deleting all recent chats"
 msgid "Delete Chats and Shared Links"
-msgstr ""
+msgstr "刪除聊天記錄和分享連結"
 
 # smartling.placeholder_format=C
 #. Button text to confirm deletion of an image.
@@ -6077,8 +6020,7 @@ msgctxt "Description at the top of the Duck.ai shared links modal"
 msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
-msgstr ""
-"刪除連結會導致連結失效。已經開啟連結並將對話加入聊天的人會保留自己的副本。"
+msgstr "刪除連結會導致連結失效。已經開啟連結並將對話加入聊天的人會保留自己的副本。"
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6191,9 +6133,7 @@ msgstr "聽寫功能暫時無法使用"
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
-msgstr ""
-"語音輸入功能使用 OpenAI 模型將您的語音轉換為文字，因此您不用輸入文字也能在 "
-"Duck.ai 中聊天。"
+msgstr "語音輸入功能使用 OpenAI 模型將您的語音轉換為文字，因此您不用輸入文字也能在 Duck.ai 中聊天。"
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6367,7 +6307,7 @@ msgstr "關閉促銷廣告"
 #. Accessible label (aria-label) for the close (X) button that dismisses the survey invitation banner in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the close button on the survey banner"
 msgid "Dismiss survey"
-msgstr ""
+msgstr "隱藏問卷調查"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
@@ -6517,9 +6457,7 @@ msgctxt "settings"
 msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
-msgstr ""
-"不想要 AI？%1$snoai.duckduckgo.com%2$s 不提供 AI 功能，且已過濾 AI 生成的圖"
-"片。 %3$s瞭解更多%4$s"
+msgstr "不想要 AI？%1$snoai.duckduckgo.com%2$s 不提供 AI 功能，且已過濾 AI 生成的圖片。 %3$s瞭解更多%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6527,9 +6465,7 @@ msgctxt "settings"
 msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
-msgstr ""
-"不想要 AI？請造訪 %1$snoai.duckduckgo.com%2$s 以進行無 AI 功能且過濾掉 AI 圖"
-"片的搜尋。%3$s瞭解更多%4$s"
+msgstr "不想要 AI？請造訪 %1$snoai.duckduckgo.com%2$s 以進行無 AI 功能且過濾掉 AI 圖片的搜尋。%3$s瞭解更多%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6811,9 +6747,7 @@ msgid ""
 "Duck.ai can now help answer questions about the page you're viewing. Page "
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
-msgstr ""
-"Duck.ai 現在可以幫助回答你正在檢視的頁面上的問題。頁面內容僅在你附加它時包"
-"含，除非你在設定中選擇自動附加頁面。"
+msgstr "Duck.ai 現在可以幫助回答你正在檢視的頁面上的問題。頁面內容僅在你附加它時包含，除非你在設定中選擇自動附加頁面。"
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6822,9 +6756,7 @@ msgctxt ""
 msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
-msgstr ""
-"Duck.ai 無法存取本機儲存空間來儲存你的聊天記錄。請檢查您的瀏覽器設定或停用任"
-"何擴充套件，然後再試一次。"
+msgstr "Duck.ai 無法存取本機儲存空間來儲存你的聊天記錄。請檢查您的瀏覽器設定或停用任何擴充套件，然後再試一次。"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6847,9 +6779,7 @@ msgid ""
 "Duck.ai is created by DuckDuckGo. We're an independent online protection "
 "company for anyone who wants to take back control of their personal "
 "information."
-msgstr ""
-"Duck.ai 由 DuckDuckGo 建立。 我們是一間獨立的線上保護公司，旨在協助任何想要重"
-"新掌控個人資訊的人。"
+msgstr "Duck.ai 由 DuckDuckGo 建立。 我們是一間獨立的線上保護公司，旨在協助任何想要重新掌控個人資訊的人。"
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6863,9 +6793,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
-msgstr ""
-"Duck.ai 仍然是 DuckDuckGo 產品，但現在將在網絡上有一個更容易記住的主頁："
-"https://duck.ai"
+msgstr "Duck.ai 仍然是 DuckDuckGo 產品，但現在將在網絡上有一個更容易記住的主頁：https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6879,8 +6807,7 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
-msgstr ""
-"Duck.ai 暫時無法使用。若問題仍存在，請將此匿名代碼%1$s透過電子郵件傳送至%2$s"
+msgstr "Duck.ai 暫時無法使用。若問題仍存在，請將此匿名代碼%1$s透過電子郵件傳送至%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6901,8 +6828,8 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"Duck.ai 讓你與熱門的 AI 模型進行私密聊天。 停用後將隱藏 Duck.ai 按鈕和連結，"
-"但你仍然可以造訪 %1$sduck.ai%2$s 直接使用。"
+"Duck.ai 讓你與熱門的 AI 模型進行私密聊天。 停用後將隱藏 Duck.ai 按鈕和連結，但你仍然可以造訪 %1$sduck.ai%2$s "
+"直接使用。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6913,9 +6840,9 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai 讓你與第三方 AI 聊天模型進行匿名對話，支援 OpenAI、Anthropic 等模型。"
-"關閉此設定將隱藏 DuckDuckGo Search 上的 Duck.ai 按鈕和連結。不過，關閉此設定"
-"後，您仍可透過造訪 %1$shttps://duck.ai%2$s 來存取 Duck.ai使用聊天功能。"
+"Duck.ai 讓你與第三方 AI 聊天模型進行匿名對話，支援 OpenAI、Anthropic 等模型。關閉此設定將隱藏 DuckDuckGo "
+"Search 上的 Duck.ai 按鈕和連結。不過，關閉此設定後，您仍可透過造訪 %1$shttps://duck.ai%2$s 來存取 "
+"Duck.ai使用聊天功能。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6976,9 +6903,8 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai、DuckDuckGo AI、私密 AI 聊天機器人、免費 AI 聊天、匿名 AI 聊天、無需"
-"註冊的 AI 聊天、OpenAI、Anthropic、Llama、Mistral、開源 AI 模型、以隱私為重點"
-"的 AI、無需帳號的 AI 聊天"
+"Duck.ai、DuckDuckGo AI、私密 AI 聊天機器人、免費 AI 聊天、匿名 AI 聊天、無需註冊的 AI "
+"聊天、OpenAI、Anthropic、Llama、Mistral、開源 AI 模型、以隱私為重點的 AI、無需帳號的 AI 聊天"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7006,10 +6932,9 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"DuckAssist 可匿名搜尋資訊並做成摘要，以便回應某些搜尋結果。您可以選擇想要 "
-"DuckAssist 出現的頻率：從不 (從搜尋結果中完全移除 DuckAssist UI)、隨選 (僅在"
-"點按協助按鈕後顯示)、有時 (僅在高度相關時顯示) 或經常 (在更廣泛的搜尋中更頻繁"
-"地顯示)。目前 DuckAssist 僅供美國 (英文) 地區使用。"
+"DuckAssist 可匿名搜尋資訊並做成摘要，以便回應某些搜尋結果。您可以選擇想要 DuckAssist 出現的頻率：從不 (從搜尋結果中完全移除 "
+"DuckAssist UI)、隨選 (僅在點按協助按鈕後顯示)、有時 (僅在高度相關時顯示) 或經常 (在更廣泛的搜尋中更頻繁地顯示)。目前 "
+"DuckAssist 僅供美國 (英文) 地區使用。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7018,8 +6943,8 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist 無法回答後續問題，但是，我們亦提供%1$s DuckDuckGo AI Chat%2$s，這"
-"是一款私密 AI 驅動的聊天服務，支援 OpenAI 和 Anthropic 等聊天模型。"
+"DuckAssist 無法回答後續問題，但是，我們亦提供%1$s DuckDuckGo AI Chat%2$s，這是一款私密 AI 驅動的聊天服務，支援 "
+"OpenAI 和 Anthropic 等聊天模型。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7028,8 +6953,8 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist 無法回答後續問題，但是，我們亦提供 DuckDuckGo %1$sAI Chat%2$s，這"
-"是一款私密 AI 驅動的聊天服務，支援 OpenAI 和 Anthropic 的聊天模型。"
+"DuckAssist 無法回答後續問題，但是，我們亦提供 DuckDuckGo %1$sAI Chat%2$s，這是一款私密 AI 驅動的聊天服務，支援 "
+"OpenAI 和 Anthropic 的聊天模型。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7041,10 +6966,8 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist 是我們搜尋結果中的一項全新功能，能夠匿名產生搜尋查詢的答案。 為了"
-"完成此任務，它將掃描維基百科與相關網站以便查詢相關內容，接著使用 AI 驅動的自"
-"然語言處理技術產生該資訊的摘要。 請注意，目前的回應僅根據維基百科與相關內容，"
-"尚未確認準確性。"
+"DuckAssist 是我們搜尋結果中的一項全新功能，能夠匿名產生搜尋查詢的答案。 為了完成此任務，它將掃描維基百科與相關網站以便查詢相關內容，接著使用 "
+"AI 驅動的自然語言處理技術產生該資訊的摘要。 請注意，目前的回應僅根據維基百科與相關內容，尚未確認準確性。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7058,11 +6981,10 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssist 是我們搜尋結果中的一項選用功能，能夠匿名產生搜尋查詢的答案。為了完"
-"成此任務，它將掃描網路以便查詢相關內容，接著使用人工智慧支援的自然語言技術，"
-"根據找到的相關資訊產生簡短的答案。DuckAssist 的回應始終直接連結至一個或兩個來"
-"源，並引用答案的來源，因此您能夠輕鬆取得更詳盡的資料。重要的是要記住，回應是"
-"從引用的來源並根據%1$s搜耙網路%2$s自動產生的，"
+"DuckAssist "
+""
+"是我們搜尋結果中的一項選用功能，能夠匿名產生搜尋查詢的答案。為了完成此任務，它將掃描網路以便查詢相關內容，接著使用人工智慧支援的自然語言技術，根據找到的相關資訊產生簡短的答案。DuckAssist "
+"的回應始終直接連結至一個或兩個來源，並引用答案的來源，因此您能夠輕鬆取得更詳盡的資料。重要的是要記住，回應是從引用的來源並根據%1$s搜耙網路%2$s自動產生的，"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -7085,9 +7007,7 @@ msgctxt "Modal body for information"
 msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
-msgstr ""
-"DuckDuckGo AI Chat 是一款私密 AI 驅動的聊天服務，目前支援 %1$s 的 %2$s 與 "
-"%3$s 的 %4$s 聊天模型。"
+msgstr "DuckDuckGo AI Chat 是一款私密 AI 驅動的聊天服務，目前支援 %1$s 的 %2$s 與 %3$s 的 %4$s 聊天模型。"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7095,9 +7015,7 @@ msgctxt "Onboarding welcome screen subtitle"
 msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
-msgstr ""
-"DuckDuckGo AI Chat 是一款私密 AI 驅動的聊天服務，目前支援 %1$s 的 %2$s 與 "
-"%3$s 的 %4$s 聊天模型。"
+msgstr "DuckDuckGo AI Chat 是一款私密 AI 驅動的聊天服務，目前支援 %1$s 的 %2$s 與 %3$s 的 %4$s 聊天模型。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -7113,9 +7031,7 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
-msgstr ""
-"DuckDuckGo AI Chat 暫時無法使用。若問題仍存在，請將此匿名代碼%1$s透過電子郵件"
-"傳送至%2$s"
+msgstr "DuckDuckGo AI Chat 暫時無法使用。若問題仍存在，請將此匿名代碼%1$s透過電子郵件傳送至%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7278,17 +7194,14 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
-msgstr ""
-"DuckDuckGo 透過自動移除姓名、電子郵件地址、電話號碼及識別中繼資料等個人身份資"
-"訊來匿名化這些報告。"
+msgstr "DuckDuckGo 透過自動移除姓名、電子郵件地址、電話號碼及識別中繼資料等個人身份資訊來匿名化這些報告。"
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
 msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
-msgstr ""
-"DuckDuckGo 將您的聊天匿名化。點擊「%1$s」，即表示你同意 Duck.ai 的%2$s。"
+msgstr "DuckDuckGo 將您的聊天匿名化。點擊「%1$s」，即表示你同意 Duck.ai 的%2$s。"
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7304,9 +7217,7 @@ msgid ""
 "DuckDuckGo blocks trackers on websites you visit, including trackers from "
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
-msgstr ""
-"DuckDuckGo將封鎖你造訪網站上的追蹤器，包括來自Google和Facebook等公司的追蹤"
-"器，它們經常試圖在你造訪其他網站時追蹤你。"
+msgstr "DuckDuckGo將封鎖你造訪網站上的追蹤器，包括來自Google和Facebook等公司的追蹤器，它們經常試圖在你造訪其他網站時追蹤你。"
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7317,11 +7228,7 @@ msgid ""
 "use it to improve results for that search, and then we promptly throw it "
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
-msgstr ""
-"DuckDuckGo的設計以隱私為主要考量。當你啟用定位功能時，只會儲存於你的本機裝置"
-"上。當你搜尋時，你的裝置會將位置傳送給我們，讓我們改善該次的搜尋結果，然後我"
-"們會立即將其丟棄，讓你繼續保持匿名。%1$s進一步瞭解我們如何設計了這項技術來保"
-"護你的隱私%2$s。"
+msgstr "DuckDuckGo的設計以隱私為主要考量。當你啟用定位功能時，只會儲存於你的本機裝置上。當你搜尋時，你的裝置會將位置傳送給我們，讓我們改善該次的搜尋結果，然後我們會立即將其丟棄，讓你繼續保持匿名。%1$s進一步瞭解我們如何設計了這項技術來保護你的隱私%2$s。"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -7340,9 +7247,7 @@ msgctxt "settings"
 msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
-msgstr ""
-"DuckDuckGo只會使用你的大概位置。我們只需要這麼一點點資訊，就能呈現更好、也更"
-"接近你的搜尋結果。%1$s瞭解更多%2$s。"
+msgstr "DuckDuckGo只會使用你的大概位置。我們只需要這麼一點點資訊，就能呈現更好、也更接近你的搜尋結果。%1$s瞭解更多%2$s。"
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7433,10 +7338,7 @@ msgid ""
 "random words from the DuckDuckGo servers. In the browser, we then select 4-5 "
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
-msgstr ""
-"當你需要通關密語建議時，我們會從DuckDuckGo伺服器收到一長串隨機單字的清單。我"
-"們會在瀏覽器中從該清單隨機挑選出4至5個單字，確認每個通關密語的長度都至少有18"
-"至20個字元。"
+msgstr "當你需要通關密語建議時，我們會從DuckDuckGo伺服器收到一長串隨機單字的清單。我們會在瀏覽器中從該清單隨機挑選出4至5個單字，確認每個通關密語的長度都至少有18至20個字元。"
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7493,7 +7395,7 @@ msgstr "編輯提示"
 #. Accessible label (aria-label) for the text area in which the user edits a previously sent chat message in Duck.ai. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the message-editing text area"
 msgid "Edit message"
-msgstr ""
+msgstr "編輯訊息"
 
 # smartling.placeholder_format=C
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
@@ -7691,9 +7593,7 @@ msgctxt "precise_user_location"
 msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
-msgstr ""
-"啟用匿名位置可提供更準確的結果，但 DuckDuckGo 仍會對你的搜尋與確切位置進行保"
-"密。"
+msgstr "啟用匿名位置可提供更準確的結果，但 DuckDuckGo 仍會對你的搜尋與確切位置進行保密。"
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7717,7 +7617,7 @@ msgstr "加密模型"
 #. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
 msgctxt "Share modal info bullet about encryption"
 msgid "Encrypted so DuckDuckGo can't read your chat."
-msgstr ""
+msgstr "已加密，因此就連 DuckDuckGo 都無法讀取你的聊天內容。"
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -7860,9 +7760,7 @@ msgctxt "cloudsave"
 msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
-msgstr ""
-"輸入新的通關密語，再按一下/點按%1$s儲存設定%2$s。這會將你的資料儲存在新的通關"
-"密語下。"
+msgstr "輸入新的通關密語，再按一下/點按%1$s儲存設定%2$s。這會將你的資料儲存在新的通關密語下。"
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -7887,8 +7785,7 @@ msgstr "輸入文字"
 #. Instructions for how to change the default search engine.
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
-msgstr ""
-"輸入以下細節：%1$s名稱%2$s：DuckDuckGo%3$s URL%4$s：%5$s暱稱%6$s：d%7$s"
+msgstr "輸入以下細節：%1$s名稱%2$s：DuckDuckGo%3$s URL%4$s：%5$s暱稱%6$s：d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -8279,9 +8176,7 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
-msgstr ""
-"像你提供的的意見回饋會直接影響我們的產品更新和改善。希望我們也能解決你分享的"
-"問題。"
+msgstr "像你提供的的意見回饋會直接影響我們的產品更新和改善。希望我們也能解決你分享的問題。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -8518,8 +8413,7 @@ msgstr "多霧"
 msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
-msgstr ""
-"按照指示關閉 DuckDuckGo 的廣告封鎖程式。你可能需要選取一個選項或按一下按鈕。"
+msgstr "按照指示關閉 DuckDuckGo 的廣告封鎖程式。你可能需要選取一個選項或按一下按鈕。"
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8536,7 +8430,7 @@ msgstr "後續問題"
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
-msgstr ""
+msgstr "後續內容仍將保密。"
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8753,8 +8647,8 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"從 Mac 上的應用程式功能表工具列中，選取<strong>DuckDuckGo</strong> &gt;"
-"<strong>檢查更新...</strong> ，然後選取<strong>安裝更新</strong>。"
+"從 Mac 上的應用程式功能表工具列中，選取<strong>DuckDuckGo</strong> "
+"&gt;<strong>檢查更新...</strong> ，然後選取<strong>安裝更新</strong>。"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9053,7 +8947,7 @@ msgstr "取得 DuckDuckGo VPN、先進的 Duck.ai 以及 Identity Theft Restorat
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
 msgctxt "Tooltip on the header logo for sunglasses searches"
 msgid "Get DuckDuckGo sunglasses and other gear."
-msgstr ""
+msgstr "取得 DuckDuckGo 太陽眼鏡及其他周邊商品。"
 
 # smartling.placeholder_format=C
 #. 'Get' refers to downloading our free browser app from the Google Play Store
@@ -9132,9 +9026,7 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, Personal Info Removal, "
 "and Identity Theft Restoration."
-msgstr ""
-"取得快速、無紀錄的 VPN、選配的進階 AI 對話、個人資訊移除，以及 Identity "
-"Theft Restoration 服務。"
+msgstr "取得快速、無紀錄的 VPN、選配的進階 AI 對話、個人資訊移除，以及 Identity Theft Restoration 服務。"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; 'advanced AI chat' refers to Duck.ai; Identity Theft Restoration is a bundled feature.
@@ -9142,8 +9034,7 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, and Identity Theft "
 "Restoration."
-msgstr ""
-"取得快速、無紀錄的 VPN、選配的進階 AI 對話，以及 Identity Theft Restoration。"
+msgstr "取得快速、無紀錄的 VPN、選配的進階 AI 對話，以及 Identity Theft Restoration。"
 
 # smartling.placeholder_format=C
 #. Description for the subscription modal where users can update their subscription to DuckDuckGo.
@@ -9151,9 +9042,7 @@ msgctxt "Description of the modal to upgrade the DuckDuckGo subscription"
 msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
-msgstr ""
-"訂閱 DuckDuckGo，即可存取 Duck.ai 的進階 AI 模型，還包括我們的 VPN 和其他頂級"
-"隱私權保護。"
+msgstr "訂閱 DuckDuckGo，即可存取 Duck.ai 的進階 AI 模型，還包括我們的 VPN 和其他頂級隱私權保護。"
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -9163,9 +9052,7 @@ msgctxt ""
 msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
-msgstr ""
-"訂閱 DuckDuckGo，即可存取 Duck.ai 的進階 AI 模型，還包括我們的 VPN 和其他頂級"
-"隱私權保護。"
+msgstr "訂閱 DuckDuckGo，即可存取 Duck.ai 的進階 AI 模型，還包括我們的 VPN 和其他頂級隱私權保護。"
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9208,9 +9095,7 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
-msgstr ""
-"取得我們快速、不記錄活動的 VPN、可選擇存取具有更高聊天限制的進階 AI 模型，以"
-"及更多高級防護。"
+msgstr "取得我們快速、不記錄活動的 VPN、可選擇存取具有更高聊天限制的進階 AI 模型，以及更多高級防護。"
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9219,16 +9104,15 @@ msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, Personal Information Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"取得我們安全的無紀錄 VPN、先進的 Duck.ai，Personal Information Removal，以及 "
-"Identity Theft Restoration。"
+"取得我們安全的無紀錄 VPN、先進的 Duck.ai，Personal Information Removal，以及 Identity Theft "
+"Restoration。"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr ""
-"取得我們安全、無日誌的 VPN、先進的 Duck.ai 以及 Identity Theft Restoration。"
+msgstr "取得我們安全、無日誌的 VPN、先進的 Duck.ai 以及 Identity Theft Restoration。"
 
 # smartling.placeholder_format=C
 msgid ""
@@ -9328,8 +9212,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"前往其他瀏覽器中的 %1$sDuck.ai 設定%2$s，或前往 DuckDuckGo 應用程式並進入 "
-"%3$s聊天記錄 › Sync & Backup › 與另一裝置同步 › 複製文字代碼%4$s"
+"前往其他瀏覽器中的 %1$sDuck.ai 設定%2$s，或前往 DuckDuckGo 應用程式並進入 %3$s聊天記錄 › Sync & Backup "
+"› 與另一裝置同步 › 複製文字代碼%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9338,8 +9222,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"前往其他瀏覽器中的 %1$sDuck.ai 設定%2$s，或在 DuckDuckGo 應用程式中前往 %3$s"
-"聊天記錄 › Sync & Backup › 與另一裝置同步%4$s"
+"前往其他瀏覽器中的 %1$sDuck.ai 設定%2$s，或在 DuckDuckGo 應用程式中前往 %3$s聊天記錄 › Sync & Backup "
+"› 與另一裝置同步%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9349,8 +9233,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"使用其他瀏覽器或 DuckDuckGo 應用程式前往 %1$sDuck.ai 設定%2$s，再前往 %3$s聊"
-"天 › Sync & Backup › 與其他裝置同步%4$s，然後掃描此代碼："
+"使用其他瀏覽器或 DuckDuckGo 應用程式前往 %1$sDuck.ai 設定%2$s，再前往 %3$s聊天 › Sync & Backup › "
+"與其他裝置同步%4$s，然後掃描此代碼："
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9360,8 +9244,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"請用其他瀏覽器或 DuckDuckGo 應用程式前往 %1$sDuck.ai 設定%2$s，然後前往 %3$s"
-"聊天 › Sync & Backup › 與其他裝置同步%4$s。或掃描您的恢復 PDF 上的二維碼。"
+"請用其他瀏覽器或 DuckDuckGo 應用程式前往 %1$sDuck.ai 設定%2$s，然後前往 %3$s聊天 › Sync & Backup › "
+"與其他裝置同步%4$s。或掃描您的恢復 PDF 上的二維碼。"
 
 # smartling.placeholder_format=C
 #. Path to the pairing code on the other device. Bold segments are UI path labels.
@@ -9369,8 +9253,7 @@ msgctxt "Detail under the first numbered step on the Enter Code tab"
 msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
-msgstr ""
-"前往 %1$sDuck.ai 設定%2$s › %3$s聊天 › Sync & Backup › 與其他裝置同步%4$s。"
+msgstr "前往 %1$sDuck.ai 設定%2$s › %3$s聊天 › Sync & Backup › 與其他裝置同步%4$s。"
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9384,8 +9267,7 @@ msgctxt "precise_user_location"
 msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
-msgstr ""
-"前往 %1$s 設定 > 隱私權和安全性 > 位置服務 %2$s，並確定「位置服務」已開啟。"
+msgstr "前往 %1$s 設定 > 隱私權和安全性 > 位置服務 %2$s，並確定「位置服務」已開啟。"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -9393,8 +9275,7 @@ msgctxt "precise_user_location"
 msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
-msgstr ""
-"前往%1$s設定>隱私權>權限管理>位置%2$s ，接著往下捲動至 %3$sDuckDuckGo%4$s。"
+msgstr "前往%1$s設定>隱私權>權限管理>位置%2$s ，接著往下捲動至 %3$sDuckDuckGo%4$s。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -10108,9 +9989,7 @@ msgstr "最近活動"
 msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
-msgstr ""
-"在鍵盤上點擊%1$s返回%2$s即可將DuckDuckGo%3$s儲存至清單。%4$s接著點擊%5$s設定"
-"為預設%6$s"
+msgstr "在鍵盤上點擊%1$s返回%2$s即可將DuckDuckGo%3$s儲存至清單。%4$s接著點擊%5$s設定為預設%6$s"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -10269,7 +10148,7 @@ msgstr "如何運作"
 #. Headline in chat history about modals for the temporary encrypted server storage explanation.
 msgctxt "Chat history about modal list item headline"
 msgid "How it works"
-msgstr ""
+msgstr "如何運作"
 
 # smartling.placeholder_format=C
 #. Text for the link that takes the user to the a model with more information about a feature.
@@ -10474,9 +10353,7 @@ msgctxt "precise_user_location"
 msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
-msgstr ""
-"如果仍然沒有可用的瀏覽器位置，那麼請前往%1$s設定 > 一般 > 重設 >「重設位置與"
-"隱私」%2$s。"
+msgstr "如果仍然沒有可用的瀏覽器位置，那麼請前往%1$s設定 > 一般 > 重設 >「重設位置與隱私」%2$s。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10486,8 +10363,8 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"如果仍然沒有可用的瀏覽器位置，那麼請在你的瀏覽器中前往 %1$s⋮ > 選單 > 設定 > "
-"網站設定 > 位置%2$s，確認DuckDuckGo是被允許的存取位置。"
+"如果仍然沒有可用的瀏覽器位置，那麼請在你的瀏覽器中前往 %1$s⋮ > 選單 > 設定 > 網站設定 > "
+"位置%2$s，確認DuckDuckGo是被允許的存取位置。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10501,8 +10378,7 @@ msgstr "如果你繼續看到此錯誤，請聯絡 %1$s。"
 msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
-msgstr ""
-"如果你沒看見%1$sDuckDuckGo，%2$s必須先將其新增至%3$s其他搜尋引擎%4$s的清單中"
+msgstr "如果你沒看見%1$sDuckDuckGo，%2$s必須先將其新增至%3$s其他搜尋引擎%4$s的清單中"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -10510,9 +10386,7 @@ msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
-msgstr ""
-"若您對我們的聊天供應商或任何特定的聊天回覆有任何疑問，也能夠直接聯絡 %1$s 與 "
-"%2$s 支援頁面。"
+msgstr "若您對我們的聊天供應商或任何特定的聊天回覆有任何疑問，也能夠直接聯絡 %1$s 與 %2$s 支援頁面。"
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10520,9 +10394,7 @@ msgctxt "Body for the Sync & Backup recovery code screen"
 msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
-msgstr ""
-"如果您無法存取裝置，需要使用此恢復碼才能恢復您儲存的聊天記錄。您可以把這個恢"
-"復碼儲存成文字檔，儲存至您的裝置。"
+msgstr "如果您無法存取裝置，需要使用此恢復碼才能恢復您儲存的聊天記錄。您可以把這個恢復碼儲存成文字檔，儲存至您的裝置。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
@@ -10684,9 +10556,7 @@ msgctxt "settings"
 msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
-msgstr ""
-"若你使用的瀏覽器較舊，在你點擊連結時，必須透過我們的伺服器來重新導向，才能避"
-"免搜尋記錄外洩。%1$s瞭解更多%2$s。"
+msgstr "若你使用的瀏覽器較舊，在你點擊連結時，必須透過我們的伺服器來重新導向，才能避免搜尋記錄外洩。%1$s瞭解更多%2$s。"
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -10696,9 +10566,7 @@ msgctxt ""
 msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
-msgstr ""
-"在 DuckDuckGo 瀏覽器中，點選設定 › Sync & Backup，然後選擇「與另一裝置同"
-"步」。"
+msgstr "在 DuckDuckGo 瀏覽器中，點選設定 › Sync & Backup，然後選擇「與另一裝置同步」。"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -11117,9 +10985,8 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"物品排序是依照你的搜尋關鍵字為依據，並經由Microsoft's Ad Network播送。點擊後"
-"會立即連接到商家的登陸頁面，但與廣告不同的是，DuckDuckGo並不會因這些結果而收"
-"到任何報酬。"
+"物品排序是依照你的搜尋關鍵字為依據，並經由Microsoft's Ad "
+"Network播送。點擊後會立即連接到商家的登陸頁面，但與廣告不同的是，DuckDuckGo並不會因這些結果而收到任何報酬。"
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -11127,9 +10994,7 @@ msgctxt "cloudsave"
 msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
-msgstr ""
-"比起強記 10 個隨機的字母與數字，只記住 4 至 5 個單字要容易許多，而且也更加安"
-"全。"
+msgstr "比起強記 10 個隨機的字母與數字，只記住 4 至 5 個單字要容易許多，而且也更加安全。"
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -11695,7 +11560,7 @@ msgstr "連結會在 7 天後到期。"
 #. Explains the seven-day share link lifetime and that viewers can save their own copy of the chat.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days. People can save a chat copy."
-msgstr ""
+msgstr "連結會在 7 天後到期。使用者可以儲存聊天副本。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -13151,9 +13016,8 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"新的提示和回應在傳送後會被加密並暫時儲存在 DuckDuckGo 伺服器上，以便在你失去"
-"網路連線時協助恢復聊天。停用聊天紀錄會刪除置頂的聊天記錄，並停用新提示和回應"
-"的暫時儲存功能。"
+"新的提示和回應在傳送後會被加密並暫時儲存在 DuckDuckGo "
+"伺服器上，以便在你失去網路連線時協助恢復聊天。停用聊天紀錄會刪除置頂的聊天記錄，並停用新提示和回應的暫時儲存功能。"
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -13813,7 +13677,7 @@ msgstr "好，瞭解！"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "OPTIONAL"
-msgstr ""
+msgstr "選填"
 
 # smartling.placeholder_format=C
 #. Separator label between actions.
@@ -13980,9 +13844,7 @@ msgstr "隨需"
 msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
-msgstr ""
-"在Mac系統中，%1$s按Maxthon > 偏好設定%2$s，在Windows中，%3$s按%4$s 圖示 > 設"
-"定%5$s"
+msgstr "在Mac系統中，%1$s按Maxthon > 偏好設定%2$s，在Windows中，%3$s按%4$s 圖示 > 設定%5$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -13990,9 +13852,7 @@ msgctxt "Instruction under the Scan QR tab sub-heading"
 msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
-msgstr ""
-"在其他裝置上前往 %1$sDuck.ai 設定%2$s › %3$s聊天 › Sync & Backup › 與其他裝置"
-"同步%4$s"
+msgstr "在其他裝置上前往 %1$sDuck.ai 設定%2$s › %3$s聊天 › Sync & Backup › 與其他裝置同步%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14000,9 +13860,7 @@ msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
 msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
-msgstr ""
-"在其他裝置上前往 %1$sDuck.ai 設定%2$s › %3$s聊天 › Sync & Backup › 與其他裝置"
-"同步%4$s，然後掃描此代碼："
+msgstr "在其他裝置上前往 %1$sDuck.ai 設定%2$s › %3$s聊天 › Sync & Backup › 與其他裝置同步%4$s，然後掃描此代碼："
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14011,8 +13869,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
-"在其他裝置上前往 %1$sDuck.ai 設定%2$s › %3$s聊天 › Sync & Backup › 與其他裝置"
-"同步%4$s。或掃描你復原 PDF 上的 QR 碼。"
+"在其他裝置上前往 %1$sDuck.ai 設定%2$s › %3$s聊天 › Sync & Backup › 與其他裝置同步%4$s。或掃描你復原 "
+"PDF 上的 QR 碼。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14039,8 +13897,7 @@ msgctxt ""
 msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
-msgstr ""
-"附上的其中一個檔案頁數超過了我們的支援範圍。請上傳頁數不超過 %1$s 的檔案。"
+msgstr "附上的其中一個檔案頁數超過了我們的支援範圍。請上傳頁數不超過 %1$s 的檔案。"
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -14402,8 +14259,7 @@ msgctxt "homepage onboarding"
 msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
-msgstr ""
-"即使你處於隱身瀏覽模式，其他搜尋引擎也會追蹤你的搜尋。我們在這期間不追蹤你。"
+msgstr "即使你處於隱身瀏覽模式，其他搜尋引擎也會追蹤你的搜尋。我們在這期間不追蹤你。"
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -14416,9 +14272,7 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Our fast, no-log VPN comes with smarter AI chats with higher limits, plus "
 "more premium protections. All in one subscription."
-msgstr ""
-"我們快速、不記錄日誌的 VPN 提供更聰明且限制更高的 AI 聊天功能，以及更多頂級保"
-"護。一站式訂閱。"
+msgstr "我們快速、不記錄日誌的 VPN 提供更聰明且限制更高的 AI 聊天功能，以及更多頂級保護。一站式訂閱。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -14432,9 +14286,7 @@ msgid ""
 "Our private browser for mobile comes equipped with our search engine, "
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
-msgstr ""
-"我們的行動裝置私密瀏覽器配備搜尋引擎、追蹤器封鎖程式、加密執行程式等眾多功"
-"能。提供%1$siOS及Android%2$s版本。"
+msgstr "我們的行動裝置私密瀏覽器配備搜尋引擎、追蹤器封鎖程式、加密執行程式等眾多功能。提供%1$siOS及Android%2$s版本。"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14686,9 +14538,7 @@ msgctxt "cloudsave"
 msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
-msgstr ""
-"我們並未將你的IP位址、瀏覽器指紋或其他相關資訊連結至通關密語檔案，因此無法找"
-"回通關密語。"
+msgstr "我們並未將你的IP位址、瀏覽器指紋或其他相關資訊連結至通關密語檔案，因此無法找回通關密語。"
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -14843,9 +14693,7 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
-msgstr ""
-"Personal Information Removal 會在販售你資訊的資料仲介網站上找出你的資訊。接下"
-"來，我們會努力為你將該資訊移除。"
+msgstr "Personal Information Removal 會在販售你資訊的資料仲介網站上找出你的資訊。接下來，我們會努力為你將該資訊移除。"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -14916,8 +14764,8 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-"將您的搜尋以問句形式完整地表達出來，能提高 AI 輔助答案自動顯示的機率，且通常"
-"能得到更好的答案。欲關閉並隱藏「Assist」按鈕，請造訪 %1$s搜尋設定%2$s。"
+"將您的搜尋以問句形式完整地表達出來，能提高 AI 輔助答案自動顯示的機率，且通常能得到更好的答案。欲關閉並隱藏「Assist」按鈕，請造訪 "
+"%1$s搜尋設定%2$s。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14926,9 +14774,8 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"將您的搜尋作為一個問題表述，並且用一個完整的句子為形式，讓 DuckAssist 更可能"
-"顯示並且通常能得出更好的答案。 欲調整此功能的運作方式或將其關閉，請造訪 "
-"%1$sDuckAssist 設定%2$s。"
+"將您的搜尋作為一個問題表述，並且用一個完整的句子為形式，讓 DuckAssist 更可能顯示並且通常能得出更好的答案。 "
+"欲調整此功能的運作方式或將其關閉，請造訪 %1$sDuckAssist 設定%2$s。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14938,9 +14785,8 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"將您的搜尋作為一個問題表述，並且用一個完整的句子為形式，讓 DuckAssist 更可能"
-"自動顯示並且通常能得出更好的答案。欲關閉並隱藏「協助」按鈕，請造訪 %1$s "
-"DuckAssist 設定 %2$s。"
+"將您的搜尋作為一個問題表述，並且用一個完整的句子為形式，讓 DuckAssist "
+"更可能自動顯示並且通常能得出更好的答案。欲關閉並隱藏「協助」按鈕，請造訪 %1$s DuckAssist 設定 %2$s。"
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14972,8 +14818,7 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
-msgstr ""
-"選擇流行的 AI 進行聊天，例如 GPT-5 迷你、克勞德海庫 4.5、米斯特拉爾等。"
+msgstr "選擇流行的 AI 進行聊天，例如 GPT-5 迷你、克勞德海庫 4.5、米斯特拉爾等。"
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -14989,8 +14834,7 @@ msgctxt "Third party map app picker"
 msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
-msgstr ""
-"選擇一項服務來導覽到你的目的地。外部應用程式不會受到 DuckDuckGo 的保護。"
+msgstr "選擇一項服務來導覽到你的目的地。外部應用程式不會受到 DuckDuckGo 的保護。"
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -15138,9 +14982,7 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
-msgstr ""
-"請貼上你的提示和有問題的輸出（請移除任何個人資訊），並描述為何該內容有害或非"
-"法。"
+msgstr "請貼上你的提示和有問題的輸出（請移除任何個人資訊），並描述為何該內容有害或非法。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15148,9 +14990,7 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
-msgstr ""
-"請貼上你的提示和有問題的輸出（請移除任何個人資訊），並描述為何該內容非法或有"
-"害。"
+msgstr "請貼上你的提示和有問題的輸出（請移除任何個人資訊），並描述為何該內容非法或有害。"
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -15908,7 +15748,7 @@ msgstr "受到保護"
 #. Headline in sync-enabled chat history about modals explaining encrypted server storage.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Protected with end-to-end encryption"
-msgstr ""
+msgstr "採用端對端加密保護"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -16045,7 +15885,7 @@ msgstr "排名"
 #. Accessible label read out by screen readers for a visual star rating, since the stars themselves convey no text. The first placeholder is the rating, the second is the maximum possible rating. Example: 'Rated 4.5 out of 5'
 msgctxt "star rating on a product"
 msgid "Rated %s out of %s"
-msgstr ""
+msgstr "獲%1$s分（滿分%2$s分）"
 
 # smartling.placeholder_format=C
 #. Placeholder will be a number. This is used to describe extension rating out of 5 stars.
@@ -16199,9 +16039,7 @@ msgctxt "Description for recent chats feature"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr ""
-"最近的聊天記錄會儲存在你的裝置本機上，而非在 DuckDuckGo 或其他的遠端伺服器"
-"中。"
+msgstr "最近的聊天記錄會儲存在你的裝置本機上，而非在 DuckDuckGo 或其他的遠端伺服器中。"
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -16209,9 +16047,7 @@ msgctxt "Description of where recent chats are stored"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr ""
-"最近的聊天記錄會儲存在你的裝置本機上，而非在 DuckDuckGo 或其他的遠端伺服器"
-"中。"
+msgstr "最近的聊天記錄會儲存在你的裝置本機上，而非在 DuckDuckGo 或其他的遠端伺服器中。"
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -16220,9 +16056,7 @@ msgid ""
 "Recent chats are stored locally on your device. New prompts and responses "
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
-msgstr ""
-"最近的聊天記錄會儲存在你的裝置本機上。新的提示和回應在傳送後會被加密並暫時儲"
-"存在 DuckDuckGo 伺服器上，以便在你斷線時協助恢復聊天。"
+msgstr "最近的聊天記錄會儲存在你的裝置本機上。新的提示和回應在傳送後會被加密並暫時儲存在 DuckDuckGo 伺服器上，以便在你斷線時協助恢復聊天。"
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -16503,8 +16337,7 @@ msgstr "重新載入 Duck.ai。"
 msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
-msgstr ""
-"按照說明重新載入 DuckDuckGo，或者點擊瀏覽器的「重新整理」或「重新載入」按鈕。"
+msgstr "按照說明重新載入 DuckDuckGo，或者點擊瀏覽器的「重新整理」或「重新載入」按鈕。"
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16675,18 +16508,14 @@ msgid ""
 "Reports are anonymous and sent to DuckDuckGo to help improve our search "
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
-msgstr ""
-"報告會匿名傳送給DuckDuckGo，幫助我們改善搜尋服務。你的匿名回饋意見也會分享"
-"給%1$s來協助改善其服務。"
+msgstr "報告會匿名傳送給DuckDuckGo，幫助我們改善搜尋服務。你的匿名回饋意見也會分享給%1$s來協助改善其服務。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
-msgstr ""
-"傳送給 DuckDuckGo 的檢舉採匿名制。請不要在你的意見回饋中包含任何個人或可識別"
-"身分的資訊。"
+msgstr "傳送給 DuckDuckGo 的檢舉採匿名制。請不要在你的意見回饋中包含任何個人或可識別身分的資訊。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16694,9 +16523,7 @@ msgid ""
 "Reports sent to DuckDuckGo include all of the text you've asked us to "
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
-msgstr ""
-"傳送給 DuckDuckGo 的報告包括你在此頁面載入時要求我們翻譯的所有文字，並且是匿"
-"名的。請不要在你的意見回饋中包含任何個人或可識別身分的資訊。"
+msgstr "傳送給 DuckDuckGo 的報告包括你在此頁面載入時要求我們翻譯的所有文字，並且是匿名的。請不要在你的意見回饋中包含任何個人或可識別身分的資訊。"
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -16787,9 +16614,7 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
-msgstr ""
-"回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。AI 輔助的回"
-"答受我們的 %1$s 服務條款%2$s約束。"
+msgstr "回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。AI 輔助的回答受我們的 %1$s 服務條款%2$s約束。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16797,9 +16622,7 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
-msgstr ""
-"回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。DuckAssist "
-"受我們的%1$s服務條款%2$s約束。"
+msgstr "回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。DuckAssist 受我們的%1$s服務條款%2$s約束。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16809,8 +16632,8 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。係根據網頁"
-"內容生成，可能會有不準確之處。Search Assist 受我們的 %1$s服務條款%2$s 約束。"
+"回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。係根據網頁內容生成，可能會有不準確之處。Search Assist 受我們的 "
+"%1$s服務條款%2$s 約束。"
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -17234,9 +17057,7 @@ msgctxt "Description for Chat History feature with Encrypted Storage option"
 msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
-msgstr ""
-"你最多可在裝置本機儲存多達 30 筆近期聊天記錄，並可選擇透過加密儲存功能儲存更"
-"多內容。"
+msgstr "你最多可在裝置本機儲存多達 30 筆近期聊天記錄，並可選擇透過加密儲存功能儲存更多內容。"
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -17261,7 +17082,7 @@ msgstr "將你的聊天記錄儲存到所有裝置上。"
 #. Headline in the About Chat History modal explaining that chats are saved locally on the user's device.
 msgctxt "Chat history about modal list item headline"
 msgid "Save your chats on this device"
-msgstr ""
+msgstr "將你的聊天記錄儲存到此裝置上"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that recent chats are saved.
@@ -17465,7 +17286,7 @@ msgctxt ""
 "Placeholder and accessibility label for the search input in the tab picker "
 "dialog"
 msgid "Search"
-msgstr ""
+msgstr "搜尋"
 
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
@@ -17502,18 +17323,16 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist 會匿名生成搜尋查詢的答案。為了達成這個目的，它會掃描網路尋找相"
-"關內容，然後使用 AI 生成簡短的回答。你可以選擇它出現的頻率：從不、隨需 (僅在"
-"點按 Assist 時)、有時 (在高度相關時)，或經常 (在廣泛的搜尋中)。目前，Search "
-"Assist 功能僅供部分英語地區使用。"
+"Search Assist 會匿名生成搜尋查詢的答案。為了達成這個目的，它會掃描網路尋找相關內容，然後使用 AI "
+"生成簡短的回答。你可以選擇它出現的頻率：從不、隨需 (僅在點按 Assist 時)、有時 (在高度相關時)，或經常 "
+"(在廣泛的搜尋中)。目前，Search Assist 功能僅供部分英語地區使用。"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
 msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
-msgstr ""
-"Search Assist 找不到足夠的可靠資訊以產生這個問題的答案。嘗試另一個搜尋。"
+msgstr "Search Assist 找不到足夠的可靠資訊以產生這個問題的答案。嘗試另一個搜尋。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -17522,8 +17341,8 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist 是一項選用功能，可匿名生成搜尋查詢的答案。為此，它%1$s掃描網"
-"路%2$s以尋找相關內容，然後使用 AI 根據找到的資訊生成簡短的答案。"
+"Search Assist 是一項選用功能，可匿名生成搜尋查詢的答案。為此，它%1$s掃描網路%2$s以尋找相關內容，然後使用 AI "
+"根據找到的資訊生成簡短的答案。"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -17643,9 +17462,7 @@ msgctxt "noresults"
 msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
-msgstr ""
-"使用 %1$s 快捷方式搜尋其他網站：搜尋「!w ducks」將直接在維基百科上搜尋"
-"「ducks」。"
+msgstr "使用 %1$s 快捷方式搜尋其他網站：搜尋「!w ducks」將直接在維基百科上搜尋「ducks」。"
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -17663,9 +17480,7 @@ msgstr "私密搜尋與封鎖追蹤器"
 msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
-msgstr ""
-"使用我們的應用程式或延伸模組進行私密搜尋，為你最常用的瀏覽器新增隱身網路搜尋"
-"功能，或直接在%1$sduckduckgo.com%2$s搜尋。"
+msgstr "使用我們的應用程式或延伸模組進行私密搜尋，為你最常用的瀏覽器新增隱身網路搜尋功能，或直接在%1$sduckduckgo.com%2$s搜尋。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -17684,9 +17499,8 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"搜尋設定會儲存在瀏覽器中的非個人瀏覽器 cookie 和本機儲存空間，但你也可以使用 "
-"Cloud Save 將設定匿名儲存在雲端的遠端伺服器上。不會在雲端中儲存任何個人身分資"
-"料，且你的通關密語永遠不會離開你的瀏覽器。"
+"搜尋設定會儲存在瀏覽器中的非個人瀏覽器 cookie 和本機儲存空間，但你也可以使用 Cloud Save "
+"將設定匿名儲存在雲端的遠端伺服器上。不會在雲端中儲存任何個人身分資料，且你的通關密語永遠不會離開你的瀏覽器。"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -17804,9 +17618,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
-msgstr ""
-"以端對端加密安全地將幾乎無限的聊天內容儲存在我們的伺服器上，並可從所有已同步"
-"的裝置存取。"
+msgstr "以端對端加密安全地將幾乎無限的聊天內容儲存在我們的伺服器上，並可從所有已同步的裝置存取。"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17814,9 +17626,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
-msgstr ""
-"以端對端加密安全地將您的聊天內容儲存在我們的伺服器上，並可從您所有的裝置存"
-"取。"
+msgstr "以端對端加密安全地將您的聊天內容儲存在我們的伺服器上，並可從您所有的裝置存取。"
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -17830,9 +17640,7 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
-msgstr ""
-"採用端對端加密，安全儲存在 DuckDuckGo 的伺服器上。除了你之外，沒有人可以看到"
-"你的資料，連我們也不行。"
+msgstr "採用端對端加密，安全儲存在 DuckDuckGo 的伺服器上。除了你之外，沒有人可以看到你的資料，連我們也不行。"
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
@@ -18238,9 +18046,7 @@ msgid ""
 "Sends a prompt to AI models with your messages with instructions on how to "
 "respond. These instructions will apply to all of your conversations going "
 "forward."
-msgstr ""
-"向 AI 模型發送提示，包含你的訊息和回應指示說明。這些只是將自動套用至往後所有"
-"對話。"
+msgstr "向 AI 模型發送提示，包含你的訊息和回應指示說明。這些只是將自動套用至往後所有對話。"
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -18362,8 +18168,7 @@ msgctxt "Chat history about modal list item"
 msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
-msgstr ""
-"開啟聊天記錄後，請設定 Sync & Backup 以確保您的聊天記錄能在各裝置間保持同步。"
+msgstr "開啟聊天記錄後，請設定 Sync & Backup 以確保您的聊天記錄能在各裝置間保持同步。"
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -18469,9 +18274,7 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
-msgstr ""
-"與 AI 模型分享城市等級的位置，以提升相關性。Duck.ai 絕不會向我們或 AI 模型透"
-"露你的精確位置。"
+msgstr "與 AI 模型分享城市等級的位置，以提升相關性。Duck.ai 絕不會向我們或 AI 模型透露你的精確位置。"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -18592,9 +18395,7 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Shield your online activity with our no-log, fast VPN. Simple to set up and "
 "easy to turn on and off anytime."
-msgstr ""
-"使用我們無記錄、快速的 VPN 來保護你的線上活動。 設定簡單，且可隨時輕鬆開啟或"
-"關閉。"
+msgstr "使用我們無記錄、快速的 VPN 來保護你的線上活動。 設定簡單，且可隨時輕鬆開啟或關閉。"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -18612,7 +18413,7 @@ msgstr "購物"
 #. Button below the zoomed easter-egg logo in the tap-to-zoom modal, beneath the sentence above it; opens /collaborations, the DuckDuckGo branded merchandise line. Short because the sentence above already carries the message. Names no product, so any merchandise logo can reuse it.
 msgctxt "Button in the merchandise logo modal (mobile)"
 msgid "Shop Now"
-msgstr ""
+msgstr "立即購物"
 
 # smartling.placeholder_format=C
 #. Label above shopping search results.
@@ -18957,18 +18758,14 @@ msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
-msgstr ""
-"提醒您，DuckDuckGo 上的所有搜尋都是私密的。關閉此功能會隱藏提醒，且永遠不會影"
-"響私密搜尋。"
+msgstr "提醒您，DuckDuckGo 上的所有搜尋都是私密的。關閉此功能會隱藏提醒，且永遠不會影響私密搜尋。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
-msgstr ""
-"提醒您，DuckDuckGo 上的所有搜尋都受到保護。關閉此功能會隱藏提醒，且永遠不會影"
-"響搜尋保護。"
+msgstr "提醒您，DuckDuckGo 上的所有搜尋都受到保護。關閉此功能會隱藏提醒，且永遠不會影響搜尋保護。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20242,7 +20039,7 @@ msgctxt "Chat history with sync modal list item description"
 msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
-msgstr ""
+msgstr "Sync & Backup 可儲存更多你的聊天記錄，並在所有裝置間同步。"
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20291,19 +20088,16 @@ msgid ""
 msgstr ""
 "同步恢復碼\n"
 "\n"
-"恢復碼允許你在多個裝置之間同步您的密碼、自動填入資料和 Duck.ai 聊天記錄，並在"
-"你無法存取某個裝置時恢復你的同步資料。\n"
+"恢復碼允許你在多個裝置之間同步您的密碼、自動填入資料和 Duck.ai 聊天記錄，並在你無法存取某個裝置時恢復你的同步資料。\n"
 "\n"
 "確保此資訊安全無虞。\n"
 "任何有權限存取此代碼的人都能存取你同步的資料。%1$s\n"
 "\n"
 "這段代碼是如何運作的？\n"
-"1. 在瀏覽器中造訪 Duck.ai 並開啟 Duck.ai 設定。2. 選取「開啟 Sync & "
-"Backup」，然後選擇「恢復已同步的資料」\n"
+"1. 在瀏覽器中造訪 Duck.ai 並開啟 Duck.ai 設定。2. 選取「開啟 Sync & Backup」，然後選擇「恢復已同步的資料」\n"
 "3. 複製上方的恢復代碼，並貼到顯示「將你的代碼貼在這裡」的地方\n"
 "\n"
-"如果你超過 18 個月未使用已啟用 Sync & Backup 的 DuckDuckGo 瀏覽器，你的資料將"
-"從伺服器上刪除，且無法恢復。"
+"如果你超過 18 個月未使用已啟用 Sync & Backup 的 DuckDuckGo 瀏覽器，你的資料將從伺服器上刪除，且無法恢復。"
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -20357,7 +20151,7 @@ msgstr "將你的聊天記錄同步到所有裝置。"
 #. Headline in sync-enabled chat history about modals explaining cross-device sync.
 msgctxt "Chat history with sync modal list item headline"
 msgid "Sync your chats across all your devices"
-msgstr ""
+msgstr "跨裝置同步你的聊天記錄"
 
 # smartling.placeholder_format=C
 #. Label preceding the list of devices currently registered to the account.
@@ -20441,9 +20235,7 @@ msgctxt "Product-tour success modal body - mobile variant"
 msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
-msgstr ""
-"隨身帶著 Duck.ai。 無論身在何處，都能透過我們免費 App 的內建功能更快速地存"
-"取。"
+msgstr "隨身帶著 Duck.ai。 無論身在何處，都能透過我們免費 App 的內建功能更快速地存取。"
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20451,9 +20243,7 @@ msgctxt "Product-tour success modal body"
 msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
-msgstr ""
-"隨時隨地帶著 Duck.ai。 使用我們免費瀏覽器的內建功能，無論你在何處瀏覽都能更快"
-"速存取。"
+msgstr "隨時隨地帶著 Duck.ai。 使用我們免費瀏覽器的內建功能，無論你在何處瀏覽都能更快速存取。"
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20696,9 +20486,7 @@ msgid ""
 "That means information sent between your device and the webpage behind this "
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
-msgstr ""
-"這代表在你的裝置與此連結通往的網頁之間傳遞的資訊處於高風險中，有可能會遭到第"
-"三方攔截。雖然極少發生，但該資訊可能包含密碼或付款詳情。"
+msgstr "這代表在你的裝置與此連結通往的網頁之間傳遞的資訊處於高風險中，有可能會遭到第三方攔截。雖然極少發生，但該資訊可能包含密碼或付款詳情。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -20814,8 +20602,7 @@ msgctxt "Error message when there was an issue saving a chat to the browser"
 msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
-msgstr ""
-"在本機儲存此聊天時發生錯誤。請檢查你的瀏覽器設定，確保已啟用本機資料儲存。"
+msgstr "在本機儲存此聊天時發生錯誤。請檢查你的瀏覽器設定，確保已啟用本機資料儲存。"
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -20847,9 +20634,7 @@ msgid ""
 "These browser permissions are used to add privacy protection on websites you "
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
-msgstr ""
-"這些瀏覽器權限可封鎖隱藏的追蹤器，並盡可能加密資訊，並將DuckDuckGo設定為預設"
-"搜尋引擎，藉此為你造訪的網站新增隱私保護。"
+msgstr "這些瀏覽器權限可封鎖隱藏的追蹤器，並盡可能加密資訊，並將DuckDuckGo設定為預設搜尋引擎，藉此為你造訪的網站新增隱私保護。"
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -20928,13 +20713,13 @@ msgctxt ""
 msgid ""
 "This chat and its generated images become public when you create and copy "
 "the link."
-msgstr ""
+msgstr "當你建立並複製連結時，這則聊天及其生成的圖片將會公開。"
 
 # smartling.placeholder_format=C
 #. Explains that creating and copying a share link makes the selected chat content public.
 msgctxt "Share modal info bullet about public access"
 msgid "This chat becomes public when you create and copy the link."
-msgstr ""
+msgstr "建立並複製連結後，這個聊天就會公開。"
 
 # smartling.placeholder_format=C
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
@@ -20949,8 +20734,8 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"此對話是使用 %2$s 的 %3$s 模型與 Duck.ai (%1$s) 產生的。AI 聊天可能會顯示不準"
-"確或令人反感的資訊 (請參閱 %4$s 取得更多資訊)。"
+"此對話是使用 %2$s 的 %3$s 模型與 Duck.ai (%1$s) 產生的。AI 聊天可能會顯示不準確或令人反感的資訊 (請參閱 %4$s "
+"取得更多資訊)。"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20959,9 +20744,7 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using multiple chat "
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
-msgstr ""
-"此對話是使用多個聊天模型與 Duck.ai (%1$s) 產生的。AI 聊天可能會顯示不準確或令"
-"人反感的資訊 (請參閱 %2$s 取得更多資訊)。"
+msgstr "此對話是使用多個聊天模型與 Duck.ai (%1$s) 產生的。AI 聊天可能會顯示不準確或令人反感的資訊 (請參閱 %2$s 取得更多資訊)。"
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20969,9 +20752,7 @@ msgctxt "Export chat feature in AI Chat"
 msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
-msgstr ""
-"這段對話是透過 Duck.ai 語音聊天產生的（%1$s）。AI 可能會提供不準確或令人反感"
-"的資訊。（更多資訊請參見%2$s）。"
+msgstr "這段對話是透過 Duck.ai 語音聊天產生的（%1$s）。AI 可能會提供不準確或令人反感的資訊。（更多資訊請參見%2$s）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -20981,8 +20762,8 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"此對話是使用 %2$s的%3$s 模型與 DuckDuckGo AI Chat (%1$s) 產生的。AI 聊天可能"
-"會顯示不準確或令人反感的資訊 (請參閱 %4$s 取得更多資訊)。"
+"此對話是使用 %2$s的%3$s 模型與 DuckDuckGo AI Chat (%1$s) 產生的。AI 聊天可能會顯示不準確或令人反感的資訊 "
+"(請參閱 %4$s 取得更多資訊)。"
 
 # smartling.placeholder_format=C
 #. Renders to the right of the device name for the row that matches this device's id.
@@ -20998,9 +20779,7 @@ msgctxt ""
 msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
-msgstr ""
-"此裝置將無法再存取你在其他裝置上的同步資料。最近的 %1$s 個聊天記錄仍將保留在"
-"本機儲存空間中。"
+msgstr "此裝置將無法再存取你在其他裝置上的同步資料。最近的 %1$s 個聊天記錄仍將保留在本機儲存空間中。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21097,9 +20876,7 @@ msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
-msgstr ""
-"這只是一則範例聊天。 開啟選單（三個點），然後選擇「釘選」，將它保持在聊天的最"
-"上方！"
+msgstr "這只是一則範例聊天。 開啟選單（三個點），然後選擇「釘選」，將它保持在聊天的最上方！"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -21127,9 +20904,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
-msgstr ""
-"此模型供應商會在 30 天內刪除與此聊天相關的資料。其他模型供應商遵循零資料保留"
-"模式。"
+msgstr "此模型供應商會在 30 天內刪除與此聊天相關的資料。其他模型供應商遵循零資料保留模式。"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -21137,9 +20912,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
-msgstr ""
-"此模型供應商不會儲存與此聊天相關的任何資料。其他模型供應商遵循限制資料保留模"
-"式。"
+msgstr "此模型供應商不會儲存與此聊天相關的任何資料。其他模型供應商遵循限制資料保留模式。"
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -21175,9 +20948,7 @@ msgctxt "First paragraph for the Sync & Backup intro screen"
 msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
-msgstr ""
-"這會將您的聊天內容以端對端加密方式儲存在 DuckDuckGo 的安全伺服器，之後您可從"
-"任何瀏覽器存取。"
+msgstr "這會將您的聊天內容以端對端加密方式儲存在 DuckDuckGo 的安全伺服器，之後您可從任何瀏覽器存取。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21185,9 +20956,7 @@ msgctxt "duckassist"
 msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
-msgstr ""
-"此設定儲存在你的瀏覽器中，這表示如果你清除 duckduckgo.com 的瀏覽器資料，那麼"
-"可能會再次看到 AI 輔助的答案。"
+msgstr "此設定儲存在你的瀏覽器中，這表示如果你清除 duckduckgo.com 的瀏覽器資料，那麼可能會再次看到 AI 輔助的答案。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21197,9 +20966,8 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"此設定儲存在你的瀏覽器中，這表示如果你清除 duckduckgo.com 的瀏覽器資料，那麼"
-"可能會再次看到 AI 輔助的答案。不過，我們也有一個起始頁面，從不在 %1$s 顯示 "
-"AI 輔助答案。"
+"此設定儲存在你的瀏覽器中，這表示如果你清除 duckduckgo.com 的瀏覽器資料，那麼可能會再次看到 AI "
+"輔助的答案。不過，我們也有一個起始頁面，從不在 %1$s 顯示 AI 輔助答案。"
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
@@ -21250,8 +21018,8 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"這將刪除此瀏覽器中所有 Duck.ai 聊天記錄，並與 Sync & Backup 中斷連線。您仍然"
-"可以在連接到 Sync & Backup 的其他瀏覽器中存取您的聊天記錄。"
+"這將刪除此瀏覽器中所有 Duck.ai 聊天記錄，並與 Sync & Backup 中斷連線。您仍然可以在連接到 Sync & Backup "
+"的其他瀏覽器中存取您的聊天記錄。"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -21396,9 +21164,7 @@ msgctxt "directions"
 msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
-msgstr ""
-"如要列印導航指引：%1$s返回地圖。%2$s選取你想列印的路線。%3$s按一下「列印」圖"
-"示。%4$s"
+msgstr "如要列印導航指引：%1$s返回地圖。%2$s選取你想列印的路線。%3$s按一下「列印」圖示。%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -21407,9 +21173,7 @@ msgid ""
 "To restore your synced data, you'll need the Recovery Code you saved when "
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
-msgstr ""
-"若要恢復同步資料，請在第一次設定同步時儲存的恢復碼。此代碼可能已以 PDF 格式儲"
-"存在您最初用於設定同步的裝置上。"
+msgstr "若要恢復同步資料，請在第一次設定同步時儲存的恢復碼。此代碼可能已以 PDF 格式儲存在您最初用於設定同步的裝置上。"
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -21417,9 +21181,7 @@ msgctxt "duckai_migration"
 msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
-msgstr ""
-"欲將你的聊天紀錄轉移至 Duck.ai，請將你的 DuckDuckGo 瀏覽器更新至最新版本並再"
-"試一次。"
+msgstr "欲將你的聊天紀錄轉移至 Duck.ai，請將你的 DuckDuckGo 瀏覽器更新至最新版本並再試一次。"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -21448,7 +21210,7 @@ msgstr "今天"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
-msgstr ""
+msgstr "切換至私密 AI 聊天，或%1$s在設定中停用%2$s。"
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -21674,8 +21436,7 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"將這段英文句子翻譯成法語：“How do I get to the nearest movie theatre？”"
+msgstr "將這段英文句子翻譯成法語：“How do I get to the nearest movie theatre？”"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -21683,8 +21444,7 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"將這段英文句子翻譯成中文：“How do I get to the nearest movie theatre？”"
+msgstr "將這段英文句子翻譯成中文：“How do I get to the nearest movie theatre？”"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -22161,9 +21921,7 @@ msgctxt "settings"
 msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
-msgstr ""
-"想要停用 AI 功能嗎？ 安裝 %1$sDuckDuckGo No AI%2$s 搜尋擴充套件以儲存你的設"
-"定。 %3$s瞭解更多%4$s"
+msgstr "想要停用 AI 功能嗎？ 安裝 %1$sDuckDuckGo No AI%2$s 搜尋擴充套件以儲存你的設定。 %3$s瞭解更多%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -22171,9 +21929,7 @@ msgctxt "settings"
 msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
-msgstr ""
-"想要停用 AI 功能嗎？ 切換至 %1$sDuckDuckGo No AI%2$s 搜尋擴充功能以儲存你的設"
-"定。 %3$s瞭解更多%4$s"
+msgstr "想要停用 AI 功能嗎？ 切換至 %1$sDuckDuckGo No AI%2$s 搜尋擴充功能以儲存你的設定。 %3$s瞭解更多%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -22373,9 +22129,7 @@ msgctxt "settings"
 msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
-msgstr ""
-"在產生時輸入 DuckAssist 答案。關閉此功能可能會導致搜尋與顯示答案之間的短暫延"
-"遲。"
+msgstr "在產生時輸入 DuckAssist 答案。關閉此功能可能會導致搜尋與顯示答案之間的短暫延遲。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -22626,9 +22380,7 @@ msgctxt "Description of the modal to upgrade to Pro"
 msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
-msgstr ""
-"透過升級至 Pro，解鎖 %1$s、比 Plus 方案更高的 AI 推理能力，以及 2 倍於 Plus "
-"方案的使用上限。"
+msgstr "透過升級至 Pro，解鎖 %1$s、比 Plus 方案更高的 AI 推理能力，以及 2 倍於 Plus 方案的使用上限。"
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -23010,9 +22762,7 @@ msgctxt "duckai_seo"
 msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
-msgstr ""
-"私下使用 ChatGPT、Claude 及其他 AI。保護聊天內容，防止駭客、詐騙者和公司的侵"
-"害。對資訊保密。免費。不需要帳戶。"
+msgstr "私下使用 ChatGPT、Claude 及其他 AI。保護聊天內容，防止駭客、詐騙者和公司的侵害。對資訊保密。免費。不需要帳戶。"
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -23222,8 +22972,7 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr ""
-"DuckDuckGo 會保護你在觀看廣告時的隱私。點擊廣告則由 Microsoft 的廣告網路管理"
+msgstr "DuckDuckGo 會保護你在觀看廣告時的隱私。點擊廣告則由 Microsoft 的廣告網路管理"
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -23231,9 +22980,7 @@ msgctxt "Single Place Hotel Offers Module"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
-msgstr ""
-"DuckDuckGo 會保護你在觀看廣告時的隱私。點擊廣告則由 TripAdvisor 的廣告網路管"
-"理。"
+msgstr "DuckDuckGo 會保護你在觀看廣告時的隱私。點擊廣告則由 TripAdvisor 的廣告網路管理。"
 
 # smartling.placeholder_format=C
 #. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
@@ -23241,7 +22988,7 @@ msgctxt "Ads GDPR"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Yelp's ad network."
-msgstr ""
+msgstr "DuckDuckGo 會保護你在觀看廣告時的隱私。點擊廣告則由 Yelp 的廣告網路管理。"
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -23283,8 +23030,8 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"請用其他瀏覽器造訪 Duck.ai，並前往 %1$sDuck.ai 設定%2$s > %3$sSync & "
-"Backup%4$s > %5$s管理%6$s，再選取%7$s與其他裝置同步%8$s。"
+"請用其他瀏覽器造訪 Duck.ai，並前往 %1$sDuck.ai 設定%2$s > %3$sSync & Backup%4$s > "
+"%5$s管理%6$s，再選取%7$s與其他裝置同步%8$s。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23294,8 +23041,8 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"在您的其他瀏覽器中造訪 Duck.ai 並開啟 Duck.ai 設定。在「Sync & Backup」下選取"
-"「開啟」，然後選取「與另一裝置同步」。或掃描您的恢復 PDF 上的二維碼。"
+"在您的其他瀏覽器中造訪 Duck.ai 並開啟 Duck.ai 設定。在「Sync & "
+"Backup」下選取「開啟」，然後選取「與另一裝置同步」。或掃描您的恢復 PDF 上的二維碼。"
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -23305,8 +23052,8 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"請用其他瀏覽器或 DuckDuckGo 應用程式造訪 Duck.ai，並前往 %1$sDuck.ai 設"
-"定%2$s > %3$sSync & Backup%4$s > %5$s管理%6$s，再選取%7$s與其他裝置同步%8$s。"
+"請用其他瀏覽器或 DuckDuckGo 應用程式造訪 Duck.ai，並前往 %1$sDuck.ai 設定%2$s > %3$sSync & "
+"Backup%4$s > %5$s管理%6$s，再選取%7$s與其他裝置同步%8$s。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23316,9 +23063,8 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"使用其他瀏覽器或 DuckDuckGo 應用程式造訪 Duck.ai，然後開啟 Duck.ai 設定。在"
-"「Sync & Backup」下選取「開啟」，然後選取「與另一裝置同步」。或掃描您的恢復 "
-"PDF 上的二維碼。"
+"使用其他瀏覽器或 DuckDuckGo 應用程式造訪 Duck.ai，然後開啟 Duck.ai 設定。在「Sync & "
+"Backup」下選取「開啟」，然後選取「與另一裝置同步」。或掃描您的恢復 PDF 上的二維碼。"
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23513,9 +23259,7 @@ msgstr "在 Duck Player 中觀看"
 msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
-msgstr ""
-"在 Duck Player 中觀看，阻擋 YouTube 上的個人化廣告，避免觀看體驗受 YouTube 推"
-"播干擾。"
+msgstr "在 Duck Player 中觀看，阻擋 YouTube 上的個人化廣告，避免觀看體驗受 YouTube 推播干擾。"
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -23535,8 +23279,8 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"在此處觀看影片即代表託管影片的網站能夠追蹤您，因為我們必須從那邊串流傳輸內"
-"容。DuckDuckGo 是一間獨立公司，與託管大多數影片的 YouTube 沒有任何關係。"
+"在此處觀看影片即代表託管影片的網站能夠追蹤您，因為我們必須從那邊串流傳輸內容。DuckDuckGo 是一間獨立公司，與託管大多數影片的 YouTube "
+"沒有任何關係。"
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -23559,9 +23303,7 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
-msgstr ""
-"我們必須先察覺問題，才能修正問題。若要檢舉有害或非法的回覆，請與 DuckDuckGo "
-"分享此對話，以便我們調查並處理該問題。"
+msgstr "我們必須先察覺問題，才能修正問題。若要檢舉有害或非法的回覆，請與 DuckDuckGo 分享此對話，以便我們調查並處理該問題。"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -23572,9 +23314,7 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share your prompt and response so we can investigate and address the "
 "issue."
-msgstr ""
-"我們必須先察覺問題，才能修正問題。若要檢舉有害或非法的回覆，請與我們分享您的"
-"提示詞與回覆內容，以便我們調查並處理該問題。"
+msgstr "我們必須先察覺問題，才能修正問題。若要檢舉有害或非法的回覆，請與我們分享您的提示詞與回覆內容，以便我們調查並處理該問題。"
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
@@ -23614,8 +23354,7 @@ msgstr "我們不會儲存你的個人資訊。"
 msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
-msgstr ""
-"我們不會儲存你的個人資訊。我們不會用廣告到處煩你。我們不會追蹤你。絕對不會。"
+msgstr "我們不會儲存你的個人資訊。我們不會用廣告到處煩你。我們不會追蹤你。絕對不會。"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23636,8 +23375,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
-msgstr ""
-"本站不追蹤任何用戶，請告訴我們為何你願意試用我們的服務，以讓我們不斷完善："
+msgstr "本站不追蹤任何用戶，請告訴我們為何你願意試用我們的服務，以讓我們不斷完善："
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23676,9 +23414,7 @@ msgctxt "homepage onboarding"
 msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
-msgstr ""
-"我們不會儲存你的搜尋紀錄。因此，我們沒有東西能夠賣給網路上那些追蹤你的廣告"
-"商。"
+msgstr "我們不會儲存你的搜尋紀錄。因此，我們沒有東西能夠賣給網路上那些追蹤你的廣告商。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -23703,8 +23439,7 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
-msgstr ""
-"我們會從資料仲介網站中尋找並移除你的個人資訊。另外還能取得 VPN 等功能。"
+msgstr "我們會從資料仲介網站中尋找並移除你的個人資訊。另外還能取得 VPN 等功能。"
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -23712,9 +23447,7 @@ msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
-msgstr ""
-"我們與所有人工智慧提供者都簽訂了協議，以確保你的聊天記錄不會用於訓練人工智"
-"慧。"
+msgstr "我們與所有人工智慧提供者都簽訂了協議，以確保你的聊天記錄不會用於訓練人工智慧。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23746,9 +23479,7 @@ msgctxt "precise_user_location"
 msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
-msgstr ""
-"我們僅會將你的匿名位置用於提供更優質、離你更近的結果。你之後可以隨時改變主"
-"意。"
+msgstr "我們僅會將你的匿名位置用於提供更優質、離你更近的結果。你之後可以隨時改變主意。"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
@@ -23756,9 +23487,7 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
-msgstr ""
-"我們會定期在資料仲介網站上掃描你的個人資訊，並在易於使用的儀表板中與你分享我"
-"們的進度。"
+msgstr "我們會定期在資料仲介網站上掃描你的個人資訊，並在易於使用的儀表板中與你分享我們的進度。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -23784,9 +23513,7 @@ msgid ""
 "We use feedback like this to improve DuckDuckGo. Suggestions will be "
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
-msgstr ""
-"我們運用這樣的回饋來完善DuckDuckGo。%1$s將視情況採納建議。修改內容可能不會立"
-"刻出現。"
+msgstr "我們運用這樣的回饋來完善DuckDuckGo。%1$s將視情況採納建議。修改內容可能不會立刻出現。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23799,9 +23526,7 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
-msgstr ""
-"我們會針對你的電子郵件、姓名、地址等資訊掃描資料仲介網站，並努力將找到的你任"
-"何相關資訊移除。"
+msgstr "我們會針對你的電子郵件、姓名、地址等資訊掃描資料仲介網站，並努力將找到的你任何相關資訊移除。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23960,9 +23685,7 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
-msgstr ""
-"歡迎來到 Duck.ai！您在這裡的所有聊天內容都是私密的，我們會將其匿名化，且不會"
-"用來訓練人工智慧模型。"
+msgstr "歡迎來到 Duck.ai！您在這裡的所有聊天內容都是私密的，我們會將其匿名化，且不會用來訓練人工智慧模型。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -23970,9 +23693,7 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
-msgstr ""
-"歡迎來到 DuckDuckGo AI Chat！您在這裡的所有聊天內容都是私密的，我們會將其匿名"
-"化，且不會用來訓練人工智慧模型。"
+msgstr "歡迎來到 DuckDuckGo AI Chat！您在這裡的所有聊天內容都是私密的，我們會將其匿名化，且不會用來訓練人工智慧模型。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -23982,8 +23703,8 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"歡迎來到 DuckDuckGo AI Chat！此聊天會話由 %1$s 的 %2$s 提供技術支援。 您在這"
-"裡的所有聊天內容都是私密的，且永遠不會被 DuckDuckGo 儲存或用來訓練 AI 模型。"
+"歡迎來到 DuckDuckGo AI Chat！此聊天會話由 %1$s 的 %2$s 提供技術支援。 您在這裡的所有聊天內容都是私密的，且永遠不會被 "
+"DuckDuckGo 儲存或用來訓練 AI 模型。"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24115,9 +23836,8 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"下載 DuckDuckGo 瀏覽器對於有興趣使用 Duck.ai 的人有哪些好處？僅參考官方 "
-"DuckDuckGo 來源。將回應分成清晰的部分，並以 Duck.ai 整合和隱私保護為重點。對"
-"於具有或沒有太多 AI 或技術經驗的人來說，保持內容相當簡短、簡單且易於理解。"
+"下載 DuckDuckGo 瀏覽器對於有興趣使用 Duck.ai 的人有哪些好處？僅參考官方 DuckDuckGo 來源。將回應分成清晰的部分，並以 "
+"Duck.ai 整合和隱私保護為重點。對於具有或沒有太多 AI 或技術經驗的人來說，保持內容相當簡短、簡單且易於理解。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24652,9 +24372,7 @@ msgctxt "new tab page"
 msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
-msgstr ""
-"使用 Duck.ai，你的聊天內容都會經過匿名處理，且絕不會用於訓練 AI。 你可以隨時"
-"在「%1$s」選單中將其開啟或關閉。"
+msgstr "使用 Duck.ai，你的聊天內容都會經過匿名處理，且絕不會用於訓練 AI。 你可以隨時在「%1$s」選單中將其開啟或關閉。"
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
@@ -24662,14 +24380,14 @@ msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, up to %s of your most recent chats will be saved on "
 "this device."
-msgstr ""
+msgstr "開啟聊天記錄後，你最多可在這台裝置上儲存 %1$s 筆近期聊天記錄。"
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline in the About Chat History modal.
 msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, your most recent chats will be saved on this device."
-msgstr ""
+msgstr "開啟聊天記錄後，你最近的聊天記錄將保存在此裝置上。"
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24683,8 +24401,7 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
-msgstr ""
-"直接在你的裝置上運作，從資料仲介網站中移除你的電子郵件、姓名、地址等資訊。"
+msgstr "直接在你的裝置上運作，從資料仲介網站中移除你的電子郵件、姓名、地址等資訊。"
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25003,8 +24720,7 @@ msgstr "你最多可以附加 %1$s 個文字選擇。"
 msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
-msgstr ""
-"你可以在 %1$s搜尋設定%2$s 中變更 Search Assist 的顯示頻率，或將其完全關閉。"
+msgstr "你可以在 %1$s搜尋設定%2$s 中變更 Search Assist 的顯示頻率，或將其完全關閉。"
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -25024,8 +24740,7 @@ msgctxt "cloudsave"
 msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
-msgstr ""
-"你可以將你的設定以另一通關密語儲存，你亦可同時刪除以舊通關密語儲存的設定。"
+msgstr "你可以將你的設定以另一通關密語儲存，你亦可同時刪除以舊通關密語儲存的設定。"
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -25180,9 +24895,7 @@ msgctxt "Description of the post-upgrade success modal"
 msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
-msgstr ""
-"您現在已獲得 %1$s 的存取權限，具備更高階的 AI 推理能力，並享有比 Plus 方案高"
-"出 2 倍的使用上限。"
+msgstr "您現在已獲得 %1$s 的存取權限，具備更高階的 AI 推理能力，並享有比 Plus 方案高出 2 倍的使用上限。"
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -25190,9 +24903,7 @@ msgctxt "Description text for the subscription welcome modal"
 msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
-msgstr ""
-"你現在可以使用進階的 AI 模型。你可以在 DuckDuckGo 瀏覽器中存取 VPN 和其他 "
-"DuckDuckGo 訂閱保護功能。"
+msgstr "你現在可以使用進階的 AI 模型。你可以在 DuckDuckGo 瀏覽器中存取 VPN 和其他 DuckDuckGo 訂閱保護功能。"
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -25213,9 +24924,7 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr ""
-"您將無法再從此瀏覽器存取已儲存的聊天記錄。最近的 30 個聊天記錄仍將保留在本地"
-"儲存空間中。這不會刪除您在加密伺服器上的聊天記錄。"
+msgstr "您將無法再從此瀏覽器存取已儲存的聊天記錄。最近的 30 個聊天記錄仍將保留在本地儲存空間中。這不會刪除您在加密伺服器上的聊天記錄。"
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -25224,9 +24933,7 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr ""
-"您將無法再從此瀏覽器存取已儲存的聊天記錄。最近的 30 個聊天記錄仍將保留在本地"
-"儲存空間中。這不會刪除您在加密伺服器上的聊天記錄。"
+msgstr "您將無法再從此瀏覽器存取已儲存的聊天記錄。最近的 30 個聊天記錄仍將保留在本地儲存空間中。這不會刪除您在加密伺服器上的聊天記錄。"
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -25253,9 +24960,7 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
-msgstr ""
-"你目前正在Chrome進行私密搜尋。不用Chrome，在我們的應用程式中也可以進行隱身瀏"
-"覽。應用程式已經安裝完畢，而且可以："
+msgstr "你目前正在Chrome進行私密搜尋。不用Chrome，在我們的應用程式中也可以進行隱身瀏覽。應用程式已經安裝完畢，而且可以："
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -25342,9 +25047,7 @@ msgctxt "Sync file storage limit modal description"
 msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
-msgstr ""
-"您 Duck.ai 聊天 (含附件) 的 Sync & Backup 儲存空間已用完。刪除 %1$s 則最舊的"
-"聊天記錄以恢復同步。置頂聊天不會刪除。"
+msgstr "您 Duck.ai 聊天 (含附件) 的 Sync & Backup 儲存空間已用完。刪除 %1$s 則最舊的聊天記錄以恢復同步。置頂聊天不會刪除。"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25353,9 +25056,7 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats. Delete the %s "
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
-msgstr ""
-"您已用完 Duck.ai 聊天記錄的 Sync & Backup 儲存空間。刪除 %1$s 則最舊的含附件"
-"聊天記錄以恢復同步。置頂聊天不會刪除。"
+msgstr "您已用完 Duck.ai 聊天記錄的 Sync & Backup 儲存空間。刪除 %1$s 則最舊的含附件聊天記錄以恢復同步。置頂聊天不會刪除。"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -25368,9 +25069,7 @@ msgstr "你的儲存空間已用完"
 msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
-msgstr ""
-"YouTube(Google所擁有的公司)不允許匿名看影片。觀看YouTube影片還是會被Youtube/"
-"Google追蹤。"
+msgstr "YouTube(Google所擁有的公司)不允許匿名看影片。觀看YouTube影片還是會被Youtube/Google追蹤。"
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -25438,9 +25137,7 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
-msgstr ""
-"您的備份將從 DuckDuckGo 的伺服器中刪除。所有裝置都將中斷同步。在以下瀏覽器"
-"中，您最近的 %1$s 筆聊天記錄將保存在本機儲存空間中："
+msgstr "您的備份將從 DuckDuckGo 的伺服器中刪除。所有裝置都將中斷同步。在以下瀏覽器中，您最近的 %1$s 筆聊天記錄將保存在本機儲存空間中："
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -25449,9 +25146,7 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
-msgstr ""
-"您的備份將從 DuckDuckGo 的伺服器中刪除。所有裝置都將中斷同步。在以下瀏覽器"
-"中，您最近的 100 筆聊天記錄將保存在本機儲存空間中："
+msgstr "您的備份將從 DuckDuckGo 的伺服器中刪除。所有裝置都將中斷同步。在以下瀏覽器中，您最近的 100 筆聊天記錄將保存在本機儲存空間中："
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -25515,16 +25210,14 @@ msgstr "您的聊天內容是私密的，且絕不會用於訓練 AI 模型"
 msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"您的聊天內容是私密的，我們會對其進行匿名處理，且不會用來訓練人工智慧模型。"
+msgstr "您的聊天內容是私密的，我們會對其進行匿名處理，且不會用來訓練人工智慧模型。"
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
 msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"您的聊天內容是私密的，我們會對其進行匿名處理，且不會用來訓練人工智慧模型。"
+msgstr "您的聊天內容是私密的，我們會對其進行匿名處理，且不會用來訓練人工智慧模型。"
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -25552,9 +25245,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
-msgstr ""
-"您的聊天內容是私密的，我們會進行匿名處理，且不會用來訓練 AI 模型。請依照這些"
-"步驟保留您的聊天記錄。"
+msgstr "您的聊天內容是私密的，我們會進行匿名處理，且不會用來訓練 AI 模型。請依照這些步驟保留您的聊天記錄。"
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -25593,8 +25284,7 @@ msgctxt "newsletter email collection"
 msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
-msgstr ""
-"你的電子信箱將不會被公開分享，%1$s或與匿名搜尋有任何關聯。[%2$s範例訊息%3$s]"
+msgstr "你的電子信箱將不會被公開分享，%1$s或與匿名搜尋有任何關聯。[%2$s範例訊息%3$s]"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -25636,10 +25326,7 @@ msgid ""
 "known as %sSHA-2%s. Only the key and associated settings file leave your "
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
-msgstr ""
-"我們將使用%1$sSHA-2%2$s安全雜湊演算法，根據你的通關密語產生一組512位的金鑰。"
-"只有金鑰及其相關設定檔案會傳至你的瀏覽器之外。我們將以該金鑰為檔名儲存設定檔"
-"案。DuckDuckGo不會知道你的通關密語。"
+msgstr "我們將使用%1$sSHA-2%2$s安全雜湊演算法，根據你的通關密語產生一組512位的金鑰。只有金鑰及其相關設定檔案會傳至你的瀏覽器之外。我們將以該金鑰為檔名儲存設定檔案。DuckDuckGo不會知道你的通關密語。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25653,9 +25340,7 @@ msgid ""
 "Your prompts are relayed through DuckDuckGo servers and stripped of "
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
-msgstr ""
-"你的提示會透過 DuckDuckGo 伺服器轉發，並移除個人識別的元資料，因此模型提供者"
-"無法將你的對話與你連結起來。"
+msgstr "你的提示會透過 DuckDuckGo 伺服器轉發，並移除個人識別的元資料，因此模型提供者無法將你的對話與你連結起來。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25699,9 +25384,7 @@ msgctxt "settings"
 msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
-msgstr ""
-"你的設定已儲存，但清除 Cookie 將會重設這些設定。啟用 %1$sDuckDuckGo No "
-"AI%2$s 擴充套件以使其永久生效。"
+msgstr "你的設定已儲存，但清除 Cookie 將會重設這些設定。啟用 %1$sDuckDuckGo No AI%2$s 擴充套件以使其永久生效。"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25710,8 +25393,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"你的設定已儲存，但清除 Cookie 將會重設這些設定。 安裝 %1$sDuckDuckGo No "
-"AI%2$s 擴充套件以使其永久生效。 %3$s瞭解更多%4$s"
+"你的設定已儲存，但清除 Cookie 將會重設這些設定。 安裝 %1$sDuckDuckGo No AI%2$s 擴充套件以使其永久生效。 "
+"%3$s瞭解更多%4$s"
 
 # smartling.placeholder_format=C
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
@@ -25730,9 +25413,7 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
-msgstr ""
-"你目前正在 Chrome 使用隱私搜尋。使用我們的瀏覽器而非 Chrome，如此一來即可取得"
-"更全面的保護。應用程式已經安裝完畢，而且可以："
+msgstr "你目前正在 Chrome 使用隱私搜尋。使用我們的瀏覽器而非 Chrome，如此一來即可取得更全面的保護。應用程式已經安裝完畢，而且可以："
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -25748,8 +25429,7 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
-msgstr ""
-"您已達到此對話的最長聊天長度。 使用「Fire Button」按鈕清除此對話以繼續。"
+msgstr "您已達到此對話的最長聊天長度。 使用「Fire Button」按鈕清除此對話以繼續。"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -26005,7 +25685,7 @@ msgstr "分"
 #. Accessible label (aria-label) for the button that opens a saved chat's options menu (pin, rename, delete, export, share) in the chat history list. Used on both desktop and mobile. Announced by screen readers only, not visible on screen.
 msgctxt "Aria label for the chat options menu button"
 msgid "menu"
-msgstr ""
+msgstr "選單"
 
 # smartling.placeholder_format=C
 #. Aria label for the button that opens the menu in the mobile variant.


### PR DESCRIPTION
This import picks up all 38 tokens added to text.json since the last merged import (Aug 14, [#911](https://github.com/duckduckgo/duckduckgo-locales/pull/911)), not just the 3 NTP Duck.ai drawer strings that prompted it. The 23,940 lines are those 38 tokens fanned out as untranslated stubs across all 103 locale .po files - ~230 lines each.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Translation-catalog-only changes with no application logic, credentials, or security-sensitive code. Risk is limited to copy/UX in localized surfaces once strings are wired in product builds.
> 
> **Overview**
> Adds **38 new gettext entries** to `duckduckgo.pot` and propagates them through locale `.po` files (per the Aug 27 import). The new copy mostly supports recent **Duck.ai** and adjacent product UI—not a single feature, but a batch of user-facing strings.
> 
> **Duck.ai chat & attachments:** attach-menu labels (`Add`, `Add File` / `Add Image` / `Add Image or File`, `Add Tabs`), tab-picker dialog (title, search, `Current Tab`, primary/secondary actions), and related accessibility labels (message edit, customize-responses textareas, survey dismiss, chat history menu).
> 
> **Chat history, sync, and sharing:** “About Chat History with Sync & Backup” modal headlines and body copy (local save, E2E encryption, sync benefits, browser-specific storage, temporary server storage), bulk delete **“Delete Chats and Shared Links”**, and expanded **share-modal** bullets (encryption, public link, generated images, follow-ups private, link expiry + save copy).
> 
> **Discovery & merchandising:** NTP one-time Duck.ai drawer strings (`OPTIONAL`, toggle headline variant, anonymized models tagline), sunglasses/collaborations tooltip and **Shop Now** modal CTA, and a **Yelp** ad-badge tooltip parallel to TripAdvisor.
> 
> **Other:** product star-rating screen reader text (`Rated %s out of %s`).
> 
> Locale files receive the new `msgid`/`msgctxt` blocks; **Afrikaans (`af_ZA`)** includes completed `msgstr` values for the new strings, and the diff also shows **line-wrap normalization** on many existing Afrikaans translations (same text, different PO formatting). Other locales are expected to follow the usual import pattern (stubs until translators fill them in).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 435bd679710211574bda08fc3b1a0b72cc9823f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->